### PR TITLE
feat(openneko): channel capability in install path + telegram VM install

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
           # picks it up on the next manifest refresh. Empty string is
           # tolerated — the deploy still completes, slack just isn't wired.
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
         run: |
           # NOTE: privileged steps (systemd drop-in, openneko binary install,
           # systemd daemon-reload) live in scripts/neko-vm-setup.sh and are
@@ -37,7 +38,7 @@ jobs:
           # SSH_USER can do without prompting for a sudo password.
           ssh -i ~/.ssh/id_ed25519 \
               "$SSH_USER@$SSH_HOST" \
-              GIT_REF="$GIT_REF" SLACK_BOT_TOKEN="$SLACK_BOT_TOKEN" \
+              GIT_REF="$GIT_REF" SLACK_BOT_TOKEN="$SLACK_BOT_TOKEN" TELEGRAM_BOT_TOKEN="$TELEGRAM_BOT_TOKEN" \
               bash -se <<'EOF'
             set -euo pipefail
             cd /opt/neko
@@ -82,6 +83,16 @@ jobs:
               # Re-install every deploy → upserts to marketplace-latest (upgrades in place, no-ops once current).
               if [ -n "${SLACK_BOT_TOKEN:-}" ]; then
                 openneko install @open-neko/plugin-slack --skip-host-check
+              fi
+              # Telegram is a CHANNEL plugin. Once the VM's openneko binary is
+              # refreshed to a release with channel support (re-run
+              # scripts/neko-vm-setup.sh), this can become a plain
+              # `openneko install @open-neko/channel-telegram`; until then the
+              # helper installs the npm package + registers the channel
+              # manifest entry directly. Gated + non-fatal — never fails deploy.
+              if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -f /opt/neko/scripts/install-telegram-channel.sh ]; then
+                bash /opt/neko/scripts/install-telegram-channel.sh \
+                  || echo "[deploy] telegram channel install non-fatal failure"
               fi
               # Worker's poll fallback picks up manifest+secrets changes
               # within 3s — no restart needed.

--- a/apps/openneko/internal/plugin/install/install.go
+++ b/apps/openneko/internal/plugin/install/install.go
@@ -464,8 +464,9 @@ type pkgPermissions struct {
 }
 
 type pkgCapabilities struct {
-	Action *manifest.ActionCapability `json:"action,omitempty"`
-	Auth   *manifest.AuthCapability   `json:"auth,omitempty"`
+	Action  *manifest.ActionCapability  `json:"action,omitempty"`
+	Auth    *manifest.AuthCapability    `json:"auth,omitempty"`
+	Channel *manifest.ChannelCapability `json:"channel,omitempty"`
 }
 
 type pkgOpenneko struct {
@@ -542,6 +543,14 @@ func convertCapabilities(c marketplace.Capabilities) manifest.Capabilities {
 	if c.Auth != nil {
 		out.Auth = &manifest.AuthCapability{ProviderLabel: c.Auth.ProviderLabel}
 	}
+	if c.Channel != nil {
+		out.Channel = &manifest.ChannelCapability{
+			ProviderLabel: c.Channel.ProviderLabel,
+			Profile:       c.Channel.Profile,
+			Directions:    c.Channel.Directions,
+			Ingress:       c.Channel.Ingress,
+		}
+	}
 	return out
 }
 
@@ -555,6 +564,9 @@ func convertOpennekoCapabilities(c *pkgCapabilities) manifest.Capabilities {
 	}
 	if c.Auth != nil {
 		out.Auth = c.Auth
+	}
+	if c.Channel != nil {
+		out.Channel = c.Channel
 	}
 	return out
 }

