### PR TITLE
Wire trial sim + scenario injector into packaged demo

### DIFF
--- a/apps/openneko/assets/compose/demo.yml
+++ b/apps/openneko/assets/compose/demo.yml
@@ -105,6 +105,77 @@ services:
     command: ["node", "packages/db/src/seed-adventureworks.mjs"]
     restart: "no"
 
+  adventureworks-simulator:
+    # Trickles realistic sales orders into the AdventureWorks DB on a
+    # schedule so the workspace reacts during a trial (briefing numbers
+    # drift, cron workflows fire, runs accumulate). Set AW_SIM_ENABLED=0
+    # to disable. Uses the worker image because psql + the tick script
+    # are already baked in at /app/db/seeds/dev/aw-sim-tick.sql; no
+    # bind-mount of repo files needed for the packaged install.
+    image: ghcr.io/open-neko/neko-worker:${OPENNEKO_VERSION:-latest}
+    restart: unless-stopped
+    depends_on:
+      adventureworks-init:
+        condition: service_completed_successfully
+    environment:
+      PGHOST: adventureworks-db
+      PGPORT: 5432
+      PGUSER: ${CUSTOMER_PGUSER:-postgres}
+      PGPASSWORD: ${CUSTOMER_PGPASSWORD:-postgres}
+      PGDATABASE: ${ADVENTUREWORKS_DB:-adventureworks}
+      AW_SIM_INTERVAL_SEC: ${AW_SIM_INTERVAL_SEC:-600}
+      AW_SIM_ORDERS_MIN: ${AW_SIM_ORDERS_MIN:-3}
+      AW_SIM_ORDERS_MAX: ${AW_SIM_ORDERS_MAX:-10}
+      AW_SIM_ENABLED: ${AW_SIM_ENABLED:-1}
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        if [ "$${AW_SIM_ENABLED}" != "1" ]; then
+          echo "[aw-sim] AW_SIM_ENABLED=$${AW_SIM_ENABLED}; sleeping forever"
+          exec tail -f /dev/null
+        fi
+        echo "[aw-sim] starting: interval=$${AW_SIM_INTERVAL_SEC}s, orders=$${AW_SIM_ORDERS_MIN}-$${AW_SIM_ORDERS_MAX} per tick"
+        while true; do
+          ORDERS=$$(awk -v mn=$${AW_SIM_ORDERS_MIN} -v mx=$${AW_SIM_ORDERS_MAX} 'BEGIN{srand(); print int(mn + rand()*(mx-mn+1))}')
+          psql -v ON_ERROR_STOP=1 -c "SET trial_sim.orders_per_tick TO '$$ORDERS'" -f /app/db/seeds/dev/aw-sim-tick.sql \
+            || echo "[aw-sim] tick failed; will retry next interval"
+          sleep "$${AW_SIM_INTERVAL_SEC}"
+        done
+
+  adventureworks-scenario-injector:
+    # L3 scripted-scenario scheduler. On startup: bootstraps trial_sim
+    # schema, then runs advance-dates.sql so demo dates land on or after
+    # CURRENT_DATE (idempotent — gated to once per 12 hours via
+    # trial_sim.state.advance_dates_at). Then loops the scenario
+    # scheduler. Set TRIAL_SIM_ENABLED=0 to disable. Uses the worker
+    # image because all scripts + scenarios + psql are baked at
+    # /app/db/seeds/dev/.
+    image: ghcr.io/open-neko/neko-worker:${OPENNEKO_VERSION:-latest}
+    restart: unless-stopped
+    depends_on:
+      adventureworks-init:
+        condition: service_completed_successfully
+    environment:
+      PGHOST: adventureworks-db
+      PGPORT: 5432
+      PGUSER: ${CUSTOMER_PGUSER:-postgres}
+      PGPASSWORD: ${CUSTOMER_PGPASSWORD:-postgres}
+      PGDATABASE: ${ADVENTUREWORKS_DB:-adventureworks}
+      TRIAL_SIM_TICK_SEC: ${TRIAL_SIM_TICK_SEC:-300}
+      TRIAL_SIM_ENABLED: ${TRIAL_SIM_ENABLED:-1}
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        if [ "$${TRIAL_SIM_ENABLED}" != "1" ]; then
+          echo "[trial-sim] TRIAL_SIM_ENABLED=$${TRIAL_SIM_ENABLED}; sleeping forever"
+          exec tail -f /dev/null
+        fi
+        exec /bin/sh /app/db/seeds/dev/scenario-injector.sh loop
+
   web:
     depends_on:
       graphjin:


### PR DESCRIPTION
## Summary

On packaged installs of the demo (`openneko start --mode demo`), the AdventureWorks dates appeared stuck in 2024-2025 and no fresh orders trickled in. Root cause: the embedded `apps/openneko/assets/compose/demo.yml` was missing both long-lived sim services that the repo-checkout `compose.adventureworks.yml` has:

- **`adventureworks-simulator`** — loops `db/seeds/dev/aw-sim-tick.sql` to trickle new sales orders (default every 10 min, 3-10 orders).
- **`adventureworks-scenario-injector`** — on startup bootstraps the `trial_sim` schema and runs `advance-dates.sql` (idempotent, gated to once per 12h) so historical operational data lands on/after `CURRENT_DATE` instead of staying frozen in 2014. Then loops the L3 scenario scheduler.

Both default-enabled (`AW_SIM_ENABLED=1`, `TRIAL_SIM_ENABLED=1`), so existing operator overrides continue to work; set either to `0` to disable.

## Why this approach

The repo compose bind-mounts `./db/seeds/dev/*` from the host and uses `postgres:16-alpine` for psql. That won't work for a packaged binary install — there's no source checkout to bind-mount from. The fix uses the worker image instead, which already has:

- `postgresql-client` installed (Dockerfile:36)
- The whole `db/` tree baked at `/app/db/` (Dockerfile:200)

So the simulator points at `/app/db/seeds/dev/aw-sim-tick.sql` and the injector points at `/app/db/seeds/dev/scenario-injector.sh` directly — no bind-mounts needed.

## Onboarding seed coverage

While auditing, confirmed the `neko-adventureworks-seed` one-shot (already wired in demo.yml) runs `packages/db/src/seed-adventureworks.mjs`, which seeds:
- organization (AdventureWorks Cycles)
- data_source (GraphJin URL)
- onboarding_wizard (company note, fiscal year, seats, priorities)
- 3 trial workflows (revenue health check, drop alert, slow-ship ops)
- `revenue_alerts_auto` action policy

All embedded migrations are in sync (verified with `scripts/sync-migrations.sh --check`).

## Test plan

- [x] `docker compose -f core.yml -f demo.yml config --quiet` parses clean
- [x] `cd apps/openneko && go build ./... && go test ./internal/compose/...` passes
- [ ] Manual: fresh install, `openneko seed && openneko start --mode demo`, confirm:
  - `docker compose logs adventureworks-scenario-injector` shows `[trial-sim] applying /app/db/seeds/dev/advance-dates.sql` then `[advance-dates] sales.salesorderheader … +N days`
  - `docker compose logs adventureworks-simulator` shows `[aw-sim] starting: interval=600s, orders=3-10 per tick` then periodic tick logs
  - `select max(orderdate) from sales.salesorderheader` lands within ~30 days of today

🤖 Generated with [Claude Code](https://claude.com/claude-code)