### PR TITLE
feat: source_change subscriptions for IFTTT-style data-source row triggers

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -125,17 +125,40 @@ openneko install @example/openneko-plugin-foo
 
 OpenNeko makes no representation about the safety of non-official marketplaces — that trust is between you and the publisher.
 
-## Update
+## Upgrade
+
+OpenNeko upgrades by replacing the `openneko` binary on your machine. The new binary embeds the bumped image pins (so `openneko start` pulls fresh `ghcr.io/open-neko/neko-*` images) and the new migrations (which apply in-process against the existing `neko-db` on next start). There's no `openneko upgrade` subcommand and no version nag — subscribe to [release notifications](https://github.com/open-neko/neko/releases) if you want a push.
+
+### macOS
 
 ```bash
-brew upgrade openneko        # macOS
-openneko stop                # leave volumes intact to preserve config + data
-openneko start --mode demo --detach
+brew update
+brew upgrade openneko
+cd ~/openneko
+openneko stop                          # leaves volumes intact — preserves config, secrets, data
+openneko start --mode demo --detach    # use the same --mode you started with
 ```
 
-`openneko start` always runs any pending migrations against `neko-db` in-process before bringing up the rest of the stack.
+### Linux
 
-For Linux, re-download the latest tarball from the [releases page](https://github.com/open-neko/neko/releases/latest) and replace `/usr/local/bin/openneko`.
+Re-download the matching tarball, replace `/usr/local/bin/openneko`, and restart:
+
+```bash
+curl -fsSL https://github.com/open-neko/neko/releases/latest/download/openneko_$(uname -s | tr A-Z a-z)_$(uname -m | sed s/x86_64/amd64/).tar.gz \
+  | tar -xz openneko
+sudo install -m 0755 openneko /usr/local/bin/
+rm openneko
+cd ~/openneko
+openneko stop                          # leaves volumes intact
+openneko start --mode demo --detach    # use the same --mode you started with
+```
+
+### What happens on `openneko start`
+
+- **Stage 1 — migrate.** Connects to `neko-db`, acquires a Postgres advisory lock, applies any pending migrations from the binary's embedded `db/migrations/*.sql`, releases the lock. Idempotent — interrupted upgrades re-apply cleanly on the next start.
+- **Stage 2 — compose up.** Writes the new embedded compose files to `.openneko/runtime/` and runs `docker compose up`. Docker pulls the `ghcr.io/open-neko/neko-*` image tags pinned to this release.
+
+Data is preserved because `openneko stop` doesn't touch volumes. Use `openneko stop --volumes` only when you want a clean slate — that wipes the metadata DB, the AdventureWorks demo state, and agent workspaces.
 
 ## Reset
 

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ That's the loop: watcher runs → finding lands → action proposed → you appr
 ## Docs
 
 - **Getting started**
-  - [INSTALL.md](INSTALL.md) — install, update, requirements, troubleshooting, connecting your data
+  - [INSTALL.md](INSTALL.md) — install, [upgrade](INSTALL.md#upgrade), requirements, troubleshooting, connecting your data
 - **How it works**
   - [ARCHITECTURE.md](ARCHITECTURE.md) — services, databases, agent runtime, operating-loop wiring (diagrams)
 - **Plugins**

--- a/apps/openneko/assets/migrations/0021_workflow_run_source_writes.sql
+++ b/apps/openneko/assets/migrations/0021_workflow_run_source_writes.sql
@@ -1,0 +1,15 @@
+-- workflow_run.source_writes — array of {table, primary_key} objects
+-- recording which data-source rows the run mutated (via action_request
+-- adapters). Read by match-handler's source_change cycle check to drop
+-- a re-fire whose incoming (table, pk) appears in a recent run of the
+-- same subscription.
+--
+-- jsonb default '[]'::jsonb so existing rows are valid without backfill.
+-- Index uses jsonb_path_ops over the array contents — match-handler
+-- queries with `source_writes @> '[{"table":"...","primary_key":{...}}]'`.
+
+ALTER TABLE workflow_run
+ADD COLUMN source_writes jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+CREATE INDEX workflow_run_source_writes_gin_idx
+  ON workflow_run USING gin (source_writes jsonb_path_ops);

--- a/apps/web/src/app/api/workflows/[workflowId]/subscriptions/dry-run/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/subscriptions/dry-run/route.ts
@@ -1,0 +1,124 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  buildSourceChangeDryRunQuery,
+  getDataSourceForOrg,
+  parseSourceChangeFilter,
+} from "@neko/llm/workflows";
+import { graphjinQuery } from "@neko/llm/graphjin";
+import { getOrgId } from "@/lib/db";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+type RouteContext = {
+  params: Promise<{ workflowId: string }>;
+};
+
+const DRY_RUN_LIMIT = 5;
+
+/**
+ * Compile a proposed source_change filter and execute it as a one-shot
+ * read against the operator's data source. Lets the agent (or operator)
+ * preview which rows a subscription would match before saving it.
+ *
+ * Body: { sourceKind: "source_change", filter: { table, where, primary_key, ... } }
+ */
+export async function POST(req: NextRequest, _context: RouteContext) {
+  const body = await req.json().catch(() => ({}));
+  const sourceKind = body.sourceKind as string | undefined;
+
+  if (sourceKind !== "source_change") {
+    return NextResponse.json(
+      {
+        error:
+          "dry-run currently supports sourceKind=\"source_change\" only",
+        code: "unsupported_source_kind",
+      },
+      { status: 400 },
+    );
+  }
+
+  const filter =
+    typeof body.filter === "object" && body.filter !== null
+      ? (body.filter as Record<string, unknown>)
+      : {};
+
+  const parsed = parseSourceChangeFilter(filter);
+  if (!parsed) {
+    return NextResponse.json(
+      {
+        error:
+          "filter requires { table: string, primary_key: string[] } and optional where/select/version_column (identifiers only)",
+        code: "invalid_filter",
+      },
+      { status: 400 },
+    );
+  }
+
+  const limit =
+    typeof body.limit === "number" && body.limit > 0 && body.limit <= 50
+      ? Math.floor(body.limit)
+      : DRY_RUN_LIMIT;
+
+  const orgId = await getOrgId();
+  const dataSource = await getDataSourceForOrg(orgId);
+  if (!dataSource) {
+    return NextResponse.json(
+      {
+        error:
+          "no data_source configured for this org — source_change subscriptions need a configured data source",
+        code: "no_data_source",
+      },
+      { status: 422 },
+    );
+  }
+
+  const payload = buildSourceChangeDryRunQuery(filter, limit);
+  if (!payload) {
+    return NextResponse.json(
+      { error: "failed to compile filter", code: "compile_failed" },
+      { status: 400 },
+    );
+  }
+
+  let result;
+  try {
+    result = await graphjinQuery({
+      baseUrl: dataSource.graphqlUrl,
+      query: payload.query,
+      variables: payload.variables,
+    });
+  } catch (err) {
+    return NextResponse.json(
+      {
+        error: err instanceof Error ? err.message : String(err),
+        code: "graphjin_error",
+        compiledQuery: payload.query,
+      },
+      { status: 502 },
+    );
+  }
+
+  if (result.errors && result.errors.length > 0) {
+    return NextResponse.json(
+      {
+        error: "graphjin returned errors",
+        code: "graphjin_errors",
+        compiledQuery: payload.query,
+        graphjinErrors: result.errors,
+      },
+      { status: 422 },
+    );
+  }
+
+  const data = (result.data ?? {}) as Record<string, unknown>;
+  const raw = data[parsed.table];
+  const rows: unknown[] = Array.isArray(raw) ? raw : [];
+
+  return NextResponse.json({
+    compiledQuery: payload.query,
+    variables: payload.variables,
+    rowCount: rows.length,
+    rows,
+  });
+}

--- a/apps/web/src/app/api/workflows/[workflowId]/subscriptions/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/subscriptions/route.ts
@@ -2,7 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import {
   checkSubscriptionWouldLoop,
   createSubscription,
+  detectMutationLoop,
+  getDataSourceForOrg,
+  getWorkflow,
   listSubscriptionsByWorkflow,
+  parseSourceChangeFilter,
   SubscriptionSelfLoopError,
   type SubscriptionSourceKind,
 } from "@neko/llm/workflows";
@@ -77,6 +81,52 @@ export async function POST(req: NextRequest, context: RouteContext) {
         );
       }
       throw e;
+    }
+  }
+
+  if (sourceKind === "source_change") {
+    const parsed = parseSourceChangeFilter(filter);
+    if (!parsed) {
+      return NextResponse.json(
+        {
+          error:
+            "source_change filter requires { table: string, primary_key: string[] } and optional where/select/version_column (identifiers only)",
+          code: "invalid_filter",
+        },
+        { status: 400 },
+      );
+    }
+
+    const dataSource = await getDataSourceForOrg(orgId);
+    if (!dataSource) {
+      return NextResponse.json(
+        {
+          error:
+            "no data_source configured for this org — source_change subscriptions need a configured data source",
+          code: "no_data_source",
+        },
+        { status: 422 },
+      );
+    }
+
+    if (!body.acknowledgeMutationLoop) {
+      const workflow = await getWorkflow(orgId, workflowId);
+      if (workflow) {
+        const loopCheck = detectMutationLoop({ filter: parsed, workflow });
+        const hasIdempotency =
+          typeof body.idempotencyKeyTemplate === "string" &&
+          body.idempotencyKeyTemplate.length > 0;
+        if (loopCheck.loops && !hasIdempotency) {
+          return NextResponse.json(
+            {
+              error: loopCheck.reason,
+              code: "mutation_loop",
+              mutationKeyword: loopCheck.mutationKeyword,
+            },
+            { status: 422 },
+          );
+        }
+      }
     }
   }
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -30,12 +30,15 @@ import {
   verifyAiCredentials,
 } from "@neko/llm";
 import {
+  getDataSourceForOrg,
   getWorkflowRunChainDepth,
+  handleSourceChangeMatch,
   handleSubscriptionMatch,
   registerBuiltinAdapters,
   seedDefaultActionPolicies,
   seedPluginActionPolicies,
   startSubscriptionManager,
+  type DataSourceContext,
   type PluginActionSeed,
 } from "@neko/llm/workflows";
 import { ensureOrgWorkspace } from "@neko/llm/work";
@@ -466,24 +469,65 @@ await b.schedule(QUEUE.WORKFLOW_OUTPUT_TTL_SWEEP, "0 * * * *", {}, {
 });
 console.log("[worker] scheduled workflow_output ttl sweep hourly");
 
