### PR TITLE
fix(worker): surface plugin action examples even on marketplace installs

### DIFF
--- a/apps/worker/src/plugins/plugin-registry.ts
+++ b/apps/worker/src/plugins/plugin-registry.ts
@@ -694,6 +694,10 @@ export class PluginRegistry {
     this.refreshing = true;
     try {
       const manifest = await readManifestFromDisk(this.options.repoRoot);
+      await enrichExamplesFromPackages(
+        manifest,
+        this.options.pluginInstallDir ?? this.options.repoRoot,
+      );
       const full = await readFullSecretsFileSoft(
         this.options.secretsConfigDir,
         (line) => console.warn(`[plugin-registry] ${line}`),
@@ -1053,6 +1057,51 @@ export class PluginRegistry {
       sandboxFactory: factory,
       networkPolicy: policy,
     });
+  }
+}
+
+/**
+ * The marketplace schema doesn't carry action `example` payloads, and the Go
+ * install path drops them — so a marketplace-installed manifest has none. The
+ * agent prompt relies on examples to get payload shapes right (small models
+ * otherwise invent wrong shapes), so read them back from each installed
+ * package's own package.json (which always carries them) and fill any kind
+ * whose manifest entry is missing one. No-ops for the source-build dev
+ * manifest, which already carries examples.
+ */
+async function enrichExamplesFromPackages(
+  manifest: PluginManifest | null,
+  installDir: string,
+): Promise<void> {
+  if (!manifest) return;
+  for (const entry of manifest.plugins) {
+    const kinds = entry.capabilities.action?.kinds;
+    if (!kinds?.length || kinds.every((k) => k.example !== undefined)) continue;
+    let byKind: Map<string, Record<string, unknown>>;
+    try {
+      const pkgPath = path.join(installDir, "node_modules", entry.name, "package.json");
+      const pkg = JSON.parse(await readFile(pkgPath, "utf8")) as {
+        openneko?: {
+          capabilities?: { action?: { kinds?: Array<{ kind?: string; example?: unknown }> } };
+        };
+      };
+      byKind = new Map(
+        (pkg.openneko?.capabilities?.action?.kinds ?? [])
+          .filter(
+            (k): k is { kind: string; example: Record<string, unknown> } =>
+              typeof k.kind === "string" && !!k.example && typeof k.example === "object",
+          )
+          .map((k) => [k.kind, k.example]),
+      );
+    } catch {
+      continue; // package unreadable → leave manifest examples untouched
+    }
+    for (const decl of kinds) {
+      if (decl.example === undefined) {
+        const ex = byKind.get(decl.kind);
+        if (ex) decl.example = ex;
+      }
+    }
   }
 }
 

--- a/apps/worker/test/plugins/plugin-registry.test.ts
+++ b/apps/worker/test/plugins/plugin-registry.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -216,6 +216,45 @@ describe("PluginRegistry", () => {
     expect(reg.status().vmsRunning).toBe(0);
     expect(runtime.starts).toEqual([]);
     expect(captured.size).toBe(4);
+    await reg.stop();
+  });
+
+  it("enriches action examples from the installed package.json when the manifest lacks them", async () => {
+    // A marketplace install drops `example` (schema forbids it), so the
+    // manifest entry has the kind but no example payload.
+    await writeFile(
+      path.join(repoRoot, "openneko.plugins.json"),
+      JSON.stringify(
+        manifestWithSlackEntry({
+          kinds: [{ kind: "send_slack_dm", description: "DM a user." }],
+        }),
+      ),
+      "utf8",
+    );
+    // The installed package's own package.json always carries the example.
+    const pkgDir = path.join(repoRoot, "node_modules", "@open-neko", "plugin-slack");
+    await mkdir(pkgDir, { recursive: true });
+    await writeFile(
+      path.join(pkgDir, "package.json"),
+      JSON.stringify({
+        name: "@open-neko/plugin-slack",
+        version: "0.2.0",
+        openneko: {
+          capabilities: {
+            action: {
+              kinds: [
+                { kind: "send_slack_dm", description: "DM a user.", example: { user: "amit", text: "hi" } },
+              ],
+            },
+          },
+        },
+      }),
+      "utf8",
+    );
+    const reg = newRegistry(new FakeRuntime());
+    await reg.start();
+    const dm = reg.getRegisteredActionDescriptors().find((d) => d.kind === "send_slack_dm");
+    expect(dm?.example).toEqual({ user: "amit", text: "hi" });
     await reg.stop();
   });
 


### PR DESCRIPTION
Smaller models need the action `example` payloads to emit correctly-shaped calls. But the marketplace schema forbids `example` (`additionalProperties:false`) and the Go install path drops it, so a marketplace-installed manifest (like the demo VM's) has `has_example:false` — the agent loses the examples.

Fix: the installed package's own `package.json` always carries the examples, so the registry enriches each manifest kind's `example` from `<installDir>/node_modules/<pkg>/package.json` at refresh time (filling only kinds missing one). Worker-only — ships via the normal deploy, no Go/marketplace/schema change, and covers all plugins. No-ops for the source-build dev manifest (already has examples).

Regression test added (`enriches action examples from the installed package.json…`). Worker: 177 tests pass, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)