--- a/apps/openneko/internal/plugin/install/install_channel_test.go
+++ b/apps/openneko/internal/plugin/install/install_channel_test.go
@@ -1,0 +1,52 @@
+package install
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/open-neko/neko/apps/openneko/internal/plugin/manifest"
+	"github.com/open-neko/neko/apps/openneko/internal/plugin/marketplace"
+)
+
+// A marketplace version that declares only a channel capability must survive
+// conversion into the installed manifest — including its opaque profile.
+func TestConvertCapabilities_Channel(t *testing.T) {
+	profile := json.RawMessage(`{"modalities":["text"],"fidelity":"summary"}`)
+	out := convertCapabilities(marketplace.Capabilities{
+		Channel: &marketplace.ChannelCapability{
+			ProviderLabel: "Telegram",
+			Profile:       profile,
+			Directions:    []string{"outbound", "inbound"},
+			Ingress:       "webhook",
+		},
+	})
+	if out.Channel == nil {
+		t.Fatal("channel capability dropped by convertCapabilities")
+	}
+	if out.Channel.ProviderLabel != "Telegram" {
+		t.Fatalf("providerLabel: got %q", out.Channel.ProviderLabel)
+	}
+	if out.Channel.Ingress != "webhook" {
+		t.Fatalf("ingress: got %q", out.Channel.Ingress)
+	}
+	if string(out.Channel.Profile) != string(profile) {
+		t.Fatalf("profile not round-tripped: got %s", out.Channel.Profile)
+	}
+	if len(out.Channel.Directions) != 2 {
+		t.Fatalf("directions: got %v", out.Channel.Directions)
+	}
+}
+
+// The --unverified path reads capabilities from the package's own package.json;
+// a channel must pass through there too.
+func TestConvertOpennekoCapabilities_Channel(t *testing.T) {
+	out := convertOpennekoCapabilities(&pkgCapabilities{
+		Channel: &manifest.ChannelCapability{
+			ProviderLabel: "Telegram",
+			Directions:    []string{"outbound"},
+		},
+	})
+	if out.Channel == nil || out.Channel.ProviderLabel != "Telegram" {
+		t.Fatalf("channel capability not passed through: %+v", out.Channel)
+	}
+}

--- a/apps/openneko/internal/plugin/manifest/manifest.go
+++ b/apps/openneko/internal/plugin/manifest/manifest.go
@@ -42,9 +42,21 @@ type AuthCapability struct {
 	ProviderLabel string `json:"providerLabel,omitempty"`
 }
 
