### PR TITLE
fix(llm): detect upstream provider errors and skip pg-boss retry

### DIFF
--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -29,6 +29,7 @@ import {
   cancelAllAgents,
   provisionHostConfig,
   resolveAgentConcurrency,
+  UpstreamProviderError,
   verifyAiCredentials,
 } from "@neko/llm";
 import { runBusinessProfileBuild } from "./jobs/business-profile-build.js";
@@ -106,6 +107,18 @@ function makeHandler<P extends ProcessingJobPayload>(
         } catch (e) {
           const msg = e instanceof Error ? e.message : String(e);
           await markFailed(processingJobId, msg);
+          // Upstream provider errors (Gemini 503, etc.) are not worth
+          // retrying — the same overloaded backend will reject the next
+          // attempt the same way. Mark failed in our table, return
+          // cleanly so pg-boss treats the job as completed and skips
+          // its retry loop. The user can re-run via the card retry
+          // button when ready.
+          if (e instanceof UpstreamProviderError) {
+            console.warn(
+              `[worker] job ${processingJobId} upstream provider unavailable; skipping pg-boss retry: ${msg}`,
+            );
+            return;
+          }
           console.warn(
             `[worker] job ${processingJobId} attempt failed; pg-boss may retry: ${msg}`,
           );

--- a/packages/llm/src/agent-error.ts
+++ b/packages/llm/src/agent-error.ts
@@ -1,0 +1,69 @@
+/**
+ * Typed errors for agent runs that fail because of an upstream LLM
+ * provider, not because the agent itself produced bad output.
+ *
+ * The hermes / claude binaries surface provider 5xx errors by printing
+ * their own error string to stdout (e.g. "API call failed after 3
+ * retries: HTTP 503: Gemini HTTP 503 (UNAVAILABLE): ..."). Without this
+ * detection that string lands in `parseJsonFromOutput` and throws a
+ * confusing "no object braces found" — and pg-boss then retries the job
+ * 2× more, hammering the same overloaded provider.
+ *
+ * The worker treats UpstreamProviderError specially: marks
+ * processing_job 'failed' with the clean message, then completes (not
+ * rejects) the pg-boss job so retries don't burn against a load-shed
+ * provider. The user retries via the card's retry button when ready.
+ */
+
+export class UpstreamProviderError extends Error {
+  readonly provider?: string;
+  readonly statusCode?: number;
+  constructor(
+    message: string,
+    opts?: { provider?: string; statusCode?: number },
+  ) {
+    super(message);
+    this.name = "UpstreamProviderError";
+    this.provider = opts?.provider;
+    this.statusCode = opts?.statusCode;
+  }
+}
+
+// Patterns we've seen in real failures. Order matters — more specific
+// patterns first so we capture the named provider when possible.
+const PATTERNS: ReadonlyArray<{ regex: RegExp; provider?: string }> = [
+  { regex: /Gemini\s+HTTP\s+(\d{3})\b/i, provider: "google-gemini" },
+  { regex: /Anthropic\s+HTTP\s+(\d{3})\b/i, provider: "anthropic" },
+  { regex: /OpenAI\s+HTTP\s+(\d{3})\b/i, provider: "openai" },
+  // Generic Hermes phrasing — covers any provider it routes to.
+  { regex: /API call failed after \d+ retries:\s*HTTP\s+(\d{3})\b/i },
+  // Bare "HTTP 5xx (UNAVAILABLE|INTERNAL|...)" as a last resort.
+  { regex: /\bHTTP\s+(5\d{2})\b.*?(UNAVAILABLE|INTERNAL|SERVICE_UNAVAILABLE|RESOURCE_EXHAUSTED)?/i },
+];
+
+/**
+ * If the agent's stdout looks like an upstream-provider error rather
+ * than a malformed JSON answer, return a typed error. Otherwise null.
+ *
+ * Only inspects the first ~1500 chars to avoid false positives on
+ * legitimate JSON that happens to mention HTTP codes inside reasoning.
+ */
+export function detectUpstreamError(stdout: string): UpstreamProviderError | null {
+  const head = stdout.slice(0, 1500).trim();
+  // A real JSON answer starts with `{` or ```json fence — bail fast.
+  if (head.startsWith("{") || head.startsWith("```")) return null;
+
+  for (const { regex, provider } of PATTERNS) {
+    const m = head.match(regex);
+    if (!m) continue;
+    const statusRaw = Number(m[1]);
+    const statusCode = Number.isFinite(statusRaw) ? statusRaw : undefined;
+    const providerLabel = provider ? ` (${provider})` : "";
+    const detail = head.slice(0, 300).replace(/\s+/g, " ").trim();
+    return new UpstreamProviderError(
+      `Upstream provider unavailable${providerLabel}: ${detail}`,
+      { provider, statusCode },
+    );
+  }
+  return null;
+}

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -23,4 +23,9 @@ export {
   type AgentConcurrency,
 } from "./agent-backend-resolver";
 export { cancelAllAgents, registerAgentCanceller } from "./agent-shutdown";
+export {
+  UpstreamProviderError,
+  detectUpstreamError,
+} from "./agent-error";
 export { provisionHostConfig } from "./host-provision";
+export * from "./work";

--- a/packages/llm/src/metric-agent.ts
+++ b/packages/llm/src/metric-agent.ts
@@ -15,6 +15,7 @@
 
 import { data_source, db, eq } from "@neko/db";
 import { resolveAgentBackend } from "./agent-backend-resolver";
+import { detectUpstreamError } from "./agent-error";
 import { parseJsonFromOutput } from "./hermes-runner";
 
 export type MetricAgentInput = {
@@ -301,6 +302,19 @@ export async function runMetricAgent(
     throw e;
   }
   const elapsedSec = ((Date.now() - startedAt) / 1000).toFixed(0);
+
+  // First, check if the agent gave up because of an upstream provider
+  // error (Gemini 503, etc.) and printed its own error to stdout. We
+  // throw a typed error so the worker can short-circuit pg-boss retries
+  // — re-running the job against a load-shed provider just multiplies
+  // the failure.
+  const upstream = detectUpstreamError(stdout);
+  if (upstream) {
+    console.warn(
+      `[metric-agent] org=${input.orgId} slug=${input.slug} upstream provider error: ${upstream.message}`,
+    );
+    throw upstream;
+  }
 
   let parsed: Partial<MetricAgentResult>;
   try {


### PR DESCRIPTION
## Summary

- Hermes prints upstream provider errors (Gemini 503, Anthropic 5xx, etc.) to stdout instead of returning JSON. Without detection that string landed in `parseJsonFromOutput` as "no object braces found", and pg-boss retried 2× more — 3+ failed calls against the same overloaded backend.
- New typed `UpstreamProviderError` + detector that scans the agent stdout head for known provider-error phrases (`API call failed after N retries`, `Gemini HTTP 5xx`, `Anthropic HTTP 5xx`, generic `HTTP 5xx UNAVAILABLE/INTERNAL`).
- Worker short-circuits pg-boss retry on this error: marks `processing_job` failed with the clean message, returns cleanly so pg-boss completes the job. Card retry button remains the recovery path.

## Why

Real failure today: classifying a chat question hit Gemini 503 → Hermes retried 3× internally and gave up → our parser threw "no object braces found" → pg-boss retried 2× more, each blowing 30+ seconds against the same overloaded backend. Total: 9 wasted Gemini calls and a misleading error message in journal/UI.

## Test plan

- [ ] Manual: temporarily set primary to a known-bad model (e.g. a preview that's currently 503-ing) and verify the journal shows `[metric-agent] upstream provider error:` and `[worker] ... skipping pg-boss retry:` instead of the parse-error stack
- [ ] Confirm `processing_job` row lands in `failed` state with the clean message visible to the UI
- [ ] Confirm pg-boss does NOT retry (only one `running ... metric_refresh` log line)
- [ ] Healthy path (gemini-2.5-pro): no behavior change — unrelated to detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)