### PR TITLE
fix: dedicated neko-migrate one-shot service breaks worker/neko-graphjin cycle

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -3,12 +3,12 @@ name: openneko release binaries
 # Fires when release-please publishes a GitHub release.
 #
 # Job graph:
-#   build-image (matrix 3 images × 2 arches = 6 cells)
+#   build-image (matrix 4 images × 2 arches = 8 cells)
 #       → publishes by digest only, no tags
 #       → runs natively on ubuntu-22.04 (amd64) and ubuntu-24.04-arm (arm64)
 #         so neither arch pays QEMU emulation overhead
-#       → all six cells run in parallel when runners are available
-#   merge-manifests (3 cells — one per image)
+#       → all eight cells run in parallel when runners are available
+#   merge-manifests (4 cells — one per image)
 #       → consumes the matched (amd64,arm64) digests for each image and
 #         publishes the multi-arch manifest as :vX.Y.Z + :latest
 #       → needs: [build-image]
@@ -39,9 +39,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
-      # 6-cell matrix enumerated explicitly: 3 images × 2 arches. Native
+      # 8-cell matrix enumerated explicitly: 4 images × 2 arches. Native
       # runners for both archs (arm64 lands on ubuntu-24.04-arm, free for
-      # public repos) so no QEMU emulation penalty. All six builds run
+      # public repos) so no QEMU emulation penalty. All eight builds run
       # in parallel when runners are available.
       matrix:
         include:
@@ -67,6 +67,14 @@ jobs:
             runner: ubuntu-22.04
           - image: neko-graphjin
             target: neko-graphjin
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+          - image: neko-cli
+            target: neko-cli
+            platform: linux/amd64
+            runner: ubuntu-22.04
+          - image: neko-cli
+            target: neko-cli
             platform: linux/arm64
             runner: ubuntu-24.04-arm
     steps:
@@ -123,7 +131,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [neko-web, neko-worker, neko-graphjin]
+        image: [neko-web, neko-worker, neko-graphjin, neko-cli]
     steps:
       - name: Resolve release tag
         id: tag

--- a/Dockerfile
+++ b/Dockerfile
@@ -220,6 +220,26 @@ EXPOSE 4100
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/entrypoint.sh"]
 CMD ["node", "--import", "tsx/esm", "apps/worker/src/index.ts"]
 
+# ─── 5c. neko-cli runtime ──────────────────────────────────────────────
+# Minimal image containing just the openneko Go binary. Used as the
+# `neko-migrate` one-shot container in compose: starts, runs
+# `openneko migrate`, exits. web / worker / neko-graphjin all depend on
+# its successful completion via service_completed_successfully, so by
+# the time they boot the schema is in place.
+#
+# Static Go binary (CGO_ENABLED=0), so debian-slim is enough — no glibc
+# version pinning needed. tini gives clean Ctrl-C / SIGTERM behavior;
+# ca-certs keeps TLS-to-managed-Postgres working if anyone points this
+# at a remote DB.
+FROM debian:bookworm-slim AS neko-cli
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates tini \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=go-build /out/openneko /usr/local/bin/openneko
+RUN chmod +x /usr/local/bin/openneko
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/openneko"]
+CMD ["--help"]
+
 # ─── 6. neko-graphjin runtime ──────────────────────────────────────────
 # OpenNeko's own GraphJin instance — exposes the metadata Postgres
 # (workflow_definition, workflow_run, workflow_output, observation,

--- a/apps/openneko/assets/compose/core.yml
+++ b/apps/openneko/assets/compose/core.yml
@@ -38,17 +38,38 @@ services:
       timeout: 5s
       retries: 20
 
+  # One-shot: applies SQL migrations to neko-db and exits. Every long-
+  # running service (web, worker, neko-graphjin) depends on this completing
+  # successfully, so by the time they start the schema is in place. Lives
+  # in the tiny neko-cli image (just the openneko Go binary + ca-certs +
+  # tini, ~80MB) so it spins up fast.
+  neko-migrate:
+    image: ghcr.io/open-neko/neko-cli:${OPENNEKO_VERSION:-latest}
+    restart: "no"
+    command: ["migrate"]
+    depends_on:
+      neko-db:
+        condition: service_healthy
+    environment:
+      NEKO_PG_HOST: neko-db
+      NEKO_PG_PORT: "5432"
+      NEKO_PG_USER: neko
+      NEKO_PG_PASSWORD: ${NEKO_PG_PASSWORD:-secret}
+      NEKO_PG_DATABASE: neko
+
   neko-graphjin:
     image: ghcr.io/open-neko/neko-graphjin:${OPENNEKO_VERSION:-latest}
     restart: unless-stopped
     depends_on:
