### PR TITLE
feat(business-profile): inline edit profile and industry insights

### DIFF
--- a/apps/web/src/app/api/profile/route.ts
+++ b/apps/web/src/app/api/profile/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import {
   and,
   customer_profile,
@@ -9,6 +9,8 @@ import {
 } from "@neko/db";
 import { getOrgId } from "@/lib/db";
 import { resolveResearchStatus } from "@/lib/provider-settings";
+
+const MAX_FIELD_LENGTH = 200_000;
 
 /**
  * GET /api/profile
@@ -64,5 +66,66 @@ export async function GET() {
           : jobRows.length > 0
             ? "processing"
             : "pending",
+  });
+}
+
+/**
+ * PATCH /api/profile
+ * Body: { businessProfile?: string; industryInsights?: string }
+ *
+ * Updates the current customer_profile row for the org. Only fields present in
+ * the body (and of type string) are written, so omitting a key preserves the
+ * existing column value. Used by the inline editor on the business-profile
+ * page; sent as a debounced save after the user pauses typing or clicks out.
+ */
+export async function PATCH(request: NextRequest) {
+  const body = (await request.json().catch(() => null)) as
+    | { businessProfile?: unknown; industryInsights?: unknown }
+    | null;
+  if (!body || typeof body !== "object") {
+    return NextResponse.json({ error: "invalid body" }, { status: 400 });
+  }
+
+  const update: { business_profile?: string; industry_insights?: string; updated_at: Date } = {
+    updated_at: new Date(),
+  };
+  if (typeof body.businessProfile === "string") {
+    if (body.businessProfile.length > MAX_FIELD_LENGTH) {
+      return NextResponse.json({ error: "businessProfile too large" }, { status: 413 });
+    }
+    update.business_profile = body.businessProfile;
+  }
+  if (typeof body.industryInsights === "string") {
+    if (body.industryInsights.length > MAX_FIELD_LENGTH) {
+      return NextResponse.json({ error: "industryInsights too large" }, { status: 413 });
+    }
+    update.industry_insights = body.industryInsights;
+  }
+  if (update.business_profile === undefined && update.industry_insights === undefined) {
+    return NextResponse.json({ error: "no fields to update" }, { status: 400 });
+  }
+
+  const orgId = await getOrgId();
+  const rows = await db()
+    .update(customer_profile)
+    .set(update)
+    .where(
+      and(
+        eq(customer_profile.org_id, orgId),
+        eq(customer_profile.is_current, true),
+      ),
+    )
+    .returning({
+      business_profile: customer_profile.business_profile,
+      industry_insights: customer_profile.industry_insights,
+    });
+
+  if (rows.length === 0) {
+    return NextResponse.json({ error: "no profile" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    businessProfile: rows[0].business_profile ?? "",
+    industryInsights: rows[0].industry_insights ?? "",
   });
 }

--- a/apps/web/src/app/business-profile/page.tsx
+++ b/apps/web/src/app/business-profile/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import AppHeader from "@/components/AppHeader";
 import SectionNav from "@/components/SectionNav";
-import Markdown from "react-markdown";
+import EditableMarkdown from "@/components/EditableMarkdown";
+import { useDebouncedSave } from "@/hooks/useDebouncedSave";
 import type { StageKind } from "@/lib/db";
 
 type Phase = "processing" | "review";
@@ -49,6 +50,51 @@ export default function ProcessingPage() {
   const [profile, setProfile] = useState("");
   const [insights, setInsights] = useState("");
   const [insightsStatus, setInsightsStatus] = useState<InsightsStatus>("processing");
+  const profileEditedRef = useRef(false);
+  const insightsEditedRef = useRef(false);
+
+  const saveProfile = useCallback(async (v: string) => {
+    const res = await fetch("/api/profile", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ businessProfile: v }),
+    });
+    if (!res.ok) throw new Error(`save failed: ${res.status}`);
+  }, []);
+  const saveInsights = useCallback(async (v: string) => {
+    const res = await fetch("/api/profile", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ industryInsights: v }),
+    });
+    if (!res.ok) throw new Error(`save failed: ${res.status}`);
+  }, []);
+  const profileSaver = useDebouncedSave<string>({ delayMs: 800, save: saveProfile });
+  const insightsSaver = useDebouncedSave<string>({ delayMs: 800, save: saveInsights });
+  const flushAll = useCallback(
+    async () => {
+      await Promise.all([profileSaver.flush(), insightsSaver.flush()]);
+    },
+    [profileSaver, insightsSaver],
+  );
+  const saveError = profileSaver.lastError ?? insightsSaver.lastError;
+
+  const handleProfileChange = useCallback(
+    (next: string) => {
+      profileEditedRef.current = true;
+      setProfile(next);
+      profileSaver.schedule(next);
+    },
+    [profileSaver],
+  );
+  const handleInsightsChange = useCallback(
+    (next: string) => {
+      insightsEditedRef.current = true;
+      setInsights(next);
+      insightsSaver.schedule(next);
+    },
+    [insightsSaver],
+  );
 
   useEffect(() => {
     if (phase !== "processing") return;
@@ -64,8 +110,10 @@ export default function ProcessingPage() {
             const pRes = await fetch("/api/profile");
             if (pRes.ok) {
               const data = await pRes.json();
-              setProfile(data.businessProfile ?? "");
-              if (data.industryInsights) setInsights(data.industryInsights);
+              if (!profileEditedRef.current) setProfile(data.businessProfile ?? "");
+              if (data.industryInsights && !insightsEditedRef.current) {
+                setInsights(data.industryInsights);
+              }
               setInsightsStatus(data.industryInsightsStatus ?? "processing");
             }
             if (!cancelled) setPhase("review");
@@ -124,7 +172,9 @@ export default function ProcessingPage() {
           const pRes = await fetch("/api/profile");
           if (pRes.ok && !cancelled) {
             const pData = await pRes.json();
-            if (pData.industryInsights) setInsights(pData.industryInsights);
+            if (pData.industryInsights && !insightsEditedRef.current) {
+              setInsights(pData.industryInsights);
+            }
             setInsightsStatus(pData.industryInsightsStatus ?? "ready");
           }
         } else {
@@ -148,7 +198,7 @@ export default function ProcessingPage() {
             const data = await res.json();
             setInsightsStatus(data.industryInsightsStatus ?? "processing");
             if (data.industryInsights) {
-              setInsights(data.industryInsights);
+              if (!insightsEditedRef.current) setInsights(data.industryInsights);
               return;
             }
           }
@@ -209,13 +259,19 @@ export default function ProcessingPage() {
       >
         <button
           className={`pill${tab === "profile" ? " on" : ""}`}
-          onClick={() => setTab("profile")}
+          onClick={async () => {
+            await flushAll();
+            setTab("profile");
+          }}
         >
           Business Profile
         </button>
         <button
           className={`pill${tab === "insights" ? " on" : ""}`}
-          onClick={() => setTab("insights")}
+          onClick={async () => {
+            await flushAll();
+            setTab("insights");
+          }}
         >
           Industry Insights
           {insightsPending && (
@@ -234,15 +290,41 @@ export default function ProcessingPage() {
 
       <div className="profile-card" style={{ animation: "fadeUp 0.6s ease 0.3s both" }}>
         {tab === "profile" ? (
-          profile ? <ProfileMarkdown content={profile} /> : <ProfileEmpty />
+          <EditableMarkdown
+            value={profile}
+            onChange={handleProfileChange}
+            onCommit={() => profileSaver.flush()}
+            placeholder={<ProfileEmpty />}
+            components={mdComponents}
+            ariaLabel="Business profile"
+          />
         ) : insightsStatus === "disabled" ? (
           <InsightsDisabled />
         ) : insights ? (
-          <ProfileMarkdown content={insights} />
+          <EditableMarkdown
+            value={insights}
+            onChange={handleInsightsChange}
+            onCommit={() => insightsSaver.flush()}
+            components={mdComponents}
+            ariaLabel="Industry insights"
+          />
         ) : (
           <InsightsLoading />
         )}
       </div>
+      {saveError && (
+        <div
+          style={{
+            marginTop: 8,
+            fontSize: 12,
+            color: "var(--text3)",
+            textAlign: "right",
+          }}
+          role="status"
+        >
+          Couldn&apos;t save — will retry on your next edit.
+        </div>
+      )}
 
       <div
         style={{
@@ -256,7 +338,10 @@ export default function ProcessingPage() {
       >
         <button
           className="pill on"
-          onClick={() => router.replace("/")}
+          onClick={async () => {
+            await flushAll();
+            router.replace("/");
+          }}
           style={{ padding: "14px 32px", fontSize: 15 }}
         >
           Continue to your briefing
@@ -265,6 +350,7 @@ export default function ProcessingPage() {
           <button
             className="pill"
             onClick={async () => {
+              await flushAll();
               try {
                 const res = await fetch("/api/insights/ensure", {
                   method: "POST",
@@ -272,6 +358,7 @@ export default function ProcessingPage() {
                   body: JSON.stringify({ force: true }),
                 });
                 if (res.ok) {
+                  insightsEditedRef.current = false;
                   setInsights("");
                   setInsightsStatus("processing");
                   setTab("insights");
@@ -377,8 +464,3 @@ const mdComponents = {
   ul: (p: React.ComponentProps<"ul">) => <ul className="pm-ul" {...p} />,
   a: (p: React.ComponentProps<"a">) => <a className="pm-cite" target="_blank" rel="noopener noreferrer" {...p} />,
 };
-
-function ProfileMarkdown({ content }: { content: string }) {
-  if (!content) return null;
-  return <Markdown components={mdComponents}>{content}</Markdown>;
-}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1832,6 +1832,18 @@ body > * { position: relative; z-index: 1; }
 }
 .pm-cite:hover { background: var(--accent); color: white; }
 
+.pm-edit { outline: none; }
+.pm-edit-idle { cursor: text; }
+.pm-edit-active {
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--text2);
+  caret-color: var(--accent);
+  outline: none;
+}
+
 @keyframes fadeUp {
   from { opacity: 0; transform: translateY(10px); }
   to { opacity: 1; transform: translateY(0); }

--- a/apps/web/src/components/EditableMarkdown.tsx
+++ b/apps/web/src/components/EditableMarkdown.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import {
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import Markdown, { type Components } from "react-markdown";
+
+type Props = {
+  value: string;
+  onChange: (next: string) => void;
+  onCommit?: () => void;
+  placeholder?: ReactNode;
+  components: Components;
+  readOnly?: boolean;
+  ariaLabel?: string;
+};
+
+type CaretPos = { x: number; y: number } | null;
+
+type CaretLookup = {
+  caretPositionFromPoint?: (x: number, y: number) => { offsetNode: Node; offset: number } | null;
+  caretRangeFromPoint?: (x: number, y: number) => Range | null;
+};
+
+export default function EditableMarkdown({
+  value,
+  onChange,
+  onCommit,
+  placeholder,
+  components,
+  readOnly,
+  ariaLabel,
+}: Props) {
+  const [editing, setEditing] = useState(false);
+  const editRef = useRef<HTMLDivElement | null>(null);
+  const pendingCaretRef = useRef<CaretPos>(null);
+
+  const enterEdit = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (readOnly) return;
+      const target = e.target as HTMLElement;
+      if (target.tagName === "A") return;
+      pendingCaretRef.current = { x: e.clientX, y: e.clientY };
+      setEditing(true);
+    },
+    [readOnly],
+  );
+
+  useLayoutEffect(() => {
+    if (!editing) return;
+    const node = editRef.current;
+    if (!node) return;
+
+    node.innerText = value;
+
+    const caret = pendingCaretRef.current;
+    pendingCaretRef.current = null;
+    const sel = window.getSelection();
+    if (!sel) {
+      node.focus();
+      return;
+    }
+    const range = document.createRange();
+    let placed = false;
+    if (caret) {
+      const doc = document as Document & CaretLookup;
+      if (typeof doc.caretPositionFromPoint === "function") {
+        const pos = doc.caretPositionFromPoint(caret.x, caret.y);
+        if (pos && node.contains(pos.offsetNode)) {
+          range.setStart(pos.offsetNode, pos.offset);
+          range.collapse(true);
+          placed = true;
+        }
+      } else if (typeof doc.caretRangeFromPoint === "function") {
+        const r = doc.caretRangeFromPoint(caret.x, caret.y);
+        if (r && node.contains(r.startContainer)) {
+          range.setStart(r.startContainer, r.startOffset);
+          range.collapse(true);
+          placed = true;
+        }
+      }
+    }
+    if (!placed) {
+      range.selectNodeContents(node);
+      range.collapse(false);
+    }
+    sel.removeAllRanges();
+    sel.addRange(range);
+    node.focus();
+    // We intentionally only re-run when entering edit mode. Re-syncing innerText
+    // on every value change would clobber the caret while typing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editing]);
+
+  const handleInput = useCallback(
+    (e: React.FormEvent<HTMLDivElement>) => {
+      onChange(e.currentTarget.innerText);
+    },
+    [onChange],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        document.execCommand("insertText", false, "\n");
+      }
+    },
+    [],
+  );
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const text = e.clipboardData.getData("text/plain");
+      if (text) document.execCommand("insertText", false, text);
+    },
+    [],
+  );
+
+  const handleBlur = useCallback(() => {
+    setEditing(false);
+    onCommit?.();
+  }, [onCommit]);
+
+  useEffect(() => {
+    if (editing) return;
+    pendingCaretRef.current = null;
+  }, [editing]);
+
+  if (editing) {
+    return (
+      <div
+        ref={editRef}
+        className="pm-edit pm-edit-active"
+        contentEditable
+        suppressContentEditableWarning
+        role="textbox"
+        aria-label={ariaLabel}
+        aria-multiline="true"
+        spellCheck
+        onInput={handleInput}
+        onKeyDown={handleKeyDown}
+        onPaste={handlePaste}
+        onBlur={handleBlur}
+      />
+    );
+  }
+
+  const hasContent = value.length > 0;
+  return (
+    <div
+      className="pm-edit pm-edit-idle"
+      onPointerDown={readOnly ? undefined : enterEdit}
+      role={readOnly ? undefined : "textbox"}
+      aria-label={ariaLabel}
+    >
+      {hasContent ? <Markdown components={components}>{value}</Markdown> : placeholder}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useDebouncedSave.ts
+++ b/apps/web/src/hooks/useDebouncedSave.ts
@@ -1,0 +1,91 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type Opts<T> = {
+  delayMs: number;
+  save: (value: T) => Promise<void>;
+};
+
+type Api<T> = {
+  schedule: (value: T) => void;
+  flush: () => Promise<void>;
+  isSaving: boolean;
+  lastError: Error | null;
+};
+
+export function useDebouncedSave<T>({ delayMs, save }: Opts<T>): Api<T> {
+  const pendingRef = useRef<{ has: boolean; value: T | undefined }>({
+    has: false,
+    value: undefined,
+  });
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tailRef = useRef<Promise<void>>(Promise.resolve());
+  const saveRef = useRef(save);
+
+  const [isSaving, setIsSaving] = useState(false);
+  const [lastError, setLastError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    saveRef.current = save;
+  }, [save]);
+
+  const runPending = useCallback(() => {
+    if (!pendingRef.current.has) return;
+    const value = pendingRef.current.value as T;
+    pendingRef.current = { has: false, value: undefined };
+    setIsSaving(true);
+    tailRef.current = tailRef.current.then(async () => {
+      try {
+        await saveRef.current(value);
+        setLastError(null);
+      } catch (err) {
+        setLastError(err instanceof Error ? err : new Error(String(err)));
+      } finally {
+        if (!pendingRef.current.has) setIsSaving(false);
+      }
+    });
+  }, []);
+
+  const schedule = useCallback(
+    (value: T) => {
+      pendingRef.current = { has: true, value };
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null;
+        runPending();
+      }, delayMs);
+    },
+    [delayMs, runPending],
+  );
+
+  const flush = useCallback(async () => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    runPending();
+    await tailRef.current;
+  }, [runPending]);
+
+  useEffect(() => {
+    const onBeforeUnload = () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      runPending();
+    };
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", onBeforeUnload);
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      runPending();
+    };
+  }, [runPending]);
+
+  return { schedule, flush, isSaving, lastError };
+}


### PR DESCRIPTION
Clicking on the rendered business profile or industry insights swaps the
markdown view for a borderless contentEditable holding the raw markdown
source — no textarea chrome, caret lands where the user clicked. Edits
debounce-save to a new PATCH /api/profile that updates the current
customer_profile row. Blur flushes the debounce immediately. Every
button under the content area (tab pills, Continue, Regenerate) awaits
flushAll() before its action so pending edits commit before navigation.

Polling effects now skip overwriting fields the user has edited;
Regenerate insights resets the edited flag so the freshly generated text
is accepted.

https://claude.ai/code/session_01VsgtC4Mq6uNuCvKHxu9God