### PR TITLE
ci(deploy): upgrade installed plugins to marketplace-latest on every deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,7 +79,8 @@ jobs:
               else
                 echo "[deploy] SLACK_BOT_TOKEN secret not set in CI; slack install will be skipped"
               fi
-              if [ -n "${SLACK_BOT_TOKEN:-}" ] && ! openneko list 2>/dev/null | grep -q '@open-neko/plugin-slack'; then
+              # Re-install every deploy → upserts to marketplace-latest (upgrades in place, no-ops once current).
+              if [ -n "${SLACK_BOT_TOKEN:-}" ]; then
                 openneko install @open-neko/plugin-slack --skip-host-check
               fi
               # Worker's poll fallback picks up manifest+secrets changes


### PR DESCRIPTION
Drops the install-only-if-absent guard in deploy.yml so the VM upgrades the Slack plugin in place (0.1.0 → 0.2.0, which carries `default_mode: auto`) instead of skipping because it's already present. Install upserts + picks marketplace-latest, so it's idempotent once current.

Sequenced after open-neko/plugins#17 (marketplace 0.2.0 entries) so the deploy resolves the new version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)