-      # Waits on worker (not neko-db directly) because GraphJin caches the
-      # neko schema at startup; if it boots before migrations finish it sees
-      # an empty schema. The worker entrypoint runs `openneko migrate` before
-      # serving /health on 4100, so worker:service_healthy is our "migrations
-      # are done" signal.
-      worker:
+      # neko-db must be reachable for graphjin to connect; neko-migrate must
+      # have finished so the schema graphjin caches at boot reflects all
+      # pending migrations. The neko.yml config also sets
+      # db_schema_poll_duration: 10s so post-boot migrations are picked up
+      # automatically, but the explicit dep keeps first-boot deterministic.
+      neko-db:
         condition: service_healthy
+      neko-migrate:
+        condition: service_completed_successfully
     environment:
       NEKO_PG_PASSWORD: ${NEKO_PG_PASSWORD:-secret}
     volumes:
@@ -64,12 +85,10 @@ services:
   web:
     image: ghcr.io/open-neko/neko-web:${OPENNEKO_VERSION:-latest}
     depends_on:
-      # Web's entrypoint applies migrations itself (`openneko migrate`),
-      # serialized with worker via a Postgres advisory lock, so it only needs
-      # the DB to be reachable. neko-graphjin is not in the chain because the
-      # /work UI doesn't need graphjin to render the setup wizard.
-      neko-db:
-        condition: service_healthy
+      # Schema is guaranteed ready by neko-migrate before web boots — no
+      # need for web's entrypoint to run migrate itself anymore.
+      neko-migrate:
+        condition: service_completed_successfully
     environment:
       <<: *neko-app-env
       WORKER_ADMIN_URL: http://worker:4100
@@ -87,8 +106,10 @@ services:
   worker:
     image: ghcr.io/open-neko/neko-worker:${OPENNEKO_VERSION:-latest}
     depends_on:
-      neko-db:
-        condition: service_healthy
+      # Same as web: neko-migrate completes before worker starts, so the
+      # entrypoint no longer runs migrate.
+      neko-migrate:
+        condition: service_completed_successfully
     environment:
       <<: *neko-app-env
       OPENNEKO_GRAPHJIN_URL: http://neko-graphjin:8089
@@ -107,9 +128,6 @@ services:
       - openneko-agent-tmp:/tmp/openneko-tmp
       - openneko-plugins:/var/lib/openneko/plugins
     healthcheck:
-      # The admin server (apps/worker/src/admin-server.ts) starts AFTER the
-      # entrypoint's `openneko migrate` step, so /health responding 200 is
-      # our schema-is-ready signal. neko-graphjin keys off this.
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:4100/health"]
       interval: 5s
       timeout: 3s

--- a/apps/openneko/assets/compose/demo.yml
+++ b/apps/openneko/assets/compose/demo.yml
@@ -89,8 +89,10 @@ services:
   neko-adventureworks-seed:
     image: ghcr.io/open-neko/neko-worker:${OPENNEKO_VERSION:-latest}
     depends_on:
-      neko-db:
-        condition: service_healthy
+      # neko-migrate completion guarantees the organization / data_source /
+      # onboarding_wizard / workflow tables this seed writes into exist.
+      neko-migrate:
+        condition: service_completed_successfully
       adventureworks-init:
         condition: service_completed_successfully
     environment:

--- a/compose.adventureworks.yml
+++ b/compose.adventureworks.yml
@@ -157,12 +157,10 @@ services:
       context: .
       target: worker
     depends_on:
-      # Worker's healthcheck only flips green AFTER its entrypoint runs
-      # `openneko migrate`, so this is our schema-is-ready signal — the seed
-      # writes into organization / data_source / onboarding_wizard / workflow
-      # tables that the migrator just produced.
-      worker:
-        condition: service_healthy
+      # neko-migrate completion guarantees the organization / data_source /
+      # onboarding_wizard / workflow tables this seed writes into exist.
+      neko-migrate:
+        condition: service_completed_successfully
       adventureworks-init:
         condition: service_completed_successfully
     environment:

--- a/compose.yml
+++ b/compose.yml
@@ -36,20 +36,40 @@ services:
       timeout: 5s
       retries: 20
 
