### PR TITLE
feat(auth,web,worker): SSO via the plugin runtime + Scalekit-ready sign-in

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -192,6 +192,8 @@ flowchart LR
 
 **Shared install library.** The install orchestration (`runInstall`), secrets store, marketplace client, and manifest helpers live in `packages/plugin-install/` (`@open-neko/plugin-install`). Both the worker (via the registry) and the CLI consume it — one source of truth for the secrets-store shape, so the file the CLI writes is exactly the file the worker reads.
 
+**Plugin-as-SSO-provider.** A plugin can opt in to OpenNeko's SSO contract by declaring `provides_auth: true` in its marketplace entry. When such a plugin is installed, the web app's `/signin` page renders a "Sign in with <provider>" button; clicking it kicks off an OIDC code-exchange that the plugin implements (`begin_auth` returns the IdP authorization URL, `complete_auth` exchanges the callback code for an `AuthIdentity`). The core upserts `app_user` from the identity and sets a signed session cookie — it never sees the IdP client secret, which lives in the plugin's VM env. The first-party `@open-neko/plugin-scalekit` fronts the entire enterprise IdP stack (Okta, Entra ID, Google Workspace, …) behind one integration. At most one auth plugin may be installed at a time; the registry surfaces a second claimant as `skipped`. The web app discovers whether an auth plugin is installed via `GET /admin/auth/status` on the worker; that endpoint reads the manifest entry's flag (no VM spawn needed) and is hot-reload-aware for the same reason actions are.
+
 ## Operating loop (OUDA)
 
 Cron starts a chain; subscriptions propagate every link after. Outputs are non-mutating; action requests are the only thing that touches the world.

--- a/apps/openneko-cli/src/cli.ts
+++ b/apps/openneko-cli/src/cli.ts
@@ -177,9 +177,9 @@ async function handleInstall(
     configDir: cliOptions.configDir,
   });
   const network =
-    result.capabilities.network.length === 0
+    result.permissions.network.length === 0
       ? "none"
-      : result.capabilities.network.join(", ");
+      : result.permissions.network.join(", ");
   const provenance =
     result.source === "unverified"
       ? "unverified npm"
@@ -211,11 +211,11 @@ async function handleList(
   }
   for (const entry of result.entries) {
     const hosts =
-      entry.capabilities.network.length === 0
+      entry.permissions.network.length === 0
         ? "no network"
-        : entry.capabilities.network.join(", ");
+        : entry.permissions.network.join(", ");
     const from = entry.marketplace ? `  from=${entry.marketplace}` : "";
-    const flags = entry.provides_auth ? "  [SSO provider]" : "";
+    const flags = entry.capabilities.auth ? "  [SSO provider]" : "";
     stdout(`${entry.name}@${entry.version}  [${hosts}]${flags}${from}`);
   }
   return 0;

--- a/apps/openneko-cli/src/cli.ts
+++ b/apps/openneko-cli/src/cli.ts
@@ -215,7 +215,8 @@ async function handleList(
         ? "no network"
         : entry.capabilities.network.join(", ");
     const from = entry.marketplace ? `  from=${entry.marketplace}` : "";
-    stdout(`${entry.name}@${entry.version}  [${hosts}]${from}`);
+    const flags = entry.provides_auth ? "  [SSO provider]" : "";
+    stdout(`${entry.name}@${entry.version}  [${hosts}]${flags}${from}`);
   }
   return 0;
 }

--- a/apps/openneko-cli/test/cli.test.ts
+++ b/apps/openneko-cli/test/cli.test.ts
@@ -155,7 +155,12 @@ describe("runCli", () => {
             name: "@open-neko/plugin-parallel-search",
             version: "0.2.0",
             integrity: INTEGRITY,
-            capabilities: { network: ["search.parallel.ai"] },
+            permissions: { network: ["search.parallel.ai"], env: [] },
+            capabilities: {
+              action: {
+                kinds: [{ kind: "web_search", description: "search" }],
+              },
+            },
             marketplace: "official",
           },
         ],

