### PR TITLE
feat: channel CLI install + operator surface (auto-enable inbound + auto-bind)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
           # picks it up on the next manifest refresh. Empty string is
           # tolerated — the deploy still completes, slack just isn't wired.
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
         run: |
           # NOTE: privileged steps (systemd drop-in, openneko binary install,
           # systemd daemon-reload) live in scripts/neko-vm-setup.sh and are
@@ -37,7 +38,7 @@ jobs:
           # SSH_USER can do without prompting for a sudo password.
           ssh -i ~/.ssh/id_ed25519 \
               "$SSH_USER@$SSH_HOST" \
-              GIT_REF="$GIT_REF" SLACK_BOT_TOKEN="$SLACK_BOT_TOKEN" \
+              GIT_REF="$GIT_REF" SLACK_BOT_TOKEN="$SLACK_BOT_TOKEN" TELEGRAM_BOT_TOKEN="$TELEGRAM_BOT_TOKEN" \
               bash -se <<'EOF'
             set -euo pipefail
             cd /opt/neko
@@ -82,6 +83,16 @@ jobs:
               # Re-install every deploy → upserts to marketplace-latest (upgrades in place, no-ops once current).
               if [ -n "${SLACK_BOT_TOKEN:-}" ]; then
                 openneko install @open-neko/plugin-slack --skip-host-check
+              fi
+              # Telegram is a CHANNEL plugin. Once the VM's openneko binary is
+              # refreshed to a release with channel support (re-run
+              # scripts/neko-vm-setup.sh), this can become a plain
+              # `openneko install @open-neko/channel-telegram`; until then the
+              # helper installs the npm package + registers the channel
+              # manifest entry directly. Gated + non-fatal — never fails deploy.
+              if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -f /opt/neko/scripts/install-telegram-channel.sh ]; then
+                bash /opt/neko/scripts/install-telegram-channel.sh \
+                  || echo "[deploy] telegram channel install non-fatal failure"
               fi
               # Worker's poll fallback picks up manifest+secrets changes
               # within 3s — no restart needed.

--- a/apps/openneko/internal/plugin/install/install.go
+++ b/apps/openneko/internal/plugin/install/install.go
@@ -464,8 +464,9 @@ type pkgPermissions struct {
 }
 
 type pkgCapabilities struct {
-	Action *manifest.ActionCapability `json:"action,omitempty"`
-	Auth   *manifest.AuthCapability   `json:"auth,omitempty"`
+	Action  *manifest.ActionCapability  `json:"action,omitempty"`
+	Auth    *manifest.AuthCapability    `json:"auth,omitempty"`
+	Channel *manifest.ChannelCapability `json:"channel,omitempty"`
 }
 
 type pkgOpenneko struct {
@@ -542,6 +543,14 @@ func convertCapabilities(c marketplace.Capabilities) manifest.Capabilities {
 	if c.Auth != nil {
 		out.Auth = &manifest.AuthCapability{ProviderLabel: c.Auth.ProviderLabel}
 	}
+	if c.Channel != nil {
+		out.Channel = &manifest.ChannelCapability{
+			ProviderLabel: c.Channel.ProviderLabel,
+			Profile:       c.Channel.Profile,
+			Directions:    c.Channel.Directions,
+			Ingress:       c.Channel.Ingress,
+		}
+	}
 	return out
 }
 
@@ -555,6 +564,9 @@ func convertOpennekoCapabilities(c *pkgCapabilities) manifest.Capabilities {
 	}
 	if c.Auth != nil {
 		out.Auth = c.Auth
+	}
+	if c.Channel != nil {
+		out.Channel = c.Channel
 	}
 	return out
 }

