### PR TITLE
fix(agent): pin claude-agent SDK to PATH binary

### DIFF
--- a/packages/llm/src/agent-backends/claude-agent.ts
+++ b/packages/llm/src/agent-backends/claude-agent.ts
@@ -13,13 +13,24 @@ import { extractSurfaceMessages } from "./surface";
 
 let _claudeOnPathChecked = false;
 let _claudeOnPath = false;
+let _claudeBinaryPath: string | undefined;
 
+// Pin the SDK to the PATH binary. Otherwise it auto-resolves a sibling pnpm package and on Debian/glibc picks the musl variant first, which fails to spawn.
 function claudeBinaryAvailable(): boolean {
   if (_claudeOnPathChecked) return _claudeOnPath;
   _claudeOnPathChecked = true;
-  const r = spawnSync("which", ["claude"], { stdio: "ignore" });
+  const r = spawnSync("which", ["claude"], { encoding: "utf8" });
   _claudeOnPath = r.status === 0;
+  if (_claudeOnPath) {
+    const out = typeof r.stdout === "string" ? r.stdout : r.stdout?.toString() ?? "";
+    _claudeBinaryPath = out.trim() || undefined;
+  }
   return _claudeOnPath;
+}
+
+function claudeBinaryPath(): string | undefined {
+  claudeBinaryAvailable();
+  return _claudeBinaryPath;
 }
 
 export type ClaudeAgentBackendConfig = {
@@ -167,10 +178,12 @@ export class ClaudeAgentBackend implements AgentBackend {
     const toolDurations = new Map<string, number>();
 
     const sdkPrompt = userMessage ?? prompt;
+    const claudePath = claudeBinaryPath();
     const sdkOptions: Record<string, unknown> = {
       model: this.config.model,
       maxTurns: MAX_TURNS,
       tools: { type: "preset", preset: "claude_code" },
+      ...(claudePath ? { pathToClaudeCodeExecutable: claudePath } : {}),
       env: {
         ...process.env,
         ANTHROPIC_API_KEY: this.config.apiKey,

--- a/packages/llm/test/claude-agent-backend.test.ts
+++ b/packages/llm/test/claude-agent-backend.test.ts
@@ -19,7 +19,7 @@ vi.mock("node:child_process", async () => {
   );
   return {
     ...actual,
-    spawnSync: () => ({ status: 0, stdout: Buffer.from(""), stderr: Buffer.from("") }),
+    spawnSync: () => ({ status: 0, stdout: "/usr/local/bin/claude\n", stderr: "" }),
   };
 });
 


### PR DESCRIPTION
## Summary

- claude-agent-sdk@0.2.128 auto-resolves its native binary from sibling pnpm packages and probes `…-linux-${arch}-musl/claude` before `…-linux-${arch}/claude`. On our `node:22-bookworm-slim` base (glibc), pnpm installs **both** variants under `.pnpm/` because it doesn't filter optional deps by libc. The SDK picks musl first → spawn fails → users see "Claude Code native binary not found".
- We already shell out to `which claude` to verify availability (the Dockerfile installs `@anthropic-ai/claude-code` globally on PATH). Capture that path and pass it as `pathToClaudeCodeExecutable` so the SDK skips its broken auto-resolution entirely.
- Surfaced by a user running the AdventureWorks seed flow from `INSTALL.md` — "Setup failed: Claude Code native binary not found at /app/node_modules/.pnpm/@anthropic-ai+claude-agent-sdk-linux-arm64-musl@0.2.128/…/claude".

## Test plan

- [x] `pnpm --filter @neko/llm test` — 115 pass, claude-agent-backend tests green
- [ ] Rebuild Docker image and re-run AdventureWorks seed flow on ARM64 host; confirm Claude Agent backend starts without the native-binary error
- [ ] Sanity-check the Hermes backend path is unchanged (no regressions in `/settings/agent` selection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)