--- a/apps/openneko-cli/test/commands.test.ts
+++ b/apps/openneko-cli/test/commands.test.ts
@@ -123,8 +123,15 @@ describe("install", () => {
           {
             version: "0.2.0",
             integrity: INTEGRITY,
-            requires_network: ["search.parallel.ai"],
-            kinds: ["web_search", "web_fetch"],
+            permissions: { network: ["search.parallel.ai"], env: [] },
+            capabilities: {
+              action: {
+                kinds: [
+                  { kind: "web_search", description: "search" },
+                  { kind: "web_fetch", description: "fetch" },
+                ],
+              },
+            },
             publishedAt: "2026-05-17",
           },
         ],
@@ -153,7 +160,7 @@ describe("install", () => {
       await readFile(path.join(repoDir, PLUGIN_MANIFEST_FILE), "utf8"),
     ) as { plugins: ManifestEntry[] };
     expect(written.plugins[0]?.marketplace).toBe("official");
-    expect(written.plugins[0]?.capabilities.network).toEqual([
+    expect(written.plugins[0]?.permissions.network).toEqual([
       "search.parallel.ai",
     ]);
   });
@@ -202,8 +209,10 @@ describe("install", () => {
         {
           version: "0.1.0",
           integrity: INTEGRITY,
-          requires_network: [],
-          kinds: ["k"],
+          permissions: { network: [], env: [] },
+          capabilities: {
+            action: { kinds: [{ kind: "k", description: "k" }] },
+          },
           publishedAt: "2026-05-17",
         },
       ],
@@ -251,8 +260,10 @@ describe("install", () => {
         {
           version: "0.1.0",
           integrity: INTEGRITY,
-          requires_network: [],
-          kinds: ["k"],
+          permissions: { network: [], env: [] },
+          capabilities: {
+            action: { kinds: [{ kind: "k", description: "k" }] },
+          },
           publishedAt: "2026-05-17",
         },
       ],
@@ -293,22 +304,30 @@ describe("install", () => {
         {
           version: "0.1.0",
           integrity: INTEGRITY,
-          requires_network: ["slack.com"],
-          requires_env: [
-            {
-              key: "SLACK_BOT_TOKEN",
-              required: true,
-              secret: true,
-              description: "xoxb- token",
+          permissions: {
+            network: ["slack.com"],
+            env: [
+              {
+                key: "SLACK_BOT_TOKEN",
+                required: true,
+                secret: true,
+                description: "xoxb- token",
+              },
+              {
+                key: "SLACK_DEFAULT_CHANNEL",
+                required: false,
+                secret: false,
+                description: "default channel",
+              },
+            ],
+          },
+          capabilities: {
+            action: {
+              kinds: [
+                { kind: "send_slack_message", description: "post" },
+              ],
             },
-            {
-              key: "SLACK_DEFAULT_CHANNEL",
-              required: false,
-              secret: false,
-              description: "default channel",
-            },
-          ],
-          kinds: ["send_slack_message"],
+          },
           publishedAt: "2026-05-17",
         },
       ],
@@ -360,16 +379,24 @@ describe("install", () => {
         {
           version: "0.1.0",
           integrity: INTEGRITY,
-          requires_network: ["slack.com"],
-          requires_env: [
-            {
-              key: "SLACK_BOT_TOKEN",
-              required: true,
-              secret: true,
-              description: "xoxb-",
+          permissions: {
+            network: ["slack.com"],
+            env: [
+              {
+                key: "SLACK_BOT_TOKEN",
+                required: true,
+                secret: true,
+                description: "xoxb-",
+              },
+            ],
+          },
+          capabilities: {
+            action: {
+              kinds: [
+                { kind: "send_slack_message", description: "post" },
+              ],
             },
-          ],
-          kinds: ["send_slack_message"],
+          },
           publishedAt: "2026-05-17",
         },
       ],
@@ -401,16 +428,24 @@ describe("install", () => {
         {
           version: "0.1.0",
           integrity: INTEGRITY,
-          requires_network: ["slack.com"],
-          requires_env: [
-            {
-              key: "SLACK_BOT_TOKEN",
-              required: true,
-              secret: true,
-              description: "xoxb-",
+          permissions: {
+            network: ["slack.com"],
+            env: [
+              {
+                key: "SLACK_BOT_TOKEN",
+                required: true,
+                secret: true,
+                description: "xoxb-",
+              },
+            ],
+          },
+          capabilities: {
+            action: {
+              kinds: [
+                { kind: "send_slack_message", description: "post" },
+              ],
             },
-          ],
-          kinds: ["send_slack_message"],
+          },
           publishedAt: "2026-05-17",
         },
       ],
@@ -454,7 +489,15 @@ describe("list", () => {
             name: "@open-neko/plugin-parallel-search",
             version: "0.2.0",
             integrity: INTEGRITY,
-            capabilities: { network: ["search.parallel.ai"] },
+            permissions: { network: ["search.parallel.ai"], env: [] },
+            capabilities: {
+              action: {
+                kinds: [
+                  { kind: "web_search", description: "search" },
+                  { kind: "web_fetch", description: "fetch" },
+                ],
+              },
+            },
             marketplace: "official",
           },
         ],
@@ -486,7 +529,10 @@ describe("remove", () => {
             name: "@open-neko/plugin-x",
             version: "0.1.0",
             integrity: INTEGRITY,
-            capabilities: { network: [] },
+            permissions: { network: [], env: [] },
+            capabilities: {
+              action: { kinds: [{ kind: "k", description: "k" }] },
+            },
           },
         ],
       }),

--- a/apps/web/src/app/api/auth/begin/route.ts
+++ b/apps/web/src/app/api/auth/begin/route.ts
@@ -1,0 +1,52 @@
+/**
+ * GET /api/auth/begin — start the SSO flow.
+ *
+ * Mint a CSRF state token, persist it (plus the return path) in an
+ * httpOnly cookie, ask the auth plugin for its IdP authorization URL,
+ * and 302 the user there. The IdP eventually bounces back to
+ * /api/auth/callback with `code` + `state`, where the cookie's state
+ * is checked against the IdP-echoed state to defeat login-CSRF.
+ *
+ * Query params:
+ *   ?returnTo=/some/internal/path  — optional, defaults to "/"
+ *   ?loginHint=user@example.com    — forwarded to the IdP as login_hint
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  beginAuth,
+  buildRedirectUri,
+  getAuthProvider,
+  newStateToken,
+  writeStateCookie,
+} from "@/lib/auth";
+
+export async function GET(request: NextRequest) {
+  const provider = await getAuthProvider();
+  if (!provider) {
+    return NextResponse.json(
+      { error: "no SSO plugin installed" },
+      { status: 503 },
+    );
+  }
+  const url = new URL(request.url);
+  const returnTo = url.searchParams.get("returnTo") ?? "/";
+  const loginHint = url.searchParams.get("loginHint");
+  const state = newStateToken();
+  await writeStateCookie(state, returnTo);
+
+  const redirectUri = buildRedirectUri(request.url);
+  try {
+    const { authorizationUrl } = await beginAuth({
+      redirectUri,
+      state,
+      loginHint: loginHint && loginHint.length > 0 ? loginHint : null,
+    });
+    return NextResponse.redirect(authorizationUrl, { status: 302 });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/web/src/app/api/auth/callback/route.ts
+++ b/apps/web/src/app/api/auth/callback/route.ts
@@ -1,0 +1,94 @@
+/**
+ * GET /api/auth/callback — finish the SSO flow.
+ *
+ * Handles the redirect from the IdP. Steps:
+ *   1. Read the state cookie. If absent / forged, fail closed.
+ *   2. Verify `state` query param matches the cookie (login-CSRF gate).
+ *   3. Call the auth plugin's complete_auth with the code, get an
+ *      identity assertion.
+ *   4. Upsert app_user from the identity.
+ *   5. Set the signed session cookie, redirect to the original
+ *      destination.
+ *
+ * Errors at any step surface as a plain text 4xx/5xx — the sign-in
+ * page picks them up if the user re-tries.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  buildRedirectUri,
+  completeAuth,
+  readAndClearStateCookie,
+  upsertUserFromIdentity,
+  writeSessionCookie,
+} from "@/lib/auth";
+
+export async function GET(request: NextRequest) {
+  const url = new URL(request.url);
+  const error = url.searchParams.get("error");
+  if (error) {
+    // The IdP itself rejected the request (consent denied, user
+    // unprovisioned, ...). Bounce back to the sign-in page with the
+    // error so the operator sees the reason rather than a blank
+    // dashboard.
+    const description = url.searchParams.get("error_description") ?? error;
+    return NextResponse.redirect(
+      new URL(
+        `/signin?error=${encodeURIComponent(description)}`,
+        request.url,
+      ),
+      { status: 302 },
+    );
+  }
+
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  if (!code || !state) {
+    return NextResponse.redirect(
+      new URL(
+        "/signin?error=missing+code+or+state+on+callback",
+        request.url,
+      ),
+      { status: 302 },
+    );
+  }
+
+  const stored = await readAndClearStateCookie();
+  if (!stored) {
+    return NextResponse.redirect(
+      new URL(
+        "/signin?error=state+cookie+missing+or+expired",
+        request.url,
+      ),
+      { status: 302 },
+    );
+  }
+  if (stored.state !== state) {
+    // Login-CSRF check: an attacker tricking the user into clicking
+    // an IdP callback URL with attacker-supplied code cannot succeed
+    // here without also having forced the matching state cookie.
+    return NextResponse.redirect(
+      new URL("/signin?error=state+mismatch", request.url),
+      { status: 302 },
+    );
+  }
+
+  try {
+    const identity = await completeAuth({
+      code,
+      redirectUri: buildRedirectUri(request.url),
+      state,
+    });
+    const user = await upsertUserFromIdentity(identity);
+    await writeSessionCookie(user.id);
+    return NextResponse.redirect(new URL(stored.returnPath, request.url), {
+      status: 302,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return NextResponse.redirect(
+      new URL(`/signin?error=${encodeURIComponent(message)}`, request.url),
+      { status: 302 },
+    );
+  }
+}

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -1,0 +1,15 @@
+/**
+ * POST /api/auth/logout — clear the session cookie.
+ *
+ * Stateless — no DB write, no IdP single-logout call. (Single-logout
+ * adds appreciable complexity for marginal benefit; if the operator
+ * needs it, the IdP's own session cleanup handles it for them.)
+ */
+
+import { NextResponse } from "next/server";
+import { clearSessionCookie } from "@/lib/auth";
+
+export async function POST() {
+  await clearSessionCookie();
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/src/app/api/auth/session/route.ts
+++ b/apps/web/src/app/api/auth/session/route.ts
@@ -1,0 +1,15 @@
+/**
+ * GET /api/auth/session — read the current user from the session cookie.
+ *
+ * Returns `{ user: { id, email, name } }` when signed in,
+ * `{ user: null }` otherwise. Client components poll this on mount to
+ * decide whether to render dashboard chrome or a "Sign in" CTA.
+ */
+
+import { NextResponse } from "next/server";
+import { getCurrentUser } from "@/lib/auth";
+
+export async function GET() {
+  const user = await getCurrentUser();
+  return NextResponse.json({ user });
+}

--- a/apps/web/src/app/api/auth/status/route.ts
+++ b/apps/web/src/app/api/auth/status/route.ts
@@ -1,0 +1,22 @@
+/**
+ * GET /api/auth/status — does the operator have an SSO plugin installed?
+ *
+ * The sign-in page calls this on mount to decide whether to render a
+ * "Sign in with <provider>" button. Result is the auth plugin's
+ * package name + the human-readable label its register() declared.
+ * If no plugin is installed, returns `{ provider: null }` and the
+ * sign-in page renders the legacy local-auth notice.
+ *
+ * The web process doesn't query the worker on every request — the
+ * worker's /admin/auth/status is itself a cheap in-memory read, and
+ * @/lib/auth wraps it with a 1-second TTL cache so concurrent loads
+ * don't fan out.
+ */
+
+import { NextResponse } from "next/server";
+import { getAuthProvider } from "@/lib/auth";
+
+export async function GET() {
+  const provider = await getAuthProvider();
+  return NextResponse.json({ provider });
+}

--- a/apps/web/src/app/signin/page.tsx
+++ b/apps/web/src/app/signin/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
+import AppHeader from "@/components/AppHeader";
 import CreatorCredit from "@/components/CreatorCredit";
 
 interface ProviderInfo {
@@ -37,43 +38,36 @@ function SignInBody() {
     };
   }, []);
 
-  const signInHref = (() => {
-    const url = new URL("/api/auth/begin", "http://placeholder");
-    url.searchParams.set("returnTo", returnTo);
-    if (loginHint.length > 0) {
-      url.searchParams.set("loginHint", loginHint);
-    }
-    return `${url.pathname}${url.search}`;
-  })();
-
   return (
     <div className="root">
-      <main className="max-w-md mx-auto pt-24 pb-12 px-6">
-        <h1 className="font-display text-3xl font-bold mb-2">Sign in</h1>
-        <p className="text-text2 text-sm mb-8">
-          Access your OpenNeko deployment.
-        </p>
+      <AppHeader />
+
+      <div className="max-w-[480px] mx-auto">
+        <h1 className="greet">Sign in</h1>
+        <p className="greet-sub">Access your OpenNeko deployment.</p>
 
         {error && (
           <div
             role="alert"
-            className="mb-6 px-4 py-3 rounded-[10px] border border-border bg-accent-soft text-accent text-sm"
+            className="mb-6 px-4 py-3.5 rounded-[14px] border border-danger-soft bg-danger-soft text-danger text-[13px] leading-[1.5]"
           >
             {error}
           </div>
         )}
 
         {!providerLoaded ? (
-          <div className="text-text3 text-sm">Checking sign-in options…</div>
+          <p className="text-text3 text-sm">Checking sign-in options…</p>
         ) : provider ? (
           <form
-            method="GET"
             action="/api/auth/begin"
-            className="flex flex-col gap-3"
+            method="GET"
+            className="settings-card"
           >
             <input type="hidden" name="returnTo" value={returnTo} />
-            <label className="flex flex-col gap-1.5 text-sm">
-              <span className="text-text2">Email (optional)</span>
+            <label className="block">
+              <span className="block font-display text-[12px] font-bold uppercase tracking-[0.12em] text-text3 mb-2">
+                Email <span className="font-body normal-case tracking-normal text-text3 font-normal">(optional)</span>
+              </span>
               <input
                 type="email"
                 name="loginHint"
@@ -81,44 +75,39 @@ function SignInBody() {
                 onChange={(e) => setLoginHint(e.target.value)}
                 placeholder="you@company.com"
                 autoComplete="email"
-                className="px-3 py-2.5 rounded-[10px] border border-border bg-white text-text text-sm focus:outline-none focus:border-accent"
+                className="w-full px-3.5 py-3 rounded-[12px] border border-border bg-white text-text text-[14px] placeholder:text-text3 focus:outline-none focus:border-accent focus:ring-2 focus:ring-accent-soft transition-colors"
               />
-              <span className="text-text3 text-[12px]">
+              <span className="mt-2 block text-text3 text-[12px] leading-[1.5]">
                 Speeds up routing to the right IdP behind {provider.providerLabel}.
               </span>
             </label>
             <button
               type="submit"
-              className="mt-2 px-4 py-2.5 rounded-[10px] bg-text text-bg font-medium text-sm hover:opacity-90 cursor-pointer"
+              className="mt-6 w-full px-4 py-3 rounded-[12px] bg-text text-bg font-display font-bold text-[15px] tracking-[-0.01em] hover:opacity-90 active:translate-y-px transition-all cursor-pointer"
             >
               Sign in with {provider.providerLabel}
             </button>
-            <a
-              href={signInHref}
-              className="hidden"
-              aria-hidden="true"
-              tabIndex={-1}
-            >
-              {/* Mirror of the form's GET URL for keyboard/screen-reader users
-                  who can't submit forms in this environment. */}
-              Sign in with {provider.providerLabel}
-            </a>
-            <p className="text-text3 text-[12px] mt-2">
-              Provided by the <code>{provider.pluginName}</code> plugin.
+            <p className="mt-5 text-text3 text-[11px] tracking-[0.02em] text-center">
+              Provided by <code className="font-mono text-text2">{provider.pluginName}</code>
             </p>
           </form>
         ) : (
-          <div className="rounded-[10px] border border-border p-4 text-sm text-text2 leading-[1.5]">
-            <p className="mb-2">No SSO plugin is installed.</p>
-            <p>
-              An operator with shell access can install one — for example,{" "}
-              <code>openneko install @open-neko/plugin-scalekit</code> — to
-              enable enterprise sign-in. Until then, OpenNeko runs in
+          <div className="settings-card">
+            <p className="font-display text-[20px] font-bold text-text mb-2 leading-tight">
+              No SSO plugin is installed.
+            </p>
+            <p className="text-text2 text-[14px] leading-[1.6]">
+              An operator with shell access can install one — for example{" "}
+              <code className="font-mono text-text bg-neutral px-1.5 py-0.5 rounded-[6px] text-[13px]">
+                openneko install @open-neko/plugin-scalekit
+              </code>{" "}
+              — to enable enterprise sign-in. Until then, OpenNeko runs in
               single-operator mode.
             </p>
           </div>
         )}
-      </main>
+      </div>
+
       <CreatorCredit />
     </div>
   );

--- a/apps/web/src/app/signin/page.tsx
+++ b/apps/web/src/app/signin/page.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import CreatorCredit from "@/components/CreatorCredit";
+
+interface ProviderInfo {
+  pluginName: string;
+  providerLabel: string;
+}
+
+function SignInBody() {
+  const params = useSearchParams();
+  const error = params.get("error");
+  const returnTo = params.get("returnTo") ?? "/";
+  const [provider, setProvider] = useState<ProviderInfo | null>(null);
+  const [providerLoaded, setProviderLoaded] = useState(false);
+  const [loginHint, setLoginHint] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/auth/status", { cache: "no-store" });
+        const body = (await res.json()) as { provider: ProviderInfo | null };
+        if (cancelled) return;
+        setProvider(body.provider ?? null);
+      } catch {
+        if (cancelled) return;
+        setProvider(null);
+      } finally {
+        if (!cancelled) setProviderLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const signInHref = (() => {
+    const url = new URL("/api/auth/begin", "http://placeholder");
+    url.searchParams.set("returnTo", returnTo);
+    if (loginHint.length > 0) {
+      url.searchParams.set("loginHint", loginHint);
+    }
+    return `${url.pathname}${url.search}`;
+  })();
+
+  return (
+    <div className="root">
+      <main className="max-w-md mx-auto pt-24 pb-12 px-6">
+        <h1 className="font-display text-3xl font-bold mb-2">Sign in</h1>
+        <p className="text-text2 text-sm mb-8">
+          Access your OpenNeko deployment.
+        </p>
+
+        {error && (
+          <div
+            role="alert"
+            className="mb-6 px-4 py-3 rounded-[10px] border border-border bg-accent-soft text-accent text-sm"
+          >
+            {error}
+          </div>
+        )}
+
+        {!providerLoaded ? (
+          <div className="text-text3 text-sm">Checking sign-in options…</div>
+        ) : provider ? (
+          <form
+            method="GET"
+            action="/api/auth/begin"
+            className="flex flex-col gap-3"
+          >
+            <input type="hidden" name="returnTo" value={returnTo} />
+            <label className="flex flex-col gap-1.5 text-sm">
+              <span className="text-text2">Email (optional)</span>
+              <input
+                type="email"
+                name="loginHint"
+                value={loginHint}
+                onChange={(e) => setLoginHint(e.target.value)}
+                placeholder="you@company.com"
+                autoComplete="email"
+                className="px-3 py-2.5 rounded-[10px] border border-border bg-white text-text text-sm focus:outline-none focus:border-accent"
+              />
+              <span className="text-text3 text-[12px]">
+                Speeds up routing to the right IdP behind {provider.providerLabel}.
+              </span>
+            </label>
+            <button
+              type="submit"
+              className="mt-2 px-4 py-2.5 rounded-[10px] bg-text text-bg font-medium text-sm hover:opacity-90 cursor-pointer"
+            >
+              Sign in with {provider.providerLabel}
+            </button>
+            <a
+              href={signInHref}
+              className="hidden"
+              aria-hidden="true"
+              tabIndex={-1}
+            >
+              {/* Mirror of the form's GET URL for keyboard/screen-reader users
+                  who can't submit forms in this environment. */}
+              Sign in with {provider.providerLabel}
+            </a>
+            <p className="text-text3 text-[12px] mt-2">
+              Provided by the <code>{provider.pluginName}</code> plugin.
+            </p>
+          </form>
+        ) : (
+          <div className="rounded-[10px] border border-border p-4 text-sm text-text2 leading-[1.5]">
+            <p className="mb-2">No SSO plugin is installed.</p>
+            <p>
+              An operator with shell access can install one — for example,{" "}
+              <code>openneko install @open-neko/plugin-scalekit</code> — to
+              enable enterprise sign-in. Until then, OpenNeko runs in
+              single-operator mode.
+            </p>
+          </div>
+        )}
+      </main>
+      <CreatorCredit />
+    </div>
+  );
+}
+
+export default function SignInPage() {
+  return (
+    <Suspense fallback={null}>
+      <SignInBody />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -15,6 +15,7 @@ export type AppHeaderProps = {
 
 export default function AppHeader({ back, children }: AppHeaderProps) {
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
+  const [user, setUser] = useState<{ email: string } | null>(null);
 
   // Quiet poll for the server's current version. When it diverges from the
   // version baked into this client bundle at build time, a new deploy has
@@ -39,6 +40,37 @@ export default function AppHeader({ back, children }: AppHeaderProps) {
       clearInterval(id);
     };
   }, []);
+
+  // Sign-out affordance is only meaningful when the user has a session
+  // (i.e. an SSO plugin is installed AND they've signed in). When no
+  // plugin is installed the proxy lets every request through and the
+  // session is always null, so nothing renders.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/auth/session", { cache: "no-store" });
+        if (cancelled || !res.ok) return;
+        const data = (await res.json()) as {
+          user: { id: string; email: string; name: string | null } | null;
+        };
+        if (data.user) setUser({ email: data.user.email });
+      } catch {
+        // best-effort
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function handleSignOut() {
+    try {
+      await fetch("/api/auth/logout", { method: "POST" });
+    } finally {
+      window.location.href = "/signin";
+    }
+  }
 
   const updateAvailable =
     latestVersion !== null && latestVersion !== APP_VERSION;
@@ -84,6 +116,20 @@ export default function AppHeader({ back, children }: AppHeaderProps) {
             >
               <span className="brand-update-dot" aria-hidden="true" />
               <span className="brand-update-label">v{latestVersion} ready · reload</span>
+            </button>
+          )}
+
+          {user && (
+            <button
+              type="button"
+              onClick={handleSignOut}
+              aria-label={`Sign out ${user.email}`}
+              title={user.email}
+              className="inline-flex items-center gap-1.5 self-start h-[41px] bg-transparent border-0 p-0 cursor-pointer text-text2 hover:text-text text-[12px] font-medium leading-none"
+            >
+              <span className="hidden sm:inline truncate max-w-[160px]">{user.email}</span>
+              <span aria-hidden="true" className="text-text3 hidden sm:inline">·</span>
+              <span>Sign out</span>
             </button>
           )}
         </div>

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,0 +1,419 @@
+/**
+ * SSO integration for the web app.
+ *
+ * Today OpenNeko's only auth is "share the password with whoever needs
+ * in" — fine for a laptop deployment, fatal for any org with an IdP.
+ * This module wires the web's sign-in flow through an installed auth
+ * plugin (e.g. Scalekit) so an enterprise operator gets standard
+ * OIDC SSO without the core having to know which IdP they use.
+ *
+ * Topology: the auth plugin lives in the worker's microsandbox VM,
+ * not in this Next process. We reach it through the worker's admin
+ * HTTP endpoint on localhost (loopback inside the deployment, never
+ * exposed). That gives us:
+ *   - Secrets stay inside the worker's per-plugin VM.
+ *   - The web process never needs the IdP client_secret.
+ *   - Hot reload of the plugin doesn't restart the web.
+ *
+ * Session model: a stateless signed cookie. The session_id is the
+ * app_user.id; an HMAC over `${user_id}.${expiresAt}` prevents
+ * tampering and binds the cookie to OPENNEKO_SESSION_SECRET. Logging
+ * a user out is a cookie delete; rotating the secret invalidates
+ * every existing session globally.
+ */
+
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { cookies } from "next/headers";
+import { and, app_user, db, eq } from "@neko/db";
+import { getOrgId } from "@/lib/db";
+
+export const SESSION_COOKIE_NAME = "openneko_session";
+export const STATE_COOKIE_NAME = "openneko_sso_state";
+
+/** Session lifetime — 12h. Re-auths after this; refresh-on-use is a v2. */
+const SESSION_TTL_SECONDS = 60 * 60 * 12;
+/** State cookie lifetime — short window for the user to complete the IdP dance. */
+const STATE_TTL_SECONDS = 10 * 60;
+
+export interface AuthProviderInfo {
+  pluginName: string;
+  providerLabel: string;
+}
+
+export interface AuthIdentity {
+  sub: string;
+  email: string;
+  name?: string | null;
+  orgId?: string | null;
+  groups?: string[];
+}
+
+export interface SessionPayload {
+  userId: string;
+  email: string;
+  name: string | null;
+  expiresAt: number;
+}
+
+function workerAdminBase(): string {
+  const raw = process.env.WORKER_ADMIN_URL ?? "http://127.0.0.1:4100";
+  return raw.replace(/\/+$/, "");
+}
+
+function sessionSecret(): string {
+  // OPENNEKO_SESSION_SECRET is the HMAC key for session cookies. We
+  // refuse to start an SSO flow without one — silently falling back to
+  // a process-random secret would invalidate sessions on every restart
+  // and (worse) let a misconfigured deployment look like it's working.
+  const secret = process.env.OPENNEKO_SESSION_SECRET;
+  if (!secret || secret.length < 32) {
+    throw new Error(
+      "OPENNEKO_SESSION_SECRET must be set to a value at least 32 characters long for SSO sessions",
+    );
+  }
+  return secret;
+}
+
+/**
+ * Ask the worker whether an SSO plugin is installed. Cached for one
+ * second to keep the sign-in page snappy under concurrent loads —
+ * the worker's hot-reload window is in seconds anyway.
+ */
+let providerCache: { value: AuthProviderInfo | null; at: number } | null = null;
+const PROVIDER_CACHE_TTL_MS = 1000;
+
+export async function getAuthProvider(): Promise<AuthProviderInfo | null> {
+  const now = Date.now();
+  if (providerCache && now - providerCache.at < PROVIDER_CACHE_TTL_MS) {
+    return providerCache.value;
+  }
+  try {
+    const res = await fetch(`${workerAdminBase()}/admin/auth/status`, {
+      method: "GET",
+      cache: "no-store",
+      signal: AbortSignal.timeout(2000),
+    });
+    if (!res.ok) {
+      providerCache = { value: null, at: now };
+      return null;
+    }
+    const body = (await res.json()) as { provider: AuthProviderInfo | null };
+    providerCache = { value: body.provider ?? null, at: now };
+    return providerCache.value;
+  } catch {
+    // Worker unreachable — treat as "no provider". The dashboard
+    // gracefully degrades to local auth in that case.
+    providerCache = { value: null, at: now };
+    return null;
+  }
+}
+
+/** Test seam — clears the provider cache between tests. */
+export function _resetAuthProviderCache() {
+  providerCache = null;
+}
+
+export async function beginAuth(params: {
+  redirectUri: string;
+  state: string;
+  loginHint?: string | null;
+}): Promise<{ authorizationUrl: string }> {
+  const res = await fetch(`${workerAdminBase()}/admin/auth/begin`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+    signal: AbortSignal.timeout(15_000),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `auth plugin begin failed (${res.status}): ${text || res.statusText}`,
+    );
+  }
+  return (await res.json()) as { authorizationUrl: string };
+}
+
+export async function completeAuth(params: {
+  code: string;
+  redirectUri: string;
+  state: string;
+}): Promise<AuthIdentity> {
+  const res = await fetch(`${workerAdminBase()}/admin/auth/complete`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(params),
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(
+      `auth plugin complete failed (${res.status}): ${text || res.statusText}`,
+    );
+  }
+  const body = (await res.json()) as { identity: AuthIdentity };
+  return body.identity;
+}
+
+/**
+ * Mint a state token: random nonce paired with the path the user was
+ * trying to reach. The path is stashed in the cookie too so callback
+ * can redirect back without trusting an open redirect parameter.
+ */
+export function newStateToken(): string {
+  return randomBytes(24).toString("base64url");
+}
+
+/**
+ * Upsert `app_user` for an SSO identity. Match priority:
+ *   1. existing row with the same `sub` (IdP-stable);
+ *   2. existing row with the same `email` (initial migration when an
+ *      operator first turns SSO on against a pre-existing email-only
+ *      user) — `sub` is then attached for future logins.
+ * Otherwise insert a new row in the only org.
+ */
+export async function upsertUserFromIdentity(
+  identity: AuthIdentity,
+): Promise<{ id: string; email: string; name: string | null }> {
+  const orgId = await getOrgId();
+  // Primary lookup: sub. Anything matching wins, regardless of email
+  // changes (people get married, change addresses — sub doesn't).
+  const bySub = await db()
+    .select({
+      id: app_user.id,
+      email: app_user.email,
+      name: app_user.name,
+    })
+    .from(app_user)
+    .where(and(eq(app_user.org_id, orgId), eq(app_user.sub, identity.sub)))
+    .limit(1);
+  if (bySub[0]) {
+    await db()
+      .update(app_user)
+      .set({
+        email: identity.email,
+        name: identity.name ?? null,
+        last_login_at: new Date(),
+        updated_at: new Date(),
+      })
+      .where(eq(app_user.id, bySub[0].id));
+    return {
+      id: bySub[0].id,
+      email: identity.email,
+      name: identity.name ?? null,
+    };
+  }
+  // Migration lookup: same email, no sub yet. Attach the sub.
+  const byEmail = await db()
+    .select({
+      id: app_user.id,
+      email: app_user.email,
+      name: app_user.name,
+      sub: app_user.sub,
+    })
+    .from(app_user)
+    .where(and(eq(app_user.org_id, orgId), eq(app_user.email, identity.email)))
+    .limit(1);
+  if (byEmail[0] && !byEmail[0].sub) {
+    await db()
+      .update(app_user)
+      .set({
+        sub: identity.sub,
+        name: identity.name ?? byEmail[0].name ?? null,
+        last_login_at: new Date(),
+        updated_at: new Date(),
+      })
+      .where(eq(app_user.id, byEmail[0].id));
+    return {
+      id: byEmail[0].id,
+      email: identity.email,
+      name: identity.name ?? byEmail[0].name ?? null,
+    };
+  }
+  if (byEmail[0]) {
+    // Same email, *different* sub already on file. Refuse rather than
+    // silently take over — the operator should resolve this manually
+    // (likely two IdP accounts pointing at the same mailbox).
+    throw new Error(
+      `app_user.email ${identity.email} is already bound to a different SSO subject; remove the row or update sub manually before re-attempting`,
+    );
+  }
+  // Brand new user.
+  const newId = `usr_${randomBytes(9).toString("base64url")}`;
+  await db()
+    .insert(app_user)
+    .values({
+      id: newId,
+      sub: identity.sub,
+      email: identity.email,
+      name: identity.name ?? null,
+      org_id: orgId,
+      role: defaultRoleForGroups(identity.groups ?? []),
+      last_login_at: new Date(),
+    });
+  return {
+    id: newId,
+    email: identity.email,
+    name: identity.name ?? null,
+  };
+}
+
+/**
+ * Coarse-grained role mapping. Anyone with an `admin` or
+ * `owners` group becomes admin; everyone else is `member`. Operators
+ * with richer requirements override `app_user.role` directly until
+ * we ship a configurable mapping screen.
+ */
+function defaultRoleForGroups(groups: string[]): string {
+  const lower = new Set(groups.map((g) => g.toLowerCase()));
+  if (lower.has("admin") || lower.has("admins") || lower.has("owners")) {
+    return "admin";
+  }
+  return "member";
+}
+
+export function encodeSession(payload: SessionPayload): string {
+  const body = `${payload.userId}.${payload.expiresAt}`;
+  const mac = createHmac("sha256", sessionSecret()).update(body).digest("base64url");
+  return `${body}.${mac}`;
+}
+
+export function decodeSession(value: string): SessionPayload | null {
+  const parts = value.split(".");
+  if (parts.length !== 3) return null;
+  const [userId, expiresAtRaw, mac] = parts;
+  if (!userId || !expiresAtRaw || !mac) return null;
+  const body = `${userId}.${expiresAtRaw}`;
+  const expected = createHmac("sha256", sessionSecret())
+    .update(body)
+    .digest("base64url");
+  const a = Buffer.from(mac);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return null;
+  if (!timingSafeEqual(a, b)) return null;
+  const expiresAt = Number.parseInt(expiresAtRaw, 10);
+  if (!Number.isFinite(expiresAt)) return null;
+  if (expiresAt < Math.floor(Date.now() / 1000)) return null;
+  return { userId, expiresAt, email: "", name: null };
+}
+
+export async function writeSessionCookie(userId: string) {
+  const expiresAt = Math.floor(Date.now() / 1000) + SESSION_TTL_SECONDS;
+  const token = encodeSession({ userId, expiresAt, email: "", name: null });
+  const jar = await cookies();
+  jar.set(SESSION_COOKIE_NAME, token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: SESSION_TTL_SECONDS,
+  });
+}
+
+export async function clearSessionCookie() {
+  const jar = await cookies();
+  jar.delete(SESSION_COOKIE_NAME);
+}
+
+export async function writeStateCookie(state: string, returnPath: string) {
+  // State + intended landing path are kept server-side via a signed
+  // cookie so the callback can verify both without an extra DB lookup
+  // and without trusting the redirect_uri query string.
+  const payload = `${state}|${encodeReturnPath(returnPath)}`;
+  const mac = createHmac("sha256", sessionSecret()).update(payload).digest("base64url");
+  const value = `${payload}.${mac}`;
+  const jar = await cookies();
+  jar.set(STATE_COOKIE_NAME, value, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    path: "/",
+    maxAge: STATE_TTL_SECONDS,
+  });
+}
+
+export async function readAndClearStateCookie(): Promise<
+  { state: string; returnPath: string } | null
+> {
+  const jar = await cookies();
+  const raw = jar.get(STATE_COOKIE_NAME)?.value;
+  if (!raw) return null;
+  jar.delete(STATE_COOKIE_NAME);
+  const split = raw.lastIndexOf(".");
+  if (split <= 0) return null;
+  const payload = raw.slice(0, split);
+  const mac = raw.slice(split + 1);
+  const expected = createHmac("sha256", sessionSecret())
+    .update(payload)
+    .digest("base64url");
+  const a = Buffer.from(mac);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length || !timingSafeEqual(a, b)) return null;
+  const pipe = payload.indexOf("|");
+  if (pipe <= 0) return null;
+  const state = payload.slice(0, pipe);
+  const returnPath = decodeReturnPath(payload.slice(pipe + 1));
+  return { state, returnPath };
+}
+
+function encodeReturnPath(p: string): string {
+  // Whitelist to internal paths only. An attacker who controls the
+  // sign-in link cannot smuggle an external redirect through the
+  // state cookie.
+  if (!p.startsWith("/") || p.startsWith("//")) return "/";
+  return Buffer.from(p).toString("base64url");
+}
+
+function decodeReturnPath(encoded: string): string {
+  try {
+    const raw = Buffer.from(encoded, "base64url").toString("utf8");
+    if (!raw.startsWith("/") || raw.startsWith("//")) return "/";
+    return raw;
+  } catch {
+    return "/";
+  }
+}
+
+/**
+ * Resolve the current session (cookie → DB lookup → user). Returns
+ * null when no session, an expired session, or a session whose user
+ * row has been deleted (IT deprovisioned them in the IdP and a
+ * background sweep deleted the row). Pages calling this can choose
+ * to redirect to /signin or render an unauthenticated view.
+ */
+export async function getCurrentUser(): Promise<{
+  id: string;
+  email: string;
+  name: string | null;
+} | null> {
+  const jar = await cookies();
+  const token = jar.get(SESSION_COOKIE_NAME)?.value;
+  if (!token) return null;
+  const session = decodeSession(token);
+  if (!session) return null;
+  const rows = await db()
+    .select({
+      id: app_user.id,
+      email: app_user.email,
+      name: app_user.name,
+    })
+    .from(app_user)
+    .where(eq(app_user.id, session.userId))
+    .limit(1);
+  if (!rows[0]) return null;
+  return rows[0];
+}
+
+/**
+ * Build the absolute callback URL the IdP will redirect to. We compute
+ * it from the incoming request rather than env so dev and prod work
+ * with the same code. Operators wanting to force a canonical host can
+ * set OPENNEKO_PUBLIC_URL (e.g. behind a load balancer that strips
+ * Host headers).
+ */
+export function buildRedirectUri(requestUrl: string): string {
+  const override = process.env.OPENNEKO_PUBLIC_URL?.replace(/\/+$/, "");
+  if (override) return `${override}/api/auth/callback`;
+  const u = new URL(requestUrl);
+  return `${u.protocol}//${u.host}/api/auth/callback`;
+}
+

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -1,0 +1,146 @@
+/**
+ * Next.js 16 Proxy (formerly middleware) — auth gate for all routes.
+ *
+ * Two-mode model:
+ *
+ *   1. No SSO plugin installed → the app runs fully open. Every browser
+ *      user gets the full app, no sign-in required. This is the
+ *      single-operator / laptop deployment.
+ *
+ *   2. An SSO plugin is installed (worker reports a provider on
+ *      /admin/auth/status) → every route is gated. A request without a
+ *      valid signed session cookie is 302'd to /signin with returnTo
+ *      pointing at the original URL.
+ *
+ * The mode is detected per-request (cached 1s) by asking the worker,
+ * so installing or removing the plugin takes effect on the next cache
+ * miss without a web restart — same hot-reload model as the rest of
+ * the plugin system.
+ *
+ * Paths exempt from the gate:
+ *   - /signin                — the sign-in page itself
+ *   - /api/auth/*            — the SSO flow endpoints
+ *   - _next/static, _next/image, favicon.ico — static assets
+ *
+ * Session verification here is the HMAC check ONLY. We do not hit the
+ * database — the per-route handler (or `getCurrentUser`) does the
+ * follow-up DB lookup if it needs the user row. Per the Next.js docs,
+ * proxy should not be the sole authorisation layer; we use it for
+ * optimistic redirects.
+ *
+ * Note: Server Functions appear as POSTs to the page they're invoked
+ * from, so the matcher's page-level gate covers them. If a future
+ * refactor moves a Server Function to a route the matcher excludes,
+ * the gate is silently lost — re-verify auth inside any Server
+ * Function that performs sensitive work.
+ */
+
+import { NextResponse, type NextRequest } from "next/server";
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+const SESSION_COOKIE_NAME = "openneko_session";
+const PROVIDER_CACHE_TTL_MS = 1_000;
+const WORKER_STATUS_TIMEOUT_MS = 1_500;
+
+interface ProviderProbe {
+  installed: boolean;
+  at: number;
+}
+
+let providerCache: ProviderProbe | null = null;
+
+function workerAdminBase(): string {
+  return (process.env.WORKER_ADMIN_URL ?? "http://127.0.0.1:4100").replace(
+    /\/+$/,
+    "",
+  );
+}
+
+/**
+ * Ask the worker whether an SSO plugin is installed. Cached for one
+ * second to keep proxy overhead negligible under load while still
+ * picking up `openneko install` within a second of the manifest write.
+ *
+ * Fails OPEN (treats as "no plugin") when the worker is unreachable —
+ * a dev environment with no worker running shouldn't be locked out.
+ * If an operator has actually configured SSO and their worker is down,
+ * action execution is already broken and that's where they'll notice.
+ */
+export async function isAuthPluginInstalled(): Promise<boolean> {
+  const now = Date.now();
+  if (providerCache && now - providerCache.at < PROVIDER_CACHE_TTL_MS) {
+    return providerCache.installed;
+  }
+  try {
+    const res = await fetch(`${workerAdminBase()}/admin/auth/status`, {
+      method: "GET",
+      signal: AbortSignal.timeout(WORKER_STATUS_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      providerCache = { installed: false, at: now };
+      return false;
+    }
+    const body = (await res.json()) as { provider: { pluginName: string } | null };
+    const installed = body.provider != null;
+    providerCache = { installed, at: now };
+    return installed;
+  } catch {
+    providerCache = { installed: false, at: now };
+    return false;
+  }
+}
+
+/** Test seam — clears the provider cache between tests. */
+export function _resetProviderCache(): void {
+  providerCache = null;
+}
+
+/**
+ * HMAC-verify the signed session cookie. Mirrors `decodeSession` in
+ * @/lib/auth but doesn't throw on missing/short secret — the proxy
+ * treats that as "no valid session" so a misconfigured deployment
+ * redirects to /signin rather than 500ing every page load.
+ */
+export function verifySessionCookie(value: string | undefined): boolean {
+  if (!value) return false;
+  const secret = process.env.OPENNEKO_SESSION_SECRET;
+  if (!secret || secret.length < 32) return false;
+  const parts = value.split(".");
+  if (parts.length !== 3) return false;
+  const [userId, expiresAtRaw, mac] = parts;
+  if (!userId || !expiresAtRaw || !mac) return false;
+  const body = `${userId}.${expiresAtRaw}`;
+  const expected = createHmac("sha256", secret).update(body).digest("base64url");
+  const a = Buffer.from(mac);
+  const b = Buffer.from(expected);
+  if (a.length !== b.length) return false;
+  if (!timingSafeEqual(a, b)) return false;
+  const expiresAt = Number.parseInt(expiresAtRaw, 10);
+  if (!Number.isFinite(expiresAt)) return false;
+  if (expiresAt < Math.floor(Date.now() / 1000)) return false;
+  return true;
+}
+
+export async function proxy(request: NextRequest): Promise<NextResponse> {
+  if (!(await isAuthPluginInstalled())) {
+    return NextResponse.next();
+  }
+  const cookie = request.cookies.get(SESSION_COOKIE_NAME)?.value;
+  if (verifySessionCookie(cookie)) {
+    return NextResponse.next();
+  }
+  const returnTo = request.nextUrl.pathname + request.nextUrl.search;
+  const url = request.nextUrl.clone();
+  url.pathname = "/signin";
+  url.search = `?returnTo=${encodeURIComponent(returnTo)}`;
+  return NextResponse.redirect(url, { status: 302 });
+}
+
+export const config = {
+  // Match everything except the SSO flow surfaces and static assets.
+  // Negative lookahead is a constant here so Next can statically
+  // analyse it at build time (per the proxy.md API reference).
+  matcher: [
+    "/((?!signin|api/auth/|_next/static/|_next/image/|favicon\\.ico).*)",
+  ],
+};

--- a/apps/web/test/lib/auth.test.ts
+++ b/apps/web/test/lib/auth.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  decodeSession,
+  encodeSession,
+  newStateToken,
+} from "@/lib/auth";
+
+describe("session encode/decode", () => {
+  const goodSecret = "a".repeat(64);
+  const otherSecret = "b".repeat(64);
+
+  beforeEach(() => {
+    process.env.OPENNEKO_SESSION_SECRET = goodSecret;
+  });
+  afterEach(() => {
+    delete process.env.OPENNEKO_SESSION_SECRET;
+  });
+
+  it("encodes then decodes a session round-trip", () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 3600;
+    const token = encodeSession({
+      userId: "usr_abc",
+      email: "",
+      name: null,
+      expiresAt,
+    });
+    const decoded = decodeSession(token);
+    expect(decoded?.userId).toBe("usr_abc");
+    expect(decoded?.expiresAt).toBe(expiresAt);
+  });
+
+  it("rejects a token signed with a different secret", () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 3600;
+    const token = encodeSession({
+      userId: "usr_abc",
+      email: "",
+      name: null,
+      expiresAt,
+    });
+    process.env.OPENNEKO_SESSION_SECRET = otherSecret;
+    expect(decodeSession(token)).toBeNull();
+  });
+
+  it("rejects a token whose body has been tampered with", () => {
+    const expiresAt = Math.floor(Date.now() / 1000) + 3600;
+    const token = encodeSession({
+      userId: "usr_abc",
+      email: "",
+      name: null,
+      expiresAt,
+    });
+    const [user, exp, mac] = token.split(".");
+    const tampered = `${user}_evil.${exp}.${mac}`;
+    expect(decodeSession(tampered)).toBeNull();
+  });
+
+  it("rejects an expired token", () => {
+    const expiresAt = Math.floor(Date.now() / 1000) - 60;
+    const token = encodeSession({
+      userId: "usr_abc",
+      email: "",
+      name: null,
+      expiresAt,
+    });
+    expect(decodeSession(token)).toBeNull();
+  });
+
+  it("rejects garbage input cleanly", () => {
+    expect(decodeSession("")).toBeNull();
+    expect(decodeSession("x.y")).toBeNull();
+    expect(decodeSession("a.b.c.d")).toBeNull();
+  });
+
+  it("throws when the session secret is missing or too short", () => {
+    delete process.env.OPENNEKO_SESSION_SECRET;
+    expect(() =>
+      encodeSession({
+        userId: "u",
+        email: "",
+        name: null,
+        expiresAt: Math.floor(Date.now() / 1000) + 60,
+      }),
+    ).toThrow(/OPENNEKO_SESSION_SECRET/);
+    process.env.OPENNEKO_SESSION_SECRET = "tooshort";
+    expect(() =>
+      encodeSession({
+        userId: "u",
+        email: "",
+        name: null,
+        expiresAt: Math.floor(Date.now() / 1000) + 60,
+      }),
+    ).toThrow(/OPENNEKO_SESSION_SECRET/);
+  });
+});
+
+describe("newStateToken", () => {
+  it("returns a high-entropy base64url string", () => {
+    const a = newStateToken();
+    const b = newStateToken();
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(a.length).toBeGreaterThanOrEqual(32);
+  });
+});

--- a/apps/web/test/proxy.test.ts
+++ b/apps/web/test/proxy.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { createHmac } from "node:crypto";
+import {
+  _resetProviderCache,
+  isAuthPluginInstalled,
+  proxy,
+  verifySessionCookie,
+} from "../src/proxy";
+
+const SECRET = "a".repeat(64);
+
+function freshFetch(
+  impl: (url: string) => Response | Promise<Response>,
+): typeof fetch {
+  return ((url: string) => Promise.resolve(impl(url))) as unknown as typeof fetch;
+}
+
+function mintCookie(opts: {
+  userId?: string;
+  expiresAt?: number;
+  secret?: string;
+} = {}): string {
+  const userId = opts.userId ?? "usr_abc";
+  const expiresAt =
+    opts.expiresAt ?? Math.floor(Date.now() / 1000) + 60 * 60;
+  const secret = opts.secret ?? SECRET;
+  const body = `${userId}.${expiresAt}`;
+  const mac = createHmac("sha256", secret).update(body).digest("base64url");
+  return `${body}.${mac}`;
+}
+
+function request(url: string, cookie?: string): NextRequest {
+  const headers = new Headers();
+  if (cookie) headers.set("cookie", `openneko_session=${cookie}`);
+  return new NextRequest(url, { headers });
+}
+
+beforeEach(() => {
+  process.env.OPENNEKO_SESSION_SECRET = SECRET;
+  _resetProviderCache();
+});
+
+afterEach(() => {
+  delete process.env.OPENNEKO_SESSION_SECRET;
+  _resetProviderCache();
+  vi.restoreAllMocks();
+});
+
+describe("verifySessionCookie", () => {
+  it("accepts a freshly minted cookie", () => {
+    expect(verifySessionCookie(mintCookie())).toBe(true);
+  });
+
+  it("rejects an empty / undefined cookie", () => {
+    expect(verifySessionCookie(undefined)).toBe(false);
+    expect(verifySessionCookie("")).toBe(false);
+  });
+
+  it("rejects a cookie signed with a different secret", () => {
+    const cookie = mintCookie({ secret: "b".repeat(64) });
+    expect(verifySessionCookie(cookie)).toBe(false);
+  });
+
+  it("rejects an expired cookie", () => {
+    const cookie = mintCookie({
+      expiresAt: Math.floor(Date.now() / 1000) - 60,
+    });
+    expect(verifySessionCookie(cookie)).toBe(false);
+  });
+
+  it("rejects a malformed cookie", () => {
+    expect(verifySessionCookie("only.two")).toBe(false);
+    expect(verifySessionCookie("a.b.c.d")).toBe(false);
+  });
+
+  it("rejects when the session secret is missing or too short", () => {
+    delete process.env.OPENNEKO_SESSION_SECRET;
+    expect(verifySessionCookie(mintCookie())).toBe(false);
+    process.env.OPENNEKO_SESSION_SECRET = "tooshort";
+    expect(verifySessionCookie(mintCookie())).toBe(false);
+  });
+});
+
+describe("isAuthPluginInstalled", () => {
+  it("returns true when the worker reports a provider", async () => {
+    vi.stubGlobal(
+      "fetch",
+      freshFetch(() =>
+        Response.json({ provider: { pluginName: "@x/y", providerLabel: "X" } }),
+      ),
+    );
+    expect(await isAuthPluginInstalled()).toBe(true);
+  });
+
+  it("returns false when the worker reports no provider", async () => {
+    vi.stubGlobal(
+      "fetch",
+      freshFetch(() => Response.json({ provider: null })),
+    );
+    expect(await isAuthPluginInstalled()).toBe(false);
+  });
+
+  it("fails open (false) when the worker is unreachable", async () => {
+    vi.stubGlobal(
+      "fetch",
+      (() => Promise.reject(new Error("ECONNREFUSED"))) as unknown as typeof fetch,
+    );
+    expect(await isAuthPluginInstalled()).toBe(false);
+  });
+
+  it("caches the result for the TTL window", async () => {
+    let calls = 0;
+    vi.stubGlobal(
+      "fetch",
+      freshFetch(() => {
+        calls++;
+        return Response.json({ provider: { pluginName: "@x/y", providerLabel: "X" } });
+      }),
+    );
+    expect(await isAuthPluginInstalled()).toBe(true);
+    expect(await isAuthPluginInstalled()).toBe(true);
+    expect(await isAuthPluginInstalled()).toBe(true);
+    expect(calls).toBe(1);
+  });
+});
+
+describe("proxy", () => {
+  it("lets every request through when no SSO plugin is installed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      freshFetch(() => Response.json({ provider: null })),
+    );
+    const res = await proxy(request("https://app.example.com/dashboard"));
+    expect(res.status).toBe(200);
+    // NextResponse.next() carries the x-middleware-next sentinel header.
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("lets a signed-in user through when the SSO plugin is installed", async () => {
+    vi.stubGlobal(
+      "fetch",
+      freshFetch(() =>
+        Response.json({ provider: { pluginName: "@x/y", providerLabel: "X" } }),
+      ),
+    );
+    const res = await proxy(
+      request("https://app.example.com/dashboard", mintCookie()),
+    );
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("redirects to /signin with returnTo when no session cookie is present", async () => {
+    vi.stubGlobal(
+      "fetch",
+      freshFetch(() =>
+        Response.json({ provider: { pluginName: "@x/y", providerLabel: "X" } }),
+      ),
+    );
+    const res = await proxy(
+      request("https://app.example.com/dashboard?foo=bar"),
+    );
+    expect(res.status).toBe(302);
+    const loc = res.headers.get("location") ?? "";
+    expect(loc).toContain("/signin");
+    expect(loc).toContain(
+      `returnTo=${encodeURIComponent("/dashboard?foo=bar")}`,
+    );
+  });
+
+  it("redirects when the session cookie has been tampered with", async () => {
+    vi.stubGlobal(
+      "fetch",
+      freshFetch(() =>
+        Response.json({ provider: { pluginName: "@x/y", providerLabel: "X" } }),
+      ),
+    );
+    const tampered = mintCookie({ secret: "b".repeat(64) });
+    const res = await proxy(
+      request("https://app.example.com/dashboard", tampered),
+    );
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location") ?? "").toContain("/signin");
+  });
+
+  it("redirects when the session cookie has expired", async () => {
+    vi.stubGlobal(
+      "fetch",
+      freshFetch(() =>
+        Response.json({ provider: { pluginName: "@x/y", providerLabel: "X" } }),
+      ),
+    );
+    const expired = mintCookie({
+      expiresAt: Math.floor(Date.now() / 1000) - 60,
+    });
+    const res = await proxy(
+      request("https://app.example.com/dashboard", expired),
+    );
+    expect(res.status).toBe(302);
+  });
+});

--- a/apps/worker/src/admin-server.ts
+++ b/apps/worker/src/admin-server.ts
@@ -10,12 +10,42 @@
  *                               pg-boss singleton holds the old creds and
  *                               there's no clean way to re-register handlers
  *                               in-place against a fresh pool.
+ *   GET  /admin/auth/status   → 200 + { provider: null | {pluginName, providerLabel} }
+ *                               Tells the web app whether an SSO plugin is
+ *                               installed so the sign-in page can render
+ *                               the appropriate button.
+ *   POST /admin/auth/begin    → 200 + { authorizationUrl }
+ *                               Body: { redirectUri, state, loginHint? }
+ *                               Proxies to the installed auth plugin's
+ *                               begin_auth RPC.
+ *   POST /admin/auth/complete → 200 + { identity }
+ *                               Body: { code, redirectUri, state }
+ *                               Proxies to the installed auth plugin's
+ *                               complete_auth RPC.
  *
  * Extracted from index.ts so the handler can be unit-tested without
  * booting pg-boss / the agent stack.
  */
 
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { AuthIdentity } from "@open-neko/plugin-types";
+
+export interface AuthHandlerSurface {
+  getAuthProvider(): {
+    pluginName: string;
+    providerLabel: string;
+  } | null;
+  beginAuth(params: {
+    redirectUri: string;
+    state: string;
+    loginHint?: string | null;
+  }): Promise<{ authorizationUrl: string }>;
+  completeAuth(params: {
+    code: string;
+    redirectUri: string;
+    state: string;
+  }): Promise<AuthIdentity>;
+}
 
 export type AdminHandlerOptions = {
   /**
@@ -28,11 +58,18 @@ export type AdminHandlerOptions = {
    * enough for the response to flush to the caller. Set to 0 in tests.
    */
   exitDelayMs?: number;
+  /**
+   * Auth surface — typically wired to the PluginRegistry. Absent when
+   * the plugin subsystem is disabled, in which case /admin/auth/*
+   * routes return 503 with a clear message.
+   */
+  auth?: AuthHandlerSurface | null;
 };
 
 export function createAdminHandler(opts: AdminHandlerOptions = {}) {
   const exit = opts.exit ?? ((code = 0) => process.exit(code));
   const exitDelayMs = opts.exitDelayMs ?? 100;
+  const auth = opts.auth ?? null;
 
   return function handle(req: IncomingMessage, res: ServerResponse) {
     if (req.method === "GET" && req.url === "/health") {
@@ -47,6 +84,135 @@ export function createAdminHandler(opts: AdminHandlerOptions = {}) {
       setTimeout(() => exit(0), exitDelayMs);
       return;
     }
+    if (req.method === "GET" && req.url === "/admin/auth/status") {
+      handleAuthStatus(res, auth);
+      return;
+    }
+    if (req.method === "POST" && req.url === "/admin/auth/begin") {
+      void handleAuthBegin(req, res, auth);
+      return;
+    }
+    if (req.method === "POST" && req.url === "/admin/auth/complete") {
+      void handleAuthComplete(req, res, auth);
+      return;
+    }
     res.writeHead(404).end();
   };
+}
+
+function handleAuthStatus(res: ServerResponse, auth: AuthHandlerSurface | null) {
+  if (!auth) {
+    json(res, 200, { provider: null });
+    return;
+  }
+  const provider = auth.getAuthProvider();
+  json(res, 200, {
+    provider: provider
+      ? {
+          pluginName: provider.pluginName,
+          providerLabel: provider.providerLabel,
+        }
+      : null,
+  });
+}
+
+async function handleAuthBegin(
+  req: IncomingMessage,
+  res: ServerResponse,
+  auth: AuthHandlerSurface | null,
+) {
+  if (!auth) {
+    json(res, 503, { error: "plugin subsystem disabled" });
+    return;
+  }
+  const body = await readJson(req).catch(() => null);
+  if (!body || typeof body !== "object") {
+    json(res, 400, { error: "request body must be JSON" });
+    return;
+  }
+  const { redirectUri, state, loginHint } = body as Record<string, unknown>;
+  if (typeof redirectUri !== "string" || !redirectUri) {
+    json(res, 400, { error: "redirectUri (string) is required" });
+    return;
+  }
+  if (typeof state !== "string" || !state) {
+    json(res, 400, { error: "state (string) is required" });
+    return;
+  }
+  try {
+    const result = await auth.beginAuth({
+      redirectUri,
+      state,
+      loginHint:
+        typeof loginHint === "string" && loginHint.length > 0
+          ? loginHint
+          : null,
+    });
+    json(res, 200, { authorizationUrl: result.authorizationUrl });
+  } catch (err) {
+    json(res, 500, {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+async function handleAuthComplete(
+  req: IncomingMessage,
+  res: ServerResponse,
+  auth: AuthHandlerSurface | null,
+) {
+  if (!auth) {
+    json(res, 503, { error: "plugin subsystem disabled" });
+    return;
+  }
+  const body = await readJson(req).catch(() => null);
+  if (!body || typeof body !== "object") {
+    json(res, 400, { error: "request body must be JSON" });
+    return;
+  }
+  const { code, redirectUri, state } = body as Record<string, unknown>;
+  if (typeof code !== "string" || !code) {
+    json(res, 400, { error: "code (string) is required" });
+    return;
+  }
+  if (typeof redirectUri !== "string" || !redirectUri) {
+    json(res, 400, { error: "redirectUri (string) is required" });
+    return;
+  }
+  if (typeof state !== "string" || !state) {
+    json(res, 400, { error: "state (string) is required" });
+    return;
+  }
+  try {
+    const identity = await auth.completeAuth({ code, redirectUri, state });
+    json(res, 200, { identity });
+  } catch (err) {
+    json(res, 500, {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+function json(res: ServerResponse, status: number, body: unknown) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    "Content-Length": Buffer.byteLength(payload).toString(),
+  });
+  res.end(payload);
+}
+
+async function readJson(req: IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+    // Cap body size to defend against runaway uploads against the
+    // worker admin port (loopback, but still).
+    if (Buffer.concat(chunks).length > 64 * 1024) {
+      throw new Error("body too large");
+    }
+  }
+  const text = Buffer.concat(chunks).toString("utf8");
+  if (!text) return {};
+  return JSON.parse(text);
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -164,7 +164,30 @@ async function runMetricRefreshSweep() {
   console.log(`[worker] scheduled sweep: enqueued ${enqueued} metric_refresh job(s)`);
 }
 
-const server = createServer(createAdminHandler());
+// The plugin registry is constructed below before the server starts
+// taking requests; we expose its auth surface via a closure so the
+// admin handler can lazily reach a freshly-installed auth plugin
+// without a server restart.
+let pluginRegistry: PluginRegistry | null = null;
+const server = createServer(
+  createAdminHandler({
+    auth: {
+      getAuthProvider: () => pluginRegistry?.getAuthProvider() ?? null,
+      beginAuth: (params) => {
+        if (!pluginRegistry) {
+          throw new Error("plugin registry not initialised");
+        }
+        return pluginRegistry.beginAuth(params);
+      },
+      completeAuth: (params) => {
+        if (!pluginRegistry) {
+          throw new Error("plugin registry not initialised");
+        }
+        return pluginRegistry.completeAuth(params);
+      },
+    },
+  }),
+);
 
 try {
   await verifyAiCredentials();
@@ -185,7 +208,7 @@ await seedDefaultActionPolicies(ADMIN_ORG_ID);
 registerBuiltinAdapters();
 console.log("[worker] action policies seeded and built-in adapters registered");
 
-const pluginRegistry = new PluginRegistry({
+pluginRegistry = new PluginRegistry({
   repoRoot: process.cwd(),
   workRoot: `${process.env.HOME ?? "/tmp"}/.openneko/plugins`,
 });
@@ -199,6 +222,9 @@ setPluginRegistryInstance(pluginRegistry);
     );
   } else {
     console.log(`[worker] plugin registry: no plugins installed`);
+  }
+  if (s.authProvider) {
+    console.log(`[worker] auth provider plugin active: ${s.authProvider}`);
   }
   for (const skipped of s.skipped) {
     console.warn(`[worker] plugin skipped ${skipped.name}: ${skipped.reason}`);
@@ -474,7 +500,9 @@ const shutdown = async (signal: string) => {
   }
   try {
     setPluginRegistryInstance(null);
-    await pluginRegistry.stop();
+    if (pluginRegistry) {
+      await pluginRegistry.stop();
+    }
   } catch (e) {
     console.error("[worker] plugin shutdown error:", e);
   }

--- a/apps/worker/src/plugins/plugin-registry.ts
+++ b/apps/worker/src/plugins/plugin-registry.ts
@@ -19,7 +19,12 @@
 // new plugin's actions are usable on the next action_request. After
 // `openneko secrets set …`, the new env value is in effect on the
 // next execute_action. No restart anywhere.
-import { type FSWatcher, existsSync, watch as fsWatch } from "node:fs";
+import {
+  type FSWatcher,
+  existsSync,
+  readFileSync,
+  watch as fsWatch,
+} from "node:fs";
 import { copyFile, mkdir, readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
@@ -701,9 +706,8 @@ interface PluginPackageMeta {
 
 function readPluginPackageMeta(packageJsonPath: string): PluginPackageMeta | null {
   try {
-    const fs = require("node:fs") as typeof import("node:fs");
     return JSON.parse(
-      fs.readFileSync(packageJsonPath, "utf8"),
+      readFileSync(packageJsonPath, "utf8"),
     ) as PluginPackageMeta;
   } catch {
     return null;

--- a/apps/worker/src/plugins/plugin-registry.ts
+++ b/apps/worker/src/plugins/plugin-registry.ts
@@ -7,8 +7,8 @@
 //   - Reads openneko.plugins.json + the per-user secrets file
 //   - Watches both via fs.watch, with a small debounce
 //   - Maps action kind → plugin id from the manifest entries'
-//     `kinds: string[]` field (populated at install time from the
-//     marketplace entry)
+//     `capabilities.action.kinds` field (populated at install time
+//     from the marketplace entry)
 //   - Spawns each plugin's microVM LAZILY — first execute_action for
 //     that kind triggers the VM spawn; cold-start cost only paid once
 //   - Owns the env-value scrubber, rebuilt on every secrets file
@@ -329,12 +329,13 @@ export class PluginRegistry {
         this.skipped.push({
           name,
           reason:
-            'provides_auth claimed by another plugin (only one SSO provider supported per deployment)',
+            'auth capability claimed by another plugin (only one SSO provider supported per deployment)',
         });
       }
       const seenKinds = new Set<string>();
       for (const [pluginId, entry] of newState.entriesByPluginId) {
-        for (const kind of entry.kinds ?? []) {
+        for (const decl of entry.capabilities.action?.kinds ?? []) {
+          const kind = decl.kind;
           if (seenKinds.has(kind)) {
             this.skipped.push({
               name: entry.name,
@@ -486,7 +487,7 @@ export class PluginRegistry {
     await this.runtime.start({
       id: pluginId,
       hostWorkspacePath,
-      network: networkModeFor(entry.capabilities.network),
+      network: networkModeFor(entry.permissions.network),
     });
 
     // Sanity-check: the VM's register() must match the manifest's
@@ -519,9 +520,13 @@ export class PluginRegistry {
         `${entry.name}: VM reports version ${registered.pluginVersion}, manifest pin is ${entry.version}`,
       );
     }
-    if (entry.kinds) {
-      const declared = new Set(entry.kinds);
-      const reported = new Set(registered.actions.map((a) => a.kind));
+    if (entry.capabilities.action) {
+      const declared = new Set(
+        entry.capabilities.action.kinds.map((a) => a.kind),
+      );
+      const reported = new Set(
+        (registered.capabilities.action?.kinds ?? []).map((a) => a.kind),
+      );
       const missing = [...declared].filter((k) => !reported.has(k));
       if (missing.length > 0) {
         await this.runtime.stop(pluginId).catch(() => {});
@@ -530,15 +535,18 @@ export class PluginRegistry {
         );
       }
     }
-    if (entry.provides_auth) {
-      if (!registered.auth) {
+    if (entry.capabilities.auth) {
+      if (!registered.capabilities.auth) {
         await this.runtime.stop(pluginId).catch(() => {});
         throw new Error(
-          `${entry.name}: manifest declares provides_auth: true but VM register() reports no auth provider`,
+          `${entry.name}: manifest declares the auth capability but VM register() reports no auth provider`,
         );
       }
-      if (registered.auth.providerLabel) {
-        this.authProviderLabels.set(pluginId, registered.auth.providerLabel);
+      if (registered.capabilities.auth.providerLabel) {
+        this.authProviderLabels.set(
+          pluginId,
+          registered.capabilities.auth.providerLabel,
+        );
       }
     }
   }
@@ -605,22 +613,18 @@ function buildState(manifest: PluginManifest | null): {
   for (const entry of manifest.plugins) {
     const pluginId = pluginIdFromName(entry.name);
     entriesByPluginId.set(pluginId, entry);
-    for (const kind of entry.kinds ?? []) {
-      if (kindToPluginId.has(kind)) {
-        // Last writer wins for the runtime path; refresh() emits a
-        // warning when this happens via the skipped[] mechanism.
-      }
-      kindToPluginId.set(kind, pluginId);
+    for (const decl of entry.capabilities.action?.kinds ?? []) {
+      // Last writer wins for the runtime path; refresh() emits a
+      // warning via the skipped[] mechanism.
+      kindToPluginId.set(decl.kind, pluginId);
     }
-    if (entry.provides_auth) {
+    if (entry.capabilities.auth) {
       if (authPluginId === null) {
         authPluginId = pluginId;
       } else {
         // Second auth-claimant — first one wins. The web app's
         // sign-in flow only handles one provider; surfacing two
-        // would mean making the operator pick at the sign-in screen,
-        // which the proposal explicitly avoids (one IdP per
-        // OpenNeko deployment is the contract).
+        // would mean making the operator pick at the sign-in screen.
         authDuplicates.push(entry.name);
       }
     }

--- a/apps/worker/src/plugins/plugin-registry.ts
+++ b/apps/worker/src/plugins/plugin-registry.ts
@@ -24,12 +24,19 @@ import { copyFile, mkdir, readFile } from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
 import {
+  BeginAuthParams,
+  BeginAuthRpcParams,
+  BeginAuthRpcResult,
+  CompleteAuthParams,
+  CompleteAuthRpcParams,
+  CompleteAuthRpcResult,
   ExecuteActionParams,
   ExecuteActionResult,
   PluginManifest,
   PluginManifestEntry,
   RegisterResult,
   RPC_PROTOCOL_VERSION,
+  type AuthIdentity,
   type PluginActionOutcome,
   type PluginActionRequest,
 } from "@open-neko/plugin-types";
@@ -80,16 +87,28 @@ export interface RegistryStatus {
   skipped: Array<{ name: string; reason: string }>;
   kinds: string[];
   vmsRunning: number;
+  /** Plugin id of the installed SSO provider (if any). */
+  authProvider: string | null;
+}
+
+/** Snapshot of the auth provider for the web app to render the sign-in page. */
+export interface AuthProviderInfo {
+  pluginId: string;
+  pluginName: string;
+  providerLabel: string;
 }
 
 interface ManifestState {
   entriesByPluginId: Map<string, PluginManifestEntry>;
   kindToPluginId: Map<string, string>;
+  /** Plugin id chosen as the SSO provider (or null if none). */
+  authPluginId: string | null;
 }
 
 const EMPTY_STATE: ManifestState = {
   entriesByPluginId: new Map(),
   kindToPluginId: new Map(),
+  authPluginId: null,
 };
 
 const REFRESH_DEBOUNCE_MS = 200;
@@ -106,6 +125,13 @@ export class PluginRegistry {
   private refreshing = false;
   private pendingRefresh = false;
   private stopped = false;
+  /**
+   * Provider labels reported by each auth plugin's register() call.
+   * Populated lazily — the first begin/complete RPC drives ensureVm
+   * which runs register() and records the label here. The web app's
+   * status endpoint falls back to a name-derived label until then.
+   */
+  private authProviderLabels: Map<string, string> = new Map();
 
   constructor(private readonly options: PluginRegistryOptions) {}
 
@@ -150,7 +176,102 @@ export class PluginRegistry {
       skipped: [...this.skipped],
       kinds: [...this.state.kindToPluginId.keys()].sort(),
       vmsRunning: countRunningVms(this.runtime, this.state),
+      authProvider: this.state.authPluginId,
     };
+  }
+
+  /**
+   * Snapshot of the installed SSO provider, if any. The web app's
+   * `/api/auth/status` route hits this through the worker's admin
+   * endpoint to decide whether to surface a "Sign in with …" button.
+   * The label defaults to the package name when the manifest doesn't
+   * carry one — the label is upgraded once register() runs and the
+   * VM reports its providerLabel.
+   */
+  getAuthProvider(): AuthProviderInfo | null {
+    const pluginId = this.state.authPluginId;
+    if (!pluginId) return null;
+    const entry = this.state.entriesByPluginId.get(pluginId);
+    if (!entry) return null;
+    const reported = this.authProviderLabels.get(pluginId);
+    return {
+      pluginId,
+      pluginName: entry.name,
+      providerLabel: reported ?? defaultProviderLabel(entry.name),
+    };
+  }
+
+  /**
+   * Drive the auth plugin's `begin_auth` over RPC. The web app calls
+   * this through the worker admin endpoint; the registry handles VM
+   * lifecycle + env injection exactly like an action call.
+   */
+  async beginAuth(
+    params: BeginAuthParams,
+  ): Promise<{ authorizationUrl: string }> {
+    const provider = this.requireAuthProviderEntry();
+    await this.ensureVm(provider.pluginId, provider.entry);
+    const env = mergeEnv(provider.entry, this.secrets);
+    if (!this.runtime) {
+      throw new Error("plugin-registry: runtime unavailable");
+    }
+    const response = await this.runtime.callRpc(
+      provider.pluginId,
+      "begin_auth",
+      JSON.stringify(BeginAuthRpcParams.parse({ params })),
+      { env },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `auth plugin ${provider.entry.name} begin_auth failed: ${response.error.code} ${response.error.message}`,
+      );
+    }
+    return BeginAuthRpcResult.parse(response.result).result;
+  }
+
+  /**
+   * Drive the auth plugin's `complete_auth` over RPC. Returns the
+   * normalized identity assertion the web app uses to upsert the
+   * `app_user` row.
+   */
+  async completeAuth(params: CompleteAuthParams): Promise<AuthIdentity> {
+    const provider = this.requireAuthProviderEntry();
+    await this.ensureVm(provider.pluginId, provider.entry);
+    const env = mergeEnv(provider.entry, this.secrets);
+    if (!this.runtime) {
+      throw new Error("plugin-registry: runtime unavailable");
+    }
+    const response = await this.runtime.callRpc(
+      provider.pluginId,
+      "complete_auth",
+      JSON.stringify(CompleteAuthRpcParams.parse({ params })),
+      { env },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `auth plugin ${provider.entry.name} complete_auth failed: ${response.error.code} ${response.error.message}`,
+      );
+    }
+    return CompleteAuthRpcResult.parse(response.result).result.identity;
+  }
+
+  private requireAuthProviderEntry(): {
+    pluginId: string;
+    entry: PluginManifestEntry;
+  } {
+    const pluginId = this.state.authPluginId;
+    if (!pluginId) {
+      throw new Error(
+        "no auth plugin installed — install one with `openneko install <name>` (e.g. @open-neko/plugin-scalekit)",
+      );
+    }
+    const entry = this.state.entriesByPluginId.get(pluginId);
+    if (!entry) {
+      throw new Error(
+        `plugin-registry: auth provider ${pluginId} disappeared from manifest mid-flight`,
+      );
+    }
+    return { pluginId, entry };
   }
 
   /**
@@ -176,8 +297,15 @@ export class PluginRegistry {
       this.secrets = secrets;
       this.scrubber = createScrubber(allSecretValues(secrets));
 
-      const newState = buildState(manifest);
+      const { state: newState, authDuplicates } = buildState(manifest);
       const removed = diffRemoved(this.state, newState);
+
+      // Clear cached labels for plugins no longer in the manifest so
+      // the next install of a different auth plugin doesn't pick up
+      // the prior plugin's label.
+      for (const id of removed) {
+        this.authProviderLabels.delete(id);
+      }
 
       // Stop VMs for plugins no longer in the manifest.
       if (this.runtime) {
@@ -197,6 +325,13 @@ export class PluginRegistry {
       // and surface conflicts when two plugins claim the same kind —
       // the first registration wins, the loser is recorded in skipped.
       this.skipped = [];
+      for (const name of authDuplicates) {
+        this.skipped.push({
+          name,
+          reason:
+            'provides_auth claimed by another plugin (only one SSO provider supported per deployment)',
+        });
+      }
       const seenKinds = new Set<string>();
       for (const [pluginId, entry] of newState.entriesByPluginId) {
         for (const kind of entry.kinds ?? []) {
@@ -395,6 +530,17 @@ export class PluginRegistry {
         );
       }
     }
+    if (entry.provides_auth) {
+      if (!registered.auth) {
+        await this.runtime.stop(pluginId).catch(() => {});
+        throw new Error(
+          `${entry.name}: manifest declares provides_auth: true but VM register() reports no auth provider`,
+        );
+      }
+      if (registered.auth.providerLabel) {
+        this.authProviderLabels.set(pluginId, registered.auth.providerLabel);
+      }
+    }
   }
 
   private async createDefaultRuntime(): Promise<PluginRuntime | null> {
@@ -442,10 +588,20 @@ async function readManifestFromDisk(
   }
 }
 
-function buildState(manifest: PluginManifest | null): ManifestState {
+function buildState(manifest: PluginManifest | null): {
+  state: ManifestState;
+  authDuplicates: string[];
+} {
   const entriesByPluginId = new Map<string, PluginManifestEntry>();
   const kindToPluginId = new Map<string, string>();
-  if (!manifest) return { entriesByPluginId, kindToPluginId };
+  if (!manifest) {
+    return {
+      state: { entriesByPluginId, kindToPluginId, authPluginId: null },
+      authDuplicates: [],
+    };
+  }
+  let authPluginId: string | null = null;
+  const authDuplicates: string[] = [];
   for (const entry of manifest.plugins) {
     const pluginId = pluginIdFromName(entry.name);
     entriesByPluginId.set(pluginId, entry);
@@ -456,8 +612,23 @@ function buildState(manifest: PluginManifest | null): ManifestState {
       }
       kindToPluginId.set(kind, pluginId);
     }
+    if (entry.provides_auth) {
+      if (authPluginId === null) {
+        authPluginId = pluginId;
+      } else {
+        // Second auth-claimant — first one wins. The web app's
+        // sign-in flow only handles one provider; surfacing two
+        // would mean making the operator pick at the sign-in screen,
+        // which the proposal explicitly avoids (one IdP per
+        // OpenNeko deployment is the contract).
+        authDuplicates.push(entry.name);
+      }
+    }
   }
-  return { entriesByPluginId, kindToPluginId };
+  return {
+    state: { entriesByPluginId, kindToPluginId, authPluginId },
+    authDuplicates,
+  };
 }
 
 function diffRemoved(prev: ManifestState, next: ManifestState): string[] {
@@ -480,6 +651,19 @@ function mergeEnv(
 
 function pluginIdFromName(name: string): string {
   return name.replace(/^@/, "").replace(/\//g, "-");
+}
+
+/**
+ * Best-effort label when the plugin's VM hasn't reported one yet.
+ * `@open-neko/plugin-scalekit` → `Scalekit`,
+ * `@some-org/plugin-okta` → `Okta`.
+ */
+function defaultProviderLabel(packageName: string): string {
+  const base =
+    packageName.split("/").pop() ?? packageName.replace(/^@/, "");
+  const stripped = base.replace(/^plugin-/, "");
+  if (!stripped) return packageName;
+  return stripped.charAt(0).toUpperCase() + stripped.slice(1);
 }
 
 function defaultResolveRunner(repoRoot: string): (pkg: string) => string {

--- a/apps/worker/test/admin-server.test.ts
+++ b/apps/worker/test/admin-server.test.ts
@@ -87,3 +87,209 @@ describe("worker admin HTTP handler", () => {
     }
   });
 });
+
+describe("worker admin /admin/auth/*", () => {
+  it("GET /admin/auth/status returns { provider: null } when no auth surface is wired", async () => {
+    const srv = await startServer(createAdminHandler());
+    try {
+      const res = await fetch(`http://127.0.0.1:${srv.port}/admin/auth/status`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({ provider: null });
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("GET /admin/auth/status returns provider info when one is registered", async () => {
+    const srv = await startServer(
+      createAdminHandler({
+        auth: {
+          getAuthProvider: () => ({
+            pluginName: "@open-neko/plugin-scalekit",
+            providerLabel: "Scalekit",
+          }),
+          beginAuth: async () => ({ authorizationUrl: "https://x" }),
+          completeAuth: async () => ({
+            sub: "u",
+            email: "u@e.com",
+            groups: [],
+          }),
+        },
+      }),
+    );
+    try {
+      const res = await fetch(`http://127.0.0.1:${srv.port}/admin/auth/status`);
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        provider: {
+          pluginName: "@open-neko/plugin-scalekit",
+          providerLabel: "Scalekit",
+        },
+      });
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("POST /admin/auth/begin proxies to the auth surface", async () => {
+    const calls: Array<{
+      redirectUri: string;
+      state: string;
+      loginHint?: string | null;
+    }> = [];
+    const srv = await startServer(
+      createAdminHandler({
+        auth: {
+          getAuthProvider: () => null,
+          beginAuth: async (p) => {
+            calls.push(p);
+            return { authorizationUrl: `https://idp/oauth?state=${p.state}` };
+          },
+          completeAuth: async () => ({
+            sub: "u",
+            email: "u@e.com",
+            groups: [],
+          }),
+        },
+      }),
+    );
+    try {
+      const res = await fetch(`http://127.0.0.1:${srv.port}/admin/auth/begin`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          redirectUri: "https://app.example.com/cb",
+          state: "csrf-1",
+          loginHint: "amit@example.com",
+        }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.json()).toEqual({
+        authorizationUrl: "https://idp/oauth?state=csrf-1",
+      });
+      expect(calls).toEqual([
+        {
+          redirectUri: "https://app.example.com/cb",
+          state: "csrf-1",
+          loginHint: "amit@example.com",
+        },
+      ]);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("POST /admin/auth/begin returns 400 when required fields are missing", async () => {
+    const srv = await startServer(
+      createAdminHandler({
+        auth: {
+          getAuthProvider: () => null,
+          beginAuth: async () => ({ authorizationUrl: "x" }),
+          completeAuth: async () => ({
+            sub: "u",
+            email: "u@e.com",
+            groups: [],
+          }),
+        },
+      }),
+    );
+    try {
+      const res = await fetch(`http://127.0.0.1:${srv.port}/admin/auth/begin`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ redirectUri: "https://x" }),
+      });
+      expect(res.status).toBe(400);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("POST /admin/auth/complete returns the identity", async () => {
+    const srv = await startServer(
+      createAdminHandler({
+        auth: {
+          getAuthProvider: () => null,
+          beginAuth: async () => ({ authorizationUrl: "x" }),
+          completeAuth: async ({ code }) => ({
+            sub: `sub-${code}`,
+            email: "amit@example.com",
+            name: "Amit",
+            orgId: "org-1",
+            groups: ["everyone"],
+          }),
+        },
+      }),
+    );
+    try {
+      const res = await fetch(
+        `http://127.0.0.1:${srv.port}/admin/auth/complete`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            code: "auth-code",
+            redirectUri: "https://app.example.com/cb",
+            state: "csrf-1",
+          }),
+        },
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { identity: { sub: string } };
+      expect(body.identity.sub).toBe("sub-auth-code");
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("auth endpoints return 503 when no auth surface is wired", async () => {
+    const srv = await startServer(createAdminHandler());
+    try {
+      const begin = await fetch(`http://127.0.0.1:${srv.port}/admin/auth/begin`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          redirectUri: "https://x",
+          state: "x",
+        }),
+      });
+      expect(begin.status).toBe(503);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("propagates plugin errors as 500", async () => {
+    const srv = await startServer(
+      createAdminHandler({
+        auth: {
+          getAuthProvider: () => null,
+          beginAuth: async () => {
+            throw new Error("SCALEKIT_CLIENT_SECRET not set");
+          },
+          completeAuth: async () => ({
+            sub: "u",
+            email: "u@e.com",
+            groups: [],
+          }),
+        },
+      }),
+    );
+    try {
+      const res = await fetch(`http://127.0.0.1:${srv.port}/admin/auth/begin`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          redirectUri: "https://x",
+          state: "x",
+        }),
+      });
+      expect(res.status).toBe(500);
+      expect(((await res.json()) as { error: string }).error).toMatch(
+        /SCALEKIT_CLIENT_SECRET/,
+      );
+    } finally {
+      await srv.close();
+    }
+  });
+});

--- a/apps/worker/test/plugins/parallel-search-e2e.test.ts
+++ b/apps/worker/test/plugins/parallel-search-e2e.test.ts
@@ -21,8 +21,15 @@ const MANIFEST_JSON = JSON.stringify({
       name: "@open-neko/plugin-parallel-search",
       version: "0.2.0",
       integrity: FAKE_INTEGRITY,
-      capabilities: { network: ["search.parallel.ai"] },
-      kinds: ["web_search", "web_fetch"],
+      permissions: { network: ["search.parallel.ai"], env: [] },
+      capabilities: {
+        action: {
+          kinds: [
+            { kind: "web_search", description: "Search the web" },
+            { kind: "web_fetch", description: "Fetch a page" },
+          ],
+        },
+      },
     },
   ],
 });

--- a/apps/worker/test/plugins/plugin-registry.test.ts
+++ b/apps/worker/test/plugins/plugin-registry.test.ts
@@ -188,6 +188,7 @@ describe("PluginRegistry", () => {
       skipped: [],
       kinds: [],
       vmsRunning: 0,
+      authProvider: null,
     });
     await reg.stop();
   });
@@ -454,6 +455,262 @@ describe("PluginRegistry", () => {
         request: makeRequest("send_slack_message"),
       }),
     ).rejects.toThrow(/register\(\) failed/);
+    await reg.stop();
+  });
+});
+
+function manifestWithAuthEntry() {
+  return {
+    schema: "https://open-neko.github.io/plugins/manifest.schema.json",
+    plugins: [
+      {
+        name: "@open-neko/plugin-scalekit",
+        version: "0.1.0",
+        integrity: FAKE_INTEGRITY,
+        capabilities: { network: ["*.scalekit.com"] },
+        kinds: [],
+        provides_auth: true,
+      },
+    ],
+  };
+}
+
+function authRegisterResponse(providerLabel = "Scalekit"): RpcResponse {
+  return rpcOk({
+    protocol: RPC_PROTOCOL_VERSION,
+    pluginName: "@open-neko/plugin-scalekit",
+    pluginVersion: "0.1.0",
+    actions: [],
+    auth: { providerLabel },
+  });
+}
+
+describe("PluginRegistry — auth provider", () => {
+  let repoRoot: string;
+  let workRoot: string;
+  let secretsConfigDir: string;
+  let runnerPath: string;
+
+  beforeEach(async () => {
+    repoRoot = await mkdtemp(path.join(tmpdir(), "openneko-repo-"));
+    workRoot = await mkdtemp(path.join(tmpdir(), "openneko-vmwork-"));
+    secretsConfigDir = await mkdtemp(path.join(tmpdir(), "openneko-secrets-"));
+    runnerPath = path.join(repoRoot, "fake-runner.js");
+    await writeFakeRunner(runnerPath);
+    setDefaultActionAdapter(mockActionAdapter);
+  });
+
+  afterEach(async () => {
+    await rm(repoRoot, { recursive: true, force: true });
+    await rm(workRoot, { recursive: true, force: true });
+    await rm(secretsConfigDir, { recursive: true, force: true });
+    setDefaultActionAdapter(mockActionAdapter);
+  });
+
+  function newRegistry(runtime: PluginRuntime) {
+    return new PluginRegistry({
+      repoRoot,
+      workRoot,
+      secretsConfigDir,
+      runtime,
+      resolveRunner: () => runnerPath,
+    });
+  }
+
+  it("getAuthProvider returns null when no auth plugin is installed", async () => {
+    const reg = newRegistry(new FakeRuntime());
+    await reg.start();
+    expect(reg.getAuthProvider()).toBeNull();
+    expect(reg.status().authProvider).toBeNull();
+    await reg.stop();
+  });
+
+  it("status reports the installed auth provider (label from manifest name pre-VM-spawn)", async () => {
+    await writeFile(
+      path.join(repoRoot, "openneko.plugins.json"),
+      JSON.stringify(manifestWithAuthEntry()),
+      "utf8",
+    );
+    const reg = newRegistry(new FakeRuntime());
+    await reg.start();
+    const provider = reg.getAuthProvider();
+    expect(provider).not.toBeNull();
+    expect(provider?.pluginName).toBe("@open-neko/plugin-scalekit");
+    // No VM yet, so label is derived from the package name.
+    expect(provider?.providerLabel).toBe("Scalekit");
+    expect(reg.status().authProvider).toContain("scalekit");
+    await reg.stop();
+  });
+
+  it("beginAuth runs ensureVm then RPCs the plugin", async () => {
+    await writeFile(
+      path.join(repoRoot, "openneko.plugins.json"),
+      JSON.stringify(manifestWithAuthEntry()),
+      "utf8",
+    );
+    const runtime = new FakeRuntime({
+      responses: {
+        register: authRegisterResponse(),
+        begin_auth: rpcOk({
+          result: {
+            authorizationUrl: "https://foo.scalekit.com/oauth/authorize?stub=1",
+          },
+        }),
+      },
+    });
+    const reg = newRegistry(runtime);
+    await reg.start();
+
+    const out = await reg.beginAuth({
+      redirectUri: "https://app.example.com/cb",
+      state: "csrf-1",
+    });
+    expect(out.authorizationUrl).toBe(
+      "https://foo.scalekit.com/oauth/authorize?stub=1",
+    );
+    // ensureVm should have run register first.
+    expect(runtime.rpcs.map((r) => r.method)).toEqual([
+      "register",
+      "begin_auth",
+    ]);
+    expect(runtime.starts).toHaveLength(1);
+    await reg.stop();
+  });
+
+  it("upgrades providerLabel from the VM's register() response", async () => {
+    await writeFile(
+      path.join(repoRoot, "openneko.plugins.json"),
+      JSON.stringify(manifestWithAuthEntry()),
+      "utf8",
+    );
+    const runtime = new FakeRuntime({
+      responses: {
+        register: authRegisterResponse("Scalekit (prod)"),
+        begin_auth: rpcOk({
+          result: { authorizationUrl: "https://x" },
+        }),
+      },
+    });
+    const reg = newRegistry(runtime);
+    await reg.start();
+    await reg.beginAuth({ redirectUri: "https://x", state: "x" });
+    expect(reg.getAuthProvider()?.providerLabel).toBe("Scalekit (prod)");
+    await reg.stop();
+  });
+
+  it("completeAuth proxies the identity from the plugin", async () => {
+    await writeFile(
+      path.join(repoRoot, "openneko.plugins.json"),
+      JSON.stringify(manifestWithAuthEntry()),
+      "utf8",
+    );
+    const runtime = new FakeRuntime({
+      responses: {
+        register: authRegisterResponse(),
+        complete_auth: rpcOk({
+          result: {
+            identity: {
+              sub: "user-42",
+              email: "amit@example.com",
+              name: "Amit Patel",
+              orgId: "org-abc",
+              groups: ["engineering"],
+            },
+          },
+        }),
+      },
+    });
+    const reg = newRegistry(runtime);
+    await reg.start();
+    const identity = await reg.completeAuth({
+      code: "auth-code",
+      redirectUri: "https://app.example.com/cb",
+      state: "csrf-1",
+    });
+    expect(identity.sub).toBe("user-42");
+    expect(identity.email).toBe("amit@example.com");
+    expect(identity.groups).toEqual(["engineering"]);
+    await reg.stop();
+  });
+
+  it("rejects an auth plugin whose VM register() does not declare auth", async () => {
+    await writeFile(
+      path.join(repoRoot, "openneko.plugins.json"),
+      JSON.stringify(manifestWithAuthEntry()),
+      "utf8",
+    );
+    const runtime = new FakeRuntime({
+      responses: {
+        register: rpcOk({
+          protocol: RPC_PROTOCOL_VERSION,
+          pluginName: "@open-neko/plugin-scalekit",
+          pluginVersion: "0.1.0",
+          actions: [],
+        }),
+        begin_auth: rpcOk({
+          result: { authorizationUrl: "https://x" },
+        }),
+      },
+    });
+    const reg = newRegistry(runtime);
+    await reg.start();
+    await expect(
+      reg.beginAuth({ redirectUri: "https://x", state: "x" }),
+    ).rejects.toThrow(/no auth provider/);
+    await reg.stop();
+  });
+
+  it("beginAuth/completeAuth throw a clear message when no auth plugin is installed", async () => {
+    const reg = newRegistry(new FakeRuntime());
+    await reg.start();
+    await expect(
+      reg.beginAuth({ redirectUri: "https://x", state: "x" }),
+    ).rejects.toThrow(/no auth plugin/);
+    await expect(
+      reg.completeAuth({
+        code: "x",
+        redirectUri: "https://x",
+        state: "x",
+      }),
+    ).rejects.toThrow(/no auth plugin/);
+    await reg.stop();
+  });
+
+  it("flags a second provides_auth claimant in skipped", async () => {
+    await writeFile(
+      path.join(repoRoot, "openneko.plugins.json"),
+      JSON.stringify({
+        schema: "https://open-neko.github.io/plugins/manifest.schema.json",
+        plugins: [
+          {
+            name: "@open-neko/plugin-scalekit",
+            version: "0.1.0",
+            integrity: FAKE_INTEGRITY,
+            capabilities: { network: ["*.scalekit.com"] },
+            kinds: [],
+            provides_auth: true,
+          },
+          {
+            name: "@acme/plugin-okta",
+            version: "0.1.0",
+            integrity: FAKE_INTEGRITY,
+            capabilities: { network: ["*.okta.com"] },
+            kinds: [],
+            provides_auth: true,
+          },
+        ],
+      }),
+      "utf8",
+    );
+    const reg = newRegistry(new FakeRuntime());
+    await reg.start();
+    expect(reg.getAuthProvider()?.pluginName).toBe(
+      "@open-neko/plugin-scalekit",
+    );
+    expect(reg.status().skipped.length).toBeGreaterThanOrEqual(1);
+    expect(reg.status().skipped.some((s) => /provides_auth/.test(s.reason))).toBe(
+      true,
+    );
     await reg.stop();
   });
 });

--- a/apps/worker/test/plugins/plugin-registry.test.ts
+++ b/apps/worker/test/plugins/plugin-registry.test.ts
@@ -22,6 +22,13 @@ import type {
 
 const FAKE_INTEGRITY = "sha512-" + "a".repeat(86) + "==";
 
+const SLACK_KIND_DECLS = [
+  { kind: "send_slack_message", description: "post" },
+  { kind: "send_slack_dm", description: "dm" },
+  { kind: "react_slack_message", description: "react" },
+  { kind: "lookup_slack_entity", description: "lookup" },
+];
+
 interface RecordedRpc {
   pluginId: string;
   method: string;
@@ -85,7 +92,9 @@ async function writeFakeRunner(file: string): Promise<void> {
   await writeFile(file, "// runner — never executed in these tests\n", "utf8");
 }
 
-function manifestWithSlackEntry(opts: { kinds?: string[] } = {}) {
+function manifestWithSlackEntry(
+  opts: { kinds?: Array<{ kind: string; description: string }> } = {},
+) {
   return {
     schema: "https://open-neko.github.io/plugins/manifest.schema.json",
     plugins: [
@@ -93,13 +102,10 @@ function manifestWithSlackEntry(opts: { kinds?: string[] } = {}) {
         name: "@open-neko/plugin-slack",
         version: "0.1.0",
         integrity: FAKE_INTEGRITY,
-        capabilities: { network: ["slack.com"] },
-        kinds: opts.kinds ?? [
-          "send_slack_message",
-          "send_slack_dm",
-          "react_slack_message",
-          "lookup_slack_entity",
-        ],
+        permissions: { network: ["slack.com"], env: [] },
+        capabilities: {
+          action: { kinds: opts.kinds ?? SLACK_KIND_DECLS },
+        },
         marketplace: "official",
       },
     ],
@@ -111,12 +117,9 @@ function fullRegisterResponse(): RpcResponse {
     protocol: RPC_PROTOCOL_VERSION,
     pluginName: "@open-neko/plugin-slack",
     pluginVersion: "0.1.0",
-    actions: [
-      { kind: "send_slack_message", description: "post" },
-      { kind: "send_slack_dm", description: "dm" },
-      { kind: "react_slack_message", description: "react" },
-      { kind: "lookup_slack_entity", description: "lookup" },
-    ],
+    capabilities: {
+      action: { kinds: SLACK_KIND_DECLS },
+    },
   });
 }
 
@@ -369,7 +372,10 @@ describe("PluginRegistry", () => {
       path.join(repoRoot, "openneko.plugins.json"),
       JSON.stringify(
         manifestWithSlackEntry({
-          kinds: ["send_slack_message", "lookup_slack_entity"],
+          kinds: [
+            { kind: "send_slack_message", description: "post" },
+            { kind: "lookup_slack_entity", description: "lookup" },
+          ],
         }),
       ),
       "utf8",
@@ -380,7 +386,11 @@ describe("PluginRegistry", () => {
           protocol: RPC_PROTOCOL_VERSION,
           pluginName: "@open-neko/plugin-slack",
           pluginVersion: "0.1.0",
-          actions: [{ kind: "send_slack_message", description: "post" }],
+          capabilities: {
+            action: {
+              kinds: [{ kind: "send_slack_message", description: "post" }],
+            },
+          },
         }),
       },
     });
@@ -405,15 +415,23 @@ describe("PluginRegistry", () => {
             name: "@open-neko/plugin-slack",
             version: "0.1.0",
             integrity: FAKE_INTEGRITY,
-            capabilities: { network: ["slack.com"] },
-            kinds: ["send_slack_message"],
+            permissions: { network: ["slack.com"], env: [] },
+            capabilities: {
+              action: {
+                kinds: [{ kind: "send_slack_message", description: "post" }],
+              },
+            },
           },
           {
             name: "@acme/plugin-slack-alt",
             version: "0.1.0",
             integrity: FAKE_INTEGRITY,
-            capabilities: { network: ["slack.com"] },
-            kinds: ["send_slack_message"],
+            permissions: { network: ["slack.com"], env: [] },
+            capabilities: {
+              action: {
+                kinds: [{ kind: "send_slack_message", description: "post" }],
+              },
+            },
           },
         ],
       }),
@@ -467,9 +485,8 @@ function manifestWithAuthEntry() {
         name: "@open-neko/plugin-scalekit",
         version: "0.1.0",
         integrity: FAKE_INTEGRITY,
-        capabilities: { network: ["*.scalekit.com"] },
-        kinds: [],
-        provides_auth: true,
+        permissions: { network: ["*.scalekit.com"], env: [] },
+        capabilities: { auth: { providerLabel: "Scalekit" } },
       },
     ],
   };
@@ -480,8 +497,7 @@ function authRegisterResponse(providerLabel = "Scalekit"): RpcResponse {
     protocol: RPC_PROTOCOL_VERSION,
     pluginName: "@open-neko/plugin-scalekit",
     pluginVersion: "0.1.0",
-    actions: [],
-    auth: { providerLabel },
+    capabilities: { auth: { providerLabel } },
   });
 }
 
@@ -525,7 +541,7 @@ describe("PluginRegistry — auth provider", () => {
     await reg.stop();
   });
 
-  it("status reports the installed auth provider (label from manifest name pre-VM-spawn)", async () => {
+  it("status reports the installed auth provider with the manifest label pre-VM-spawn", async () => {
     await writeFile(
       path.join(repoRoot, "openneko.plugins.json"),
       JSON.stringify(manifestWithAuthEntry()),
@@ -536,7 +552,6 @@ describe("PluginRegistry — auth provider", () => {
     const provider = reg.getAuthProvider();
     expect(provider).not.toBeNull();
     expect(provider?.pluginName).toBe("@open-neko/plugin-scalekit");
-    // No VM yet, so label is derived from the package name.
     expect(provider?.providerLabel).toBe("Scalekit");
     expect(reg.status().authProvider).toContain("scalekit");
     await reg.stop();
@@ -568,7 +583,6 @@ describe("PluginRegistry — auth provider", () => {
     expect(out.authorizationUrl).toBe(
       "https://foo.scalekit.com/oauth/authorize?stub=1",
     );
-    // ensureVm should have run register first.
     expect(runtime.rpcs.map((r) => r.method)).toEqual([
       "register",
       "begin_auth",
@@ -645,7 +659,7 @@ describe("PluginRegistry — auth provider", () => {
           protocol: RPC_PROTOCOL_VERSION,
           pluginName: "@open-neko/plugin-scalekit",
           pluginVersion: "0.1.0",
-          actions: [],
+          capabilities: {},
         }),
         begin_auth: rpcOk({
           result: { authorizationUrl: "https://x" },
@@ -676,7 +690,7 @@ describe("PluginRegistry — auth provider", () => {
     await reg.stop();
   });
 
-  it("flags a second provides_auth claimant in skipped", async () => {
+  it("flags a second auth-capability claimant in skipped", async () => {
     await writeFile(
       path.join(repoRoot, "openneko.plugins.json"),
       JSON.stringify({
@@ -686,17 +700,15 @@ describe("PluginRegistry — auth provider", () => {
             name: "@open-neko/plugin-scalekit",
             version: "0.1.0",
             integrity: FAKE_INTEGRITY,
-            capabilities: { network: ["*.scalekit.com"] },
-            kinds: [],
-            provides_auth: true,
+            permissions: { network: ["*.scalekit.com"], env: [] },
+            capabilities: { auth: { providerLabel: "Scalekit" } },
           },
           {
             name: "@acme/plugin-okta",
             version: "0.1.0",
             integrity: FAKE_INTEGRITY,
-            capabilities: { network: ["*.okta.com"] },
-            kinds: [],
-            provides_auth: true,
+            permissions: { network: ["*.okta.com"], env: [] },
+            capabilities: { auth: { providerLabel: "Okta" } },
           },
         ],
       }),
@@ -708,7 +720,7 @@ describe("PluginRegistry — auth provider", () => {
       "@open-neko/plugin-scalekit",
     );
     expect(reg.status().skipped.length).toBeGreaterThanOrEqual(1);
-    expect(reg.status().skipped.some((s) => /provides_auth/.test(s.reason))).toBe(
+    expect(reg.status().skipped.some((s) => /auth capability/.test(s.reason))).toBe(
       true,
     );
     await reg.stop();

--- a/packages/plugin-install/src/manifest.ts
+++ b/packages/plugin-install/src/manifest.ts
@@ -19,27 +19,50 @@ export function manifestPathFor(repoRoot: string): string {
   return path.join(repoRoot, PLUGIN_MANIFEST_FILE);
 }
 
+/** Env-var requirement schema (same shape across marketplace + manifest). */
+export interface ManifestEnvRequirement {
+  key: string;
+  required?: boolean;
+  secret?: boolean;
+  description: string;
+}
+
+/** What the plugin needs from the runtime — sandbox network + operator-supplied env. */
+export interface ManifestPermissions {
+  network: string[];
+  env: ManifestEnvRequirement[];
+}
+
+/** A single declared action — kind + description, no handler. */
+export interface ManifestActionDeclaration {
+  kind: string;
+  description: string;
+}
+
+/**
+ * What the plugin contributes. The keyset declares the surfaces this
+ * plugin implements; absence of a key means the plugin does not
+ * contribute that surface.
+ */
+export interface ManifestCapabilities {
+  action?: { kinds: ManifestActionDeclaration[] };
+  auth?: { providerLabel?: string };
+}
+
 export interface ManifestEntry {
   name: string;
   version: string;
   integrity: string;
-  capabilities: { network: string[] };
+  /** Runtime requirements: network egress + env-var schema. */
+  permissions: ManifestPermissions;
+  /** Surfaces this plugin contributes (presence = declaration). */
+  capabilities: ManifestCapabilities;
   /**
-   * Action kinds this plugin handles. Copied at install time from
-   * the marketplace version entry so the worker can build a kind →
-   * plugin map from the file alone (no VM spawn needed to know who
-   * handles what — enables hot-reload).
+   * Resolved env values (operator-supplied). Worker merges these with
+   * the per-user secrets store, with the per-user store winning.
    */
-  kinds?: string[];
-  /**
-   * True when this plugin implements the SSO contract. Copied at
-   * install time from the marketplace entry's `provides_auth`. The
-   * web app reads this flag (via the worker admin endpoint) to
-   * decide whether to light up "Sign in with …" on the sign-in page.
-   */
-  provides_auth?: boolean;
   env?: Record<string, string>;
-  /** Display name of the marketplace this plugin came from (for traceability). */
+  /** Display name of the marketplace this plugin came from (traceability). */
   marketplace?: string;
 }
 

--- a/packages/plugin-install/src/manifest.ts
+++ b/packages/plugin-install/src/manifest.ts
@@ -31,6 +31,13 @@ export interface ManifestEntry {
    * handles what — enables hot-reload).
    */
   kinds?: string[];
+  /**
+   * True when this plugin implements the SSO contract. Copied at
+   * install time from the marketplace entry's `provides_auth`. The
+   * web app reads this flag (via the worker admin endpoint) to
+   * decide whether to light up "Sign in with …" on the sign-in page.
+   */
+  provides_auth?: boolean;
   env?: Record<string, string>;
   /** Display name of the marketplace this plugin came from (for traceability). */
   marketplace?: string;

--- a/packages/plugin-install/src/marketplace-client.ts
+++ b/packages/plugin-install/src/marketplace-client.ts
@@ -19,14 +19,26 @@ export interface MarketplaceEnvRequirement {
   description: string;
 }
 
+export interface MarketplacePermissions {
+  network: string[];
+  env: MarketplaceEnvRequirement[];
+}
+
+export interface MarketplaceActionDeclaration {
+  kind: string;
+  description: string;
+}
+
+export interface MarketplaceCapabilities {
+  action?: { kinds: MarketplaceActionDeclaration[] };
+  auth?: { providerLabel?: string };
+}
+
 export interface MarketplaceVersion {
   version: string;
   integrity: string;
-  requires_network: string[];
-  requires_env?: MarketplaceEnvRequirement[];
-  kinds: string[];
-  /** True when this version implements the SSO auth contract. */
-  provides_auth?: boolean;
+  permissions: MarketplacePermissions;
+  capabilities: MarketplaceCapabilities;
   publishedAt: string;
   yanked?: boolean;
   yanked_reason?: string;

--- a/packages/plugin-install/src/marketplace-client.ts
+++ b/packages/plugin-install/src/marketplace-client.ts
@@ -25,6 +25,8 @@ export interface MarketplaceVersion {
   requires_network: string[];
   requires_env?: MarketplaceEnvRequirement[];
   kinds: string[];
+  /** True when this version implements the SSO auth contract. */
+  provides_auth?: boolean;
   publishedAt: string;
   yanked?: boolean;
   yanked_reason?: string;

--- a/packages/plugin-install/src/run-install.ts
+++ b/packages/plugin-install/src/run-install.ts
@@ -69,7 +69,7 @@ export interface InstallResult {
   name: string;
   version: string;
   integrity: string;
-  capabilities: { network: string[] };
+  permissions: { network: string[] };
   marketplace: string | null;
   source: "marketplace" | "unverified";
   /** Required env keys that were prompted for and saved during this install. */
@@ -168,9 +168,11 @@ export async function runInstall(
     name: plugin.name,
     version: version.version,
     integrity: version.integrity,
-    capabilities: { network: version.requires_network ?? [] },
-    kinds: version.kinds ?? [],
-    ...(version.provides_auth ? { provides_auth: true } : {}),
+    permissions: {
+      network: version.permissions?.network ?? [],
+      env: version.permissions?.env ?? [],
+    },
+    capabilities: version.capabilities,
     marketplace: chosen.marketplaceName,
   };
   await writeManifest(options.repoRoot, upsertEntry(manifest, entry));
@@ -178,7 +180,7 @@ export async function runInstall(
     name: plugin.name,
     version: version.version,
     integrity: version.integrity,
-    capabilities: { network: version.requires_network ?? [] },
+    permissions: { network: entry.permissions.network },
     marketplace: chosen.marketplaceName,
     source: "marketplace",
     envSaved: envOutcome.saved,
@@ -191,7 +193,7 @@ async function resolveRequiredEnv(
   version: MarketplaceVersion,
   options: InstallOptions,
 ): Promise<{ saved: string[]; alreadySet: string[] }> {
-  const required = (version.requires_env ?? []).filter(
+  const required = (version.permissions?.env ?? []).filter(
     (r) => r.required !== false,
   );
   if (required.length === 0) return { saved: [], alreadySet: [] };
@@ -233,16 +235,29 @@ async function installUnverified(
       `--unverified install: cannot read package.json for ${name} after install`,
     );
   }
+  const ozNeko = meta.openneko;
+  if (!ozNeko?.capabilities) {
+    throw new Error(
+      `--unverified install: ${name} package.json must declare openneko.capabilities`,
+    );
+  }
   const entry: ManifestEntry = {
     name,
     version: meta.version,
     integrity: meta._integrity ?? "sha512-unknown",
-    capabilities: { network: meta.openneko?.requires_network ?? [] },
+    permissions: {
+      network: ozNeko.permissions?.network ?? [],
+      env: ozNeko.permissions?.env ?? [],
+    },
+    capabilities: ozNeko.capabilities,
   };
   const manifest = (await readManifest(options.repoRoot)) ?? emptyManifest();
   await writeManifest(options.repoRoot, upsertEntry(manifest, entry));
   return {
-    ...entry,
+    name,
+    version: entry.version,
+    integrity: entry.integrity,
+    permissions: { network: entry.permissions.network },
     marketplace: null,
     source: "unverified",
     envSaved: [],
@@ -253,7 +268,21 @@ async function installUnverified(
 interface NpmPackageMeta {
   version: string;
   _integrity?: string;
-  openneko?: { requires_network?: string[] };
+  openneko?: {
+    permissions?: {
+      network?: string[];
+      env?: Array<{
+        key: string;
+        required?: boolean;
+        secret?: boolean;
+        description: string;
+      }>;
+    };
+    capabilities?: {
+      action?: { kinds: Array<{ kind: string; description: string }> };
+      auth?: { providerLabel?: string };
+    };
+  };
 }
 
 async function readPackageMeta(

--- a/packages/plugin-install/src/run-install.ts
+++ b/packages/plugin-install/src/run-install.ts
@@ -170,6 +170,7 @@ export async function runInstall(
     integrity: version.integrity,
     capabilities: { network: version.requires_network ?? [] },
     kinds: version.kinds ?? [],
+    ...(version.provides_auth ? { provides_auth: true } : {}),
     marketplace: chosen.marketplaceName,
   };
   await writeManifest(options.repoRoot, upsertEntry(manifest, entry));

--- a/packages/plugin-install/test/marketplace-client.test.ts
+++ b/packages/plugin-install/test/marketplace-client.test.ts
@@ -24,15 +24,19 @@ function marketplace(): Marketplace {
           {
             version: "0.1.0",
             integrity: INTEGRITY,
-            requires_network: [],
-            kinds: ["a"],
+            permissions: { network: [], env: [] },
+            capabilities: {
+              action: { kinds: [{ kind: "a", description: "a" }] },
+            },
             publishedAt: "2026-05-17",
           },
           {
             version: "0.2.0",
             integrity: INTEGRITY,
-            requires_network: ["api.example.com"],
-            kinds: ["a"],
+            permissions: { network: ["api.example.com"], env: [] },
+            capabilities: {
+              action: { kinds: [{ kind: "a", description: "a" }] },
+            },
             publishedAt: "2026-05-18",
           },
         ],

--- a/packages/plugin-install/test/run-install.test.ts
+++ b/packages/plugin-install/test/run-install.test.ts
@@ -286,6 +286,76 @@ describe("runInstall", () => {
     expect(result.marketplace).toBe("acme");
   });
 
+  it("copies provides_auth into the manifest entry when the marketplace version declares it", async () => {
+    const plugin = {
+      name: "@open-neko/plugin-scalekit",
+      title: "Scalekit SSO",
+      description: "...",
+      source: "https://github.com/open-neko/plugins",
+      versions: [
+        {
+          version: "0.1.0",
+          integrity: INTEGRITY,
+          requires_network: ["*.scalekit.com"],
+          kinds: [],
+          provides_auth: true,
+          publishedAt: "2026-05-17",
+        },
+      ],
+    };
+    const fixtures = new Map([
+      [OFFICIAL_MARKETPLACE_URL, marketplaceWith([plugin])],
+    ]);
+    await runInstall({
+      repoRoot: repoDir,
+      spec: "@open-neko/plugin-scalekit",
+      trustedMarketplaces: [officialMarketplace],
+      secretsConfigDir: configDir,
+      marketplaceClient: fakeClient(fixtures),
+      npmRunner: async () => {},
+      envPrompt: async () => "",
+    });
+    const written = JSON.parse(
+      await readFile(path.join(repoDir, PLUGIN_MANIFEST_FILE), "utf8"),
+    );
+    expect(written.plugins[0].provides_auth).toBe(true);
+    expect(written.plugins[0].kinds).toEqual([]);
+  });
+
+  it("omits provides_auth from the manifest when the version doesn't declare it", async () => {
+    const plugin = {
+      name: "@open-neko/plugin-noauth",
+      title: "noauth",
+      description: "...",
+      source: "https://github.com/open-neko/plugins",
+      versions: [
+        {
+          version: "0.1.0",
+          integrity: INTEGRITY,
+          requires_network: [],
+          kinds: ["do_something"],
+          publishedAt: "2026-05-17",
+        },
+      ],
+    };
+    const fixtures = new Map([
+      [OFFICIAL_MARKETPLACE_URL, marketplaceWith([plugin])],
+    ]);
+    await runInstall({
+      repoRoot: repoDir,
+      spec: "@open-neko/plugin-noauth",
+      trustedMarketplaces: [officialMarketplace],
+      secretsConfigDir: configDir,
+      marketplaceClient: fakeClient(fixtures),
+      npmRunner: async () => {},
+      envPrompt: async () => "",
+    });
+    const written = JSON.parse(
+      await readFile(path.join(repoDir, PLUGIN_MANIFEST_FILE), "utf8"),
+    );
+    expect(written.plugins[0].provides_auth).toBeUndefined();
+  });
+
   it("errors on conflict when a plugin appears in multiple trusted marketplaces", async () => {
     const plugin = {
       name: "@conflict/p",

--- a/packages/plugin-install/test/run-install.test.ts
+++ b/packages/plugin-install/test/run-install.test.ts
@@ -11,6 +11,7 @@ import {
   OFFICIAL_MARKETPLACE_URL,
   type Marketplace,
   type MarketplaceClient,
+  type MarketplaceVersion,
 } from "../src/marketplace-client";
 import { PLUGIN_MANIFEST_FILE, PLUGIN_MANIFEST_SCHEMA_URL } from "../src/manifest";
 
@@ -32,6 +33,20 @@ function fakeClient(fixtures: Map<string, Marketplace>): MarketplaceClient {
       if (!m) throw new Error(`no fixture for ${url}`);
       return m;
     },
+  };
+}
+
+function actionVersion(
+  overrides: Partial<MarketplaceVersion> & { kinds: Array<{ kind: string; description: string }> },
+): MarketplaceVersion {
+  const { kinds, ...rest } = overrides;
+  return {
+    version: "0.1.0",
+    integrity: INTEGRITY,
+    permissions: { network: [], env: [] },
+    capabilities: { action: { kinds } },
+    publishedAt: "2026-05-17",
+    ...rest,
   };
 }
 
@@ -81,15 +96,7 @@ describe("runInstall", () => {
       title: "Good",
       description: "...",
       source: "https://github.com/open-neko/plugins",
-      versions: [
-        {
-          version: "0.1.0",
-          integrity: INTEGRITY,
-          requires_network: [],
-          kinds: ["x"],
-          publishedAt: "2026-05-17",
-        },
-      ],
+      versions: [actionVersion({ kinds: [{ kind: "x", description: "x" }] })],
     };
     const fixtures = new Map([
       [OFFICIAL_MARKETPLACE_URL, marketplaceWith([plugin])],
@@ -118,6 +125,7 @@ describe("runInstall", () => {
       await readFile(path.join(repoDir, PLUGIN_MANIFEST_FILE), "utf8"),
     );
     expect(written.plugins[0].marketplace).toBe("official");
+    expect(written.plugins[0].capabilities.action.kinds[0].kind).toBe("x");
     expect(written.schema).toBe(PLUGIN_MANIFEST_SCHEMA_URL);
   });
 
@@ -128,21 +136,20 @@ describe("runInstall", () => {
       description: "...",
       source: "https://github.com/open-neko/plugins",
       versions: [
-        {
-          version: "0.1.0",
-          integrity: INTEGRITY,
-          requires_network: ["slack.com"],
-          requires_env: [
-            {
-              key: "SLACK_BOT_TOKEN",
-              required: true,
-              secret: true,
-              description: "xoxb-",
-            },
-          ],
-          kinds: ["send_slack_message"],
-          publishedAt: "2026-05-17",
-        },
+        actionVersion({
+          permissions: {
+            network: ["slack.com"],
+            env: [
+              {
+                key: "SLACK_BOT_TOKEN",
+                required: true,
+                secret: true,
+                description: "xoxb-",
+              },
+            ],
+          },
+          kinds: [{ kind: "send_slack_message", description: "send" }],
+        }),
       ],
     };
     const fixtures = new Map([
@@ -186,16 +193,15 @@ describe("runInstall", () => {
       description: "...",
       source: "https://github.com/open-neko/plugins",
       versions: [
-        {
-          version: "0.1.0",
-          integrity: INTEGRITY,
-          requires_network: ["slack.com"],
-          requires_env: [
-            { key: "SLACK_BOT_TOKEN", required: true, secret: true, description: "x" },
-          ],
-          kinds: ["send_slack_message"],
-          publishedAt: "2026-05-17",
-        },
+        actionVersion({
+          permissions: {
+            network: ["slack.com"],
+            env: [
+              { key: "SLACK_BOT_TOKEN", required: true, secret: true, description: "x" },
+            ],
+          },
+          kinds: [{ kind: "send_slack_message", description: "send" }],
+        }),
       ],
     };
     const fixtures = new Map([
@@ -223,16 +229,15 @@ describe("runInstall", () => {
       description: "x",
       source: "https://github.com/x/x",
       versions: [
-        {
-          version: "0.1.0",
-          integrity: INTEGRITY,
-          requires_network: [],
-          requires_env: [
-            { key: "X_KEY", required: true, secret: true, description: "x" },
-          ],
-          kinds: ["x"],
-          publishedAt: "2026-05-17",
-        },
+        actionVersion({
+          permissions: {
+            network: [],
+            env: [
+              { key: "X_KEY", required: true, secret: true, description: "x" },
+            ],
+          },
+          kinds: [{ kind: "x", description: "x" }],
+        }),
       ],
     };
     const fixtures = new Map([
@@ -257,15 +262,7 @@ describe("runInstall", () => {
       title: "x",
       description: "x",
       source: "https://github.com/acme/x",
-      versions: [
-        {
-          version: "0.1.0",
-          integrity: INTEGRITY,
-          requires_network: [],
-          kinds: ["k"],
-          publishedAt: "2026-05-17",
-        },
-      ],
+      versions: [actionVersion({ kinds: [{ kind: "k", description: "k" }] })],
     };
     const fixtures = new Map([
       [OFFICIAL_MARKETPLACE_URL, marketplaceWith([])],
@@ -286,7 +283,7 @@ describe("runInstall", () => {
     expect(result.marketplace).toBe("acme");
   });
 
-  it("copies provides_auth into the manifest entry when the marketplace version declares it", async () => {
+  it("copies the auth capability into the manifest entry when the marketplace version declares it", async () => {
     const plugin = {
       name: "@open-neko/plugin-scalekit",
       title: "Scalekit SSO",
@@ -296,11 +293,10 @@ describe("runInstall", () => {
         {
           version: "0.1.0",
           integrity: INTEGRITY,
-          requires_network: ["*.scalekit.com"],
-          kinds: [],
-          provides_auth: true,
+          permissions: { network: ["*.scalekit.com"], env: [] },
+          capabilities: { auth: { providerLabel: "Scalekit" } },
           publishedAt: "2026-05-17",
-        },
+        } satisfies MarketplaceVersion,
       ],
     };
     const fixtures = new Map([
@@ -318,24 +314,20 @@ describe("runInstall", () => {
     const written = JSON.parse(
       await readFile(path.join(repoDir, PLUGIN_MANIFEST_FILE), "utf8"),
     );
-    expect(written.plugins[0].provides_auth).toBe(true);
-    expect(written.plugins[0].kinds).toEqual([]);
+    expect(written.plugins[0].capabilities.auth.providerLabel).toBe("Scalekit");
+    expect(written.plugins[0].capabilities.action).toBeUndefined();
   });
 
-  it("omits provides_auth from the manifest when the version doesn't declare it", async () => {
+  it("omits the auth capability from the manifest when the version doesn't declare one", async () => {
     const plugin = {
       name: "@open-neko/plugin-noauth",
       title: "noauth",
       description: "...",
       source: "https://github.com/open-neko/plugins",
       versions: [
-        {
-          version: "0.1.0",
-          integrity: INTEGRITY,
-          requires_network: [],
-          kinds: ["do_something"],
-          publishedAt: "2026-05-17",
-        },
+        actionVersion({
+          kinds: [{ kind: "do_something", description: "do" }],
+        }),
       ],
     };
     const fixtures = new Map([
@@ -353,7 +345,10 @@ describe("runInstall", () => {
     const written = JSON.parse(
       await readFile(path.join(repoDir, PLUGIN_MANIFEST_FILE), "utf8"),
     );
-    expect(written.plugins[0].provides_auth).toBeUndefined();
+    expect(written.plugins[0].capabilities.auth).toBeUndefined();
+    expect(written.plugins[0].capabilities.action.kinds[0].kind).toBe(
+      "do_something",
+    );
   });
 
   it("errors on conflict when a plugin appears in multiple trusted marketplaces", async () => {
@@ -362,15 +357,7 @@ describe("runInstall", () => {
       title: "x",
       description: "x",
       source: "https://github.com/x/y",
-      versions: [
-        {
-          version: "0.1.0",
-          integrity: INTEGRITY,
-          requires_network: [],
-          kinds: ["k"],
-          publishedAt: "2026-05-17",
-        },
-      ],
+      versions: [actionVersion({ kinds: [{ kind: "k", description: "k" }] })],
     };
     const fixtures = new Map([
       [OFFICIAL_MARKETPLACE_URL, marketplaceWith([plugin])],

--- a/packages/plugin-types/src/action.ts
+++ b/packages/plugin-types/src/action.ts
@@ -1,16 +1,18 @@
 import { z } from "zod";
 
+export const ActionKindName = z
+  .string()
+  .min(1)
+  .regex(
+    /^[a-z][a-z0-9_]*$/,
+    "action kind must be lowercase snake_case (matches OpenNeko convention)",
+  );
+
 /**
  * Serializable subset of OpenNeko's ActionRequestRecord that crosses the
  * worker ↔ plugin RPC boundary. The worker's plugin loader translates
  * its internal record into this shape before dispatch, and the plugin
  * returns a PluginActionOutcome that the loader translates back.
- *
- * Field choices:
- * - omit DB-only fields (workflow_run_id, observation refs, status,
- *   timestamps) — plugins should never depend on those
- * - keep payload as the agent-supplied object the plugin needs to act on
- * - keep target as the canonical resource identifier
  */
 export const PluginActionRequest = z.object({
   id: z.string(),
@@ -33,14 +35,15 @@ export const PluginActionOutcome = z.object({
 
 export type PluginActionOutcome = z.infer<typeof PluginActionOutcome>;
 
+/**
+ * Single declared action — a snake_case kind the agent can request,
+ * plus the description the agent uses to pick it. Same shape lives in
+ * the marketplace entry, the installed manifest, and the plugin's
+ * runtime register() result; the worker checks all three agree before
+ * dispatching.
+ */
 export const PluginActionDeclaration = z.object({
-  kind: z
-    .string()
-    .min(1)
-    .regex(
-      /^[a-z][a-z0-9_]*$/,
-      "action kind must be lowercase snake_case (matches OpenNeko convention)",
-    ),
+  kind: ActionKindName,
   description: z.string().min(1),
 });
 

--- a/packages/plugin-types/src/auth.ts
+++ b/packages/plugin-types/src/auth.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+
+/**
+ * Plugin-as-SSO-provider contract.
+ *
+ * OpenNeko's core stays identity-vendor-neutral by delegating the OIDC
+ * code-exchange to any installed plugin whose manifest declares
+ * `provides_auth: true`. The contract is intentionally generic: a
+ * begin-auth call yields a provider URL + state, and a complete-auth
+ * call exchanges the authorization code for an identity assertion.
+ *
+ * Plugins implement these two methods and the core gets a pluggable
+ * "Sign in with <provider>" flow — Scalekit (which fronts Okta /
+ * Entra / Google Workspace / etc.), a direct Okta plugin, a
+ * self-hosted Keycloak plugin, all fit the same shape.
+ */
+
+export const AuthIdentity = z.object({
+  /** Stable subject identifier from the IdP. Treated as the primary key. */
+  sub: z.string().min(1),
+  email: z.string().min(3),
+  /** Display name. May be absent for IdPs that don't return one. */
+  name: z.string().nullable().optional(),
+  /**
+   * IdP-supplied tenant identifier. Scalekit returns its organization id
+   * here; raw OIDC plugins typically map this to the `org_id` claim.
+   * Optional because not every IdP supplies it.
+   */
+  orgId: z.string().nullable().optional(),
+  /**
+   * Group / role memberships from the IdP, used by OpenNeko's role
+   * mapping. Empty list means the IdP returned no groups — the core
+   * falls back to a default role.
+   */
+  groups: z.array(z.string()).default([]),
+});
+
+export type AuthIdentity = z.infer<typeof AuthIdentity>;
+
+export const BeginAuthParams = z.object({
+  /**
+   * Where the IdP should send the user after the code is issued. Must
+   * be on OpenNeko itself (e.g. https://neko.example/api/auth/callback).
+   * The plugin passes this verbatim as the OIDC redirect_uri.
+   */
+  redirectUri: z.string().min(1),
+  /**
+   * Opaque CSRF token the core minted before redirecting. The plugin
+   * forwards it to the IdP as the OAuth state parameter; the core
+   * checks it on callback to defeat login-CSRF. Plugins MUST NOT
+   * inspect or mutate it.
+   */
+  state: z.string().min(1),
+  /**
+   * Optional email or hostname hint the user typed at the sign-in
+   * page. Lets the plugin route to the right downstream IdP without
+   * an extra "which company are you?" screen — Scalekit uses this
+   * for connection discovery.
+   */
+  loginHint: z.string().nullable().optional(),
+});
+
+export type BeginAuthParams = z.infer<typeof BeginAuthParams>;
+
+export const BeginAuthResult = z.object({
+  /**
+   * Fully-built provider URL the browser should be redirected to. The
+   * plugin owns building the query string (client_id, scope,
+   * response_type, state, redirect_uri, connection hints, etc.).
+   */
+  authorizationUrl: z.string().min(1),
+});
+
+export type BeginAuthResult = z.infer<typeof BeginAuthResult>;
+
+export const CompleteAuthParams = z.object({
+  /** The `code` query parameter the IdP returned on its redirect. */
+  code: z.string().min(1),
+  /** The redirect_uri originally passed to begin_auth — required for token exchange. */
+  redirectUri: z.string().min(1),
+  /**
+   * State value the IdP echoed back. The core has already verified it
+   * matches what it minted; the plugin gets it for symmetry and so
+   * future PKCE-style flows can bind code_verifier to it.
+   */
+  state: z.string().min(1),
+});
+
+export type CompleteAuthParams = z.infer<typeof CompleteAuthParams>;
+
+export const CompleteAuthResult = z.object({
+  identity: AuthIdentity,
+});
+
+export type CompleteAuthResult = z.infer<typeof CompleteAuthResult>;
+
+export const PluginAuthDeclaration = z.object({
+  /**
+   * Short human-readable provider label rendered on the sign-in
+   * button (e.g. "Scalekit", "Okta", "Keycloak"). The core falls back
+   * to the plugin's package name when this is absent.
+   */
+  providerLabel: z.string().min(1).optional(),
+});
+
+export type PluginAuthDeclaration = z.infer<typeof PluginAuthDeclaration>;

--- a/packages/plugin-types/src/auth.ts
+++ b/packages/plugin-types/src/auth.ts
@@ -4,15 +4,13 @@ import { z } from "zod";
  * Plugin-as-SSO-provider contract.
  *
  * OpenNeko's core stays identity-vendor-neutral by delegating the OIDC
- * code-exchange to any installed plugin whose manifest declares
- * `provides_auth: true`. The contract is intentionally generic: a
- * begin-auth call yields a provider URL + state, and a complete-auth
- * call exchanges the authorization code for an identity assertion.
+ * code-exchange to any installed plugin whose manifest declares an
+ * `auth` capability. A begin-auth call yields a provider URL + state,
+ * and a complete-auth call exchanges the authorization code for an
+ * identity assertion.
  *
- * Plugins implement these two methods and the core gets a pluggable
- * "Sign in with <provider>" flow — Scalekit (which fronts Okta /
- * Entra / Google Workspace / etc.), a direct Okta plugin, a
- * self-hosted Keycloak plugin, all fit the same shape.
+ * Scalekit (fronts Okta / Entra / Google Workspace / etc.), a direct
+ * Okta plugin, a self-hosted Keycloak plugin — all fit the same shape.
  */
 
 export const AuthIdentity = z.object({
@@ -24,7 +22,6 @@ export const AuthIdentity = z.object({
   /**
    * IdP-supplied tenant identifier. Scalekit returns its organization id
    * here; raw OIDC plugins typically map this to the `org_id` claim.
-   * Optional because not every IdP supplies it.
    */
   orgId: z.string().nullable().optional(),
   /**
@@ -54,8 +51,7 @@ export const BeginAuthParams = z.object({
   /**
    * Optional email or hostname hint the user typed at the sign-in
    * page. Lets the plugin route to the right downstream IdP without
-   * an extra "which company are you?" screen — Scalekit uses this
-   * for connection discovery.
+   * an extra "which company are you?" screen.
    */
   loginHint: z.string().nullable().optional(),
 });
@@ -93,14 +89,3 @@ export const CompleteAuthResult = z.object({
 });
 
 export type CompleteAuthResult = z.infer<typeof CompleteAuthResult>;
-
-export const PluginAuthDeclaration = z.object({
-  /**
-   * Short human-readable provider label rendered on the sign-in
-   * button (e.g. "Scalekit", "Okta", "Keycloak"). The core falls back
-   * to the plugin's package name when this is absent.
-   */
-  providerLabel: z.string().min(1).optional(),
-});
-
-export type PluginAuthDeclaration = z.infer<typeof PluginAuthDeclaration>;

--- a/packages/plugin-types/src/define-plugin.ts
+++ b/packages/plugin-types/src/define-plugin.ts
@@ -3,6 +3,12 @@ import {
   PluginActionOutcome,
   PluginActionRequest,
 } from "./action.js";
+import {
+  BeginAuthParams,
+  BeginAuthResult,
+  CompleteAuthParams,
+  CompleteAuthResult,
+} from "./auth.js";
 
 export type PluginActionHandler = (
   request: PluginActionRequest,
@@ -12,10 +18,39 @@ export interface PluginActionDefinition extends PluginActionDeclaration {
   handler: PluginActionHandler;
 }
 
+export type BeginAuthHandler = (
+  params: BeginAuthParams,
+) => Promise<BeginAuthResult> | BeginAuthResult;
+
+export type CompleteAuthHandler = (
+  params: CompleteAuthParams,
+) => Promise<CompleteAuthResult> | CompleteAuthResult;
+
+/**
+ * SSO provider implementation. Plugins that opt in to OpenNeko's auth
+ * contract supply both handlers. The host (worker → web) drives the
+ * OIDC dance: it calls `begin` to get an authorization URL,
+ * redirects the browser there, then on callback calls `complete` to
+ * trade the code for an identity assertion.
+ */
+export interface PluginAuthDefinition {
+  /** Short label rendered on the sign-in button. */
+  providerLabel?: string;
+  begin: BeginAuthHandler;
+  complete: CompleteAuthHandler;
+}
+
 export interface PluginDefinition {
   name: string;
   version: string;
   actions?: PluginActionDefinition[];
+  /**
+   * Optional SSO provider implementation. When set, the plugin's
+   * manifest entry should also carry `provides_auth: true` so the
+   * host can light up the "Sign in with …" UI without first spawning
+   * the VM.
+   */
+  auth?: PluginAuthDefinition;
 }
 
 /**
@@ -48,6 +83,14 @@ export function definePlugin(definition: PluginDefinition): PluginDefinition {
       throw new Error(
         `definePlugin: action "${action.kind}" must provide a handler function`,
       );
+    }
+  }
+  if (definition.auth) {
+    if (typeof definition.auth.begin !== "function") {
+      throw new Error("definePlugin: auth.begin must be a function");
+    }
+    if (typeof definition.auth.complete !== "function") {
+      throw new Error("definePlugin: auth.complete must be a function");
     }
   }
   return definition;

--- a/packages/plugin-types/src/define-plugin.ts
+++ b/packages/plugin-types/src/define-plugin.ts
@@ -26,50 +26,57 @@ export type CompleteAuthHandler = (
   params: CompleteAuthParams,
 ) => Promise<CompleteAuthResult> | CompleteAuthResult;
 
-/**
- * SSO provider implementation. Plugins that opt in to OpenNeko's auth
- * contract supply both handlers. The host (worker → web) drives the
- * OIDC dance: it calls `begin` to get an authorization URL,
- * redirects the browser there, then on callback calls `complete` to
- * trade the code for an identity assertion.
- */
-export interface PluginAuthDefinition {
-  /** Short label rendered on the sign-in button. */
+/** Implementation shape for the action capability — kinds with handlers. */
+export interface ActionCapabilityImpl {
+  kinds: PluginActionDefinition[];
+}
+
+/** Implementation shape for the auth capability — the OIDC begin/complete handlers. */
+export interface AuthCapabilityImpl {
   providerLabel?: string;
   begin: BeginAuthHandler;
   complete: CompleteAuthHandler;
 }
 
+/**
+ * What the plugin author returns from definePlugin. Mirror of
+ * PluginCapabilitiesDeclaration but each present surface carries
+ * handlers in addition to its declared metadata.
+ */
+export interface PluginCapabilitiesImpl {
+  action?: ActionCapabilityImpl;
+  auth?: AuthCapabilityImpl;
+}
+
 export interface PluginDefinition {
   name: string;
   version: string;
-  actions?: PluginActionDefinition[];
-  /**
-   * Optional SSO provider implementation. When set, the plugin's
-   * manifest entry should also carry `provides_auth: true` so the
-   * host can light up the "Sign in with …" UI without first spawning
-   * the VM.
-   */
-  auth?: PluginAuthDefinition;
+  capabilities: PluginCapabilitiesImpl;
 }
 
 /**
- * Plugin entrypoint helper. Returns the same object passed in, but with
- * the type narrowed so editors give plugin authors completion on the
- * action shape. Authors do:
+ * Plugin entrypoint helper. Validates that `capabilities` declares at
+ * least one surface and that each declared surface has its required
+ * handlers, then returns the same object so editors give plugin
+ * authors completion on the capability shape.
  *
  *     export default definePlugin({
  *       name: "@open-neko/plugin-parallel-search",
  *       version: "0.1.0",
- *       actions: [{
- *         kind: "web_search",
- *         description: "Search the web via Parallel.ai",
- *         handler: async (req) => { ... },
- *       }],
+ *       capabilities: {
+ *         action: {
+ *           kinds: [{
+ *             kind: "web_search",
+ *             description: "Search the web",
+ *             handler: async (req) => { ... },
+ *           }],
+ *         },
+ *       },
  *     });
  *
- * The plugin's runner script (provided by this package via `runPlugin`)
- * imports the default export and dispatches RPC calls to it.
+ * The plugin's runner script (provided by this package via
+ * `runPluginEntrypoint`) imports the default export and dispatches RPC
+ * calls to it.
  */
 export function definePlugin(definition: PluginDefinition): PluginDefinition {
   if (!definition.name) {
@@ -78,19 +85,34 @@ export function definePlugin(definition: PluginDefinition): PluginDefinition {
   if (!definition.version) {
     throw new Error("definePlugin: version is required");
   }
-  for (const action of definition.actions ?? []) {
-    if (typeof action.handler !== "function") {
+  const caps = definition.capabilities;
+  if (!caps || (caps.action == null && caps.auth == null)) {
+    throw new Error(
+      "definePlugin: capabilities must declare at least one surface (action, auth)",
+    );
+  }
+  if (caps.action) {
+    if (!Array.isArray(caps.action.kinds) || caps.action.kinds.length === 0) {
       throw new Error(
-        `definePlugin: action "${action.kind}" must provide a handler function`,
+        "definePlugin: capabilities.action.kinds must list at least one action",
       );
     }
-  }
-  if (definition.auth) {
-    if (typeof definition.auth.begin !== "function") {
-      throw new Error("definePlugin: auth.begin must be a function");
+    for (const a of caps.action.kinds) {
+      if (typeof a.handler !== "function") {
+        throw new Error(
+          `definePlugin: action "${a.kind}" must provide a handler function`,
+        );
+      }
     }
-    if (typeof definition.auth.complete !== "function") {
-      throw new Error("definePlugin: auth.complete must be a function");
+  }
+  if (caps.auth) {
+    if (typeof caps.auth.begin !== "function") {
+      throw new Error("definePlugin: capabilities.auth.begin must be a function");
+    }
+    if (typeof caps.auth.complete !== "function") {
+      throw new Error(
+        "definePlugin: capabilities.auth.complete must be a function",
+      );
     }
   }
   return definition;

--- a/packages/plugin-types/src/index.ts
+++ b/packages/plugin-types/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./manifest.js";
 export * from "./rpc.js";
 export * from "./action.js";
+export * from "./auth.js";
 export * from "./define-plugin.js";
 export * from "./runner.js";

--- a/packages/plugin-types/src/manifest.ts
+++ b/packages/plugin-types/src/manifest.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { PluginActionDeclaration } from "./action.js";
 
 export const HostPattern = z
   .string()
@@ -19,11 +20,12 @@ export const EnvVarName = z
   );
 
 /**
- * One env var a plugin needs at runtime. Listed in the marketplace
- * entry; the openneko CLI prompts the operator for any required ones
- * during `openneko install` and stores them in the per-user secrets
- * file at ~/.config/openneko/secrets.json. The worker reads that file
- * and injects the values into the plugin's microVM at exec time.
+ * One env var a plugin needs at runtime. Listed under `permissions.env`
+ * in the marketplace entry and installed manifest; the openneko CLI
+ * prompts the operator for any required ones during `openneko install`
+ * and stores values in ~/.config/openneko/secrets.json. The worker
+ * reads that file and injects values into the plugin's microVM at exec
+ * time.
  */
 export const PluginEnvRequirement = z.object({
   key: EnvVarName,
@@ -35,21 +37,74 @@ export const PluginEnvRequirement = z.object({
 
 export type PluginEnvRequirement = z.infer<typeof PluginEnvRequirement>;
 
-export const PluginCapabilities = z
+/**
+ * What the plugin needs from the runtime to operate.
+ *
+ * - `network`: hostnames the sandbox must allow outbound traffic to.
+ *   Enforced at the VM boundary — the plugin cannot reach hosts not
+ *   listed here.
+ * - `env`: env vars the operator must supply. `openneko install`
+ *   prompts and refuses to complete if a required value is missing.
+ *
+ * Same shape in the marketplace entry and the installed manifest.
+ */
+export const PluginPermissions = z
   .object({
     network: z.array(HostPattern).default([]),
+    env: z.array(PluginEnvRequirement).default([]),
   })
-  .default({ network: [] });
+  .default({ network: [], env: [] });
 
-export type PluginCapabilities = z.infer<typeof PluginCapabilities>;
+export type PluginPermissions = z.infer<typeof PluginPermissions>;
 
-export const ActionKindName = z
-  .string()
-  .min(1)
-  .regex(
-    /^[a-z][a-z0-9_]*$/,
-    "action kind must be lowercase snake_case",
-  );
+/**
+ * Action capability — a plugin contributes one or more named action
+ * handlers the agent can invoke. Each kind has a snake_case identifier
+ * and a description the agent uses to pick the right one.
+ */
+export const ActionCapabilityDeclaration = z.object({
+  kinds: z.array(PluginActionDeclaration).min(1),
+});
+
+export type ActionCapabilityDeclaration = z.infer<
+  typeof ActionCapabilityDeclaration
+>;
+
+/**
+ * Auth capability — a plugin acts as the SSO provider for OpenNeko.
+ * Singleton: only one installed plugin may declare this. Presence of
+ * `capabilities.auth` on a manifest entry is what lights up the
+ * "Sign in with …" UI; no VM spawn needed to make that decision.
+ */
+export const AuthCapabilityDeclaration = z.object({
+  /**
+   * Short human-readable provider label rendered on the sign-in
+   * button (e.g. "Scalekit", "Okta", "Keycloak"). The host falls back
+   * to a name-derived label when this is absent.
+   */
+  providerLabel: z.string().min(1).optional(),
+});
+
+export type AuthCapabilityDeclaration = z.infer<typeof AuthCapabilityDeclaration>;
+
+/**
+ * The full capability map a plugin contributes. Each surface a plugin
+ * implements becomes a key here; the keyset IS the declaration — there
+ * are no parallel flags. To add a new surface: add a key, its
+ * declaration schema, the matching impl, and the RPC dispatch.
+ */
+export const PluginCapabilitiesDeclaration = z
+  .object({
+    action: ActionCapabilityDeclaration.optional(),
+    auth: AuthCapabilityDeclaration.optional(),
+  })
+  .refine((c) => c.action != null || c.auth != null, {
+    message: "capabilities must declare at least one surface (action, auth)",
+  });
+
+export type PluginCapabilitiesDeclaration = z.infer<
+  typeof PluginCapabilitiesDeclaration
+>;
 
 export const PluginManifestEntry = z.object({
   name: z
@@ -68,27 +123,10 @@ export const PluginManifestEntry = z.object({
   integrity: z
     .string()
     .regex(/^sha512-[A-Za-z0-9+/=]+$/, "integrity must be sha512-<base64>"),
-  capabilities: PluginCapabilities,
+  permissions: PluginPermissions,
+  capabilities: PluginCapabilitiesDeclaration,
   /**
-   * Action kinds this plugin handles — copied at install time from
-   * the marketplace entry's `kinds`. Lets the worker build a kind →
-   * plugin map from the file alone, without spawning a VM to call
-   * register(). Optional so older manifests written before this
-   * field existed still parse; the worker treats a missing list as
-   * "discover via register() at boot" (legacy fallback).
-   */
-  kinds: z.array(ActionKindName).optional(),
-  /**
-   * True when this plugin implements the SSO contract (begin_auth +
-   * complete_auth RPC methods). Copied at install time from the
-   * marketplace entry. The host inspects this flag to decide whether
-   * to show a "Sign in with …" button on the sign-in page — no VM
-   * spawn needed to make that decision. At most one installed plugin
-   * may set this; the registry refuses to register a second.
-   */
-  provides_auth: z.boolean().optional(),
-  /**
-   * Inline env values to set for this plugin. The CLI normally writes
+   * Resolved env values for this plugin. The CLI normally writes
    * secrets to the gitignored per-user store at ~/.config/openneko/
    * secrets.json; this field is for tests + non-secret defaults. The
    * worker merges both, with the per-user store winning.

--- a/packages/plugin-types/src/manifest.ts
+++ b/packages/plugin-types/src/manifest.ts
@@ -79,6 +79,15 @@ export const PluginManifestEntry = z.object({
    */
   kinds: z.array(ActionKindName).optional(),
   /**
+   * True when this plugin implements the SSO contract (begin_auth +
+   * complete_auth RPC methods). Copied at install time from the
+   * marketplace entry. The host inspects this flag to decide whether
+   * to show a "Sign in with …" button on the sign-in page — no VM
+   * spawn needed to make that decision. At most one installed plugin
+   * may set this; the registry refuses to register a second.
+   */
+  provides_auth: z.boolean().optional(),
+  /**
    * Inline env values to set for this plugin. The CLI normally writes
    * secrets to the gitignored per-user store at ~/.config/openneko/
    * secrets.json; this field is for tests + non-secret defaults. The

--- a/packages/plugin-types/src/rpc.ts
+++ b/packages/plugin-types/src/rpc.ts
@@ -4,6 +4,13 @@ import {
   PluginActionOutcome,
   PluginActionRequest,
 } from "./action.js";
+import {
+  BeginAuthParams,
+  BeginAuthResult,
+  CompleteAuthParams,
+  CompleteAuthResult,
+  PluginAuthDeclaration,
+} from "./auth.js";
 
 /**
  * JSON-RPC over stdio between the OpenNeko worker (caller) and a plugin
@@ -19,7 +26,12 @@ import {
 
 export const RPC_PROTOCOL_VERSION = 1 as const;
 
-export const RpcMethod = z.enum(["register", "execute_action"]);
+export const RpcMethod = z.enum([
+  "register",
+  "execute_action",
+  "begin_auth",
+  "complete_auth",
+]);
 export type RpcMethod = z.infer<typeof RpcMethod>;
 
 /** Initial handshake the worker sends before any other method. */
@@ -36,6 +48,14 @@ export const RegisterResult = z.object({
   pluginName: z.string(),
   pluginVersion: z.string(),
   actions: z.array(PluginActionDeclaration).default([]),
+  /**
+   * Present when the plugin acts as an SSO identity provider. Absence
+   * is normal — most plugins only contribute actions. The host pairs
+   * this with the manifest's `provides_auth: true` flag: the flag is
+   * what makes the auth flow visible in the UI; this declaration
+   * supplies the human-readable label.
+   */
+  auth: PluginAuthDeclaration.optional(),
 });
 export type RegisterResult = z.infer<typeof RegisterResult>;
 
@@ -48,6 +68,26 @@ export const ExecuteActionResult = z.object({
   outcome: PluginActionOutcome,
 });
 export type ExecuteActionResult = z.infer<typeof ExecuteActionResult>;
+
+export const BeginAuthRpcParams = z.object({
+  params: BeginAuthParams,
+});
+export type BeginAuthRpcParams = z.infer<typeof BeginAuthRpcParams>;
+
+export const BeginAuthRpcResult = z.object({
+  result: BeginAuthResult,
+});
+export type BeginAuthRpcResult = z.infer<typeof BeginAuthRpcResult>;
+
+export const CompleteAuthRpcParams = z.object({
+  params: CompleteAuthParams,
+});
+export type CompleteAuthRpcParams = z.infer<typeof CompleteAuthRpcParams>;
+
+export const CompleteAuthRpcResult = z.object({
+  result: CompleteAuthResult,
+});
+export type CompleteAuthRpcResult = z.infer<typeof CompleteAuthRpcResult>;
 
 export const RpcOk = z.object({
   ok: z.literal(true),

--- a/packages/plugin-types/src/rpc.ts
+++ b/packages/plugin-types/src/rpc.ts
@@ -9,19 +9,14 @@ import {
   BeginAuthResult,
   CompleteAuthParams,
   CompleteAuthResult,
-  PluginAuthDeclaration,
 } from "./auth.js";
+import { AuthCapabilityDeclaration } from "./manifest.js";
 
 /**
  * JSON-RPC over stdio between the OpenNeko worker (caller) and a plugin
  * process inside its microsandbox VM (callee). v1 uses one-shot exec per
  * call — the worker invokes `node /workspace/plugin/run.js <method>
- * <json-params>` and reads a single JSON response from stdout. This
- * matches microsandbox's one-shot `exec()` model without requiring
- * long-running stdio streaming.
- *
- * If/when we add long-running stdio in a future microsandbox SDK rev,
- * this same wire format applies — just framed by newlines per request.
+ * <json-params>` and reads a single JSON response from stdout.
  */
 
 export const RPC_PROTOCOL_VERSION = 1 as const;
@@ -42,20 +37,23 @@ export const RpcHello = z.object({
 });
 export type RpcHello = z.infer<typeof RpcHello>;
 
-/** Returned by the plugin's register() — the surface it contributes. */
+/**
+ * Returned by the plugin's register() — the live-from-code capability
+ * map. The worker validates this against the manifest's declared
+ * capabilities; mismatched name, version, or surfaces refuse the VM.
+ */
 export const RegisterResult = z.object({
   protocol: z.literal(RPC_PROTOCOL_VERSION),
   pluginName: z.string(),
   pluginVersion: z.string(),
-  actions: z.array(PluginActionDeclaration).default([]),
-  /**
-   * Present when the plugin acts as an SSO identity provider. Absence
-   * is normal — most plugins only contribute actions. The host pairs
-   * this with the manifest's `provides_auth: true` flag: the flag is
-   * what makes the auth flow visible in the UI; this declaration
-   * supplies the human-readable label.
-   */
-  auth: PluginAuthDeclaration.optional(),
+  capabilities: z.object({
+    action: z
+      .object({
+        kinds: z.array(PluginActionDeclaration),
+      })
+      .optional(),
+    auth: AuthCapabilityDeclaration.optional(),
+  }),
 });
 export type RegisterResult = z.infer<typeof RegisterResult>;
 
@@ -69,24 +67,16 @@ export const ExecuteActionResult = z.object({
 });
 export type ExecuteActionResult = z.infer<typeof ExecuteActionResult>;
 
-export const BeginAuthRpcParams = z.object({
-  params: BeginAuthParams,
-});
+export const BeginAuthRpcParams = z.object({ params: BeginAuthParams });
 export type BeginAuthRpcParams = z.infer<typeof BeginAuthRpcParams>;
 
-export const BeginAuthRpcResult = z.object({
-  result: BeginAuthResult,
-});
+export const BeginAuthRpcResult = z.object({ result: BeginAuthResult });
 export type BeginAuthRpcResult = z.infer<typeof BeginAuthRpcResult>;
 
-export const CompleteAuthRpcParams = z.object({
-  params: CompleteAuthParams,
-});
+export const CompleteAuthRpcParams = z.object({ params: CompleteAuthParams });
 export type CompleteAuthRpcParams = z.infer<typeof CompleteAuthRpcParams>;
 
-export const CompleteAuthRpcResult = z.object({
-  result: CompleteAuthResult,
-});
+export const CompleteAuthRpcResult = z.object({ result: CompleteAuthResult });
 export type CompleteAuthRpcResult = z.infer<typeof CompleteAuthRpcResult>;
 
 export const RpcOk = z.object({

--- a/packages/plugin-types/src/runner.ts
+++ b/packages/plugin-types/src/runner.ts
@@ -20,13 +20,9 @@ export interface RunPluginOptions {
 
 /**
  * Single-shot RPC dispatcher used by plugin runner scripts. Reads the
- * method name + params JSON, dispatches to the plugin's declarations or
- * handlers, returns an RpcResponse. The plugin runner writes the
- * response as JSON to stdout for the worker to parse.
- *
- * v1 contract: one process per call. If/when a future microsandbox SDK
- * supports long-running stdio streams, the same dispatcher can be
- * driven in a loop reading newline-delimited requests.
+ * method name + params JSON, dispatches to the plugin's declared
+ * capability handlers, returns an RpcResponse. The plugin runner writes
+ * the response as JSON to stdout for the worker to parse.
  */
 export async function dispatchPluginRpc(
   plugin: PluginDefinition,
@@ -52,19 +48,26 @@ export async function dispatchPluginRpc(
 }
 
 function buildRegisterResult(plugin: PluginDefinition): RegisterResult {
+  const caps = plugin.capabilities;
   return RegisterResult.parse({
     protocol: RPC_PROTOCOL_VERSION,
     pluginName: plugin.name,
     pluginVersion: plugin.version,
-    actions: (plugin.actions ?? []).map((a) => ({
-      kind: a.kind,
-      description: a.description,
-    })),
-    auth: plugin.auth
-      ? plugin.auth.providerLabel
-        ? { providerLabel: plugin.auth.providerLabel }
-        : {}
-      : undefined,
+    capabilities: {
+      action: caps.action
+        ? {
+            kinds: caps.action.kinds.map((a) => ({
+              kind: a.kind,
+              description: a.description,
+            })),
+          }
+        : undefined,
+      auth: caps.auth
+        ? caps.auth.providerLabel
+          ? { providerLabel: caps.auth.providerLabel }
+          : {}
+        : undefined,
+    },
   });
 }
 
@@ -73,11 +76,13 @@ async function runExecuteAction(
   paramsJson: string,
 ): Promise<ExecuteActionResult> {
   const parsed = ExecuteActionParams.parse(JSON.parse(paramsJson));
-  const action = (plugin.actions ?? []).find(
+  const action = plugin.capabilities.action?.kinds.find(
     (a) => a.kind === parsed.request.kind,
   );
   if (!action) {
-    throw new Error(`plugin does not handle action kind "${parsed.request.kind}"`);
+    throw new Error(
+      `plugin does not handle action kind "${parsed.request.kind}"`,
+    );
   }
   const outcome = await action.handler(parsed.request);
   return ExecuteActionResult.parse({ outcome });
@@ -87,11 +92,12 @@ async function runBeginAuth(
   plugin: PluginDefinition,
   paramsJson: string,
 ): Promise<BeginAuthRpcResult> {
-  if (!plugin.auth) {
+  const auth = plugin.capabilities.auth;
+  if (!auth) {
     throw new Error("plugin does not implement an auth provider");
   }
   const parsed = BeginAuthRpcParams.parse(JSON.parse(paramsJson));
-  const result = await plugin.auth.begin(parsed.params);
+  const result = await auth.begin(parsed.params);
   return BeginAuthRpcResult.parse({ result });
 }
 
@@ -99,11 +105,12 @@ async function runCompleteAuth(
   plugin: PluginDefinition,
   paramsJson: string,
 ): Promise<CompleteAuthRpcResult> {
-  if (!plugin.auth) {
+  const auth = plugin.capabilities.auth;
+  if (!auth) {
     throw new Error("plugin does not implement an auth provider");
   }
   const parsed = CompleteAuthRpcParams.parse(JSON.parse(paramsJson));
-  const result = await plugin.auth.complete(parsed.params);
+  const result = await auth.complete(parsed.params);
   return CompleteAuthRpcResult.parse({ result });
 }
 
@@ -114,7 +121,7 @@ async function runCompleteAuth(
  *
  *     // run.js
  *     import plugin from "./plugin.js";
- *     import { runPluginEntrypoint } from "@open-neko/plugin-types/runner";
+ *     import { runPluginEntrypoint } from "@open-neko/plugin-types";
  *     await runPluginEntrypoint(plugin);
  */
 export async function runPluginEntrypoint(

--- a/packages/plugin-types/src/runner.ts
+++ b/packages/plugin-types/src/runner.ts
@@ -1,4 +1,8 @@
 import {
+  BeginAuthRpcParams,
+  BeginAuthRpcResult,
+  CompleteAuthRpcParams,
+  CompleteAuthRpcResult,
   ExecuteActionParams,
   ExecuteActionResult,
   RegisterResult,
@@ -34,6 +38,10 @@ export async function dispatchPluginRpc(
         return rpcOk(buildRegisterResult(plugin));
       case "execute_action":
         return rpcOk(await runExecuteAction(plugin, options.paramsJson));
+      case "begin_auth":
+        return rpcOk(await runBeginAuth(plugin, options.paramsJson));
+      case "complete_auth":
+        return rpcOk(await runCompleteAuth(plugin, options.paramsJson));
       default:
         return rpcErr("UNKNOWN_METHOD", `unknown RPC method: ${options.method}`);
     }
@@ -52,6 +60,11 @@ function buildRegisterResult(plugin: PluginDefinition): RegisterResult {
       kind: a.kind,
       description: a.description,
     })),
+    auth: plugin.auth
+      ? plugin.auth.providerLabel
+        ? { providerLabel: plugin.auth.providerLabel }
+        : {}
+      : undefined,
   });
 }
 
@@ -68,6 +81,30 @@ async function runExecuteAction(
   }
   const outcome = await action.handler(parsed.request);
   return ExecuteActionResult.parse({ outcome });
+}
+
+async function runBeginAuth(
+  plugin: PluginDefinition,
+  paramsJson: string,
+): Promise<BeginAuthRpcResult> {
+  if (!plugin.auth) {
+    throw new Error("plugin does not implement an auth provider");
+  }
+  const parsed = BeginAuthRpcParams.parse(JSON.parse(paramsJson));
+  const result = await plugin.auth.begin(parsed.params);
+  return BeginAuthRpcResult.parse({ result });
+}
+
+async function runCompleteAuth(
+  plugin: PluginDefinition,
+  paramsJson: string,
+): Promise<CompleteAuthRpcResult> {
+  if (!plugin.auth) {
+    throw new Error("plugin does not implement an auth provider");
+  }
+  const parsed = CompleteAuthRpcParams.parse(JSON.parse(paramsJson));
+  const result = await plugin.auth.complete(parsed.params);
+  return CompleteAuthRpcResult.parse({ result });
 }
 
 /**

--- a/packages/plugin-types/test/define-plugin.test.ts
+++ b/packages/plugin-types/test/define-plugin.test.ts
@@ -48,4 +48,54 @@ describe("definePlugin", () => {
       }),
     ).toThrow(/handler/);
   });
+
+  it("accepts an auth-only plugin", () => {
+    const plugin = definePlugin({
+      name: "@open-neko/plugin-auth",
+      version: "0.1.0",
+      auth: {
+        providerLabel: "Test IdP",
+        begin: async () => ({
+          authorizationUrl: "https://idp.example.com/oauth/authorize",
+        }),
+        complete: async () => ({
+          identity: {
+            sub: "u-1",
+            email: "x@y.com",
+            groups: [],
+          },
+        }),
+      },
+    });
+    expect(plugin.auth?.providerLabel).toBe("Test IdP");
+    expect(plugin.actions).toBeUndefined();
+  });
+
+  it("throws when auth.begin is not a function", () => {
+    expect(() =>
+      definePlugin({
+        name: "@x/y",
+        version: "0.1.0",
+        auth: {
+          begin: "nope" as unknown as () => Promise<never>,
+          complete: async () => ({
+            identity: { sub: "x", email: "x@y.com", groups: [] },
+          }),
+        },
+      }),
+    ).toThrow(/auth\.begin/);
+  });
+
+  it("throws when auth.complete is not a function", () => {
+    expect(() =>
+      definePlugin({
+        name: "@x/y",
+        version: "0.1.0",
+        auth: {
+          begin: async () => ({ authorizationUrl: "https://x" }),
+          complete: "nope" as unknown as () => Promise<never>,
+        },
+      }),
+    ).toThrow(/auth\.complete/);
+  });
 });

--- a/packages/plugin-types/test/define-plugin.test.ts
+++ b/packages/plugin-types/test/define-plugin.test.ts
@@ -2,20 +2,70 @@ import { describe, expect, it } from "vitest";
 import { definePlugin } from "../src/define-plugin";
 
 describe("definePlugin", () => {
-  it("returns the same shape and accepts a valid plugin", () => {
+  it("accepts an action-only plugin and returns the same shape", () => {
     const plugin = definePlugin({
       name: "@open-neko/plugin-example",
       version: "0.1.0",
-      actions: [
-        {
-          kind: "demo",
-          description: "demo action",
-          handler: async () => ({ result: { ok: true } }),
+      capabilities: {
+        action: {
+          kinds: [
+            {
+              kind: "demo",
+              description: "demo action",
+              handler: async () => ({ result: { ok: true } }),
+            },
+          ],
         },
-      ],
+      },
     });
     expect(plugin.name).toBe("@open-neko/plugin-example");
-    expect(plugin.actions?.[0]?.kind).toBe("demo");
+    expect(plugin.capabilities.action?.kinds[0]?.kind).toBe("demo");
+  });
+
+  it("accepts an auth-only plugin", () => {
+    const plugin = definePlugin({
+      name: "@open-neko/plugin-auth",
+      version: "0.1.0",
+      capabilities: {
+        auth: {
+          providerLabel: "Test IdP",
+          begin: async () => ({
+            authorizationUrl: "https://idp.example.com/oauth/authorize",
+          }),
+          complete: async () => ({
+            identity: { sub: "u-1", email: "x@y.com", groups: [] },
+          }),
+        },
+      },
+    });
+    expect(plugin.capabilities.auth?.providerLabel).toBe("Test IdP");
+    expect(plugin.capabilities.action).toBeUndefined();
+  });
+
+  it("accepts a plugin that contributes both action + auth", () => {
+    const plugin = definePlugin({
+      name: "@open-neko/plugin-mixed",
+      version: "0.1.0",
+      capabilities: {
+        action: {
+          kinds: [
+            {
+              kind: "ping",
+              description: "ping",
+              handler: async () => ({ result: { ok: true } }),
+            },
+          ],
+        },
+        auth: {
+          begin: async () => ({ authorizationUrl: "https://x" }),
+          complete: async () => ({
+            identity: { sub: "u-1", email: "x@y.com", groups: [] },
+          }),
+        },
+      },
+    });
+    expect(plugin.capabilities.action).toBeDefined();
+    expect(plugin.capabilities.auth).toBeDefined();
   });
 
   it("throws when name or version is missing", () => {
@@ -23,14 +73,36 @@ describe("definePlugin", () => {
       definePlugin({
         name: "",
         version: "0.1.0",
-      } as unknown as Parameters<typeof definePlugin>[0]),
+        capabilities: { auth: { begin: async () => ({ authorizationUrl: "x" }), complete: async () => ({ identity: { sub: "u", email: "x@y.com", groups: [] } }) } },
+      }),
     ).toThrow(/name is required/);
     expect(() =>
       definePlugin({
         name: "@x/y",
         version: "",
-      } as unknown as Parameters<typeof definePlugin>[0]),
+        capabilities: { auth: { begin: async () => ({ authorizationUrl: "x" }), complete: async () => ({ identity: { sub: "u", email: "x@y.com", groups: [] } }) } },
+      }),
     ).toThrow(/version is required/);
+  });
+
+  it("throws when capabilities declares neither surface", () => {
+    expect(() =>
+      definePlugin({
+        name: "@x/y",
+        version: "0.1.0",
+        capabilities: {},
+      }),
+    ).toThrow(/at least one surface/);
+  });
+
+  it("throws when capabilities.action.kinds is empty", () => {
+    expect(() =>
+      definePlugin({
+        name: "@x/y",
+        version: "0.1.0",
+        capabilities: { action: { kinds: [] } },
+      }),
+    ).toThrow(/at least one action/);
   });
 
   it("throws when an action's handler is not a function", () => {
@@ -38,37 +110,19 @@ describe("definePlugin", () => {
       definePlugin({
         name: "@x/y",
         version: "0.1.0",
-        actions: [
-          {
-            kind: "bad",
-            description: "broken",
-            handler: "not a function" as unknown as () => Promise<never>,
+        capabilities: {
+          action: {
+            kinds: [
+              {
+                kind: "bad",
+                description: "broken",
+                handler: "not a function" as unknown as () => Promise<never>,
+              },
+            ],
           },
-        ],
+        },
       }),
     ).toThrow(/handler/);
-  });
-
-  it("accepts an auth-only plugin", () => {
-    const plugin = definePlugin({
-      name: "@open-neko/plugin-auth",
-      version: "0.1.0",
-      auth: {
-        providerLabel: "Test IdP",
-        begin: async () => ({
-          authorizationUrl: "https://idp.example.com/oauth/authorize",
-        }),
-        complete: async () => ({
-          identity: {
-            sub: "u-1",
-            email: "x@y.com",
-            groups: [],
-          },
-        }),
-      },
-    });
-    expect(plugin.auth?.providerLabel).toBe("Test IdP");
-    expect(plugin.actions).toBeUndefined();
   });
 
   it("throws when auth.begin is not a function", () => {
@@ -76,11 +130,13 @@ describe("definePlugin", () => {
       definePlugin({
         name: "@x/y",
         version: "0.1.0",
-        auth: {
-          begin: "nope" as unknown as () => Promise<never>,
-          complete: async () => ({
-            identity: { sub: "x", email: "x@y.com", groups: [] },
-          }),
+        capabilities: {
+          auth: {
+            begin: "nope" as unknown as () => Promise<never>,
+            complete: async () => ({
+              identity: { sub: "x", email: "x@y.com", groups: [] },
+            }),
+          },
         },
       }),
     ).toThrow(/auth\.begin/);
@@ -91,9 +147,11 @@ describe("definePlugin", () => {
       definePlugin({
         name: "@x/y",
         version: "0.1.0",
-        auth: {
-          begin: async () => ({ authorizationUrl: "https://x" }),
-          complete: "nope" as unknown as () => Promise<never>,
+        capabilities: {
+          auth: {
+            begin: async () => ({ authorizationUrl: "https://x" }),
+            complete: "nope" as unknown as () => Promise<never>,
+          },
         },
       }),
     ).toThrow(/auth\.complete/);

--- a/packages/plugin-types/test/manifest.test.ts
+++ b/packages/plugin-types/test/manifest.test.ts
@@ -5,6 +5,8 @@ import {
   PluginEnvRequirement,
   PluginManifest,
   PluginManifestEntry,
+  PluginPermissions,
+  PluginCapabilitiesDeclaration,
 } from "../src/manifest";
 
 describe("HostPattern", () => {
@@ -21,24 +23,103 @@ describe("HostPattern", () => {
   });
 });
 
+describe("PluginPermissions", () => {
+  it("defaults network and env to empty arrays", () => {
+    const parsed = PluginPermissions.parse(undefined);
+    expect(parsed.network).toEqual([]);
+    expect(parsed.env).toEqual([]);
+  });
+
+  it("accepts populated network + env", () => {
+    const parsed = PluginPermissions.parse({
+      network: ["api.parallel.ai"],
+      env: [{ key: "API_KEY", description: "a key" }],
+    });
+    expect(parsed.network).toEqual(["api.parallel.ai"]);
+    expect(parsed.env[0]?.key).toBe("API_KEY");
+    expect(parsed.env[0]?.required).toBe(true);
+    expect(parsed.env[0]?.secret).toBe(true);
+  });
+});
+
+describe("PluginCapabilitiesDeclaration", () => {
+  it("accepts an action-only plugin", () => {
+    const parsed = PluginCapabilitiesDeclaration.parse({
+      action: {
+        kinds: [{ kind: "demo", description: "demo action" }],
+      },
+    });
+    expect(parsed.action?.kinds[0]?.kind).toBe("demo");
+    expect(parsed.auth).toBeUndefined();
+  });
+
+  it("accepts an auth-only plugin", () => {
+    const parsed = PluginCapabilitiesDeclaration.parse({
+      auth: { providerLabel: "Scalekit" },
+    });
+    expect(parsed.auth?.providerLabel).toBe("Scalekit");
+    expect(parsed.action).toBeUndefined();
+  });
+
+  it("accepts a plugin contributing both surfaces", () => {
+    const parsed = PluginCapabilitiesDeclaration.parse({
+      action: { kinds: [{ kind: "demo", description: "x" }] },
+      auth: {},
+    });
+    expect(parsed.action).toBeDefined();
+    expect(parsed.auth).toBeDefined();
+  });
+
+  it("rejects a capability map with neither surface declared", () => {
+    expect(() => PluginCapabilitiesDeclaration.parse({})).toThrow(
+      /at least one surface/,
+    );
+  });
+
+  it("rejects action with an empty kinds list", () => {
+    expect(() =>
+      PluginCapabilitiesDeclaration.parse({ action: { kinds: [] } }),
+    ).toThrow();
+  });
+
+  it("rejects malformed action kind name", () => {
+    expect(() =>
+      PluginCapabilitiesDeclaration.parse({
+        action: { kinds: [{ kind: "BadKind", description: "x" }] },
+      }),
+    ).toThrow();
+  });
+});
+
 describe("PluginManifestEntry", () => {
   const base: Record<string, unknown> = {
     name: "@open-neko/plugin-parallel-search",
     version: "0.1.0",
-    integrity: "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    capabilities: { network: ["api.parallel.ai"] },
+    integrity:
+      "sha512-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    permissions: { network: ["api.parallel.ai"], env: [] },
+    capabilities: {
+      action: { kinds: [{ kind: "web_search", description: "search" }] },
+    },
   };
 
   it("accepts a valid entry", () => {
     const parsed = PluginManifestEntry.parse(base);
     expect(parsed.name).toBe("@open-neko/plugin-parallel-search");
-    expect(parsed.capabilities.network).toEqual(["api.parallel.ai"]);
+    expect(parsed.permissions.network).toEqual(["api.parallel.ai"]);
+    expect(parsed.capabilities.action?.kinds[0]?.kind).toBe("web_search");
   });
 
   it("rejects semver ranges (must be pinned)", () => {
-    expect(() => PluginManifestEntry.parse({ ...base, version: "^0.1.0" })).toThrow();
-    expect(() => PluginManifestEntry.parse({ ...base, version: "0.1.x" })).toThrow();
-    expect(() => PluginManifestEntry.parse({ ...base, version: "latest" })).toThrow();
+    expect(() =>
+      PluginManifestEntry.parse({ ...base, version: "^0.1.0" }),
+    ).toThrow();
+    expect(() =>
+      PluginManifestEntry.parse({ ...base, version: "0.1.x" }),
+    ).toThrow();
+    expect(() =>
+      PluginManifestEntry.parse({ ...base, version: "latest" }),
+    ).toThrow();
   });
 
   it("rejects integrity that is not sha512", () => {
@@ -50,24 +131,25 @@ describe("PluginManifestEntry", () => {
     ).toThrow();
   });
 
-  it("defaults capabilities to empty network array", () => {
-    const parsed = PluginManifestEntry.parse({ ...base, capabilities: undefined });
-    expect(parsed.capabilities.network).toEqual([]);
+  it("defaults permissions to empty network + env when omitted", () => {
+    const parsed = PluginManifestEntry.parse({ ...base, permissions: undefined });
+    expect(parsed.permissions.network).toEqual([]);
+    expect(parsed.permissions.env).toEqual([]);
   });
 
-  it("accepts provides_auth: true on an auth-only entry", () => {
+  it("accepts an auth-only entry", () => {
     const parsed = PluginManifestEntry.parse({
       ...base,
-      kinds: [],
-      provides_auth: true,
+      capabilities: { auth: { providerLabel: "Scalekit" } },
     });
-    expect(parsed.provides_auth).toBe(true);
-    expect(parsed.kinds).toEqual([]);
+    expect(parsed.capabilities.auth?.providerLabel).toBe("Scalekit");
+    expect(parsed.capabilities.action).toBeUndefined();
   });
 
-  it("provides_auth defaults to undefined when omitted", () => {
-    const parsed = PluginManifestEntry.parse(base);
-    expect(parsed.provides_auth).toBeUndefined();
+  it("rejects an entry with no capability declared", () => {
+    expect(() =>
+      PluginManifestEntry.parse({ ...base, capabilities: {} }),
+    ).toThrow(/at least one surface/);
   });
 });
 

--- a/packages/plugin-types/test/manifest.test.ts
+++ b/packages/plugin-types/test/manifest.test.ts
@@ -54,6 +54,21 @@ describe("PluginManifestEntry", () => {
     const parsed = PluginManifestEntry.parse({ ...base, capabilities: undefined });
     expect(parsed.capabilities.network).toEqual([]);
   });
+
+  it("accepts provides_auth: true on an auth-only entry", () => {
+    const parsed = PluginManifestEntry.parse({
+      ...base,
+      kinds: [],
+      provides_auth: true,
+    });
+    expect(parsed.provides_auth).toBe(true);
+    expect(parsed.kinds).toEqual([]);
+  });
+
+  it("provides_auth defaults to undefined when omitted", () => {
+    const parsed = PluginManifestEntry.parse(base);
+    expect(parsed.provides_auth).toBeUndefined();
+  });
 });
 
 describe("EnvVarName", () => {

--- a/packages/plugin-types/test/rpc.test.ts
+++ b/packages/plugin-types/test/rpc.test.ts
@@ -37,17 +37,31 @@ describe("RegisterResult", () => {
         protocol: 999,
         pluginName: "@x/y",
         pluginVersion: "0.0.0",
-        actions: [],
+        capabilities: {},
       }),
     ).toThrow();
-    expect(
-      RegisterResult.parse({
-        protocol: RPC_PROTOCOL_VERSION,
-        pluginName: "@x/y",
-        pluginVersion: "0.0.0",
-        actions: [{ kind: "web_search", description: "search the web" }],
-      }).actions,
-    ).toHaveLength(1);
+    const parsed = RegisterResult.parse({
+      protocol: RPC_PROTOCOL_VERSION,
+      pluginName: "@x/y",
+      pluginVersion: "0.0.0",
+      capabilities: {
+        action: {
+          kinds: [{ kind: "web_search", description: "search the web" }],
+        },
+      },
+    });
+    expect(parsed.capabilities.action?.kinds).toHaveLength(1);
+  });
+
+  it("accepts an auth-only register result", () => {
+    const parsed = RegisterResult.parse({
+      protocol: RPC_PROTOCOL_VERSION,
+      pluginName: "@x/y-auth",
+      pluginVersion: "0.0.0",
+      capabilities: { auth: { providerLabel: "Test IdP" } },
+    });
+    expect(parsed.capabilities.auth?.providerLabel).toBe("Test IdP");
+    expect(parsed.capabilities.action).toBeUndefined();
   });
 });
 

--- a/packages/plugin-types/test/runner.test.ts
+++ b/packages/plugin-types/test/runner.test.ts
@@ -6,21 +6,25 @@ import { RPC_PROTOCOL_VERSION, RegisterResult, RpcResponse } from "../src/rpc";
 const samplePlugin = definePlugin({
   name: "@open-neko/plugin-example",
   version: "0.1.0",
-  actions: [
-    {
-      kind: "echo",
-      description: "echoes the payload as the result",
-      handler: async (req) => ({
-        commandOrOperation: `echo:${req.kind}`,
-        externalRef: `ext-${req.id}`,
-        result: { received: req.payload ?? null },
-      }),
+  capabilities: {
+    action: {
+      kinds: [
+        {
+          kind: "echo",
+          description: "echoes the payload as the result",
+          handler: async (req) => ({
+            commandOrOperation: `echo:${req.kind}`,
+            externalRef: `ext-${req.id}`,
+            result: { received: req.payload ?? null },
+          }),
+        },
+      ],
     },
-  ],
+  },
 });
 
-describe("dispatchPluginRpc", () => {
-  it("register returns the declared actions", async () => {
+describe("dispatchPluginRpc — action capability", () => {
+  it("register returns the declared action kinds under capabilities.action", async () => {
     const response = await dispatchPluginRpc(samplePlugin, {
       method: "register",
       paramsJson: "{}",
@@ -29,9 +33,10 @@ describe("dispatchPluginRpc", () => {
     if (!response.ok) return;
     const registered = RegisterResult.parse(response.result);
     expect(registered.protocol).toBe(RPC_PROTOCOL_VERSION);
-    expect(registered.actions).toEqual([
+    expect(registered.capabilities.action?.kinds).toEqual([
       { kind: "echo", description: "echoes the payload as the result" },
     ]);
+    expect(registered.capabilities.auth).toBeUndefined();
   });
 
   it("execute_action runs the matching handler and returns its outcome", async () => {
@@ -104,36 +109,41 @@ describe("dispatchPluginRpc", () => {
   });
 });
 
-describe("dispatchPluginRpc — auth", () => {
+describe("dispatchPluginRpc — auth capability", () => {
   const authPlugin = definePlugin({
     name: "@open-neko/plugin-auth-example",
     version: "0.1.0",
-    auth: {
-      providerLabel: "Example IdP",
-      begin: async ({ state }) => ({
-        authorizationUrl: `https://idp.example.com/oauth/authorize?state=${state}`,
-      }),
-      complete: async ({ code }) => ({
-        identity: {
-          sub: `sub-${code}`,
-          email: "amit@example.com",
-          name: "Amit",
-          orgId: null,
-          groups: ["everyone"],
-        },
-      }),
+    capabilities: {
+      auth: {
+        providerLabel: "Example IdP",
+        begin: async ({ state }) => ({
+          authorizationUrl: `https://idp.example.com/oauth/authorize?state=${state}`,
+        }),
+        complete: async ({ code }) => ({
+          identity: {
+            sub: `sub-${code}`,
+            email: "amit@example.com",
+            name: "Amit",
+            orgId: null,
+            groups: ["everyone"],
+          },
+        }),
+      },
     },
   });
 
-  it("register surfaces providerLabel for auth plugins", async () => {
+  it("register surfaces providerLabel under capabilities.auth", async () => {
     const r = await dispatchPluginRpc(authPlugin, {
       method: "register",
       paramsJson: "{}",
     });
     expect(r.ok).toBe(true);
     if (!r.ok) return;
-    const out = r.result as { auth?: { providerLabel?: string } };
-    expect(out.auth?.providerLabel).toBe("Example IdP");
+    const out = r.result as {
+      capabilities: { auth?: { providerLabel?: string }; action?: unknown };
+    };
+    expect(out.capabilities.auth?.providerLabel).toBe("Example IdP");
+    expect(out.capabilities.action).toBeUndefined();
   });
 
   it("begin_auth returns the plugin's authorization URL", async () => {

--- a/packages/plugin-types/test/runner.test.ts
+++ b/packages/plugin-types/test/runner.test.ts
@@ -103,3 +103,89 @@ describe("dispatchPluginRpc", () => {
     expect(response.ok).toBe(false);
   });
 });
+
+describe("dispatchPluginRpc — auth", () => {
+  const authPlugin = definePlugin({
+    name: "@open-neko/plugin-auth-example",
+    version: "0.1.0",
+    auth: {
+      providerLabel: "Example IdP",
+      begin: async ({ state }) => ({
+        authorizationUrl: `https://idp.example.com/oauth/authorize?state=${state}`,
+      }),
+      complete: async ({ code }) => ({
+        identity: {
+          sub: `sub-${code}`,
+          email: "amit@example.com",
+          name: "Amit",
+          orgId: null,
+          groups: ["everyone"],
+        },
+      }),
+    },
+  });
+
+  it("register surfaces providerLabel for auth plugins", async () => {
+    const r = await dispatchPluginRpc(authPlugin, {
+      method: "register",
+      paramsJson: "{}",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const out = r.result as { auth?: { providerLabel?: string } };
+    expect(out.auth?.providerLabel).toBe("Example IdP");
+  });
+
+  it("begin_auth returns the plugin's authorization URL", async () => {
+    const r = await dispatchPluginRpc(authPlugin, {
+      method: "begin_auth",
+      paramsJson: JSON.stringify({
+        params: {
+          redirectUri: "https://app.example.com/cb",
+          state: "csrf-token",
+        },
+      }),
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const out = r.result as { result: { authorizationUrl: string } };
+    expect(out.result.authorizationUrl).toBe(
+      "https://idp.example.com/oauth/authorize?state=csrf-token",
+    );
+  });
+
+  it("complete_auth returns the identity", async () => {
+    const r = await dispatchPluginRpc(authPlugin, {
+      method: "complete_auth",
+      paramsJson: JSON.stringify({
+        params: {
+          code: "auth-code",
+          redirectUri: "https://app.example.com/cb",
+          state: "csrf-token",
+        },
+      }),
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const out = r.result as {
+      result: { identity: { sub: string; email: string } };
+    };
+    expect(out.result.identity.sub).toBe("sub-auth-code");
+    expect(out.result.identity.email).toBe("amit@example.com");
+  });
+
+  it("begin_auth on a non-auth plugin returns PLUGIN_ERROR", async () => {
+    const r = await dispatchPluginRpc(samplePlugin, {
+      method: "begin_auth",
+      paramsJson: JSON.stringify({
+        params: {
+          redirectUri: "https://x",
+          state: "x",
+        },
+      }),
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.error.message).toMatch(/auth provider/);
+  });
+});


### PR DESCRIPTION
## Summary

Adds enterprise SSO as a thin auth contract over the existing plugin runtime. Install `@open-neko/plugin-scalekit` (or any future `@open-neko/plugin-okta` / `-auth0` / `-keycloak`) and a "Sign in with &lt;provider&gt;" button lights up on `/signin` without a core rebuild.

- **Types/install**: mirror the new auth contract from `open-neko/plugins`. `ManifestEntry` + `MarketplaceVersion` carry `provides_auth`; `runInstall` flows it through.
- **Worker registry**: discovers the auth provider from the manifest (no VM spawn), refuses a second claimant (surfaced via `skipped`), and exposes `getAuthProvider()` / `beginAuth()` / `completeAuth()` reusing the existing `ensureVm` + env-injection plumbing actions use.
- **Worker admin server**: new `/admin/auth/{status,begin,complete}` routes with bounded JSON bodies and clear error mapping (503 when no plugin, 500 for plugin errors).
- **Web**: signed-cookie session (HMAC over `user_id.expiresAt`), `/api/auth/{status,begin,callback,session,logout}` routes, `/signin` page with provider auto-discovery + optional `login_hint`. `upsertUserFromIdentity` matches sub-first then email-migrates; refuses sub reassignments.
- **CLI**: `openneko list` shows `[SSO provider]` next to auth plugins.

The web process never sees the IdP client secret — it lives in the plugin's microVM env. Hot-reloading the auth plugin (`openneko install` / `openneko secrets set`) takes effect on the next sign-in without a worker restart.

Paired with [open-neko/plugins#1](https://github.com/open-neko/plugins/pull/1) which adds the contract + Scalekit plugin.

## Test plan
- [x] `pnpm -r typecheck` — clean across all packages
- [x] `pnpm -r test` — 35 plugin-types + 39 plugin-install + 52 CLI + 109 worker + 93 web tests pass (DB-dependent suites skip cleanly without Postgres)
- [x] New tests cover: registry auth-provider discovery, duplicate-claimant rejection, beginAuth/completeAuth proxy, register()-time auth declaration check, admin-server `/admin/auth/*` happy + error paths, session HMAC round-trip + tamper + expiry + wrong-secret rejection
- [ ] End-to-end against a real Scalekit env once the operator wires `SCALEKIT_ENVIRONMENT_URL` / `SCALEKIT_CLIENT_ID` / `SCALEKIT_CLIENT_SECRET`

## Required operator config

- `OPENNEKO_SESSION_SECRET` — random 32+ char string for cookie HMAC (web)
- `OPENNEKO_PUBLIC_URL` — optional; override callback host behind a load balancer
- `openneko install @open-neko/plugin-scalekit` — prompts for the Scalekit env URL + client id + secret

https://claude.ai/code/session_01RVgofVM5wJwYaYMLsNfNSt

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVgofVM5wJwYaYMLsNfNSt)_