### PR TITLE
ci: dedupe PR checks + auto-merge release-please PRs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,8 +3,6 @@ name: PR checks
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,7 +26,19 @@ jobs:
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ steps.app-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Auto-merge the release PR as soon as PR checks pass. Without this,
+      # release-please opens a PR and waits for a human to click merge —
+      # which means cutting a release is a manual step every time.
+      - name: Enable auto-merge on release PR
+        if: steps.release.outputs.prs_created == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          PR_NUMBER=$(echo '${{ steps.release.outputs.prs }}' | jq -r '.[0].number')
+          gh pr merge --auto --squash "$PR_NUMBER"


### PR DESCRIPTION
Two small CI tidy-ups that together turn every merge-to-main into a zero-click release cycle.

## 1. Drop push-to-main trigger from PR checks

Each merge to main fired `PR checks` twice: once on push, once on the release-please bot's auto-PR. The `concurrency` group doesn't dedupe across event types (push and pull_request use different `github.ref` values), so both runs went through the full pipeline.

Branch protection already gates merges on PR checks passing, so the post-merge re-run is pure duplication. `Deploy to VM` still runs its own `pnpm build` on push as a deploy guardrail.

## 2. Auto-merge release-please PRs

Release-please opens a PR with the version bump + CHANGELOG and waits for a human merge. That checkpoint is almost always "yes ship it." Enable auto-merge on the PR right after release-please creates/updates it; PR checks still gate the merge.

**Net release flow becomes:** merge feature PR → release-please opens/updates PR → auto-merge armed → PR checks pass → release PR merges → release fires. No manual intervention.

**Caveat:** GitHub auto-merge respects branch protection. This works because the repo doesn't require approvals (status checks alone are fine). If approval requirements are added later, this becomes a no-op until a second token approves the bot PR.

## Test plan

- [ ] CI runs once on this PR (validates the workflow files still parse)
- [ ] After merge, observe Actions tab: only one PR-checks run per merge cycle (was two)
- [ ] Next conventional commit on main triggers release-please → its PR auto-merges → release fires without a human click

🤖 Generated with [Claude Code](https://claude.com/claude-code)