### PR TITLE
fix(build): drop dead else branch tripping next build typecheck

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -76,6 +76,13 @@ jobs:
           NEKO_PG_DATABASE: neko
         run: node packages/db/src/migrate.mjs
 
+      # Typecheck apps/web + apps/worker. Deploy runs `pnpm build`, which
+      # invokes next build → tsc; PR checks otherwise only run vitest, so a
+      # type error in workspace code (e.g. packages/llm) can slip through and
+      # break VM deploy on main. tsc --noEmit reproduces that gate cheaply.
+      - name: Typecheck
+        run: pnpm -r --if-present typecheck
+
       - name: Test
         env:
           NEKO_PG_HOST: localhost

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts 2>&1 | tee /tmp/neko-worker.log",
     "start": "tsx src/index.ts",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "vitest run --config vitest.e2e.config.ts"
@@ -21,6 +22,7 @@
   "devDependencies": {
     "@types/node": "^20",
     "@types/pg": "^8.20.0",
+    "typescript": "^5",
     "vitest": "^2.1.8"
   }
 }

--- a/packages/llm/src/agent-backends/claude-agent.ts
+++ b/packages/llm/src/agent-backends/claude-agent.ts
@@ -22,8 +22,7 @@ function claudeBinaryAvailable(): boolean {
   const r = spawnSync("which", ["claude"], { encoding: "utf8" });
   _claudeOnPath = r.status === 0;
   if (_claudeOnPath) {
-    const out = typeof r.stdout === "string" ? r.stdout : r.stdout?.toString() ?? "";
-    _claudeBinaryPath = out.trim() || undefined;
+    _claudeBinaryPath = r.stdout.trim() || undefined;
   }
   return _claudeOnPath;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
+      typescript:
+        specifier: ^5
+        version: 5.9.3
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.39)(lightningcss@1.32.0)


### PR DESCRIPTION
## Summary

Unblocks `Deploy to VM` on main. The latest run failed at the `Pull, build, restart` step ([run #31](https://github.com/open-neko/neko/actions/runs/25756999728/job/75648944697)) because `pnpm build` → `next build` runs a TypeScript pass that PR checks don't — and it hit a dead branch in `packages/llm/src/agent-backends/claude-agent.ts:25`.

`spawnSync(..., { encoding: "utf8" })` returns `SpawnSyncReturns<string>`, so `r.stdout` is typed `string`. The ternary's else branch was therefore unreachable; `r.stdout` narrowed to `never`, and `.toString()` on `never` failed the typecheck:

```
Type error: Property 'toString' does not exist on type 'never'.
> 25 |     const out = typeof r.stdout === "string" ? r.stdout : r.stdout?.toString() ?? "";
```

Dropped the dead branch. `pnpm build` now passes locally end-to-end.

## Test plan

- [x] `pnpm build` succeeds locally (apps/web finishes the Next.js typecheck/build)
- [ ] Merge → Deploy to VM workflow goes green on main

Note: PR checks run `pnpm test` but not `pnpm build`, which is why this slipped past #7. Worth a follow-up to add a build step to PR checks so the next typecheck regression is caught before main.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cq7KkZw5GjgsfpeXmSHxkM)_