+  # One-shot: applies SQL migrations to neko-db and exits. Every long-
+  # running service (web, worker, neko-graphjin) depends on this completing
+  # successfully, so by the time they start the schema is in place.
+  neko-migrate:
+    build:
+      context: .
+      target: neko-cli
+    restart: "no"
+    command: ["migrate"]
+    depends_on:
+      neko-db:
+        condition: service_healthy
+    environment:
+      NEKO_PG_HOST: neko-db
+      NEKO_PG_PORT: "5432"
+      NEKO_PG_USER: neko
+      NEKO_PG_PASSWORD: secret
+      NEKO_PG_DATABASE: neko
+
   neko-graphjin:
     build:
       context: .
       target: neko-graphjin
     restart: unless-stopped
     depends_on:
-      # Waits on worker (not neko-db directly) because GraphJin caches the
-      # neko schema at startup; if it boots before migrations finish it sees
-      # an empty schema. The worker entrypoint runs `openneko migrate` before
-      # serving /health on 4100, so worker:service_healthy is our "migrations
-      # are done" signal. Web migrates concurrently — the migrator's advisory
-      # lock keeps them from racing.
-      worker:
+      # neko-db must be reachable for graphjin to connect; neko-migrate must
+      # have finished so graphjin's schema cache reflects all pending
+      # migrations. db_schema_poll_duration: 10s in neko.yml also picks up
+      # post-boot migrations, but the explicit dep keeps first-boot
+      # deterministic.
+      neko-db:
         condition: service_healthy
+      neko-migrate:
+        condition: service_completed_successfully
     # The custom entrypoint reads the password from /openneko-config/config.json
     # (written by the worker entrypoint + the /setup wizard) on every container
     # start, so password rotation works after a simple `docker compose restart
@@ -72,11 +92,9 @@ services:
       context: .
       target: web
     depends_on:
-      # Web's entrypoint applies migrations itself (`openneko migrate`),
-      # serialized with worker via a Postgres advisory lock, so it only needs
-      # the DB to be reachable — no init container, no ordering versus worker.
-      neko-db:
-        condition: service_healthy
+      # Schema is guaranteed ready by neko-migrate before web boots.
+      neko-migrate:
+        condition: service_completed_successfully
       neko-graphjin:
         condition: service_started
     environment:
@@ -98,10 +116,9 @@ services:
       context: .
       target: worker
     depends_on:
-      # Same story as web — entrypoint migrates. No ordering versus
-      # neko-graphjin needed; in fact graphjin depends on us via healthcheck.
-      neko-db:
-        condition: service_healthy
+      # Schema is guaranteed ready by neko-migrate before worker boots.
+      neko-migrate:
+        condition: service_completed_successfully
     environment:
       <<: *neko-app-env
       OPENNEKO_GRAPHJIN_URL: http://neko-graphjin:8089
@@ -120,10 +137,6 @@ services:
       - openneko-agent-home:/tmp/openneko-home
       - openneko-agent-tmp:/tmp/openneko-tmp
     healthcheck:
-      # The admin server (apps/worker/src/admin-server.ts) starts AFTER the
-      # entrypoint's `openneko migrate` step, so /health responding 200 is
-      # our schema-is-ready signal. neko-graphjin and other downstream
-      # services key off this.
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:4100/health"]
       interval: 5s
       timeout: 3s

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -91,28 +91,11 @@ if (force || !fs.existsSync(secretPath)) {
 }
 JS
 
-# Apply DB migrations using the vendored openneko binary. Both web and worker
-# call this on every boot; an advisory lock inside migrator.Apply() serializes
-# concurrent invocations so the slow side blocks until the fast side is done
-# and then no-ops. Skips cleanly in environments without openneko on PATH (e.g.
-# minimal test images) — callers there are expected to have migrated separately.
-if command -v openneko >/dev/null 2>&1; then
-  PG_HOST="${NEKO_PG_HOST:-neko-db}"
-  PG_PORT="${NEKO_PG_PORT:-5432}"
-  PG_USER="${NEKO_PG_USER:-neko}"
-  PG_DB="${NEKO_PG_DATABASE:-neko}"
-  echo "[entrypoint] waiting for postgres at ${PG_HOST}:${PG_PORT}"
-  i=0
-  until pg_isready -h "${PG_HOST}" -p "${PG_PORT}" -U "${PG_USER}" -d "${PG_DB}" >/dev/null 2>&1; do
-    i=$((i+1))
-    if [ "$i" -ge 60 ]; then
-      echo "[entrypoint] postgres did not become reachable within 60s; bailing" >&2
-      exit 1
-    fi
-    sleep 1
-  done
-  echo "[entrypoint] running openneko migrate"
-  openneko migrate
-fi
+# Migrations: a dedicated `neko-migrate` compose service (ghcr.io/open-neko/neko-cli)
+# runs `openneko migrate` once before web/worker start, gated via
+# `depends_on: neko-migrate: service_completed_successfully`. So web and worker
+# can trust the schema is in place by the time their entrypoints run and we don't
+# repeat the migrate here. Bare-Docker users (no compose orchestration) need to
+# run `openneko migrate` against the DB themselves before starting these images.
 
 exec "$@"