+// ChannelCapability — the plugin is a frontend (Slack, Telegram, voice, …).
+// Profile is round-tripped as raw JSON: the CLI doesn't interpret the
+// capability profile, it just carries it into the installed manifest for the
+// worker (which fully validates it).
+type ChannelCapability struct {
+	ProviderLabel string          `json:"providerLabel"`
+	Profile       json.RawMessage `json:"profile,omitempty"`
+	Directions    []string        `json:"directions,omitempty"`
+	Ingress       string          `json:"ingress,omitempty"`
+}
+
 type Capabilities struct {
-	Action *ActionCapability `json:"action,omitempty"`
-	Auth   *AuthCapability   `json:"auth,omitempty"`
+	Action  *ActionCapability  `json:"action,omitempty"`
+	Auth    *AuthCapability    `json:"auth,omitempty"`
+	Channel *ChannelCapability `json:"channel,omitempty"`
 }
 
 type Entry struct {

--- a/apps/openneko/internal/plugin/marketplace/client.go
+++ b/apps/openneko/internal/plugin/marketplace/client.go
@@ -40,9 +40,19 @@ type AuthCapability struct {
 	ProviderLabel string `json:"providerLabel,omitempty"`
 }
 
+// ChannelCapability — a frontend (Slack, Telegram, voice, …). Profile is
+// carried as raw JSON; the worker validates it.
+type ChannelCapability struct {
+	ProviderLabel string          `json:"providerLabel"`
+	Profile       json.RawMessage `json:"profile,omitempty"`
+	Directions    []string        `json:"directions,omitempty"`
+	Ingress       string          `json:"ingress,omitempty"`
+}
+
 type Capabilities struct {
-	Action *ActionCapability `json:"action,omitempty"`
-	Auth   *AuthCapability   `json:"auth,omitempty"`
+	Action  *ActionCapability  `json:"action,omitempty"`
+	Auth    *AuthCapability    `json:"auth,omitempty"`
+	Channel *ChannelCapability `json:"channel,omitempty"`
 }
 
 type Version struct {

--- a/scripts/install-telegram-channel.sh
+++ b/scripts/install-telegram-channel.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Install the Telegram channel plugin on neko-vm during deploy.
+#
+# Channel plugins are not yet first-class in the Go `openneko install` path
+# (its capability model predates `capabilities.channel`), so this fetches the
+# published npm package into the plugin dir and registers the channel manifest
+# entry directly — the TS worker fully supports capabilities.channel and picks
+# up manifest+secret changes within ~3s via its poll fallback.
+#
+# Invoked gated + non-fatal from .github/workflows/deploy.yml. No-ops cleanly
+# when TELEGRAM_BOT_TOKEN is absent. Reads OPENNEKO_PLUGIN_INSTALL_DIR +
+# OPENNEKO_PLUGINS_MANIFEST_PATH from the deploy environment.
+set -uo pipefail
+
+PKG="@open-neko/channel-telegram"
+VER="0.2.0"
+INTEGRITY="sha512-6DCDiVh+CMU6wCuyp3N2RMIhpehs/C0vC2nP08XzFzo/8uK1GLO0YpN4wXYp3RUMcrYBiOvCLyx4+gbuNE/yEw=="
+
+TOKEN="${TELEGRAM_BOT_TOKEN:-}"
+if [ -z "$TOKEN" ]; then
+  echo "[telegram] TELEGRAM_BOT_TOKEN not set; skipping"
+  exit 0
+fi
+: "${OPENNEKO_PLUGIN_INSTALL_DIR:?need OPENNEKO_PLUGIN_INSTALL_DIR}"
+: "${OPENNEKO_PLUGINS_MANIFEST_PATH:?need OPENNEKO_PLUGINS_MANIFEST_PATH}"
+
+echo "[telegram] saving bot token to the secrets store"
+openneko secrets set "$PKG" TELEGRAM_BOT_TOKEN "$TOKEN" || echo "[telegram] secrets set returned nonzero"
+
+NM="$OPENNEKO_PLUGIN_INSTALL_DIR/node_modules/$PKG"
+if [ ! -f "$NM/dist/run.js" ]; then
+  echo "[telegram] installing $PKG@$VER into $OPENNEKO_PLUGIN_INSTALL_DIR"
+  ( cd "$OPENNEKO_PLUGIN_INSTALL_DIR" && npm install "$PKG@$VER" --no-audit --no-fund 2>&1 | tail -8 ) \
+    || echo "[telegram] npm install returned nonzero"
+fi
+if [ ! -f "$NM/dist/run.js" ]; then
+  echo "[telegram] ERROR: $NM/dist/run.js missing after install; not registering"
+  exit 0
+fi
+
+echo "[telegram] registering channel manifest entry in $OPENNEKO_PLUGINS_MANIFEST_PATH"
+MANIFEST="$OPENNEKO_PLUGINS_MANIFEST_PATH" TG_INTEGRITY="$INTEGRITY" TG_VER="$VER" \
+  node --input-type=module <<'NODE'
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+const path = process.env.MANIFEST;
+const SCHEMA = "https://open-neko.github.io/plugins/manifest.schema.json";
+const m = existsSync(path)
+  ? JSON.parse(readFileSync(path, "utf8"))
+  : { schema: SCHEMA, plugins: [] };
+m.schema ||= SCHEMA;
+m.plugins ||= [];
+const entry = {
+  name: "@open-neko/channel-telegram",
+  version: process.env.TG_VER,
+  integrity: process.env.TG_INTEGRITY,
+  permissions: {
+    network: ["api.telegram.org"],
+    env: [
+      { key: "TELEGRAM_BOT_TOKEN", required: true, secret: true, description: "Bot token from @BotFather." },
+      { key: "TELEGRAM_WEBHOOK_SECRET", required: false, secret: true, description: "Optional webhook secret_token for verify_inbound." },
+    ],
+  },
+  capabilities: {
+    channel: {
+      providerLabel: "Telegram",
+      directions: ["outbound", "inbound"],
+      ingress: "webhook",
+      profile: {
+        modalities: ["text"],
+        richMedia: { markdown: true, cards: false, charts: false, images: true, interactiveControls: true },
+        interaction: { turnTaking: "async", canApproveInline: true, quickReplies: true },
+        constraints: { maxOutboundChars: 4096, latencyClass: "interactive", attentionModel: "push" },
+        fidelity: "summary",
+      },
+    },
+  },
+  marketplace: "npm",
+};
+m.plugins = m.plugins.filter((p) => p && p.name !== entry.name);
+m.plugins.push(entry);
+writeFileSync(path, JSON.stringify(m, null, 2) + "\n");
+console.log(`[telegram] manifest plugins: ${m.plugins.map((p) => p.name).join(", ")}`);
+NODE
+
+echo "[telegram] done — worker registers the channel within ~3s"


### PR DESCRIPTION
Makes `channel` a first-class capability in the Go `openneko` CLI (it only modeled action/auth before, so channel plugins fell through the install path) and installs @open-neko/channel-telegram on neko-vm via the deploy. Go build + tests green; pairs with the marketplace PR in open-neko/plugins. Bridge install is gated + non-fatal; native `openneko install` works once the VM binary is refreshed to this release.