--- a/apps/openneko/internal/plugin/install/install_channel_test.go
+++ b/apps/openneko/internal/plugin/install/install_channel_test.go
@@ -1,0 +1,52 @@
+package install
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/open-neko/neko/apps/openneko/internal/plugin/manifest"
+	"github.com/open-neko/neko/apps/openneko/internal/plugin/marketplace"
+)
+
+// A marketplace version that declares only a channel capability must survive
+// conversion into the installed manifest — including its opaque profile.
+func TestConvertCapabilities_Channel(t *testing.T) {
+	profile := json.RawMessage(`{"modalities":["text"],"fidelity":"summary"}`)
+	out := convertCapabilities(marketplace.Capabilities{
+		Channel: &marketplace.ChannelCapability{
+			ProviderLabel: "Telegram",
+			Profile:       profile,
+			Directions:    []string{"outbound", "inbound"},
+			Ingress:       "webhook",
+		},
+	})
+	if out.Channel == nil {
+		t.Fatal("channel capability dropped by convertCapabilities")
+	}
+	if out.Channel.ProviderLabel != "Telegram" {
+		t.Fatalf("providerLabel: got %q", out.Channel.ProviderLabel)
+	}
+	if out.Channel.Ingress != "webhook" {
+		t.Fatalf("ingress: got %q", out.Channel.Ingress)
+	}
+	if string(out.Channel.Profile) != string(profile) {
+		t.Fatalf("profile not round-tripped: got %s", out.Channel.Profile)
+	}
+	if len(out.Channel.Directions) != 2 {
+		t.Fatalf("directions: got %v", out.Channel.Directions)
+	}
+}
+
+// The --unverified path reads capabilities from the package's own package.json;
+// a channel must pass through there too.
+func TestConvertOpennekoCapabilities_Channel(t *testing.T) {
+	out := convertOpennekoCapabilities(&pkgCapabilities{
+		Channel: &manifest.ChannelCapability{
+			ProviderLabel: "Telegram",
+			Directions:    []string{"outbound"},
+		},
+	})
+	if out.Channel == nil || out.Channel.ProviderLabel != "Telegram" {
+		t.Fatalf("channel capability not passed through: %+v", out.Channel)
+	}
+}

--- a/apps/openneko/internal/plugin/manifest/manifest.go
+++ b/apps/openneko/internal/plugin/manifest/manifest.go
@@ -42,9 +42,21 @@ type AuthCapability struct {
 	ProviderLabel string `json:"providerLabel,omitempty"`
 }
 