--- a/packages/llm/src/workflows/subscription-manager.ts
+++ b/packages/llm/src/workflows/subscription-manager.ts
@@ -131,6 +131,11 @@ export function startSubscriptionManager(
         opts.onError?.(err, sub);
       },
     });
+    // The handle's `ready` promise rejects when the WS connection fails;
+    // the same failure already fires onError above, so absorb the rejection
+    // here to keep it from surfacing as an unhandled rejection that crashes
+    // the worker. Manager-level callers consume errors via opts.onError.
+    handle.ready.catch(() => {});
     handles.set(sub.id, handle);
   };
 

--- a/packages/llm/test/subscription-manager.test.ts
+++ b/packages/llm/test/subscription-manager.test.ts
@@ -39,7 +39,7 @@ describe("startSubscriptionManager — transport resolver", () => {
   beforeEach(() => {
     subscribeMock.mockReset();
     listEnabledMock.mockReset();
-    subscribeMock.mockReturnValue({ stop: vi.fn() });
+    subscribeMock.mockReturnValue({ stop: vi.fn(), ready: Promise.resolve() });
   });
 
   afterEach(() => {
@@ -134,7 +134,7 @@ describe("startSubscriptionManager — transport resolver", () => {
       | undefined;
     subscribeMock.mockImplementation((args: { onNext: (m: unknown) => unknown }) => {
       pushedOnNext = args.onNext;
-      return { stop: vi.fn() };
+      return { stop: vi.fn(), ready: Promise.resolve() };
     });
 
     const onMatch = vi.fn();


### PR DESCRIPTION
## Summary

Fresh `openneko start --mode demo` on v1.13.1 deadlocks because the worker and neko-graphjin each need the other to be healthy first. The worker also crashes its process on any WebSocket hiccup, putting it in a permanent restart loop. Two real bugs caught running the end-to-end demo install path.

- **Compose cycle** — `neko-graphjin.depends_on: worker:service_healthy` was originally added as a "migrations done" signal. After source_change subscriptions shipped in v1.13.x, the worker started subscribing to neko-graphjin at boot. Cycle, deadlock.
- **Unhandled rejection in subscription manager** — `graphjinSubscribe`'s WS error handler rejected the handle's `ready` promise without any `.catch()` consumer. Node 22's default unhandled-rejection-crashes-process behavior killed the worker on every first-boot WS error.

## Approach

Restructured migrations into a dedicated one-shot service so every long-running service has a single unambiguous "schema is in place" gate, with no startup cycles possible.

- New `neko-migrate` compose service: runs `openneko migrate`, exits. Gated on `neko-db:service_healthy`.
- `web`, `worker`, `neko-graphjin`, and `neko-adventureworks-seed` all depend on `neko-migrate:service_completed_successfully`.
- New `neko-cli` Dockerfile stage — debian-slim + the static `openneko` Go binary + tini + ca-certs (~125 MB). Added to the release-binaries matrix (now 4 images × 2 arches = 8 build cells, 4 merge cells).
- `entrypoint.sh` no longer shells out to `openneko migrate`. Bare-Docker users (no compose orchestration) now need to run migrate themselves.
- `subscription-manager` attaches a no-op `.catch()` to the WS handle's `ready` so transient WS errors surface via the existing `onError` callback instead of crashing the worker.
- Same restructuring mirrored in `compose.yml` + `compose.adventureworks.yml` so source-build dev matches binary-ship.

## Test plan

- [x] `pnpm --filter @neko/llm test` — 299 passed, 60 skipped (postgres-needing tests)
- [x] `go test ./...` in `apps/openneko/` — all packages green
- [x] `docker build --target neko-cli` — image builds, openneko binary runs, `migrate --help` resolves, image is ~125 MB
- [x] `docker compose -f apps/openneko/assets/compose/core.yml -f apps/openneko/assets/compose/demo.yml config` — combined dependency graph has no cycles
- [ ] Post-merge: `brew upgrade openneko && openneko reset --all && openneko start --mode demo` against the v1.13.2 release should reach the setup wizard without the worker restart loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)