+type CachedDataSource = { ctx: DataSourceContext; expiresAt: number };
+const DATA_SOURCE_CACHE_MS = 60_000;
+const dataSourceCache = new Map<string, CachedDataSource>();
+
+async function loadDataSourceContext(orgId: string): Promise<DataSourceContext> {
+  const now = Date.now();
+  const cached = dataSourceCache.get(orgId);
+  if (cached && cached.expiresAt > now) return cached.ctx;
+  const ctx = await getDataSourceForOrg(orgId);
+  if (!ctx) throw new Error(`no data_source configured for org ${orgId}`);
+  dataSourceCache.set(orgId, { ctx, expiresAt: now + DATA_SOURCE_CACHE_MS });
+  return ctx;
+}
+
 const subscriptionManager = startSubscriptionManager({
-  baseUrl: GRAPHJIN_URL,
+  resolveTransport: async (sub) => {
+    if (sub.sourceKind === "source_change") {
+      const ctx = await loadDataSourceContext(sub.orgId);
+      return { baseUrl: ctx.subscriptionUrl ?? ctx.graphqlUrl };
+    }
+    return { baseUrl: GRAPHJIN_URL };
+  },
   refreshIntervalMs: 60_000,
   onMatch: async (event) => {
-    if (event.kind !== "workflow_output") return;
-    const decision = await handleSubscriptionMatch({
-      subscription: event.subscription,
-      output: event.output,
-      resolveProducingRunChainDepth: getWorkflowRunChainDepth,
-    });
-    if (decision.action === "dropped") {
-      console.log(
-        `[subscription-manager] dropped match sub=${event.subscription.id} output=${event.output.id}: ${decision.reason}`,
-      );
-    } else {
-      console.log(
-        `[subscription-manager] enqueued sub=${event.subscription.id} output=${event.output.id} obs=${decision.observationId}`,
-      );
+    if (event.kind === "workflow_output") {
+      const decision = await handleSubscriptionMatch({
+        subscription: event.subscription,
+        output: event.output,
+        resolveProducingRunChainDepth: getWorkflowRunChainDepth,
+      });
+      if (decision.action === "dropped") {
+        console.log(
+          `[subscription-manager] dropped match sub=${event.subscription.id} output=${event.output.id}: ${decision.reason}`,
+        );
+      } else {
+        console.log(
+          `[subscription-manager] enqueued sub=${event.subscription.id} output=${event.output.id} obs=${decision.observationId}`,
+        );
+      }
+      return;
+    }
+    if (event.kind === "source_change") {
+      const ctx = await loadDataSourceContext(event.subscription.orgId);
+      const decision = await handleSourceChangeMatch({
+        subscription: event.subscription,
+        match: event.match,
+        dataSourceId: ctx.id,
+      });
+      const pk = JSON.stringify(event.match.primary_key);
+      if (decision.action === "dropped") {
+        console.log(
+          `[subscription-manager] dropped source_change sub=${event.subscription.id} ${event.match.table}:${pk}: ${decision.reason}`,
+        );
+      } else {
+        console.log(
+          `[subscription-manager] enqueued source_change sub=${event.subscription.id} ${event.match.table}:${pk} obs=${decision.observationId}`,
+        );
+      }
+      return;
     }
   },
   onError: (err, sub) => {

--- a/db/graphjin/dev.example.yml
+++ b/db/graphjin/dev.example.yml
@@ -18,6 +18,12 @@ cors_allowed_origins:
 default_limit: 20
 enable_tracing: true
 
+# Subscription polling — GraphJin re-runs each subscription's query on this
+# cadence and pushes new matches over the WebSocket. Latency for source_change
+# triggers is bounded by this interval. 5s is a safe default for an operational
+# DB; tune down on quiet schemas, up on busy ones.
+subs_poll_duration: 5s
+
 mcp:
   disable: false
   allow_config_updates: false

--- a/db/migrations/0021_workflow_run_source_writes.sql
+++ b/db/migrations/0021_workflow_run_source_writes.sql
@@ -1,0 +1,15 @@
+-- workflow_run.source_writes — array of {table, primary_key} objects
+-- recording which data-source rows the run mutated (via action_request
+-- adapters). Read by match-handler's source_change cycle check to drop
+-- a re-fire whose incoming (table, pk) appears in a recent run of the
+-- same subscription.
+--
+-- jsonb default '[]'::jsonb so existing rows are valid without backfill.
+-- Index uses jsonb_path_ops over the array contents — match-handler
+-- queries with `source_writes @> '[{"table":"...","primary_key":{...}}]'`.
+
+ALTER TABLE workflow_run
+ADD COLUMN source_writes jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+CREATE INDEX workflow_run_source_writes_gin_idx
+  ON workflow_run USING gin (source_writes jsonb_path_ops);

--- a/db/seeds/dev/scenarios/low-stock-reorder.sql
+++ b/db/seeds/dev/scenarios/low-stock-reorder.sql
@@ -1,0 +1,46 @@
+-- low-stock-reorder.sql
+-- Drops the on-hand quantity for one popular product below its reorder
+-- point. The "Stock Reorder Watch" workflow has a source_change
+-- subscription on productinventory; GraphJin re-polls every 5s
+-- (subs_poll_duration in db/graphjin/dev.example.yml) so the workflow
+-- should fire within seconds of this script committing.
+--
+-- Picks the highest-quantity inventory row that's currently well above
+-- reorder, so the drop is meaningful (i.e. a real "now below reorder"
+-- event, not a row that was already below). Robust to whatever AW data
+-- the operator's stack happens to have loaded.
+
+\set ON_ERROR_STOP on
+
+DO $$
+DECLARE
+  v_productid int;
+  v_locationid int;
+  v_reorder smallint;
+  v_target_quantity smallint;
+  v_product_name varchar;
+BEGIN
+  SELECT pi.productid, pi.locationid, p.reorderpoint, p.name
+  INTO v_productid, v_locationid, v_reorder, v_product_name
+  FROM production.productinventory pi
+  JOIN production.product p ON p.productid = pi.productid
+  WHERE pi.quantity > p.reorderpoint + 50
+    AND p.finishedgoodsflag = 1
+  ORDER BY pi.quantity DESC
+  LIMIT 1;
+
+  IF v_productid IS NULL THEN
+    RAISE NOTICE '[trial-sim] low-stock-reorder: no eligible product found (every row already at or below reorder + 50)';
+    RETURN;
+  END IF;
+
+  v_target_quantity := GREATEST(v_reorder - 5, 0)::smallint;
+
+  UPDATE production.productinventory
+  SET quantity = v_target_quantity,
+      modifieddate = now()
+  WHERE productid = v_productid AND locationid = v_locationid;
+
+  RAISE NOTICE '[trial-sim] low-stock-reorder: % (productid=%, locationid=%) quantity → % (reorder=%)',
+    v_product_name, v_productid, v_locationid, v_target_quantity, v_reorder;
+END $$;

--- a/db/seeds/dev/trial-sim-schema.sql
+++ b/db/seeds/dev/trial-sim-schema.sql
@@ -202,7 +202,9 @@ VALUES
   ('france-takeover',         'france-takeover.sql',          150,  '0 22 * * 0',  'UTC',
    'top-territory-watch',     ARRAY['briefing','run']),
   ('approved-action-history', 'approved-action-history.sql',  NULL, '0 0 * * *',   'UTC',
-   NULL,                      ARRAY[]::text[])
+   NULL,                      ARRAY[]::text[]),
+  ('low-stock-reorder',       'low-stock-reorder.sql',        15,   '0 13 * * 4',  'UTC',
+   'stock-reorder-watch',     ARRAY['briefing','run'])
 ON CONFLICT (id) DO UPDATE SET
   sql_path               = EXCLUDED.sql_path,
   initial_offset_minutes = EXCLUDED.initial_offset_minutes,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -697,6 +697,9 @@ export const workflow_run = pgTable(
     finished_at: ts("finished_at"),
     summary: text("summary"),
     error: text("error"),
+    source_writes: jsonb("source_writes")
+      .notNull()
+      .default(sql`'[]'::jsonb`),
     created_at: ts("created_at").notNull().defaultNow(),
     updated_at: ts("updated_at").notNull().defaultNow(),
   },

--- a/packages/db/src/seed-adventureworks.mjs
+++ b/packages/db/src/seed-adventureworks.mjs
@@ -81,10 +81,11 @@ const sourceRows = await client.query(
 );
 if (sourceRows.rowCount === 0) {
   await client.query(
-    `insert into data_source (org_id, kind, graphql_url, mcp_url, label)
-     values ($1, 'graphjin', $2, $3, 'AdventureWorks')`,
+    `insert into data_source (org_id, kind, graphql_url, subscription_url, mcp_url, label)
+     values ($1, 'graphjin', $2, $3, $4, 'AdventureWorks')`,
     [
       orgId,
+      `${DEFAULT_GRAPHJIN_ROOT}/api/v1/graphql`,
       `${DEFAULT_GRAPHJIN_ROOT}/api/v1/graphql`,
       `${DEFAULT_GRAPHJIN_ROOT}/api/v1/mcp`,
     ],
@@ -154,18 +155,61 @@ if (wfRows.rowCount === 0) {
       cron: "30 8 * * *",
       cron_timezone: "UTC",
     },
+    {
+      name: "Stock Reorder Watch",
+      description: "Reacts to inventory rows that drop below the product's reorder point. Subscription-triggered (no cron); fires per low-stock row.",
+      goal: "Triggered by a source_change subscription on production.productinventory when a row's quantity falls below the related product's reorderpoint. The trigger_payload includes table, primary_key={productid,locationid}, and snapshot. Query AdventureWorks via GraphJin to fetch the product name, current quantity, reorderpoint, and listprice. Emit one workflow_output with kind=recommendation, mood=act, scope='inventory', topic='reorder_point' summarizing the gap and recommending a reorder quantity. Do NOT mutate productinventory or productorders here — the responder reads only.",
+      cron: null,
+      cron_timezone: null,
+    },
   ];
   for (const wf of trialWorkflows) {
+    const hasCron = wf.cron !== null && wf.cron !== undefined;
     await client.query(
       `insert into workflow_definition (
          org_id, name, description, goal, cron, cron_timezone,
          cron_enabled, enabled, status
-       ) values ($1, $2, $3, $4, $5, $6, true, true, 'active')
+       ) values ($1, $2, $3, $4, $5, $6, $7, true, 'active')
        on conflict (org_id, name) do nothing`,
-      [orgId, wf.name, wf.description, wf.goal, wf.cron, wf.cron_timezone],
+      [
+        orgId,
+        wf.name,
+        wf.description,
+        wf.goal,
+        wf.cron,
+        wf.cron_timezone ?? "UTC",
+        hasCron,
+      ],
     );
   }
   console.log(`[seed-adventureworks] inserted ${trialWorkflows.length} trial workflows`);
+
+  const stockWatchRows = await client.query(
+    "select id from workflow_definition where org_id = $1 and name = 'Stock Reorder Watch' limit 1",
+    [orgId],
+  );
+  const stockWatchWorkflowId = stockWatchRows.rows[0]?.id;
+  if (stockWatchWorkflowId) {
+    await client.query(
+      `insert into subscription (
+         org_id, workflow_id, source_kind, filter, enabled,
+         max_concurrent_runs, idempotency_key_template
+       ) values ($1, $2, 'source_change', $3::jsonb, true, 5, $4)`,
+      [
+        orgId,
+        stockWatchWorkflowId,
+        JSON.stringify({
+          table: "productinventory",
+          where: { quantity: { lt: { col: "product.reorderpoint" } } },
+          primary_key: ["productid", "locationid"],
+          version_column: "modifieddate",
+          select: ["quantity"],
+        }),
+        "reorder-{primary_key}",
+      ],
+    );
+    console.log("[seed-adventureworks] wired Stock Reorder Watch subscription");
+  }
 } else {
   console.log("[seed-adventureworks] workflows already exist; leaving them unchanged");
 }

--- a/packages/llm/src/work/prompt.ts
+++ b/packages/llm/src/work/prompt.ts
@@ -102,7 +102,47 @@ When updating: list first, then call create_workflow with the SAME
 \`name\` and the modified fields. Narrate the change in plain language
 before calling the tool — the tool also emits a confirmation card with a
 link to the detail page.
-</workflows>`;
+</workflows>
+
+<subscriptions>
+The operator can ask you to make a workflow fire when something changes
+in their data ("alert me when stock drops below reorder point"; "fire
+the renewal workflow when an account's status flips to at_risk"). This
+is the IFTTT pattern — the trigger is a row change in the data source,
+the action is one of your workflows.
+
+The flow:
+1. Create the responder workflow first via \`create_workflow\` (cronless;
+   it'll be subscription-triggered).
+2. Introspect the data source with the GraphJin MCP — \`list_tables\` to
+   find candidates, \`describe_table\` to confirm column names + the
+   primary key, \`get_table_sample\` if you need to see real values.
+3. Call \`mcp__neko_subscription_builder__dry_run_subscription\` with the
+   proposed \`filter\` to confirm the rows match the operator's intent.
+4. Call \`mcp__neko_subscription_builder__create_subscription\` to wire
+   the responder workflow to the trigger.
+
+Filter shape:
+\`\`\`json
+{
+  "table": "productinventory",
+  "where": { "quantity": { "lt": { "col": "product.reorderpoint" } } },
+  "primary_key": ["productid", "locationid"],
+  "version_column": "modifieddate",
+  "select": ["quantity"]
+}
+\`\`\`
+\`primary_key\` is required and drives idempotency (the same row can't
+re-trigger within an hour). \`where\` goes verbatim into the GraphJin
+subscription — use nested-table EXISTS (\`{ product: { … } }\`) and
+column-reference operands (\`{ col: "…" }\`) freely.
+
+If the responder workflow writes back to the watched table, the
+\`create_subscription\` tool will return \`code: "mutation_loop"\`.
+Resolve it by adding an \`idempotency_key_template\` (e.g.
+\`"reorder-{primary_key}"\`) — never blindly pass
+\`acknowledge_mutation_loop: true\` without confirming with the operator.
+</subscriptions>`;
   }
   return `<workflows>
 The operator can ask you to set up or modify workflows directly in chat.

--- a/packages/llm/src/work/run-chat-turn.ts
+++ b/packages/llm/src/work/run-chat-turn.ts
@@ -9,6 +9,7 @@ import {
 } from "../workflows/fence-parsers";
 import {
   buildPolicyBuilderServer,
+  buildSubscriptionBuilderServer,
   buildWorkflowBuilderServer,
   handleWorkActionRequest,
   policySavedCard,
@@ -247,6 +248,10 @@ export async function runChatTurn(
                   orgId,
                   createdByThreadId: threadId,
                   createdByRunId: runId,
+                  emit: wrappedEmit,
+                }),
+                neko_subscription_builder: buildSubscriptionBuilderServer({
+                  orgId,
                   emit: wrappedEmit,
                 }),
               }

--- a/packages/llm/src/workflows/builder-cards.ts
+++ b/packages/llm/src/workflows/builder-cards.ts
@@ -1,6 +1,7 @@
 import type { AgentSurfaceMessage } from "../agent-backend";
 import type { ActionPolicyRecord } from "./action-store";
-import type { WorkflowRecord } from "./store";
+import type { SubscriptionRecord, WorkflowRecord } from "./store";
+import type { SourceChangeFilter } from "./subscription-query";
 
 function briefingCard(args: {
   surfaceId: string;
@@ -55,6 +56,40 @@ export function workflowSavedCard(args: {
       "",
       `[Open detail](/workflows?id=${args.workflow.id})`,
     ].join("\n"),
+  });
+}
+
+export function subscriptionSavedCard(args: {
+  subscription: SubscriptionRecord;
+  workflowName: string;
+}): AgentSurfaceMessage[] {
+  const filter = args.subscription.filter as Partial<SourceChangeFilter>;
+  const table = typeof filter.table === "string" ? filter.table : "?";
+  const pkList = Array.isArray(filter.primary_key)
+    ? filter.primary_key.join(", ")
+    : "?";
+  const whereSummary =
+    filter.where && Object.keys(filter.where).length > 0
+      ? "`" +
+        Object.keys(filter.where as Record<string, unknown>).join("`, `") +
+        "`"
+      : "_(no filter)_";
+  return briefingCard({
+    surfaceId: `subscription-save-${args.subscription.id}`,
+    greeting: "Wired subscription",
+    subtitle: args.workflowName,
+    body: [
+      `**${args.workflowName}** will fire on changes to \`${table}\` (pk: \`${pkList}\`).`,
+      "",
+      `**Filter columns:** ${whereSummary}`,
+      args.subscription.idempotencyKeyTemplate
+        ? `**Idempotency key:** \`${args.subscription.idempotencyKeyTemplate}\``
+        : null,
+      "",
+      `[Open detail](/workflows?id=${args.subscription.workflowId})`,
+    ]
+      .filter((s) => s !== null)
+      .join("\n"),
   });
 }
 

--- a/packages/llm/src/workflows/cycle-detection.ts
+++ b/packages/llm/src/workflows/cycle-detection.ts
@@ -2,8 +2,12 @@ import { db, sql } from "@neko/db";
 import {
   listRecentOutputsByWorkflow as defaultListRecent,
   type RecentOutputSummary,
+  type WorkflowRecord,
 } from "./store";
-import type { WorkflowOutputFilter } from "./subscription-query";
+import type {
+  SourceChangeFilter,
+  WorkflowOutputFilter,
+} from "./subscription-query";
 
 export type FilterableOutput = {
   scope: string | null;
@@ -125,4 +129,54 @@ export async function checkSubscriptionWouldLoop(
     `Subscription filter matches ${matches.length} of this workflow's recent output(s) — this would create a self-loop. Narrow the filter (scope, mood, kinds) so the workflow's own outputs no longer match.`,
     matches.map((m) => m.id),
   );
+}
+
+export type MutationLoopCheck =
+  | { loops: false }
+  | { loops: true; reason: string; mutationKeyword: string };
+
+const MUTATION_KEYWORDS = [
+  "update",
+  "insert",
+  "write",
+  "mutate",
+  "modify",
+  "set",
+  "delete",
+  "upsert",
+  "patch",
+  "create",
+] as const;
+
+/**
+ * Save-time mutation-loop heuristic for source_change subscriptions. If the
+ * consumer workflow's text (goal + description + steps) mentions both the
+ * watched table and a mutation verb, the responder is likely to write back
+ * to the table and re-trigger itself. Best-effort — false positives are
+ * possible; operators can override by setting idempotency_key_template or
+ * acknowledging the warning explicitly.
+ */
+export function detectMutationLoop(args: {
+  filter: SourceChangeFilter;
+  workflow: Pick<WorkflowRecord, "goal" | "description" | "steps">;
+}): MutationLoopCheck {
+  const corpus = [
+    args.workflow.goal ?? "",
+    args.workflow.description ?? "",
+    ...args.workflow.steps.map((s) => s.description),
+  ]
+    .join("\n")
+    .toLowerCase();
+
+  const tableLower = args.filter.table.toLowerCase();
+  if (!corpus.includes(tableLower)) return { loops: false };
+
+  const keyword = MUTATION_KEYWORDS.find((w) => corpus.includes(w));
+  if (!keyword) return { loops: false };
+
+  return {
+    loops: true,
+    mutationKeyword: keyword,
+    reason: `consumer workflow text mentions "${args.filter.table}" and the mutation verb "${keyword}" — it may write back to the watched table and re-trigger itself. Set idempotency_key_template (e.g. include {primary_key}) or pass acknowledgeMutationLoop: true to confirm.`,
+  };
 }

--- a/packages/llm/src/workflows/index.ts
+++ b/packages/llm/src/workflows/index.ts
@@ -35,10 +35,18 @@ export {
   type WorkflowBuilderContext,
 } from "./builder-server";
 export {
+  buildSubscriptionBuilderServer,
+  type SubscriptionBuilderContext,
+} from "./subscription-builder-server";
+export {
   buildPolicyBuilderServer,
   type PolicyBuilderContext,
 } from "./policy-builder-server";
-export { policySavedCard, workflowSavedCard } from "./builder-cards";
+export {
+  policySavedCard,
+  subscriptionSavedCard,
+  workflowSavedCard,
+} from "./builder-cards";
 export { buildWorkflowOutputServer } from "./output-server";
 export { buildWorkflowRunnerPrompt } from "./runner-prompt";
 export {
@@ -70,10 +78,12 @@ export {
   deleteSubscription,
   emitWorkflowOutput,
   finishWorkflowRun,
+  getDataSourceForOrg,
   getObservation,
   getWorkflow,
   getWorkflowByOrgName,
   getWorkflowRunChainDepth,
+  hasRecentSourceWriteForWorkflow,
   linkOutputSourceObservations,
   listRecentOutputsByWorkflow,
   listCronWorkflows,
@@ -85,9 +95,11 @@ export {
   saveWorkflow,
   setSubscriptionEnabled,
   startOfTodayUtc,
+  writeSourceChangeLog,
   type CreateObservationInput,
   type CreateSubscriptionInput,
   type CreateWorkflowRunInput,
+  type DataSourceContext,
   type ObservationConsumerKind,
   type ObservationRecord,
   type SaveWorkflowInput,
@@ -102,8 +114,14 @@ export {
   type WorkflowTriggers,
 } from "./store";
 export {
+  buildSourceChangeDryRunQuery,
   buildSubscriptionQuery,
+  parseSourceChangeFilter,
+  parseSourceChangeMatch,
   parseWorkflowOutputMatch,
+  type JsonScalar,
+  type SourceChangeFilter,
+  type SourceChangeMatch,
   type SubscriptionQueryPayload,
   type WorkflowOutputFilter,
   type WorkflowOutputMatch,
@@ -113,19 +131,25 @@ export {
   type SubscriptionManagerHandle,
   type SubscriptionManagerOptions,
   type SubscriptionMatchEvent,
+  type SubscriptionTransport,
+  type ResolveTransport,
 } from "./subscription-manager";
 export {
+  handleSourceChangeMatch,
   handleSubscriptionMatch,
+  type HandleSourceChangeMatchOptions,
   type HandleSubscriptionMatchOptions,
   type MatchHandlerDecision,
 } from "./match-handler";
 export {
   checkSubscriptionWouldLoop,
+  detectMutationLoop,
   isWorkflowInAncestorChain,
   outputMatchesFilter,
   SubscriptionSelfLoopError,
   type CheckSubscriptionWouldLoopOptions,
   type FilterableOutput,
+  type MutationLoopCheck,
 } from "./cycle-detection";
 export {
   approveActionRequest,

--- a/packages/llm/src/workflows/match-handler.ts
+++ b/packages/llm/src/workflows/match-handler.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { enqueue as defaultEnqueue, QUEUE } from "@neko/db/jobs";
 import { isWorkflowInAncestorChain as defaultIsCycle } from "./cycle-detection";
 import {
@@ -6,10 +7,17 @@ import {
   countWorkflowRunsSince as defaultCountRunsSince,
   createObservation as defaultCreateObservation,
   getWorkflow as defaultGetWorkflow,
+  hasRecentSourceWriteForWorkflow as defaultHasRecentSourceWrite,
   startOfTodayUtc,
+  writeSourceChangeLog as defaultWriteSourceChangeLog,
   type SubscriptionRecord,
+  type WorkflowRecord,
 } from "./store";
-import type { WorkflowOutputMatch } from "./subscription-query";
+import type {
+  JsonScalar,
+  SourceChangeMatch,
+  WorkflowOutputMatch,
+} from "./subscription-query";
 
 export type MatchHandlerDecision =
   | { action: "enqueued"; observationId: string; jobId: string | null }
@@ -35,15 +43,29 @@ export type HandleSubscriptionMatchOptions = {
   ) => Promise<number | null>;
 };
 
+export type HandleSourceChangeMatchOptions = {
+  subscription: SubscriptionRecord;
+  match: SourceChangeMatch;
+  dataSourceId: string;
+  fanoutWindowMs?: number;
+  /** Override for tests. */
+  enqueue?: typeof defaultEnqueue;
+  createObservation?: typeof defaultCreateObservation;
+  countWorkflowRunsForSubscription?: typeof defaultCountInFlight;
+  countWorkflowRunsSince?: typeof defaultCountRunsSince;
+  getWorkflow?: typeof defaultGetWorkflow;
+  hasRecentSourceWriteForWorkflow?: typeof defaultHasRecentSourceWrite;
+  writeSourceChangeLog?: typeof defaultWriteSourceChangeLog;
+};
+
 const DEFAULT_MAX_CHAIN_DEPTH = 20;
 const DEFAULT_MAX_FANOUT_PER_OUTPUT = 32;
 const DEFAULT_FANOUT_WINDOW_MS = 60_000;
 
 /**
- * Handle a subscription match: enforce loop-safety limits, write a
- * consumer-side observation row, then enqueue a WORKFLOW_RUN_FIRE job
- * for the consuming workflow. Returns the decision so callers can log
- * or assert against it.
+ * Handle a workflow_output subscription match: enforce loop-safety limits,
+ * write a consumer-side observation row, then enqueue a WORKFLOW_RUN_FIRE
+ * job for the consuming workflow.
  */
 export async function handleSubscriptionMatch(
   opts: HandleSubscriptionMatchOptions,
@@ -85,10 +107,6 @@ export async function handleSubscriptionMatch(
     }
   }
 
-  // Precise cycle check: walk the lineage backwards from the producing
-  // run. If the consumer workflow already appears in the chain, firing
-  // would close a cycle. Catches multi-workflow loops (A→B→A) and any
-  // misauthored self-subscription the save-time check missed.
   const cycle = await isCycle(
     opts.output.workflow_run_id,
     opts.subscription.workflowId,
@@ -108,31 +126,13 @@ export async function handleSubscriptionMatch(
     };
   }
 
-  const inFlight = await countInFlight(opts.subscription.id, "running");
-  if (inFlight >= opts.subscription.maxConcurrentRuns) {
-    return {
-      action: "dropped",
-      reason: `subscription ${opts.subscription.id} at max_concurrent_runs (${inFlight}/${opts.subscription.maxConcurrentRuns})`,
-    };
-  }
-
-  const consumer = await getWorkflow(
-    opts.subscription.orgId,
-    opts.subscription.workflowId,
-  );
-  if (consumer?.dailyRunBudget !== null && consumer?.dailyRunBudget !== undefined) {
-    const ranToday = await countRunsSince(
-      opts.subscription.orgId,
-      opts.subscription.workflowId,
-      startOfTodayUtc(),
-    );
-    if (ranToday >= consumer.dailyRunBudget) {
-      return {
-        action: "dropped",
-        reason: `consumer workflow ${opts.subscription.workflowId} reached daily_run_budget (${ranToday}/${consumer.dailyRunBudget})`,
-      };
-    }
-  }
+  const guard = await applyDeliveryGuards({
+    subscription: opts.subscription,
+    countInFlight,
+    countRunsSince,
+    getWorkflow,
+  });
+  if (!guard.allowed) return { action: "dropped", reason: guard.reason };
 
   const observationRow = await createObservation({
     orgId: opts.subscription.orgId,
@@ -144,7 +144,10 @@ export async function handleSubscriptionMatch(
     mood: (opts.output.mood as "good" | "watch" | "act" | null) ?? null,
   });
 
-  const singletonKey = buildIdempotencyKey(opts.subscription, opts.output);
+  const singletonKey = buildWorkflowOutputIdempotencyKey(
+    opts.subscription,
+    opts.output,
+  );
 
   const jobId = await enqueue(
     QUEUE.WORKFLOW_RUN_FIRE,
@@ -174,7 +177,150 @@ export async function handleSubscriptionMatch(
   };
 }
 
-function buildIdempotencyKey(
+/**
+ * Handle a source_change subscription match: detect the responder-write cycle
+ * via `workflow_run.source_writes`, write an audit row to source_change_log,
+ * write a consumer-side observation (no source_output_id — the trigger came
+ * from the operator's data, not an OpenNeko workflow), then enqueue
+ * WORKFLOW_RUN_FIRE.
+ */
+export async function handleSourceChangeMatch(
+  opts: HandleSourceChangeMatchOptions,
+): Promise<MatchHandlerDecision> {
+  const enqueue = opts.enqueue ?? defaultEnqueue;
+  const createObservation = opts.createObservation ?? defaultCreateObservation;
+  const countInFlight =
+    opts.countWorkflowRunsForSubscription ?? defaultCountInFlight;
+  const countRunsSince =
+    opts.countWorkflowRunsSince ?? defaultCountRunsSince;
+  const getWorkflow = opts.getWorkflow ?? defaultGetWorkflow;
+  const hasRecentSourceWrite =
+    opts.hasRecentSourceWriteForWorkflow ?? defaultHasRecentSourceWrite;
+  const writeAudit = opts.writeSourceChangeLog ?? defaultWriteSourceChangeLog;
+  const fanoutWindowMs = opts.fanoutWindowMs ?? DEFAULT_FANOUT_WINDOW_MS;
+
+  const recentWrite = await hasRecentSourceWrite({
+    workflowId: opts.subscription.workflowId,
+    table: opts.match.table,
+    primaryKey: opts.match.primary_key,
+    sinceMs: fanoutWindowMs,
+  });
+  if (recentWrite) {
+    return {
+      action: "dropped",
+      reason: `cycle detected — workflow ${opts.subscription.workflowId} recently wrote to ${opts.match.table}:${JSON.stringify(opts.match.primary_key)}`,
+    };
+  }
+
+  const guard = await applyDeliveryGuards({
+    subscription: opts.subscription,
+    countInFlight,
+    countRunsSince,
+    getWorkflow,
+  });
+  if (!guard.allowed) return { action: "dropped", reason: guard.reason };
+
+  const pkSummary = summarizePrimaryKey(opts.match.primary_key);
+  const observationRow = await createObservation({
+    orgId: opts.subscription.orgId,
+    sourceOutputId: null,
+    consumerKind: "workflow",
+    consumerWorkflowId: opts.subscription.workflowId,
+    subscriptionId: opts.subscription.id,
+    title: `${opts.match.table} ${pkSummary}`,
+    body: JSON.stringify(opts.match.snapshot).slice(0, 4_000),
+    mood: null,
+  });
+
+  await writeAudit({
+    orgId: opts.subscription.orgId,
+    sourceId: opts.dataSourceId,
+    tableName: opts.match.table,
+    changeKind: "subscription_match",
+    payload: {
+      subscription_id: opts.subscription.id,
+      observation_id: observationRow.id,
+      primary_key: opts.match.primary_key,
+      snapshot: opts.match.snapshot,
+      version_token: opts.match.version_token,
+    },
+  });
+
+  const singletonKey = buildSourceChangeIdempotencyKey(
+    opts.subscription,
+    opts.match,
+  );
+
+  const jobId = await enqueue(
+    QUEUE.WORKFLOW_RUN_FIRE,
+    {
+      orgId: opts.subscription.orgId,
+      workflowId: opts.subscription.workflowId,
+      triggerKind: "subscription" as const,
+      triggerPayload: {
+        subscription_id: opts.subscription.id,
+        observation_id: observationRow.id,
+        table: opts.match.table,
+        primary_key: opts.match.primary_key,
+        snapshot: opts.match.snapshot,
+        version_token: opts.match.version_token,
+      },
+      triggeredBySubscriptionId: opts.subscription.id,
+      triggeredByObservationId: observationRow.id,
+    },
+    {
+      singletonKey,
+      singletonHours: 1,
+    },
+  );
+
+  return {
+    action: "enqueued",
+    observationId: observationRow.id,
+    jobId,
+  };
+}
+
+type GuardArgs = {
+  subscription: SubscriptionRecord;
+  countInFlight: typeof defaultCountInFlight;
+  countRunsSince: typeof defaultCountRunsSince;
+  getWorkflow: typeof defaultGetWorkflow;
+};
+
+type GuardResult =
+  | { allowed: true }
+  | { allowed: false; reason: string };
+
+async function applyDeliveryGuards(args: GuardArgs): Promise<GuardResult> {
+  const inFlight = await args.countInFlight(args.subscription.id, "running");
+  if (inFlight >= args.subscription.maxConcurrentRuns) {
+    return {
+      allowed: false,
+      reason: `subscription ${args.subscription.id} at max_concurrent_runs (${inFlight}/${args.subscription.maxConcurrentRuns})`,
+    };
+  }
+  const consumer: WorkflowRecord | null = await args.getWorkflow(
+    args.subscription.orgId,
+    args.subscription.workflowId,
+  );
+  if (consumer?.dailyRunBudget != null) {
+    const ranToday = await args.countRunsSince(
+      args.subscription.orgId,
+      args.subscription.workflowId,
+      startOfTodayUtc(),
+    );
+    if (ranToday >= consumer.dailyRunBudget) {
+      return {
+        allowed: false,
+        reason: `consumer workflow ${args.subscription.workflowId} reached daily_run_budget (${ranToday}/${consumer.dailyRunBudget})`,
+      };
+    }
+  }
+  return { allowed: true };
+}
+
+function buildWorkflowOutputIdempotencyKey(
   sub: SubscriptionRecord,
   output: WorkflowOutputMatch,
 ): string {
@@ -185,4 +331,35 @@ function buildIdempotencyKey(
       .replace("{source_version}", output.created_at);
   }
   return `${sub.id}:${output.id}:${output.created_at}`;
+}
+
+function buildSourceChangeIdempotencyKey(
+  sub: SubscriptionRecord,
+  match: SourceChangeMatch,
+): string {
+  const pkHash = hashPrimaryKey(match.primary_key);
+  const versionToken = match.version_token ?? "none";
+  if (sub.idempotencyKeyTemplate) {
+    return sub.idempotencyKeyTemplate
+      .replace("{subscription_id}", sub.id)
+      .replace("{source_record_id}", pkHash)
+      .replace("{primary_key}", pkHash)
+      .replace("{source_version}", versionToken);
+  }
+  return `${sub.id}:${pkHash}:${versionToken}`;
+}
+
+function hashPrimaryKey(pk: Record<string, JsonScalar>): string {
+  const parts = Object.entries(pk)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${v == null ? "" : String(v)}`);
+  return createHash("sha256")
+    .update(parts.join(""))
+    .digest("hex")
+    .slice(0, 16);
+}
+
+function summarizePrimaryKey(pk: Record<string, JsonScalar>): string {
+  const parts = Object.entries(pk).map(([k, v]) => `${k}=${v == null ? "" : String(v)}`);
+  return parts.length === 0 ? "()" : `(${parts.join(", ")})`;
 }

--- a/packages/llm/src/workflows/store.ts
+++ b/packages/llm/src/workflows/store.ts
@@ -1,10 +1,12 @@
 import {
   and,
+  data_source,
   db,
   desc,
   eq,
   inArray,
   observation,
+  source_change_log,
   sql,
   subscription,
   workflow_definition,
@@ -771,4 +773,87 @@ export async function listRecentOutputsByWorkflow(
     mood: r.mood,
     createdAt: r.created_at,
   }));
+}
+
+// ─── data_source helpers ────────────────────────────────────────────────────
+
+export type DataSourceContext = {
+  id: string;
+  graphqlUrl: string;
+  subscriptionUrl: string | null;
+  mcpUrl: string | null;
+};
+
+export async function getDataSourceForOrg(
+  orgId: string,
+): Promise<DataSourceContext | null> {
+  const rows = await db()
+    .select({
+      id: data_source.id,
+      graphql_url: data_source.graphql_url,
+      subscription_url: data_source.subscription_url,
+      mcp_url: data_source.mcp_url,
+    })
+    .from(data_source)
+    .where(eq(data_source.org_id, orgId))
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    id: row.id,
+    graphqlUrl: row.graphql_url,
+    subscriptionUrl: row.subscription_url,
+    mcpUrl: row.mcp_url,
+  };
+}
+
+// ─── source_change helpers ──────────────────────────────────────────────────
+
+/**
+ * Has any recent workflow_run of `workflowId` mutated (table, primaryKey)?
+ * Backs the source_change cycle check — a responder workflow that writes
+ * back to the table it's subscribed to would otherwise re-trigger itself.
+ * Adapters populate `workflow_run.source_writes` (jsonb array of
+ * `{table, primary_key}`); we check containment via `@>`.
+ */
+export async function hasRecentSourceWriteForWorkflow(args: {
+  workflowId: string;
+  table: string;
+  primaryKey: Record<string, unknown>;
+  sinceMs: number;
+}): Promise<boolean> {
+  const since = new Date(Date.now() - args.sinceMs);
+  const needle = JSON.stringify([
+    { table: args.table, primary_key: args.primaryKey },
+  ]);
+  const rows = await db()
+    .select({ id: workflow_run.id })
+    .from(workflow_run)
+    .where(
+      and(
+        eq(workflow_run.workflow_id, args.workflowId),
+        sql`${workflow_run.created_at} >= ${since}`,
+        sql`${workflow_run.source_writes} @> ${needle}::jsonb`,
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+export async function writeSourceChangeLog(args: {
+  orgId: string;
+  sourceId: string;
+  tableName: string;
+  changeKind: string;
+  payload: Record<string, unknown>;
+}): Promise<void> {
+  await db()
+    .insert(source_change_log)
+    .values({
+      org_id: args.orgId,
+      source_id: args.sourceId,
+      table_name: args.tableName,
+      change_kind: args.changeKind,
+      payload: args.payload,
+    });
 }

--- a/packages/llm/src/workflows/subscription-builder-server.ts
+++ b/packages/llm/src/workflows/subscription-builder-server.ts
@@ -1,0 +1,304 @@
+import { createSdkMcpServer, tool } from "@anthropic-ai/claude-agent-sdk";
+import { z } from "zod";
+import type { AgentEvent } from "../agent-backend";
+import { graphjinQuery } from "../graphjin/client";
+import { subscriptionSavedCard } from "./builder-cards";
+import { detectMutationLoop } from "./cycle-detection";
+import {
+  createSubscription,
+  getDataSourceForOrg,
+  getWorkflow,
+  getWorkflowByOrgName,
+  listSubscriptionsByWorkflow,
+  type SubscriptionRecord,
+} from "./store";
+import {
+  buildSourceChangeDryRunQuery,
+  parseSourceChangeFilter,
+} from "./subscription-query";
+
+export type SubscriptionBuilderContext = {
+  orgId: string;
+  emit?: (event: AgentEvent) => Promise<void> | void;
+};
+
+const SOURCE_CHANGE_FILTER_SCHEMA = z.object({
+  table: z.string().min(1).max(120),
+  where: z.record(z.string(), z.unknown()).optional(),
+  select: z.array(z.string().min(1).max(120)).optional(),
+  primary_key: z.array(z.string().min(1).max(120)).min(1).max(8),
+  version_column: z.string().min(1).max(120).optional(),
+});
+
+const CREATE_SUBSCRIPTION_INPUT = {
+  workflow_name: z
+    .string()
+    .min(1)
+    .max(120)
+    .describe(
+      "Exact name of the responder workflow (the one that fires when the trigger matches). Use list_workflows first if you don't know it.",
+    ),
+  source_kind: z
+    .enum(["source_change"])
+    .default("source_change")
+    .describe(
+      "What this subscription watches. source_change = a row in the operator's data source matching `filter` changes. workflow_output flows are not configured via this tool; use list_workflows + subscribe via the workflow detail page.",
+    ),
+  filter: SOURCE_CHANGE_FILTER_SCHEMA.describe(
+    "GraphJin where-clause + table + primary_key. Use describe_table from the GraphJin MCP to discover columns. primary_key is REQUIRED (composite keys allowed) and drives delivery idempotency.",
+  ),
+  enabled: z.boolean().optional(),
+  idempotency_key_template: z
+    .string()
+    .max(200)
+    .optional()
+    .describe(
+      "Custom singleton-key template. Tokens: {subscription_id}, {primary_key}, {source_version}. Set when the responder workflow mutates the watched table so the same row can't re-trigger itself within an hour.",
+    ),
+  acknowledge_mutation_loop: z
+    .boolean()
+    .optional()
+    .describe(
+      "Set to true to bypass the save-time check that warns when the responder's text mentions the watched table + a mutation verb. Only set after confirming with the operator that the loop is intended (or idempotency_key_template is set).",
+    ),
+};
+
+const DRY_RUN_INPUT = {
+  filter: SOURCE_CHANGE_FILTER_SCHEMA,
+  limit: z.number().int().min(1).max(50).optional(),
+};
+
+const LIST_SUBSCRIPTIONS_INPUT = {
+  workflow_name: z.string().min(1).max(120).optional(),
+};
+
+export function buildSubscriptionBuilderServer(
+  ctx: SubscriptionBuilderContext,
+) {
+  const createSubscriptionTool = tool(
+    "create_subscription",
+    [
+      "Wire a workflow to trigger when a row in the operator's data source",
+      "matches a filter (the IFTTT 'if this' side). Before calling, use the",
+      "GraphJin MCP to introspect the schema: `list_tables`, `describe_table`",
+      "to confirm column names and the primary_key. Use `dry_run_subscription`",
+      "to preview which rows match BEFORE saving — most failures come from",
+      "filters that match more (or fewer) rows than the operator expected.",
+      "Errors return a structured `code` so you can retry with a fix.",
+    ].join(" "),
+    CREATE_SUBSCRIPTION_INPUT,
+    async (args) => {
+      const workflow = await getWorkflowByOrgName(ctx.orgId, args.workflow_name);
+      if (!workflow) {
+        return toolError({
+          code: "workflow_not_found",
+          message: `no workflow named "${args.workflow_name}" in this org. Use list_workflows to find the right name.`,
+        });
+      }
+
+      const parsed = parseSourceChangeFilter(args.filter);
+      if (!parsed) {
+        return toolError({
+          code: "invalid_filter",
+          message:
+            "filter shape rejected — check table/primary_key are identifiers and primary_key is non-empty.",
+        });
+      }
+
+      const dataSource = await getDataSourceForOrg(ctx.orgId);
+      if (!dataSource) {
+        return toolError({
+          code: "no_data_source",
+          message:
+            "no data_source configured for this org. Source_change subscriptions need a configured data source.",
+        });
+      }
+
+      if (!args.acknowledge_mutation_loop) {
+        const loop = detectMutationLoop({ filter: parsed, workflow });
+        const hasIdempotency =
+          typeof args.idempotency_key_template === "string" &&
+          args.idempotency_key_template.length > 0;
+        if (loop.loops && !hasIdempotency) {
+          return toolError({
+            code: "mutation_loop",
+            message: loop.reason,
+            mutationKeyword: loop.mutationKeyword,
+            hint: "Confirm with the operator. If the loop is intended, set idempotency_key_template (e.g. 'reorder-{primary_key}') or pass acknowledge_mutation_loop: true.",
+          });
+        }
+      }
+
+      const sub = await createSubscription({
+        orgId: ctx.orgId,
+        workflowId: workflow.id,
+        sourceKind: "source_change",
+        filter: args.filter as Record<string, unknown>,
+        enabled: args.enabled ?? true,
+        idempotencyKeyTemplate: args.idempotency_key_template ?? null,
+      });
+
+      if (ctx.emit) {
+        await ctx.emit({
+          type: "surface",
+          messages: subscriptionSavedCard({
+            subscription: sub,
+            workflowName: workflow.name,
+          }),
+        });
+      }
+
+      return toolOk({
+        action: "created",
+        subscriptionId: sub.id,
+        workflowId: workflow.id,
+        workflowName: workflow.name,
+        table: parsed.table,
+        primaryKey: parsed.primary_key,
+      });
+    },
+  );
+
+  const dryRunSubscriptionTool = tool(
+    "dry_run_subscription",
+    [
+      "Compile a proposed source_change filter and run it as a one-shot read",
+      "against the data source, returning up to `limit` matching rows. Use",
+      "this BEFORE create_subscription to validate the filter against real",
+      "data — checks both that the filter is syntactically valid and that",
+      "the matches are what the operator expected.",
+    ].join(" "),
+    DRY_RUN_INPUT,
+    async (args) => {
+      const parsed = parseSourceChangeFilter(args.filter);
+      if (!parsed) {
+        return toolError({
+          code: "invalid_filter",
+          message: "filter rejected at compile time.",
+        });
+      }
+      const dataSource = await getDataSourceForOrg(ctx.orgId);
+      if (!dataSource) {
+        return toolError({
+          code: "no_data_source",
+          message: "no data_source configured for this org.",
+        });
+      }
+      const limit = args.limit ?? 5;
+      const payload = buildSourceChangeDryRunQuery(args.filter, limit);
+      if (!payload) {
+        return toolError({
+          code: "compile_failed",
+          message: "filter passed validation but failed to compile.",
+        });
+      }
+      let result;
+      try {
+        result = await graphjinQuery({
+          baseUrl: dataSource.graphqlUrl,
+          query: payload.query,
+          variables: payload.variables,
+        });
+      } catch (err) {
+        return toolError({
+          code: "graphjin_error",
+          message: err instanceof Error ? err.message : String(err),
+          compiledQuery: payload.query,
+        });
+      }
+      if (result.errors && result.errors.length > 0) {
+        return toolError({
+          code: "graphjin_errors",
+          message: "graphjin returned errors — usually means the table/column doesn't exist or the where clause is malformed.",
+          compiledQuery: payload.query,
+          graphjinErrors: result.errors,
+        });
+      }
+      const data = (result.data ?? {}) as Record<string, unknown>;
+      const raw = data[parsed.table];
+      const rows: unknown[] = Array.isArray(raw) ? raw : [];
+      return toolOk({
+        table: parsed.table,
+        rowCount: rows.length,
+        rows,
+        compiledQuery: payload.query,
+      });
+    },
+  );
+
+  const listSubscriptionsTool = tool(
+    "list_subscriptions",
+    [
+      "List existing subscriptions for a workflow, so you can answer questions",
+      "like 'what's triggering this' or check before creating a duplicate.",
+      "If workflow_name is omitted, returns nothing (the org-wide listing",
+      "lives in the /workflows UI, not here, to keep token use bounded).",
+    ].join(" "),
+    LIST_SUBSCRIPTIONS_INPUT,
+    async (args) => {
+      if (!args.workflow_name) {
+        return toolOk({ subscriptions: [] });
+      }
+      const workflow = await getWorkflowByOrgName(
+        ctx.orgId,
+        args.workflow_name,
+      );
+      if (!workflow) {
+        return toolError({
+          code: "workflow_not_found",
+          message: `no workflow named "${args.workflow_name}".`,
+        });
+      }
+      const subs = await listSubscriptionsByWorkflow(ctx.orgId, workflow.id);
+      return toolOk({
+        workflowId: workflow.id,
+        workflowName: workflow.name,
+        subscriptions: subs.map(summarizeSubscription),
+      });
+    },
+  );
+
+  return createSdkMcpServer({
+    name: "neko_subscription_builder",
+    version: "1.0.0",
+    tools: [
+      createSubscriptionTool,
+      dryRunSubscriptionTool,
+      listSubscriptionsTool,
+    ],
+  });
+}
+
+function summarizeSubscription(s: SubscriptionRecord) {
+  return {
+    id: s.id,
+    sourceKind: s.sourceKind,
+    filter: s.filter,
+    enabled: s.enabled,
+    idempotencyKeyTemplate: s.idempotencyKeyTemplate,
+    createdAt: s.createdAt.toISOString(),
+  };
+}
+
+function toolOk(payload: Record<string, unknown>) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ ok: true, ...payload }),
+      },
+    ],
+  };
+}
+
+function toolError(payload: { code: string; message: string } & Record<string, unknown>) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ ok: false, ...payload }),
+      },
+    ],
+    isError: true,
+  };
+}

--- a/packages/llm/src/workflows/subscription-manager.ts
+++ b/packages/llm/src/workflows/subscription-manager.ts
@@ -8,7 +8,10 @@ import {
 } from "./store";
 import {
   buildSubscriptionQuery,
+  parseSourceChangeFilter,
+  parseSourceChangeMatch,
   parseWorkflowOutputMatch,
+  type SourceChangeMatch,
   type WorkflowOutputMatch,
 } from "./subscription-query";
 
@@ -17,10 +20,23 @@ export type SubscriptionMatchEvent =
       kind: "workflow_output";
       subscription: SubscriptionRecord;
       output: WorkflowOutputMatch;
+    }
+  | {
+      kind: "source_change";
+      subscription: SubscriptionRecord;
+      match: SourceChangeMatch;
     };
 
-export type SubscriptionManagerOptions = {
+export type SubscriptionTransport = {
   baseUrl: string;
+};
+
+export type ResolveTransport = (
+  sub: SubscriptionRecord,
+) => Promise<SubscriptionTransport>;
+
+export type SubscriptionManagerOptions = {
+  resolveTransport: ResolveTransport;
   onMatch: (event: SubscriptionMatchEvent) => void | Promise<void>;
   refreshIntervalMs?: number;
   onError?: (err: Error, sub?: SubscriptionRecord) => void;
@@ -52,7 +68,7 @@ export function startSubscriptionManager(
     rejectReady = rej;
   });
 
-  const openOne = (sub: SubscriptionRecord) => {
+  const openOne = async (sub: SubscriptionRecord): Promise<void> => {
     const payload = buildSubscriptionQuery({
       sourceKind: sub.sourceKind,
       filter: sub.filter,
@@ -60,30 +76,55 @@ export function startSubscriptionManager(
     });
     if (!payload) {
       console.warn(
-        `[subscription-manager] skipping subscription ${sub.id} — source_kind="${sub.sourceKind}" not wired yet`,
+        `[subscription-manager] skipping subscription ${sub.id} — source_kind="${sub.sourceKind}" not wired or filter invalid`,
       );
       return;
     }
-    const handle = graphjinSubscribe<{ workflow_output?: unknown }>({
-      baseUrl: opts.baseUrl,
+
+    let transport: SubscriptionTransport;
+    try {
+      transport = await opts.resolveTransport(sub);
+    } catch (err) {
+      opts.onError?.(
+        err instanceof Error ? err : new Error(String(err)),
+        sub,
+      );
+      return;
+    }
+
+    const handle = graphjinSubscribe<{ data?: unknown } & Record<string, unknown>>({
+      baseUrl: transport.baseUrl,
       query: payload.query,
       variables: payload.variables,
       onNext: async (msg) => {
-        if (sub.sourceKind === "workflow_output") {
-          const match = parseWorkflowOutputMatch(msg);
-          if (!match) return;
-          try {
+        try {
+          if (sub.sourceKind === "workflow_output") {
+            const match = parseWorkflowOutputMatch(msg);
+            if (!match) return;
             await opts.onMatch({
               kind: "workflow_output",
               subscription: sub,
               output: match,
             });
-          } catch (err) {
-            opts.onError?.(
-              err instanceof Error ? err : new Error(String(err)),
-              sub,
-            );
+            return;
           }
+          if (sub.sourceKind === "source_change") {
+            const filter = parseSourceChangeFilter(sub.filter);
+            if (!filter) return;
+            const match = parseSourceChangeMatch(msg, filter);
+            if (!match) return;
+            await opts.onMatch({
+              kind: "source_change",
+              subscription: sub,
+              match,
+            });
+            return;
+          }
+        } catch (err) {
+          opts.onError?.(
+            err instanceof Error ? err : new Error(String(err)),
+            sub,
+          );
         }
       },
       onError: (err) => {
@@ -108,7 +149,8 @@ export function startSubscriptionManager(
       if (!desired.has(id)) closeOne(id);
     }
     for (const row of rows) {
-      if (!handles.has(row.id)) openOne(row);
+      if (handles.has(row.id)) continue;
+      await openOne(row);
     }
   };
 

--- a/packages/llm/src/workflows/subscription-query.ts
+++ b/packages/llm/src/workflows/subscription-query.ts
@@ -13,18 +13,6 @@ export type SubscriptionQueryPayload = {
   variables: Record<string, unknown>;
 };
 
-/**
- * Build the GraphJin subscription query for a subscription row's filter.
- * The shape is shaped per source_kind:
- *   workflow_output → matches workflow_output rows (the canonical
- *     workflow-chaining case)
- *   source_change   → not implemented yet (will hit source_change_log)
- *   external_event  → not implemented yet
- *
- * Returns null for source kinds that aren't wired in this slice; the
- * subscription manager logs and skips those rows so future work can land
- * additively without breaking existing subscriptions.
- */
 export function buildSubscriptionQuery(args: {
   sourceKind: SubscriptionSourceKind;
   filter: Record<string, unknown>;
@@ -32,6 +20,9 @@ export function buildSubscriptionQuery(args: {
 }): SubscriptionQueryPayload | null {
   if (args.sourceKind === "workflow_output") {
     return buildWorkflowOutputSubscription(args.filter, args.orgId);
+  }
+  if (args.sourceKind === "source_change") {
+    return buildSourceChangeSubscription(args.filter);
   }
   return null;
 }
@@ -102,4 +93,167 @@ export function parseWorkflowOutputMatch(
     title: String(row.title ?? ""),
     created_at: String(row.created_at),
   };
+}
+
+// ─── source_change ──────────────────────────────────────────────────────────
+// Subscriptions over the operator's data-source DB. Filter is a passthrough to
+// GraphJin: `table` + `where` go straight into the compiled subscription. Org
+// isolation is enforced by which data_source row the manager subscribes to
+// (the operator's tables have no org_id column we could inject).
+
+export type JsonScalar = string | number | boolean | null;
+
+export type SourceChangeFilter = {
+  table: string;
+  where?: Record<string, unknown>;
+  select?: string[];
+  primary_key: string[];
+  version_column?: string;
+};
+
+export type SourceChangeMatch = {
+  table: string;
+  primary_key: Record<string, JsonScalar>;
+  snapshot: Record<string, unknown>;
+  version_token: string | null;
+};
+
+function buildSourceChangeSubscription(
+  filter: Record<string, unknown>,
+): SubscriptionQueryPayload | null {
+  return buildSourceChangeOperation(filter, {
+    kind: "subscription",
+    operationName: "SourceChangeMatch",
+    limit: 1,
+  });
+}
+
+/**
+ * Build a one-shot read against the data source using the same filter as the
+ * subscription, for the dry-run endpoint. Same projection, ordering, and where
+ * clause; just a `query` instead of a `subscription` and a configurable limit.
+ */
+export function buildSourceChangeDryRunQuery(
+  filter: Record<string, unknown>,
+  limit = 5,
+): SubscriptionQueryPayload | null {
+  return buildSourceChangeOperation(filter, {
+    kind: "query",
+    operationName: "SourceChangeDryRun",
+    limit,
+  });
+}
+
+function buildSourceChangeOperation(
+  filter: Record<string, unknown>,
+  opts: {
+    kind: "subscription" | "query";
+    operationName: string;
+    limit: number;
+  },
+): SubscriptionQueryPayload | null {
+  const parsed = parseSourceChangeFilter(filter);
+  if (!parsed) return null;
+
+  const orderCol = parsed.version_column ?? parsed.primary_key[0];
+  const selectCols = uniqueOrdered([
+    ...parsed.primary_key,
+    ...(parsed.select ?? []),
+    ...(parsed.version_column ? [parsed.version_column] : []),
+  ]);
+
+  const whereInputType = `${parsed.table}WhereInput`;
+  const projection = selectCols.map((c) => `    ${c}`).join("\n");
+  const query = `${opts.kind} ${opts.operationName}($where: ${whereInputType}) {
+  ${parsed.table}(where: $where, order_by: { ${orderCol}: desc }, limit: ${opts.limit}) {
+${projection}
+  }
+}`;
+
+  return { query, variables: { where: parsed.where ?? {} } };
+}
+
+/** Validates a SourceChangeFilter's shape; returns null when invalid. */
+export function parseSourceChangeFilter(
+  filter: Record<string, unknown>,
+): SourceChangeFilter | null {
+  if (!filter || typeof filter !== "object") return null;
+  const f = filter as Partial<SourceChangeFilter>;
+  if (typeof f.table !== "string" || f.table.length === 0) return null;
+  if (!isIdentifier(f.table)) return null;
+  if (!Array.isArray(f.primary_key) || f.primary_key.length === 0) return null;
+  if (!f.primary_key.every((c) => typeof c === "string" && isIdentifier(c))) {
+    return null;
+  }
+  if (f.where != null && (typeof f.where !== "object" || Array.isArray(f.where))) {
+    return null;
+  }
+  if (
+    f.select != null &&
+    (!Array.isArray(f.select) ||
+      !f.select.every((c) => typeof c === "string" && isIdentifier(c)))
+  ) {
+    return null;
+  }
+  if (
+    f.version_column != null &&
+    (typeof f.version_column !== "string" || !isIdentifier(f.version_column))
+  ) {
+    return null;
+  }
+  return {
+    table: f.table,
+    where: f.where ?? {},
+    select: f.select,
+    primary_key: f.primary_key,
+    version_column: f.version_column,
+  };
+}
+
+export function parseSourceChangeMatch(
+  payload: { data: unknown } | null | undefined,
+  filter: SourceChangeFilter,
+): SourceChangeMatch | null {
+  if (!payload || !payload.data || typeof payload.data !== "object") return null;
+  const data = payload.data as Record<string, unknown>;
+  const rows = data[filter.table];
+  if (!Array.isArray(rows) || rows.length === 0) return null;
+  const row = rows[0];
+  if (!row || typeof row !== "object" || Array.isArray(row)) return null;
+  const rowObj = row as Record<string, unknown>;
+
+  const pk: Record<string, JsonScalar> = {};
+  for (const col of filter.primary_key) {
+    const v = rowObj[col];
+    if (v === undefined) return null;
+    pk[col] = v as JsonScalar;
+  }
+
+  const versionCol = filter.version_column;
+  const version_token =
+    versionCol && rowObj[versionCol] != null ? String(rowObj[versionCol]) : null;
+
+  return {
+    table: filter.table,
+    primary_key: pk,
+    snapshot: rowObj,
+    version_token,
+  };
+}
+
+const IDENT_RE = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+function isIdentifier(s: string): boolean {
+  return IDENT_RE.test(s);
+}
+
+function uniqueOrdered(xs: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const x of xs) {
+    if (seen.has(x)) continue;
+    seen.add(x);
+    out.push(x);
+  }
+  return out;
 }

--- a/packages/llm/src/workflows/tool-defaults.ts
+++ b/packages/llm/src/workflows/tool-defaults.ts
@@ -10,6 +10,10 @@ export const WORKFLOW_BUILDER_ALLOWED_TOOLS = [
   "WebSearch",
   "AskUserQuestion",
   "mcp__neko_workflow_builder__create_workflow",
+  "mcp__neko_workflow_builder__list_workflows",
+  "mcp__neko_subscription_builder__create_subscription",
+  "mcp__neko_subscription_builder__dry_run_subscription",
+  "mcp__neko_subscription_builder__list_subscriptions",
 ] as const;
 
 export const WORKFLOW_RUNNER_DEFAULT_ALLOWED_TOOLS = [

--- a/packages/llm/test/builder-cards.test.ts
+++ b/packages/llm/test/builder-cards.test.ts
@@ -1,10 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
   policySavedCard,
+  subscriptionSavedCard,
   workflowSavedCard,
 } from "../src/workflows/builder-cards";
 import type { ActionPolicyRecord } from "../src/workflows/action-store";
-import type { WorkflowRecord } from "../src/workflows/store";
+import type {
+  SubscriptionRecord,
+  WorkflowRecord,
+} from "../src/workflows/store";
 
 const workflowFixture: WorkflowRecord = {
   id: "wf-1",
@@ -101,6 +105,77 @@ describe("workflowSavedCard", () => {
     });
     const body = (messages[1].updateComponents as { components: Array<{ id: string; text?: string }> }).components.find((c) => c.id === "body");
     expect(body?.text).toContain("_No description._");
+  });
+});
+
+const subscriptionFixture: SubscriptionRecord = {
+  id: "sub-1",
+  orgId: "org-1",
+  workflowId: "wf-1",
+  sourceKind: "source_change",
+  filter: {
+    table: "productinventory",
+    where: { quantity: { lt: { col: "product.reorderpoint" } } },
+    primary_key: ["productid", "locationid"],
+    version_column: "modifieddate",
+  },
+  enabled: true,
+  debounceMs: 0,
+  maxConcurrentRuns: 5,
+  maxChainDepthOverride: null,
+  idempotencyKeyTemplate: "reorder-{primary_key}",
+  createdAt: new Date("2026-05-23T00:00:00Z"),
+  updatedAt: new Date("2026-05-23T00:00:00Z"),
+};
+
+describe("subscriptionSavedCard", () => {
+  it("emits a v0.9 createSurface + updateComponents pair keyed by sub id", () => {
+    const messages = subscriptionSavedCard({
+      subscription: subscriptionFixture,
+      workflowName: "Stock alert",
+    });
+    expect(messages).toHaveLength(2);
+    expect(messages[0]).toMatchObject({
+      createSurface: { surfaceId: "subscription-save-sub-1" },
+    });
+  });
+
+  it("renders table, primary_key, filter columns, and idempotency key", () => {
+    const messages = subscriptionSavedCard({
+      subscription: subscriptionFixture,
+      workflowName: "Stock alert",
+    });
+    const body = (
+      messages[1].updateComponents as {
+        components: Array<{ id: string; text?: string }>;
+      }
+    ).components.find((c) => c.id === "body");
+    expect(body?.text).toContain("Stock alert");
+    expect(body?.text).toContain("productinventory");
+    expect(body?.text).toContain("productid, locationid");
+    expect(body?.text).toContain("quantity");
+    expect(body?.text).toContain("reorder-{primary_key}");
+    expect(body?.text).toContain("[Open detail](/workflows?id=wf-1)");
+  });
+
+  it("falls back to '(no filter)' when the where clause is empty", () => {
+    const messages = subscriptionSavedCard({
+      subscription: {
+        ...subscriptionFixture,
+        filter: {
+          table: "productinventory",
+          where: {},
+          primary_key: ["productid", "locationid"],
+        },
+      },
+      workflowName: "Stock alert",
+    });
+    const body = (
+      messages[1].updateComponents as {
+        components: Array<{ id: string; text?: string }>;
+      }
+    ).components.find((c) => c.id === "body");
+    expect(body?.text).toContain("_(no filter)_");
   });
 });
 

--- a/packages/llm/test/cycle-detection.test.ts
+++ b/packages/llm/test/cycle-detection.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   checkSubscriptionWouldLoop,
+  detectMutationLoop,
   outputMatchesFilter,
   SubscriptionSelfLoopError,
 } from "../src/workflows/cycle-detection";
+import type { SourceChangeFilter } from "../src/workflows/subscription-query";
 
 describe("outputMatchesFilter", () => {
   const baseOutput = {
@@ -127,6 +129,71 @@ describe("checkSubscriptionWouldLoop", () => {
       expect(e).toBeInstanceOf(SubscriptionSelfLoopError);
       const err = e as SubscriptionSelfLoopError;
       expect(err.matchingOutputIds).toEqual(["out-a", "out-b"]);
+    }
+  });
+});
+
+describe("detectMutationLoop", () => {
+  const filter: SourceChangeFilter = {
+    table: "productinventory",
+    where: {},
+    primary_key: ["productid", "locationid"],
+  };
+
+  it("returns loops:false when the workflow text doesn't mention the table", () => {
+    const result = detectMutationLoop({
+      filter,
+      workflow: {
+        goal: "send a slack message",
+        description: "alerts to ops",
+        steps: [{ id: "s1", description: "post to channel" }],
+      },
+    });
+    expect(result.loops).toBe(false);
+  });
+
+  it("returns loops:false when the table is mentioned but no mutation verb", () => {
+    const result = detectMutationLoop({
+      filter,
+      workflow: {
+        goal: "report productinventory levels",
+        description: "",
+        steps: [{ id: "s1", description: "read inventory" }],
+      },
+    });
+    expect(result.loops).toBe(false);
+  });
+
+  it("flags when the table + a mutation verb both appear", () => {
+    const result = detectMutationLoop({
+      filter,
+      workflow: {
+        goal: "draft purchase order and update productinventory quantity",
+        description: "",
+        steps: [{ id: "s1", description: "modify stock" }],
+      },
+    });
+    expect(result.loops).toBe(true);
+    if (result.loops) {
+      expect(result.mutationKeyword).toBe("update");
+      expect(result.reason).toMatch(/productinventory/);
+    }
+  });
+
+  it("matches across goal/description/steps corpus (case-insensitive)", () => {
+    const result = detectMutationLoop({
+      filter,
+      workflow: {
+        goal: "alert on low stock",
+        description: "",
+        steps: [
+          { id: "s1", description: "Insert a row into ProductInventory" },
+        ],
+      },
+    });
+    expect(result.loops).toBe(true);
+    if (result.loops) {
+      expect(result.mutationKeyword).toBe("insert");
     }
   });
 });

--- a/packages/llm/test/match-handler.test.ts
+++ b/packages/llm/test/match-handler.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
-import { handleSubscriptionMatch } from "../src/workflows/match-handler";
+import {
+  handleSourceChangeMatch,
+  handleSubscriptionMatch,
+} from "../src/workflows/match-handler";
 import type { SubscriptionRecord } from "../src/workflows/store";
-import type { WorkflowOutputMatch } from "../src/workflows/subscription-query";
+import type {
+  SourceChangeMatch,
+  WorkflowOutputMatch,
+} from "../src/workflows/subscription-query";
 
 function fakeSubscription(
   overrides: Partial<SubscriptionRecord> = {},
@@ -129,5 +135,184 @@ describe("handleSubscriptionMatch", () => {
     });
     const jobOpts = enqueue.mock.calls[0][2];
     expect(jobOpts.singletonKey).toBe("sub:sub-1:out:out-1");
+  });
+});
+
+function fakeSourceChangeMatch(
+  overrides: Partial<SourceChangeMatch> = {},
+): SourceChangeMatch {
+  return {
+    table: overrides.table ?? "productinventory",
+    primary_key: overrides.primary_key ?? { productid: 680, locationid: 6 },
+    snapshot:
+      overrides.snapshot ?? {
+        productid: 680,
+        locationid: 6,
+        quantity: 12,
+        modifieddate: "2026-05-23T10:00:00.000Z",
+      },
+    version_token:
+      overrides.version_token === undefined
+        ? "2026-05-23T10:00:00.000Z"
+        : overrides.version_token,
+  };
+}
+
+describe("handleSourceChangeMatch", () => {
+  it("drops when the workflow recently wrote to the same (table, pk)", async () => {
+    const enqueue = vi.fn();
+    const createObservation = vi.fn();
+    const writeSourceChangeLog = vi.fn();
+    const decision = await handleSourceChangeMatch({
+      subscription: fakeSubscription({ sourceKind: "source_change" }),
+      match: fakeSourceChangeMatch(),
+      dataSourceId: "ds-1",
+      enqueue: enqueue as never,
+      createObservation: createObservation as never,
+      writeSourceChangeLog: writeSourceChangeLog as never,
+      countWorkflowRunsForSubscription: async () => 0,
+      countWorkflowRunsSince: async () => 0,
+      getWorkflow: async () => null,
+      hasRecentSourceWriteForWorkflow: async () => true,
+    });
+    expect(decision.action).toBe("dropped");
+    if (decision.action === "dropped") {
+      expect(decision.reason).toMatch(/recently wrote/);
+    }
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(createObservation).not.toHaveBeenCalled();
+    expect(writeSourceChangeLog).not.toHaveBeenCalled();
+  });
+
+  it("drops when subscription is at max_concurrent_runs", async () => {
+    const enqueue = vi.fn();
+    const decision = await handleSourceChangeMatch({
+      subscription: fakeSubscription({
+        sourceKind: "source_change",
+        maxConcurrentRuns: 3,
+      }),
+      match: fakeSourceChangeMatch(),
+      dataSourceId: "ds-1",
+      enqueue: enqueue as never,
+      createObservation: vi.fn() as never,
+      writeSourceChangeLog: vi.fn() as never,
+      countWorkflowRunsForSubscription: async () => 3,
+      countWorkflowRunsSince: async () => 0,
+      getWorkflow: async () => null,
+      hasRecentSourceWriteForWorkflow: async () => false,
+    });
+    expect(decision.action).toBe("dropped");
+    if (decision.action === "dropped") {
+      expect(decision.reason).toMatch(/max_concurrent_runs/);
+    }
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it("enqueues fire + writes audit + composite-PK idempotency on happy path", async () => {
+    const enqueue = vi.fn().mockResolvedValue("job-abc");
+    const createObservation = vi.fn().mockResolvedValue({
+      id: "obs-sc-1",
+      orgId: "org-1",
+    });
+    const writeSourceChangeLog = vi.fn().mockResolvedValue(undefined);
+
+    const decision = await handleSourceChangeMatch({
+      subscription: fakeSubscription({ sourceKind: "source_change" }),
+      match: fakeSourceChangeMatch(),
+      dataSourceId: "ds-1",
+      enqueue: enqueue as never,
+      createObservation: createObservation as never,
+      writeSourceChangeLog: writeSourceChangeLog as never,
+      countWorkflowRunsForSubscription: async () => 0,
+      countWorkflowRunsSince: async () => 0,
+      getWorkflow: async () => null,
+      hasRecentSourceWriteForWorkflow: async () => false,
+    });
+
+    expect(decision.action).toBe("enqueued");
+    if (decision.action === "enqueued") {
+      expect(decision.observationId).toBe("obs-sc-1");
+      expect(decision.jobId).toBe("job-abc");
+    }
+
+    expect(createObservation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceOutputId: null,
+        subscriptionId: "sub-1",
+        title: expect.stringContaining("productinventory"),
+      }),
+    );
+
+    expect(writeSourceChangeLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orgId: "org-1",
+        sourceId: "ds-1",
+        tableName: "productinventory",
+        changeKind: "subscription_match",
+      }),
+    );
+
+    const [, jobData, jobOpts] = enqueue.mock.calls[0];
+    expect(jobData.triggeredBySubscriptionId).toBe("sub-1");
+    expect(jobData.triggeredByObservationId).toBe("obs-sc-1");
+    expect(jobData.triggerPayload).toMatchObject({
+      table: "productinventory",
+      primary_key: { productid: 680, locationid: 6 },
+    });
+
+    // Idempotency key: ${sub.id}:${pkHash}:${versionToken}
+    // pkHash is sha256(sorted entries).slice(0,16), version_token = match.version_token
+    expect(jobOpts.singletonKey).toMatch(
+      /^sub-1:[0-9a-f]{16}:2026-05-23T10:00:00\.000Z$/,
+    );
+    expect(jobOpts.singletonHours).toBe(1);
+  });
+
+  it("idempotency key uses 'none' when version_token is null", async () => {
+    const enqueue = vi.fn().mockResolvedValue("job-id");
+    const createObservation = vi
+      .fn()
+      .mockResolvedValue({ id: "obs-2", orgId: "org-1" });
+    await handleSourceChangeMatch({
+      subscription: fakeSubscription({ sourceKind: "source_change" }),
+      match: fakeSourceChangeMatch({ version_token: null }),
+      dataSourceId: "ds-1",
+      enqueue: enqueue as never,
+      createObservation: createObservation as never,
+      writeSourceChangeLog: vi.fn() as never,
+      countWorkflowRunsForSubscription: async () => 0,
+      countWorkflowRunsSince: async () => 0,
+      getWorkflow: async () => null,
+      hasRecentSourceWriteForWorkflow: async () => false,
+    });
+    const jobOpts = enqueue.mock.calls[0][2];
+    expect(jobOpts.singletonKey).toMatch(/^sub-1:[0-9a-f]{16}:none$/);
+  });
+
+  it("honors a custom idempotencyKeyTemplate with {primary_key}", async () => {
+    const enqueue = vi.fn().mockResolvedValue("job-id");
+    const createObservation = vi
+      .fn()
+      .mockResolvedValue({ id: "obs-3", orgId: "org-1" });
+    await handleSourceChangeMatch({
+      subscription: fakeSubscription({
+        sourceKind: "source_change",
+        idempotencyKeyTemplate:
+          "reorder-{primary_key}-{source_version}",
+      }),
+      match: fakeSourceChangeMatch(),
+      dataSourceId: "ds-1",
+      enqueue: enqueue as never,
+      createObservation: createObservation as never,
+      writeSourceChangeLog: vi.fn() as never,
+      countWorkflowRunsForSubscription: async () => 0,
+      countWorkflowRunsSince: async () => 0,
+      getWorkflow: async () => null,
+      hasRecentSourceWriteForWorkflow: async () => false,
+    });
+    const jobOpts = enqueue.mock.calls[0][2];
+    expect(jobOpts.singletonKey).toMatch(
+      /^reorder-[0-9a-f]{16}-2026-05-23T10:00:00\.000Z$/,
+    );
   });
 });

--- a/packages/llm/test/subscription-manager.test.ts
+++ b/packages/llm/test/subscription-manager.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SubscriptionRecord } from "../src/workflows/store";
+
+const subscribeMock = vi.fn();
+const listEnabledMock = vi.fn();
+
+vi.mock("../src/graphjin/client", () => ({
+  graphjinSubscribe: (args: unknown) => subscribeMock(args),
+}));
+
+vi.mock("../src/workflows/store", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/workflows/store")>();
+  return {
+    ...actual,
+    listEnabledSubscriptions: () => listEnabledMock(),
+  };
+});
+
+import { startSubscriptionManager } from "../src/workflows/subscription-manager";
+
+function fakeSub(overrides: Partial<SubscriptionRecord> = {}): SubscriptionRecord {
+  return {
+    id: overrides.id ?? "sub-x",
+    orgId: overrides.orgId ?? "org-1",
+    workflowId: overrides.workflowId ?? "wf-1",
+    sourceKind: overrides.sourceKind ?? "workflow_output",
+    filter: overrides.filter ?? {},
+    enabled: overrides.enabled ?? true,
+    debounceMs: overrides.debounceMs ?? 0,
+    maxConcurrentRuns: overrides.maxConcurrentRuns ?? 5,
+    maxChainDepthOverride: overrides.maxChainDepthOverride ?? null,
+    idempotencyKeyTemplate: overrides.idempotencyKeyTemplate ?? null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+describe("startSubscriptionManager — transport resolver", () => {
+  beforeEach(() => {
+    subscribeMock.mockReset();
+    listEnabledMock.mockReset();
+    subscribeMock.mockReturnValue({ stop: vi.fn() });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("routes workflow_output to neko-graphjin URL and source_change to data-source URL", async () => {
+    listEnabledMock.mockResolvedValueOnce([
+      fakeSub({
+        id: "sub-wfo",
+        sourceKind: "workflow_output",
+        filter: { scope: "apac_churn" },
+      }),
+      fakeSub({
+        id: "sub-src",
+        sourceKind: "source_change",
+        filter: {
+          table: "productinventory",
+          where: { quantity: { lt: 50 } },
+          primary_key: ["productid", "locationid"],
+        },
+      }),
+    ]);
+
+    const resolveTransport = vi.fn(async (sub: SubscriptionRecord) =>
+      sub.sourceKind === "source_change"
+        ? { baseUrl: "http://data-source-graphjin:8080" }
+        : { baseUrl: "http://neko-graphjin:8089" },
+    );
+
+    const mgr = startSubscriptionManager({
+      resolveTransport,
+      onMatch: vi.fn(),
+    });
+    await mgr.ready;
+
+    expect(subscribeMock).toHaveBeenCalledTimes(2);
+    const calls = subscribeMock.mock.calls.map((c) => c[0]);
+    const wfoCall = calls.find((c) =>
+      c.query.includes("WorkflowOutputMatch"),
+    );
+    const srcCall = calls.find((c) =>
+      c.query.includes("SourceChangeMatch"),
+    );
+    expect(wfoCall?.baseUrl).toBe("http://neko-graphjin:8089");
+    expect(srcCall?.baseUrl).toBe("http://data-source-graphjin:8080");
+
+    await mgr.stop();
+  });
+
+  it("skips and logs when filter is invalid for source_change", async () => {
+    listEnabledMock.mockResolvedValueOnce([
+      fakeSub({
+        id: "sub-bad",
+        sourceKind: "source_change",
+        filter: { table: "productinventory" }, // missing primary_key
+      }),
+    ]);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const mgr = startSubscriptionManager({
+      resolveTransport: async () => ({ baseUrl: "http://x" }),
+      onMatch: vi.fn(),
+    });
+    await mgr.ready;
+
+    expect(subscribeMock).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("skipping subscription sub-bad"),
+    );
+
+    warnSpy.mockRestore();
+    await mgr.stop();
+  });
+
+  it("emits source_change events via onMatch with parsed match payload", async () => {
+    listEnabledMock.mockResolvedValueOnce([
+      fakeSub({
+        id: "sub-src",
+        sourceKind: "source_change",
+        filter: {
+          table: "productinventory",
+          where: {},
+          primary_key: ["productid", "locationid"],
+          version_column: "modifieddate",
+        },
+      }),
+    ]);
+
+    let pushedOnNext:
+      | ((msg: unknown) => Promise<void> | void)
+      | undefined;
+    subscribeMock.mockImplementation((args: { onNext: (m: unknown) => unknown }) => {
+      pushedOnNext = args.onNext;
+      return { stop: vi.fn() };
+    });
+
+    const onMatch = vi.fn();
+    const mgr = startSubscriptionManager({
+      resolveTransport: async () => ({ baseUrl: "http://x" }),
+      onMatch,
+    });
+    await mgr.ready;
+
+    expect(pushedOnNext).toBeDefined();
+    await pushedOnNext!({
+      data: {
+        productinventory: [
+          {
+            productid: 680,
+            locationid: 6,
+            quantity: 12,
+            modifieddate: "2026-05-23T10:00:00.000Z",
+          },
+        ],
+      },
+    });
+
+    expect(onMatch).toHaveBeenCalledTimes(1);
+    const event = onMatch.mock.calls[0]![0];
+    expect(event.kind).toBe("source_change");
+    expect(event.match.table).toBe("productinventory");
+    expect(event.match.primary_key).toEqual({ productid: 680, locationid: 6 });
+    expect(event.match.version_token).toBe("2026-05-23T10:00:00.000Z");
+
+    await mgr.stop();
+  });
+
+  it("invokes onError when resolveTransport rejects without crashing the manager", async () => {
+    listEnabledMock.mockResolvedValueOnce([
+      fakeSub({ id: "sub-fail", sourceKind: "source_change", filter: {
+        table: "productinventory",
+        primary_key: ["productid"],
+      } }),
+    ]);
+    const onError = vi.fn();
+
+    const mgr = startSubscriptionManager({
+      resolveTransport: async () => {
+        throw new Error("no data_source for org");
+      },
+      onMatch: vi.fn(),
+      onError,
+    });
+    await mgr.ready;
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]![0].message).toContain("no data_source");
+    expect(subscribeMock).not.toHaveBeenCalled();
+
+    await mgr.stop();
+  });
+});

--- a/packages/llm/test/subscription-query.test.ts
+++ b/packages/llm/test/subscription-query.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   buildSubscriptionQuery,
+  parseSourceChangeFilter,
+  parseSourceChangeMatch,
   parseWorkflowOutputMatch,
+  type SourceChangeFilter,
 } from "../src/workflows/subscription-query";
 
 describe("buildSubscriptionQuery (workflow_output)", () => {
@@ -31,13 +34,6 @@ describe("buildSubscriptionQuery (workflow_output)", () => {
   });
 
   it("returns null for source_kinds not yet wired", () => {
-    expect(
-      buildSubscriptionQuery({
-        sourceKind: "source_change",
-        orgId: "org-abc",
-        filter: {},
-      }),
-    ).toBeNull();
     expect(
       buildSubscriptionQuery({
         sourceKind: "external_event",
@@ -77,5 +73,195 @@ describe("parseWorkflowOutputMatch", () => {
     expect(
       parseWorkflowOutputMatch({ data: { workflow_output: [] } }),
     ).toBeNull();
+  });
+});
+
+describe("buildSubscriptionQuery (source_change)", () => {
+  it("emits the where verbatim and projects pk + select + version", () => {
+    const payload = buildSubscriptionQuery({
+      sourceKind: "source_change",
+      orgId: "org-abc",
+      filter: {
+        table: "productinventory",
+        where: {
+          quantity: { lt: { col: "product.reorderpoint" } },
+        },
+        select: ["quantity"],
+        primary_key: ["productid", "locationid"],
+        version_column: "modifieddate",
+      },
+    });
+    expect(payload).not.toBeNull();
+    expect(payload!.variables).toEqual({
+      where: { quantity: { lt: { col: "product.reorderpoint" } } },
+    });
+    expect(payload!.query).toContain(
+      "subscription SourceChangeMatch($where: productinventoryWhereInput)",
+    );
+    expect(payload!.query).toContain(
+      "productinventory(where: $where, order_by: { modifieddate: desc }, limit: 1)",
+    );
+    // pk columns + select + version_column, deduped and ordered
+    expect(payload!.query).toContain("productid");
+    expect(payload!.query).toContain("locationid");
+    expect(payload!.query).toContain("quantity");
+    expect(payload!.query).toContain("modifieddate");
+  });
+
+  it("does NOT inject org_id (operator tables have no such column)", () => {
+    const payload = buildSubscriptionQuery({
+      sourceKind: "source_change",
+      orgId: "org-abc",
+      filter: {
+        table: "productinventory",
+        where: { quantity: { lt: 50 } },
+        primary_key: ["productid", "locationid"],
+      },
+    });
+    expect(payload!.variables.where).toEqual({ quantity: { lt: 50 } });
+    const where = payload!.variables.where as Record<string, unknown>;
+    expect(where).not.toHaveProperty("org_id");
+  });
+
+  it("falls back to primary_key[0] for order_by when version_column omitted", () => {
+    const payload = buildSubscriptionQuery({
+      sourceKind: "source_change",
+      orgId: "org-abc",
+      filter: {
+        table: "orders",
+        where: {},
+        primary_key: ["id"],
+      },
+    });
+    expect(payload!.query).toContain("order_by: { id: desc }");
+  });
+
+  it("returns null for invalid filter shape (missing table)", () => {
+    expect(
+      buildSubscriptionQuery({
+        sourceKind: "source_change",
+        orgId: "org-abc",
+        filter: { primary_key: ["id"] },
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null for invalid filter shape (missing primary_key)", () => {
+    expect(
+      buildSubscriptionQuery({
+        sourceKind: "source_change",
+        orgId: "org-abc",
+        filter: { table: "productinventory" },
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects non-identifier table/column names (defense in depth)", () => {
+    expect(
+      buildSubscriptionQuery({
+        sourceKind: "source_change",
+        orgId: "org-abc",
+        filter: {
+          table: "products; drop table users; --",
+          primary_key: ["id"],
+        },
+      }),
+    ).toBeNull();
+    expect(
+      buildSubscriptionQuery({
+        sourceKind: "source_change",
+        orgId: "org-abc",
+        filter: {
+          table: "productinventory",
+          primary_key: ["id; --"],
+        },
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("parseSourceChangeFilter", () => {
+  it("returns the filter for a valid shape", () => {
+    const parsed = parseSourceChangeFilter({
+      table: "productinventory",
+      where: { quantity: { lt: 100 } },
+      primary_key: ["productid", "locationid"],
+      version_column: "modifieddate",
+    });
+    expect(parsed).not.toBeNull();
+    expect(parsed!.table).toBe("productinventory");
+    expect(parsed!.primary_key).toEqual(["productid", "locationid"]);
+  });
+
+  it("rejects an empty primary_key array", () => {
+    expect(
+      parseSourceChangeFilter({
+        table: "productinventory",
+        primary_key: [],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("parseSourceChangeMatch", () => {
+  const filter: SourceChangeFilter = {
+    table: "productinventory",
+    where: {},
+    primary_key: ["productid", "locationid"],
+    version_column: "modifieddate",
+  };
+
+  it("extracts composite primary_key + snapshot + version_token", () => {
+    const match = parseSourceChangeMatch(
+      {
+        data: {
+          productinventory: [
+            {
+              productid: 680,
+              locationid: 6,
+              quantity: 12,
+              modifieddate: "2026-05-23T10:00:00.000Z",
+            },
+          ],
+        },
+      },
+      filter,
+    );
+    expect(match).not.toBeNull();
+    expect(match!.table).toBe("productinventory");
+    expect(match!.primary_key).toEqual({ productid: 680, locationid: 6 });
+    expect(match!.snapshot.quantity).toBe(12);
+    expect(match!.version_token).toBe("2026-05-23T10:00:00.000Z");
+  });
+
+  it("returns null version_token when version_column unset on filter", () => {
+    const match = parseSourceChangeMatch(
+      {
+        data: {
+          productinventory: [{ productid: 1, locationid: 1, quantity: 50 }],
+        },
+      },
+      { ...filter, version_column: undefined },
+    );
+    expect(match?.version_token).toBeNull();
+  });
+
+  it("returns null on empty result", () => {
+    expect(parseSourceChangeMatch(null, filter)).toBeNull();
+    expect(
+      parseSourceChangeMatch({ data: { productinventory: [] } }, filter),
+    ).toBeNull();
+  });
+
+  it("returns null when a primary_key column is missing on the row", () => {
+    const match = parseSourceChangeMatch(
+      {
+        data: {
+          productinventory: [{ productid: 1, quantity: 5 }],
+        },
+      },
+      filter,
+    );
+    expect(match).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Wires `source_kind="source_change"` through the subscription manager so workflows can be triggered directly by row changes in the operator's data source — the IFTTT pattern (stock dropping below reorder, account flipping to at_risk, etc.) rather than only via cron + `workflow_output` chains.

Closes the loop opened by [dosco/graphjin#590](https://github.com/dosco/graphjin/issues/590) / PR [#591](https://github.com/dosco/graphjin/pull/591), which adds `{col: "..."}` operand syntax to where-clauses. The seeded demo filter uses that syntax; static-threshold filters work against any GraphJin version.

## How it works

- **Compiler / parser** (`subscription-query.ts`) — new `buildSourceChangeSubscription` emits the where clause verbatim into a GraphJin subscription against the operator's table. Filter shape `{table, where, primary_key, select?, version_column?}`; `primary_key` is required and drives delivery idempotency.
- **Two-arm match event** (`subscription-manager.ts`) — `SubscriptionMatchEvent` becomes a discriminated union (`workflow_output | source_change`). New `resolveTransport` callback lets the manager subscribe to the data-source GraphJin (per-org `data_source.subscription_url`) for `source_change` while keeping `workflow_output` on `neko-graphjin`.
- **Match handler** (`match-handler.ts`) — `handleSourceChangeMatch`: observation with `sourceOutputId=null`, audit row to `source_change_log`, idempotency key built from composite-PK hash + `version_token`, cycle detection via the new `workflow_run.source_writes` column (`hasRecentSourceWriteForWorkflow`). Shared in-flight + daily-budget guards extracted to `applyDeliveryGuards`.
- **Migration 0021** — adds `workflow_run.source_writes jsonb` + GIN index.
- **REST surface** — `route.ts` validates the `source_change` filter shape and runs a save-time mutation-loop heuristic (`detectMutationLoop`) that blocks responders likely to write back to the watched table (override via `idempotencyKeyTemplate` or `acknowledgeMutationLoop: true`). New `POST /subscriptions/dry-run` endpoint compiles the filter and runs a one-shot read so operators can preview matches before saving.
- **Conversational MCP** — new `neko_subscription_builder` server (`create_subscription`, `dry_run_subscription`, `list_subscriptions`) mounted in `/work` alongside `neko_workflow_builder` under the same `mcpTools` capability flag. Prompt section walks the agent through the IFTTT pattern.
- **Worker wiring** (`apps/worker/src/index.ts`) — resolves `data_source` per-org with a 60s cache and routes `source_change` events into `handleSourceChangeMatch`.

## Demo

`seed-adventureworks.mjs` adds a "Stock Reorder Watch" workflow + subscription against `production.productinventory`. New `db/seeds/dev/scenarios/low-stock-reorder.sql` drops one product's quantity below `reorderpoint` so the demo fires end-to-end. Catalog entry in `trial-sim-schema.sql`.

The seeded filter uses `{quantity: {lt: {col: "product.reorderpoint"}}}` which needs the dosco/graphjin release that follows v3.18.23 (PR #591 merged to master at `a74be81`); demo will work once a release tag containing that commit lands and `compose.adventureworks.yml`'s pin is bumped.

## Upgrade docs

`INSTALL.md` gains a proper Upgrade section: explicit macOS (`brew update && brew upgrade openneko`) and Linux (curl + tar + `sudo install`) one-liners, plus Stage-1-migrate / Stage-2-compose-up explanation. README's docs index deep-links to it.

## Out of scope (follow-ups)

- **Action-executor populates `source_writes`.** The runtime cycle check is wired but no built-in adapter reports its mutation targets yet. Until they do, the save-time mutation-loop heuristic carries the safety burden. Tracked separately.
- **Bumping `dosco/graphjin` pin** in `compose.adventureworks.yml` from 3.18.18. Waiting on a release tag past v3.18.23.

## Test plan

- [x] `pnpm -F @neko/llm test` — 299 passed, 60 skipped (integration tests need Postgres)
- [x] `pnpm -F @neko/worker run typecheck` — clean
- [x] `pnpm -F @neko/web run typecheck` — clean
- [x] `node --check packages/db/src/seed-adventureworks.mjs` — clean
- [ ] Manual: `docker compose -f compose.yml -f compose.adventureworks.yml up`, seed, fire `low-stock-reorder` scenario, watch worker log `enqueued source_change` (blocked on the GraphJin release for the col-ref filter)
- [ ] Integration: `subscription-chain.test.ts` + `subscription-store.test.ts` against real Postgres (CI exercises these)

🤖 Generated with [Claude Code](https://claude.com/claude-code)