+// ChannelCapability — the plugin is a frontend (Slack, Telegram, voice, …).
+// Profile is round-tripped as raw JSON: the CLI doesn't interpret the
+// capability profile, it just carries it into the installed manifest for the
+// worker (which fully validates it).
+type ChannelCapability struct {
+	ProviderLabel string          `json:"providerLabel"`
+	Profile       json.RawMessage `json:"profile,omitempty"`
+	Directions    []string        `json:"directions,omitempty"`
+	Ingress       string          `json:"ingress,omitempty"`
+}
+
 type Capabilities struct {
-	Action *ActionCapability `json:"action,omitempty"`
-	Auth   *AuthCapability   `json:"auth,omitempty"`
+	Action  *ActionCapability  `json:"action,omitempty"`
+	Auth    *AuthCapability    `json:"auth,omitempty"`
+	Channel *ChannelCapability `json:"channel,omitempty"`
 }
 
 type Entry struct {

--- a/apps/openneko/internal/plugin/marketplace/client.go
+++ b/apps/openneko/internal/plugin/marketplace/client.go
@@ -40,9 +40,19 @@ type AuthCapability struct {
 	ProviderLabel string `json:"providerLabel,omitempty"`
 }
 
+// ChannelCapability — a frontend (Slack, Telegram, voice, …). Profile is
+// carried as raw JSON; the worker validates it.
+type ChannelCapability struct {
+	ProviderLabel string          `json:"providerLabel"`
+	Profile       json.RawMessage `json:"profile,omitempty"`
+	Directions    []string        `json:"directions,omitempty"`
+	Ingress       string          `json:"ingress,omitempty"`
+}
+
 type Capabilities struct {
-	Action *ActionCapability `json:"action,omitempty"`
-	Auth   *AuthCapability   `json:"auth,omitempty"`
+	Action  *ActionCapability  `json:"action,omitempty"`
+	Auth    *AuthCapability    `json:"auth,omitempty"`
+	Channel *ChannelCapability `json:"channel,omitempty"`
 }
 
 type Version struct {

--- a/apps/worker/src/channels/delivery.ts
+++ b/apps/worker/src/channels/delivery.ts
@@ -66,6 +66,35 @@ export function registerChannelOutputDelivery(): void {
   setWorkflowOutputDeliveryHook(onOutput);
 }
 
+/**
+ * Auto-bind delivery to a sender on first inbound contact: the operator DMs the
+ * bot once and starts receiving outputs there, never hand-writing a binding.
+ * Idempotent — only writes when no binding for (org, channel) exists yet.
+ */
+export async function ensureInboundBinding(
+  orgId: string,
+  channelPlugin: string,
+  recipient: Record<string, unknown>,
+): Promise<void> {
+  const existing = await db()
+    .select({ id: delivery_binding.id })
+    .from(delivery_binding)
+    .where(
+      and(
+        eq(delivery_binding.org_id, orgId),
+        eq(delivery_binding.channel_plugin, channelPlugin),
+      ),
+    )
+    .limit(1);
+  if (existing.length > 0) return;
+  await db()
+    .insert(delivery_binding)
+    .values({ org_id: orgId, channel_plugin: channelPlugin, recipient, enabled: true });
+  console.log(
+    `[channel-inbound] auto-bound ${channelPlugin} → ${JSON.stringify(recipient)} (first inbound from this sender)`,
+  );
+}
+
 /** Route one inbound IntentEvent to the same agent entry points the web uses. */
 export async function dispatchInboundIntent(
   orgId: string,
@@ -172,10 +201,11 @@ export async function ingestInboundWebhook(
   } catch {
     return { ok: false, dispatched: 0 };
   }
-  const intents = (await reg.parseInbound(pluginName, raw)) as IntentEvent[];
+  const { intents, recipient } = await reg.parseInbound(pluginName, raw);
+  if (recipient) await ensureInboundBinding(orgId, pluginName, recipient);
   for (const intent of intents) {
     try {
-      await dispatchInboundIntent(orgId, intent);
+      await dispatchInboundIntent(orgId, intent as IntentEvent);
     } catch (err) {
       console.warn(
         `[channel-inbound] dispatch error: ${err instanceof Error ? err.message : err}`,

--- a/apps/worker/src/channels/inbound-poll.ts
+++ b/apps/worker/src/channels/inbound-poll.ts
@@ -1,81 +1,80 @@
-// Local inbound for Telegram without a public URL. Telegram webhooks need a
-// public HTTPS endpoint; for `pnpm dev` we instead long-poll getUpdates. This
-// is the doc's sanctioned "thin worker-side ingress owns the socket/poll while
-// projection + parsing stay in the VM" path: the worker does the GET, but each
-// raw Update is normalized to IntentEvents by the plugin's parse_inbound RPC.
-// Opt-in via TELEGRAM_INBOUND_POLL=1.
+// Inbound transport for channels on hosts without a public webhook URL. For every
+// installed inbound-capable channel, the worker loops the plugin's poll_inbound
+// RPC (provider-agnostic — no Telegram-specific code here), normalizes each raw
+// update via parse_inbound, auto-binds delivery to the sender on first contact,
+// and dispatches the intents to the same agent entry points the web uses.
+//
+// No env flag: a channel that declares an inbound direction is polled
+// automatically. Channels reachable by a public webhook (OPENNEKO_PUBLIC_URL set
+// + ingress="webhook") receive inbound via POST /channels/:plugin/inbound instead
+// and are skipped here.
 import { getPluginRegistryInstance } from "../plugins/registry-instance.js";
-import { dispatchInboundIntent } from "./delivery.js";
-
-const TELEGRAM_PLUGIN = "@open-neko/channel-telegram";
+import { dispatchInboundIntent, ensureInboundBinding } from "./delivery.js";
 
 type IntentEvent = Parameters<typeof dispatchInboundIntent>[1];
 
-export function startTelegramInboundPoll(orgId: string): { stop: () => void } | null {
-  if (process.env.TELEGRAM_INBOUND_POLL !== "1") return null;
+const POLL_INTERVAL_MS = 3_000;
+const msg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** Start inbound transports for all installed inbound channels. Returns a stop handle. */
+export function startChannelInbound(orgId: string): { stop: () => void } {
+  let stopped = false;
   const reg = getPluginRegistryInstance();
-  const token = reg?.getPluginEnv(TELEGRAM_PLUGIN)?.TELEGRAM_BOT_TOKEN;
-  if (!reg || !token) {
-    console.warn(
-      "[telegram-poll] TELEGRAM_INBOUND_POLL=1 but no bot token / registry; poller disabled",
-    );
-    return null;
+  if (!reg) return { stop: () => { stopped = true; } };
+
+  const hasPublicWebhook = Boolean(process.env.OPENNEKO_PUBLIC_URL);
+  const inboundProviders = reg
+    .getChannelProviders()
+    .filter((p) => p.directions.includes("inbound"));
+
+  for (const provider of inboundProviders) {
+    if (hasPublicWebhook && provider.ingress === "webhook") {
+      console.log(
+        `[channel-inbound] ${provider.pluginName}: webhook ingress at ${process.env.OPENNEKO_PUBLIC_URL}/channels/${encodeURIComponent(provider.pluginName)}/inbound`,
+      );
+      continue;
+    }
+    void pollLoop(provider.pluginName);
   }
 
-  let offset = 0;
-  let stopped = false;
-
-  const loop = async (): Promise<void> => {
-    console.log("[telegram-poll] inbound poller started (getUpdates long-poll)");
+  async function pollLoop(pluginName: string): Promise<void> {
+    let cursor: string | undefined;
+    let warnedUnsupported = false;
+    console.log(`[channel-inbound] ${pluginName}: polling for inbound (no public webhook URL)`);
     while (!stopped) {
       try {
-        const url = `https://api.telegram.org/bot${token}/getUpdates?timeout=25&offset=${offset}`;
-        const res = await fetch(url, { signal: AbortSignal.timeout(30_000) });
-        const data = (await res.json()) as {
-          ok: boolean;
-          result?: Array<{ update_id: number }>;
-        };
-        if (data.ok && data.result) {
-          for (const update of data.result) {
-            offset = update.update_id + 1;
-            const u = update as {
-              message?: { chat?: { id?: number | string } };
-              callback_query?: { message?: { chat?: { id?: number | string } } };
-            };
-            const chatId = u.message?.chat?.id ?? u.callback_query?.message?.chat?.id;
-            console.log(
-              `[telegram-poll] update ${update.update_id} from chat ${chatId ?? "?"}`,
-            );
-            try {
-              const intents = (await reg.parseInbound(
-                TELEGRAM_PLUGIN,
-                update,
-              )) as IntentEvent[];
-              for (const intent of intents) {
-                await dispatchInboundIntent(orgId, intent);
-              }
-            } catch (err) {
-              console.warn(
-                `[telegram-poll] dispatch error: ${err instanceof Error ? err.message : err}`,
-              );
+        const r = getPluginRegistryInstance();
+        if (!r) return;
+        const { updates, cursor: next } = await r.pollInbound(pluginName, cursor);
+        if (next) cursor = next;
+        for (const raw of updates) {
+          try {
+            const { intents, recipient } = await r.parseInbound(pluginName, raw);
+            if (recipient) await ensureInboundBinding(orgId, pluginName, recipient);
+            for (const intent of intents) {
+              await dispatchInboundIntent(orgId, intent as IntentEvent);
             }
+          } catch (err) {
+            console.warn(`[channel-inbound] ${pluginName} dispatch error: ${msg(err)}`);
           }
         }
       } catch (err) {
-        if (!stopped) {
-          console.warn(
-            `[telegram-poll] getUpdates error: ${err instanceof Error ? err.message : err}`,
-          );
-          await new Promise((r) => setTimeout(r, 3_000));
+        const m = msg(err);
+        if (m.includes("does not implement poll_inbound")) {
+          if (!warnedUnsupported) {
+            console.warn(
+              `[channel-inbound] ${pluginName}: no poll transport and no public webhook URL — inbound disabled. Set OPENNEKO_PUBLIC_URL to use webhook ingress.`,
+            );
+            warnedUnsupported = true;
+          }
+          return; // can't be polled; retrying won't help
         }
+        if (!stopped) console.warn(`[channel-inbound] ${pluginName} poll error: ${m}`);
       }
+      if (!stopped) await sleep(POLL_INTERVAL_MS);
     }
-  };
+  }
 
-  void loop();
-  return {
-    stop: () => {
-      stopped = true;
-    },
-  };
+  return { stop: () => { stopped = true; } };
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -49,7 +49,7 @@ import {
   ingestInboundWebhook,
   registerChannelOutputDelivery,
 } from "./channels/delivery.js";
-import { startTelegramInboundPoll } from "./channels/inbound-poll.js";
+import { startChannelInbound } from "./channels/inbound-poll.js";
 import type PgBossLib from "pg-boss";
 import { runBusinessProfileBuild } from "./jobs/business-profile-build.js";
 import { runIndustryInsightsBuild } from "./jobs/industry-insights-build.js";
@@ -623,12 +623,12 @@ server.listen(PORT, () => {
   );
 });
 
-const telegramPoll = startTelegramInboundPoll(ADMIN_ORG_ID);
+const channelInbound = startChannelInbound(ADMIN_ORG_ID);
 
 const shutdown = async (signal: string) => {
   console.log(`[worker] received ${signal}; shutting down`);
   clearInterval(reconcileTimer);
-  telegramPoll?.stop();
+  channelInbound.stop();
   server.close();
   const cancelled = cancelAllAgents();
   if (cancelled > 0) {

--- a/apps/worker/src/plugins/plugin-registry.ts
+++ b/apps/worker/src/plugins/plugin-registry.ts
@@ -548,8 +548,15 @@ export class PluginRegistry {
     return response.result as { delivered: boolean; ref?: string };
   }
 
-  /** Normalize a raw inbound substrate payload to IntentEvents via parse_inbound. */
-  async parseInbound(pluginName: string, raw: unknown): Promise<unknown[]> {
+  /**
+   * Normalize a raw inbound substrate payload to IntentEvents via parse_inbound,
+   * plus the sender's channel-native recipient (so the worker can auto-bind
+   * delivery on first contact).
+   */
+  async parseInbound(
+    pluginName: string,
+    raw: unknown,
+  ): Promise<{ intents: unknown[]; recipient?: Record<string, unknown> }> {
     const { pluginId, entry } = this.requireChannelPluginEntry(pluginName);
     await this.ensureVm(pluginId, entry);
     const env = mergeEnv(entry, this.secrets);
@@ -565,7 +572,14 @@ export class PluginRegistry {
         `channel ${entry.name} parse_inbound failed: ${response.error.code} ${response.error.message}`,
       );
     }
-    return (response.result as { intents?: unknown[] }).intents ?? [];
+    const result = response.result as {
+      intents?: unknown[];
+      recipient?: Record<string, unknown>;
+    };
+    return {
+      intents: result.intents ?? [],
+      ...(result.recipient ? { recipient: result.recipient } : {}),
+    };
   }
 
   /** Verify a webhook signature in-VM via verify_inbound (secret stays in the VM). */
@@ -590,6 +604,33 @@ export class PluginRegistry {
       );
     }
     return (response.result as { ok: boolean }).ok;
+  }
+
+  /** Pull the next batch of inbound updates via poll_inbound — for hosts without a public webhook URL. */
+  async pollInbound(
+    pluginName: string,
+    cursor?: string,
+  ): Promise<{ updates: unknown[]; cursor?: string }> {
+    const { pluginId, entry } = this.requireChannelPluginEntry(pluginName);
+    await this.ensureVm(pluginId, entry);
+    const env = mergeEnv(entry, this.secrets);
+    if (!this.runtime) throw new Error("plugin-registry: runtime unavailable");
+    const response = await this.runtime.callRpc(
+      pluginId,
+      "poll_inbound",
+      JSON.stringify(cursor ? { cursor } : {}),
+      { env },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `channel ${entry.name} poll_inbound failed: ${response.error.code} ${response.error.message}`,
+      );
+    }
+    const result = response.result as { updates?: unknown[]; cursor?: string };
+    return {
+      updates: result.updates ?? [],
+      ...(result.cursor ? { cursor: result.cursor } : {}),
+    };
   }
 
   /**

--- a/apps/worker/test/channels/delivery.test.ts
+++ b/apps/worker/test/channels/delivery.test.ts
@@ -12,14 +12,23 @@ vi.mock("@neko/db/jobs", () => ({
   enqueue: vi.fn(async () => "job-1"),
   QUEUE: { ACTION_EXECUTE: "action_execute", WORK_RUN: "work_run" },
 }));
+const h = vi.hoisted(() => ({
+  binds: [] as Array<Record<string, unknown>>,
+  existing: [] as unknown[],
+}));
 vi.mock("@neko/db", () => ({
   db: vi.fn(() => ({
-    insert: () => ({ values: () => ({ returning: async () => [{ id: "pj-1" }] }) }),
-    select: () => ({ from: () => ({ where: async () => [] }) }),
+    insert: () => ({
+      values: (v: Record<string, unknown>) => {
+        h.binds.push(v);
+        return { returning: async () => [{ id: "pj-1" }] };
+      },
+    }),
+    select: () => ({ from: () => ({ where: () => ({ limit: async () => h.existing }) }) }),
   })),
   and: (...a: unknown[]) => a,
   eq: (...a: unknown[]) => a,
-  delivery_binding: { org_id: {}, enabled: {} },
+  delivery_binding: { org_id: {}, enabled: {}, channel_plugin: {}, id: {} },
   processing_job: { id: {} },
 }));
 vi.mock("@neko/llm", () => ({ resolveAgentBackend: vi.fn(async () => ({ id: "hermes" })) }));
@@ -41,7 +50,11 @@ import {
   rejectActionRequest,
 } from "@neko/llm/workflows";
 import { createWorkThread } from "@neko/llm/work";
-import { dispatchInboundIntent, ingestInboundWebhook } from "../../src/channels/delivery";
+import {
+  dispatchInboundIntent,
+  ensureInboundBinding,
+  ingestInboundWebhook,
+} from "../../src/channels/delivery";
 import { getPluginRegistryInstance } from "../../src/plugins/registry-instance.js";
 
 beforeEach(() => vi.clearAllMocks());
@@ -91,12 +104,16 @@ describe("dispatchInboundIntent — utterance", () => {
 describe("ingestInboundWebhook", () => {
   const fakeReg = {
     verifyInbound: vi.fn(async () => true),
-    parseInbound: vi.fn(async () => [{ kind: "decision", decisionRef: "ar-1", choice: "approve" }]),
+    parseInbound: vi.fn(async () => ({
+      intents: [{ kind: "decision", decisionRef: "ar-1", choice: "approve" }],
+    })),
   };
 
   beforeEach(() => {
     fakeReg.verifyInbound.mockResolvedValue(true);
-    fakeReg.parseInbound.mockResolvedValue([{ kind: "decision", decisionRef: "ar-1", choice: "approve" }]);
+    fakeReg.parseInbound.mockResolvedValue({
+      intents: [{ kind: "decision", decisionRef: "ar-1", choice: "approve" }],
+    });
     vi.mocked(getPluginRegistryInstance).mockReturnValue(fakeReg as never);
     vi.mocked(getActionRequest).mockResolvedValue({ id: "ar-1", status: "pending_approval", kind: "k" } as never);
   });
@@ -121,5 +138,29 @@ describe("ingestInboundWebhook", () => {
     vi.mocked(getPluginRegistryInstance).mockReturnValue(null);
     const res = await ingestInboundWebhook("org-1", "@open-neko/channel-telegram", {}, "{}");
     expect(res).toEqual({ ok: false, dispatched: 0 });
+  });
+});
+
+describe("ensureInboundBinding (auto-bind on first inbound)", () => {
+  beforeEach(() => {
+    h.binds.length = 0;
+    h.existing = [];
+  });
+
+  it("writes a binding when none exists for (org, channel)", async () => {
+    await ensureInboundBinding("org-1", "@open-neko/channel-telegram", { kind: "telegram", chatId: 99 });
+    expect(h.binds).toHaveLength(1);
+    expect(h.binds[0]).toMatchObject({
+      org_id: "org-1",
+      channel_plugin: "@open-neko/channel-telegram",
+      recipient: { kind: "telegram", chatId: 99 },
+      enabled: true,
+    });
+  });
+
+  it("is idempotent — skips writing when a binding already exists", async () => {
+    h.existing = [{ id: "b1" }];
+    await ensureInboundBinding("org-1", "@open-neko/channel-telegram", { kind: "telegram", chatId: 99 });
+    expect(h.binds).toHaveLength(0);
   });
 });

--- a/apps/worker/test/plugins/plugin-registry-channels.test.ts
+++ b/apps/worker/test/plugins/plugin-registry-channels.test.ts
@@ -192,18 +192,36 @@ describe("PluginRegistry — channel capability", () => {
     await reg.stop();
   });
 
-  it("parseInbound returns the intents the VM parsed", async () => {
+  it("parseInbound returns the intents + sender recipient the VM parsed", async () => {
     await writeManifest();
     const runtime = new FakeRuntime({
       register: channelRegisterResponse(),
-      parse_inbound: rpcOk({ intents: [{ kind: "decision", decisionRef: "ar-1", choice: "approve" }] }),
+      parse_inbound: rpcOk({
+        intents: [{ kind: "decision", decisionRef: "ar-1", choice: "approve" }],
+        recipient: { kind: "telegram", chatId: 42 },
+      }),
     });
     const reg = newRegistry(runtime);
     await reg.start();
-    const intents = await reg.parseInbound(CHANNEL_NAME, {
+    const { intents, recipient } = await reg.parseInbound(CHANNEL_NAME, {
       callback_query: { data: "approve:ar-1" },
     });
     expect(intents).toEqual([{ kind: "decision", decisionRef: "ar-1", choice: "approve" }]);
+    expect(recipient).toEqual({ kind: "telegram", chatId: 42 });
+    await reg.stop();
+  });
+
+  it("pollInbound returns the VM's update batch + advanced cursor", async () => {
+    await writeManifest();
+    const runtime = new FakeRuntime({
+      register: channelRegisterResponse(),
+      poll_inbound: rpcOk({ updates: [{ update_id: 5 }], cursor: "6" }),
+    });
+    const reg = newRegistry(runtime);
+    await reg.start();
+    const { updates, cursor } = await reg.pollInbound(CHANNEL_NAME, "3");
+    expect(updates).toEqual([{ update_id: 5 }]);
+    expect(cursor).toBe("6");
     await reg.stop();
   });
 

--- a/packages/plugin-types/src/channel.ts
+++ b/packages/plugin-types/src/channel.ts
@@ -88,8 +88,28 @@ export type DeliverResult = z.infer<typeof DeliverResult>;
 export const ParseInboundParams = z.object({ raw: z.unknown() });
 export type ParseInboundParams = z.infer<typeof ParseInboundParams>;
 
-export const ParseInboundResult = z.object({ intents: z.array(z.unknown()) });
+export const ParseInboundResult = z.object({
+  intents: z.array(z.unknown()),
+  // Sender's channel-native address (the chat that messaged us). Lets the worker
+  // auto-create a delivery binding on first contact, so operators never hand-write
+  // one. Optional: outbound-only or anonymous inbound omit it.
+  recipient: ChannelRecipient.optional(),
+});
 export type ParseInboundResult = z.infer<typeof ParseInboundResult>;
+
+// poll_inbound — the provider-agnostic pull transport. The worker loops this when
+// no public webhook URL is configured (local/dev, no-ingress hosts); the plugin
+// fetches its native update batch and returns the updates already split, each fed
+// back through parse_inbound. `cursor` is an opaque continuation token the worker
+// echoes on the next call.
+export const PollInboundParams = z.object({ cursor: z.string().optional() });
+export type PollInboundParams = z.infer<typeof PollInboundParams>;
+
+export const PollInboundResult = z.object({
+  updates: z.array(z.unknown()),
+  cursor: z.string().optional(),
+});
+export type PollInboundResult = z.infer<typeof PollInboundResult>;
 
 export const VerifyInboundParams = z.object({
   headers: z.record(z.string(), z.string()),

--- a/packages/plugin-types/src/define-plugin.ts
+++ b/packages/plugin-types/src/define-plugin.ts
@@ -25,6 +25,8 @@ import type {
   DeliverResult,
   ParseInboundParams,
   ParseInboundResult,
+  PollInboundParams,
+  PollInboundResult,
   VerifyInboundParams,
   VerifyInboundResult,
 } from "./channel.js";
@@ -68,6 +70,10 @@ export type ParseInboundHandler = (
 export type VerifyInboundHandler = (
   params: VerifyInboundParams,
 ) => Promise<VerifyInboundResult> | VerifyInboundResult;
+
+export type PollInboundHandler = (
+  params: PollInboundParams,
+) => Promise<PollInboundResult> | PollInboundResult;
 
 /** Implementation shape for the action capability — kinds with handlers. */
 export interface ActionCapabilityImpl {
@@ -114,6 +120,9 @@ export interface ChannelCapabilityImpl {
   deliver: DeliverHandler;
   parseInbound?: ParseInboundHandler;
   verifyInbound?: VerifyInboundHandler;
+  // Pull transport for hosts without a public webhook URL. Optional: channels
+  // that only support webhook ingress omit it.
+  pollInbound?: PollInboundHandler;
 }
 
 /**

--- a/packages/plugin-types/src/rpc.ts
+++ b/packages/plugin-types/src/rpc.ts
@@ -44,6 +44,7 @@ export const RpcMethod = z.enum([
   "deliver",
   "parse_inbound",
   "verify_inbound",
+  "poll_inbound",
 ]);
 export type RpcMethod = z.infer<typeof RpcMethod>;
 

--- a/packages/plugin-types/src/runner.ts
+++ b/packages/plugin-types/src/runner.ts
@@ -22,6 +22,8 @@ import {
   DeliverResult,
   ParseInboundParams,
   ParseInboundResult,
+  PollInboundParams,
+  PollInboundResult,
   VerifyInboundParams,
   VerifyInboundResult,
 } from "./channel.js";
@@ -64,6 +66,8 @@ export async function dispatchPluginRpc(
         return rpcOk(await runParseInbound(plugin, options.paramsJson));
       case "verify_inbound":
         return rpcOk(await runVerifyInbound(plugin, options.paramsJson));
+      case "poll_inbound":
+        return rpcOk(await runPollInbound(plugin, options.paramsJson));
       default:
         return rpcErr("UNKNOWN_METHOD", `unknown RPC method: ${options.method}`);
     }
@@ -233,6 +237,18 @@ async function runVerifyInbound(
   }
   const parsed = VerifyInboundParams.parse(JSON.parse(paramsJson));
   return VerifyInboundResult.parse(await channel.verifyInbound(parsed));
+}
+
+async function runPollInbound(
+  plugin: PluginDefinition,
+  paramsJson: string,
+): Promise<PollInboundResult> {
+  const channel = plugin.capabilities.channel;
+  if (!channel?.pollInbound) {
+    throw new Error("plugin's channel does not implement poll_inbound");
+  }
+  const parsed = PollInboundParams.parse(JSON.parse(paramsJson));
+  return PollInboundResult.parse(await channel.pollInbound(parsed));
 }
 
 /**

--- a/scripts/install-telegram-channel.sh
+++ b/scripts/install-telegram-channel.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# Install the Telegram channel plugin on neko-vm during deploy.
+#
+# Channel plugins are not yet first-class in the Go `openneko install` path
+# (its capability model predates `capabilities.channel`), so this fetches the
+# published npm package into the plugin dir and registers the channel manifest
+# entry directly — the TS worker fully supports capabilities.channel and picks
+# up manifest+secret changes within ~3s via its poll fallback.
+#
+# Invoked gated + non-fatal from .github/workflows/deploy.yml. No-ops cleanly
+# when TELEGRAM_BOT_TOKEN is absent. Reads OPENNEKO_PLUGIN_INSTALL_DIR +
+# OPENNEKO_PLUGINS_MANIFEST_PATH from the deploy environment.
+set -uo pipefail
+
+PKG="@open-neko/channel-telegram"
+VER="0.2.0"
+INTEGRITY="sha512-6DCDiVh+CMU6wCuyp3N2RMIhpehs/C0vC2nP08XzFzo/8uK1GLO0YpN4wXYp3RUMcrYBiOvCLyx4+gbuNE/yEw=="
+
+TOKEN="${TELEGRAM_BOT_TOKEN:-}"
+if [ -z "$TOKEN" ]; then
+  echo "[telegram] TELEGRAM_BOT_TOKEN not set; skipping"
+  exit 0
+fi
+: "${OPENNEKO_PLUGIN_INSTALL_DIR:?need OPENNEKO_PLUGIN_INSTALL_DIR}"
+: "${OPENNEKO_PLUGINS_MANIFEST_PATH:?need OPENNEKO_PLUGINS_MANIFEST_PATH}"
+
+echo "[telegram] saving bot token to the secrets store"
+openneko secrets set "$PKG" TELEGRAM_BOT_TOKEN "$TOKEN" || echo "[telegram] secrets set returned nonzero"
+
+NM="$OPENNEKO_PLUGIN_INSTALL_DIR/node_modules/$PKG"
+if [ ! -f "$NM/dist/run.js" ]; then
+  echo "[telegram] installing $PKG@$VER into $OPENNEKO_PLUGIN_INSTALL_DIR"
+  ( cd "$OPENNEKO_PLUGIN_INSTALL_DIR" && npm install "$PKG@$VER" --no-audit --no-fund 2>&1 | tail -8 ) \
+    || echo "[telegram] npm install returned nonzero"
+fi
+if [ ! -f "$NM/dist/run.js" ]; then
+  echo "[telegram] ERROR: $NM/dist/run.js missing after install; not registering"
+  exit 0
+fi
+
+echo "[telegram] registering channel manifest entry in $OPENNEKO_PLUGINS_MANIFEST_PATH"
+MANIFEST="$OPENNEKO_PLUGINS_MANIFEST_PATH" TG_INTEGRITY="$INTEGRITY" TG_VER="$VER" \
+  node --input-type=module <<'NODE'
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+const path = process.env.MANIFEST;
+const SCHEMA = "https://open-neko.github.io/plugins/manifest.schema.json";
+const m = existsSync(path)
+  ? JSON.parse(readFileSync(path, "utf8"))
+  : { schema: SCHEMA, plugins: [] };
+m.schema ||= SCHEMA;
+m.plugins ||= [];
+const entry = {
+  name: "@open-neko/channel-telegram",
+  version: process.env.TG_VER,
+  integrity: process.env.TG_INTEGRITY,
+  permissions: {
+    network: ["api.telegram.org"],
+    env: [
+      { key: "TELEGRAM_BOT_TOKEN", required: true, secret: true, description: "Bot token from @BotFather." },
+      { key: "TELEGRAM_WEBHOOK_SECRET", required: false, secret: true, description: "Optional webhook secret_token for verify_inbound." },
+    ],
+  },
+  capabilities: {
+    channel: {
+      providerLabel: "Telegram",
+      directions: ["outbound", "inbound"],
+      ingress: "webhook",
+      profile: {
+        modalities: ["text"],
+        richMedia: { markdown: true, cards: false, charts: false, images: true, interactiveControls: true },
+        interaction: { turnTaking: "async", canApproveInline: true, quickReplies: true },
+        constraints: { maxOutboundChars: 4096, latencyClass: "interactive", attentionModel: "push" },
+        fidelity: "summary",
+      },
+    },
+  },
+  marketplace: "npm",
+};
+m.plugins = m.plugins.filter((p) => p && p.name !== entry.name);
+m.plugins.push(entry);
+writeFileSync(path, JSON.stringify(m, null, 2) + "\n");
+console.log(`[telegram] manifest plugins: ${m.plugins.map((p) => p.name).join(", ")}`);
+NODE
+
+echo "[telegram] done — worker registers the channel within ~3s"


### PR DESCRIPTION
Worker side of the operator-friendly channel surface (pairs with open-neko/plugins#22).

- **Auto-enable inbound (no env flag):** `startChannelInbound` replaces the env-gated `startTelegramInboundPoll` — it polls every installed *inbound* channel via the new provider-agnostic `poll_inbound` RPC. No Telegram-specific code in the worker (backend-portable); channels with a public webhook URL use the existing `/channels/:plugin/inbound` route instead.
- **Auto-bind on first inbound:** `ensureInboundBinding` writes the `delivery_binding` the first time a sender messages in — operators never hand-write one or type a chat id.
- **Contract:** `parseInbound` now returns the sender `recipient`; registry gains `pollInbound` (mirror of the published `@open-neko/plugin-types`).

Operator flow: **install → token → DM the bot.** Worker tests: 175 pass (+ new poll/recipient/auto-bind coverage). VM execution still pending nested-virt (tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
