### PR TITLE
Work surface: confirmation cards, new-thread Ask, workflow management + settings polish

### DIFF
--- a/apps/web/src/a2ui/catalog.ts
+++ b/apps/web/src/a2ui/catalog.ts
@@ -18,6 +18,7 @@ export const CATALOG_ID = "urn:app:catalog:briefing:v1";
 export const ComponentTypes = {
   Briefing: "Briefing",
   BriefingCard: "BriefingCard",
+  Confirmation: "Confirmation",
   MetricCard: "MetricCard",
   ChatResponse: "ChatResponse",
   Markdown: "Markdown",
@@ -52,6 +53,13 @@ export interface MarkdownProps {
   text: string;
 }
 
+export interface ConfirmationProps {
+  component: "Confirmation";
+  label: string; // action eyebrow, e.g. "Created workflow"
+  title: string; // the saved entity's name
+  children: string[]; // IDs of body components (typically a Markdown)
+}
+
 export interface BriefingCardProps {
   component: "BriefingCard";
   metricId: string;   // DB UUID — needed for pin/dashboard API calls
@@ -71,4 +79,5 @@ export interface BriefingCardProps {
 export type ComponentProps =
   | BriefingProps
   | BriefingCardProps
+  | ConfirmationProps
   | MarkdownProps;

--- a/apps/web/src/a2ui/components.tsx
+++ b/apps/web/src/a2ui/components.tsx
@@ -17,7 +17,12 @@ import {
 import { registerComponent, renderChildren } from "./renderer";
 import type { RenderContext } from "./renderer";
 import type { A2UIComponent } from "./types";
-import type { BriefingCardProps, BriefingProps, MarkdownProps } from "./catalog";
+import type {
+  BriefingCardProps,
+  BriefingProps,
+  ConfirmationProps,
+  MarkdownProps,
+} from "./catalog";
 import BriefingCard from "@/components/BriefingCard";
 
 // ─── Briefing ───
@@ -32,6 +37,31 @@ registerComponent("Briefing", (comp: A2UIComponent, ctx: RenderContext) => {
         {props.subtitle}
       </div>
       {props.children && renderChildren(props.children, ctx)}
+    </div>
+  );
+});
+
+// ─── Confirmation ───
+registerComponent("Confirmation", (comp: A2UIComponent, ctx: RenderContext) => {
+  const props = comp as unknown as ConfirmationProps & { id: string };
+  return (
+    <div
+      key={props.id}
+      className="work-confirm"
+      style={{ animation: "fadeUp 0.4s ease both" }}
+    >
+      <div className="work-confirm-head">
+        <span className="work-confirm-check" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M5 13l4 4L19 7" />
+          </svg>
+        </span>
+        <span className="work-confirm-label">{props.label}</span>
+      </div>
+      {props.title ? <div className="work-confirm-title">{props.title}</div> : null}
+      {props.children ? (
+        <div className="work-confirm-body">{renderChildren(props.children, ctx)}</div>
+      ) : null}
     </div>
   );
 });

--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -378,10 +378,8 @@ export default function WorkScreen() {
     void loadMemories();
   }, [gateChecked, gateError]);
 
-  // React to URL thread changes. The /work page (no threadId) picks the most
-  // recent thread and redirects to its URL — that navigation re-fires this
-  // effect with the resolved threadId, which then loads the bundle without
-  // remounting the screen.
+  // React to URL thread changes. The /work page (no threadId) is the new-thread
+  // state: clear the screen and let the composer create a thread on first send.
   useEffect(() => {
     if (!gateChecked || gateError) return;
     if (routeThreadId) {
@@ -410,15 +408,7 @@ export default function WorkScreen() {
     el.style.height = `${Math.min(el.scrollHeight, 222)}px`;
   }, [draft]);
 
-  async function resolveLandingThread() {
-    const res = await fetch("/api/work/threads");
-    if (!res.ok) return;
-    const data = (await res.json()) as { threads: { id: string }[] };
-    const nextId = data.threads?.[0]?.id ?? null;
-    if (nextId) {
-      router.replace(`/work/${nextId}`);
-      return;
-    }
+  function resolveLandingThread() {
     activeThreadIdRef.current = null;
     setActiveThreadId(null);
     activeRunStreamRef.current?.close();
@@ -426,6 +416,7 @@ export default function WorkScreen() {
     setSending(false);
     updateActiveRunId(null);
     setBundle(null);
+    setPendingMemories([]);
   }
 
   async function loadThread(threadId: string) {
@@ -698,11 +689,16 @@ export default function WorkScreen() {
     setStreamError(null);
     setSending(true);
     updateActiveRunId(run.id);
-    // We don't have a per-event id locally for unstreamed events. 0 means
-    // "give me everything from the start of the run"; the SSE server
-    // dedupes against what we've already applied locally.
-    const afterId = 0;
-    void streamAndRefreshRun(threadId, run.id, afterId);
+    // The loaded bundle already holds this in-flight run's persisted events.
+    // Resuming replays them from the start (afterId 0), so drop the local copy
+    // first — otherwise replayed events append as duplicates (doubled tool rows
+    // and assistant text).
+    setBundle((prev) =>
+      prev
+        ? { ...prev, eventsByRun: { ...prev.eventsByRun, [run.id]: [] } }
+        : prev,
+    );
+    void streamAndRefreshRun(threadId, run.id, 0);
   }
 
   async function streamAndRefreshRun(
@@ -1459,6 +1455,14 @@ function buildRunTimeline(events: WorkEvent[]): {
         break;
       }
       case "tool_start": {
+        // A tool_start can arrive twice (e.g. a replayed in-flight run);
+        // update the existing row in place rather than emitting a duplicate.
+        const existing = toolsById.get(event.id);
+        if (existing) {
+          existing.name = event.name;
+          existing.input = event.input;
+          break;
+        }
         flushTextSegment();
         const item: ToolItem = {
           id: event.id,
@@ -1995,10 +1999,45 @@ function toolSubtitle(tool: ToolItem): string {
   return "";
 }
 
+// Back-compat: confirmation cards (workflow/trigger/rule saves) used to be
+// emitted as the dashboard `Briefing` root, which renders the 52px display
+// greeting — jarring inside the chat timeline. They now emit a `Confirmation`
+// component. Run events persisted before that change are frozen as `Briefing`,
+// so normalize them here at render time. A real briefing (BriefingCard
+// children) is left untouched.
+function remapLegacyConfirmations(messages: A2UIMessage[]): A2UIMessage[] {
+  return messages.map((message) => {
+    if (!("updateComponents" in message)) return message;
+    const comps = message.updateComponents.components;
+    const isConfirmation =
+      comps.some((c) => c.component === "Briefing") &&
+      !comps.some((c) => c.component === "BriefingCard");
+    if (!isConfirmation) return message;
+    return {
+      ...message,
+      updateComponents: {
+        ...message.updateComponents,
+        components: comps.map((c) => {
+          if (c.component !== "Briefing") return c;
+          const { greeting, subtitle, role, isExample, ...rest } = c;
+          void role;
+          void isExample;
+          return {
+            ...rest,
+            component: "Confirmation",
+            label: typeof greeting === "string" ? greeting : "",
+            title: typeof subtitle === "string" ? subtitle : "",
+          };
+        }),
+      },
+    };
+  });
+}
+
 function SurfaceBlock({ messages }: { messages: A2UIMessage[] }) {
   const surfaces = useMemo(() => {
     let next = new Map<string, SurfaceState>();
-    for (const message of messages) {
+    for (const message of remapLegacyConfirmations(messages)) {
       next = applyMessage(next, message);
     }
     return next;

--- a/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
+++ b/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
@@ -2,8 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Workflow } from "lucide-react";
+import { Workflow, Trash2 } from "lucide-react";
 import { cn } from "@/lib/cn";
+import { confirmDialog } from "@/components/ConfirmModal";
 import { describeSchedule } from "@/lib/cron-english";
 
 type WorkflowListItem = {
@@ -198,6 +199,28 @@ export default function WorkflowsPage() {
     [router, searchParams],
   );
 
+  const deleteWorkflow = useCallback(
+    async (id: string, name: string) => {
+      const ok = await confirmDialog({
+        title: `Delete "${name}"?`,
+        description:
+          "This removes the workflow along with its triggers, run history, and proposed actions.",
+        confirmLabel: "Delete",
+        destructive: true,
+      });
+      if (!ok) return;
+      const res = await fetch(`/api/workflows/${id}`, { method: "DELETE" });
+      if (!res.ok) {
+        setError(`Couldn't delete (HTTP ${res.status})`);
+        return;
+      }
+      if (selectedId === id) select(null);
+      setWorkflows((prev) => prev?.filter((w) => w.id !== id) ?? prev);
+      void fetchList();
+    },
+    [selectedId, select, fetchList],
+  );
+
   const grouped = useMemo(() => {
     const active: WorkflowListItem[] = [];
     const paused: WorkflowListItem[] = [];
@@ -240,7 +263,7 @@ export default function WorkflowsPage() {
         </div>
         <button
           type="button"
-          className="workflows-new-btn library-head-action"
+          className="workflows-new-btn library-head-action ml-auto"
           onClick={() =>
             router.push(
               `/work?seed=${encodeURIComponent("Set up a new workflow that ")}`,
@@ -268,54 +291,47 @@ export default function WorkflowsPage() {
             >+ New workflow</button> gets you started.
           </div>
         ) : (
-          <div className="workflows-layout">
-            <div className="min-w-0">
-              {grouped.active.length > 0 && (
-                <WorkflowGroup
-                  title="Active"
-                  count={grouped.active.length}
-                  items={grouped.active}
-                  selectedId={selectedId}
-                  onSelect={select}
-                  sparklines={sparklines}
-                  onSparkline={recordSparkline}
-                />
-              )}
-              {grouped.paused.length > 0 && (
-                <WorkflowGroup
-                  title="Paused"
-                  count={grouped.paused.length}
-                  items={grouped.paused}
-                  selectedId={selectedId}
-                  onSelect={select}
-                  sparklines={sparklines}
-                  onSparkline={recordSparkline}
-                />
-              )}
-              {grouped.broken.length > 0 && (
-                <WorkflowGroup
-                  title="Needs attention"
-                  count={grouped.broken.length}
-                  items={grouped.broken}
-                  selectedId={selectedId}
-                  onSelect={select}
-                  sparklines={sparklines}
-                  onSparkline={recordSparkline}
-                />
-              )}
-            </div>
-
-          {selectedId && (
-            <WorkflowDrawer
-              key={selectedId}
-              workflowId={selectedId}
-              onClose={() => select(null)}
-              onMutated={() => {
-                void fetchList();
-              }}
-            />
-          )}
-        </div>
+          <div className="workflows-list min-w-0">
+            {grouped.active.length > 0 && (
+              <WorkflowGroup
+                title="Active"
+                count={grouped.active.length}
+                items={grouped.active}
+                selectedId={selectedId}
+                onSelect={select}
+                onDelete={deleteWorkflow}
+                onMutated={fetchList}
+                sparklines={sparklines}
+                onSparkline={recordSparkline}
+              />
+            )}
+            {grouped.paused.length > 0 && (
+              <WorkflowGroup
+                title="Paused"
+                count={grouped.paused.length}
+                items={grouped.paused}
+                selectedId={selectedId}
+                onSelect={select}
+                onDelete={deleteWorkflow}
+                onMutated={fetchList}
+                sparklines={sparklines}
+                onSparkline={recordSparkline}
+              />
+            )}
+            {grouped.broken.length > 0 && (
+              <WorkflowGroup
+                title="Needs attention"
+                count={grouped.broken.length}
+                items={grouped.broken}
+                selectedId={selectedId}
+                onSelect={select}
+                onDelete={deleteWorkflow}
+                onMutated={fetchList}
+                sparklines={sparklines}
+                onSparkline={recordSparkline}
+              />
+            )}
+          </div>
       )}
     </>
   );
@@ -327,6 +343,8 @@ function WorkflowGroup({
   items,
   selectedId,
   onSelect,
+  onDelete,
+  onMutated,
   sparklines,
   onSparkline,
 }: {
@@ -334,7 +352,9 @@ function WorkflowGroup({
   count: number;
   items: WorkflowListItem[];
   selectedId: string | null;
-  onSelect: (id: string) => void;
+  onSelect: (id: string | null) => void;
+  onDelete: (id: string, name: string) => void;
+  onMutated: () => void;
   sparklines: Record<string, number[]>;
   onSparkline: (id: string, values: number[]) => void;
 }) {
@@ -349,7 +369,9 @@ function WorkflowGroup({
             key={w.id}
             w={w}
             active={selectedId === w.id}
-            onSelect={() => onSelect(w.id)}
+            onSelect={() => onSelect(selectedId === w.id ? null : w.id)}
+            onDelete={() => onDelete(w.id, w.name)}
+            onMutated={onMutated}
             sparkline={sparklines[w.id]}
             onSparkline={(values) => onSparkline(w.id, values)}
           />
@@ -363,12 +385,16 @@ function WorkflowRow({
   w,
   active,
   onSelect,
+  onDelete,
+  onMutated,
   sparkline,
   onSparkline,
 }: {
   w: WorkflowListItem;
   active: boolean;
   onSelect: () => void;
+  onDelete: () => void;
+  onMutated: () => void;
   sparkline: number[] | undefined;
   onSparkline: (values: number[]) => void;
 }) {
@@ -397,38 +423,52 @@ function WorkflowRow({
 
   return (
     <li>
-      <button
-        type="button"
-        className={`workflows-row${active ? " is-active" : ""}`}
-        onClick={onSelect}
-      >
-        <div className="font-display text-base font-bold tracking-[-0.01em] text-text">{w.name}</div>
-        {w.description && (
-          <div className="text-[13px] text-text2 mt-1 leading-[1.45]">{w.description}</div>
-        )}
-        <div className="workflows-row-meta">
-          <span>
-            {describeSchedule(w.cron, w.cronTimezone, w.cronEnabled)}
-          </span>
-          {hasActivity && (
-            <>
-              <span className="opacity-60">·</span>
-              <Sparkline values={sparkline ?? []} />
-            </>
+      <div className={`workflows-row${active ? " is-active" : ""}`}>
+        <button
+          type="button"
+          className="workflows-row-main"
+          onClick={onSelect}
+          aria-expanded={active}
+        >
+          <div className="font-display text-base font-bold tracking-[-0.01em] text-text">{w.name}</div>
+          {w.description && (
+            <div className="text-[13px] text-text2 mt-1 leading-[1.45]">{w.description}</div>
           )}
-        </div>
-      </button>
+          <div className="workflows-row-meta">
+            <span>
+              {describeSchedule(w.cron, w.cronTimezone, w.cronEnabled)}
+            </span>
+            {hasActivity && (
+              <>
+                <span className="opacity-60">·</span>
+                <Sparkline values={sparkline ?? []} />
+              </>
+            )}
+          </div>
+        </button>
+        <button
+          type="button"
+          className="workflows-row-delete"
+          title="Delete workflow"
+          aria-label={`Delete ${w.name}`}
+          onClick={(event) => {
+            event.stopPropagation();
+            onDelete();
+          }}
+        >
+          <Trash2 size={14} strokeWidth={2} />
+        </button>
+        {active && <WorkflowDetail workflowId={w.id} onMutated={onMutated} />}
+      </div>
     </li>
   );
 }
 
-function WorkflowDrawer({
+function WorkflowDetail({
   workflowId,
-  onClose,
   onMutated,
 }: {
   workflowId: string;
-  onClose: () => void;
   onMutated: () => void;
 }) {
   const router = useRouter();
@@ -528,37 +568,17 @@ function WorkflowDrawer({
 
   if (error) {
     return (
-      <aside className="workflow-drawer">
-        <div className="workflow-drawer-head">
-          <button
-            type="button"
-            className="border-0 bg-transparent text-xl leading-none text-text3 cursor-pointer px-1 hover:text-text"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            ×
-          </button>
-        </div>
+      <div className="workflow-detail">
         <div className="py-6 text-center text-[13px] text-danger">{error}</div>
-      </aside>
+      </div>
     );
   }
 
   if (!data) {
     return (
-      <aside className="workflow-drawer">
-        <div className="workflow-drawer-head">
-          <button
-            type="button"
-            className="border-0 bg-transparent text-xl leading-none text-text3 cursor-pointer px-1 hover:text-text"
-            onClick={onClose}
-            aria-label="Close"
-          >
-            ×
-          </button>
-        </div>
+      <div className="workflow-detail">
         <div className="py-6 text-center text-[13px] text-text3">Loading…</div>
-      </aside>
+      </div>
     );
   }
 
@@ -568,23 +588,10 @@ function WorkflowDrawer({
   const budgetPct = budgetCap ? Math.round((budgetUsed / budgetCap) * 100) : 0;
 
   return (
-    <aside className="workflow-drawer">
-      <div className="workflow-drawer-head">
-        <div>
-          <div className="font-display text-lg font-extrabold tracking-[-0.01em] leading-tight text-text">{workflow.name}</div>
-          <div className="text-xs text-text3 mt-1 font-mono">
-            {workflow.enabled ? "active" : "paused"}
-            {workflow.cron ? ` · ${workflow.cronEnabled ? "cron" : "cron paused"}` : ""}
-          </div>
-        </div>
-        <button
-          type="button"
-          className="border-0 bg-transparent text-xl leading-none text-text3 cursor-pointer px-1 hover:text-text"
-          onClick={onClose}
-          aria-label="Close"
-        >
-          ×
-        </button>
+    <div className="workflow-detail">
+      <div className="text-xs text-text3 mb-4 font-mono">
+        {workflow.enabled ? "active" : "paused"}
+        {workflow.cron ? ` · ${workflow.cronEnabled ? "cron" : "cron paused"}` : ""}
       </div>
 
       <div className="workflow-drawer-actions">
@@ -825,7 +832,7 @@ function WorkflowDrawer({
           edit in /work
         </button>
       </div>
-    </aside>
+    </div>
   );
 }
 

--- a/apps/web/src/app/api/workflows/[workflowId]/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/route.ts
@@ -204,3 +204,26 @@ export async function PATCH(request: Request, context: RouteContext) {
 
   return NextResponse.json({ ok: true });
 }
+
+// Removing the definition cascades (via FK ON DELETE CASCADE) to its
+// subscriptions/triggers, runs, outputs, and proposed action requests.
+export async function DELETE(_request: Request, context: RouteContext) {
+  const { workflowId } = await context.params;
+  const orgId = await getOrgId();
+
+  const result = await db()
+    .delete(workflow_definition)
+    .where(
+      and(
+        eq(workflow_definition.org_id, orgId),
+        eq(workflow_definition.id, workflowId),
+      ),
+    )
+    .returning({ id: workflow_definition.id });
+
+  if (result.length === 0) {
+    return NextResponse.json({ error: "workflow not found" }, { status: 404 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -18,7 +18,6 @@ import {
   getAgentBackendSettings,
   getAgentSettingsPayload,
 } from "@/lib/agent-backend-settings";
-import { getInstallPolicy } from "@/lib/install-policy-settings";
 import SetupWizard from "./SetupWizard";
 
 /**
@@ -56,28 +55,20 @@ export default async function SettingsPage() {
   }
 
   // ── Ongoing-edits mode: card index linking to focused sub-pages. ──
-  const [dataReady, primaryReady, researchStatus, agent, installPolicy] = await Promise.all([
+  const [dataReady, primaryReady, researchStatus, agent] = await Promise.all([
     hasDataSourceSetup(orgId),
     hasPrimaryProviderSetup(orgId),
     resolveResearchStatus(orgId),
     getAgentBackendSettings(orgId),
-    getInstallPolicy(orgId),
   ]);
 
-  const wideningSwitches = [
-    installPolicy.allowUnverified,
-    installPolicy.allowGitUrlInstalls,
-    installPolicy.allowSandboxedSkillEscape,
-  ].filter(Boolean).length;
-  const communityMarketplaces = installPolicy.allowedMarketplaces.length - 1;
-  const securityStatus =
-    wideningSwitches === 0 && communityMarketplaces <= 0
-      ? "Secure defaults"
-      : `${wideningSwitches} widening switch${wideningSwitches === 1 ? "" : "es"}${
-          communityMarketplaces > 0 ? `, +${communityMarketplaces} marketplace${communityMarketplaces === 1 ? "" : "s"}` : ""
-        }`;
-
-  const cards = [
+  const cards: {
+    href: string;
+    title: string;
+    copy: string;
+    status?: string;
+    statusOk?: boolean;
+  }[] = [
     {
       href: "/settings/data",
       title: "Data source",
@@ -106,15 +97,11 @@ export default async function SettingsPage() {
       href: "/settings/rules",
       title: "Rules",
       copy: "Decide what OpenNeko can act on its own, what queues for review, and what's never allowed. Create and edit via Ask.",
-      status: "Editable via Ask",
-      statusOk: true,
     },
     {
       href: "/settings/security",
       title: "Security",
       copy: "Trust floor for plugin and skill installs — which marketplaces are allowed, whether unverified or community installs are permitted.",
-      status: securityStatus,
-      statusOk: true,
     },
   ];
 
@@ -136,9 +123,11 @@ export default async function SettingsPage() {
                 <h2 className="settings-card-title">{card.title}</h2>
                 <p className="settings-card-copy">{card.copy}</p>
               </div>
-              <div className="settings-source">
-                <strong className={card.statusOk ? "is-ok" : "is-warn"}>{card.status}</strong>
-              </div>
+              {card.status ? (
+                <div className="settings-source">
+                  <strong className={card.statusOk ? "is-ok" : "is-warn"}>{card.status}</strong>
+                </div>
+              ) : null}
             </div>
           </Link>
         ))}

--- a/apps/web/src/app/settings/security/SecurityForm.tsx
+++ b/apps/web/src/app/settings/security/SecurityForm.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import AppHeader from "@/components/AppHeader";
+import CreatorCredit from "@/components/CreatorCredit";
+import SectionNav from "@/components/SectionNav";
 import { Button } from "@/components/ui/Button";
 
 type InstallPolicy = {
@@ -27,6 +30,7 @@ const INPUT_CLS =
   "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-[15px] font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
 
 export default function SecurityForm({ initial }: { initial: InstallPolicyPayload }) {
+  const router = useRouter();
   const [policy, setPolicy] = useState<InstallPolicy>(initial.policy);
   const [newMarketplace, setNewMarketplace] = useState("");
   const [saving, setSaving] = useState(false);
@@ -91,86 +95,113 @@ export default function SecurityForm({ initial }: { initial: InstallPolicyPayloa
   }
 
   return (
-    <div className="root">
-      <AppHeader />
-      <div className="greet">Security settings.</div>
-      <div className="greet-sub mb-6">
-        Trust floor for plugin and skill installs. Defaults are
-        secure-by-default — flip a switch on to widen the install
-        surface, off to narrow it back.
-      </div>
+    <>
+      <div
+        className="root"
+        style={{ "--page-width": "min(1000px, 100%)" } as React.CSSProperties}
+      >
+        <AppHeader>
+          <SectionNav current="settings" />
+        </AppHeader>
 
-      <section className="flex flex-col gap-6 mt-2">
-        <Toggle
-          label="Allow unverified installs"
-          help="Lets operators run `openneko install <pkg> --unverified` (bypasses every marketplace). Use only for plugin authoring or emergency hotfixes — integrity comes from npm on trust."
-          checked={policy.allowUnverified}
-          onChange={(v) => toggle("allowUnverified", v)}
-        />
+        <div className="mt-1 mb-3.5 font-mono text-[12.5px] text-text3 flex items-center gap-2">
+          <button
+            type="button"
+            className="bg-transparent border-0 text-text3 cursor-pointer font-[inherit] p-0 hover:text-accent"
+            onClick={() => router.push("/settings")}
+          >
+            ← Settings
+          </button>
+          <span className="opacity-50">/</span>
+          <span>Security</span>
+        </div>
 
-        <Toggle
-          label="Allow community-skill installs from git URLs"
-          help="Lets operators run `openneko install <git-url>` to pull a skill directly from GitHub / GitLab / Codeberg. Skills run in-process with the worker by default — combine with the sandbox-escape switch below for untrusted sources."
-          checked={policy.allowGitUrlInstalls}
-          onChange={(v) => toggle("allowGitUrlInstalls", v)}
-        />
+        <div className="flex items-baseline justify-between gap-4 mb-3">
+          <h1 className="font-display text-3xl font-extrabold tracking-[-0.02em] text-text">
+            Security
+          </h1>
+        </div>
 
-        <Toggle
-          label="Sandbox shell blocks of untrusted skills"
-          help="When installing a skill from a non-trusted source, run any shell blocks in its body inside a one-shot microVM. Slower but contained. Recommended when allowing git-URL installs."
-          checked={policy.allowSandboxedSkillEscape}
-          onChange={(v) => toggle("allowSandboxedSkillEscape", v)}
-        />
+        <p className="text-sm leading-normal text-text2 mb-6 max-w-[640px]">
+          Trust floor for plugin and skill installs. Defaults are
+          secure-by-default — flip a switch on to widen the install surface, off
+          to narrow it back.
+        </p>
 
-        <div className={FIELD_CLS}>
-          <label className={LABEL_CLS}>Allowed marketplaces</label>
-          <p className={HELP_CLS}>
-            Marketplaces this deployment trusts. The official OpenNeko
-            marketplace is always trusted. Add community marketplaces by
-            URL.
-          </p>
-          <ul className="flex flex-col gap-2 mt-1">
-            {policy.allowedMarketplaces.map((url) => (
-              <li
-                key={url}
-                className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-bg"
-              >
-                <code className="flex-1 truncate text-[13px] text-text2">{url}</code>
-                {url === OFFICIAL_MARKETPLACE_URL ? (
-                  <span className="text-[12px] text-text3">official</span>
-                ) : (
-                  <button
-                    type="button"
-                    className="text-[12px] text-text2 underline"
-                    onClick={() => removeMarketplace(url)}
-                  >
-                    remove
-                  </button>
-                )}
-              </li>
-            ))}
-          </ul>
-          <div className="flex gap-2 mt-2">
-            <input
-              type="url"
-              placeholder="https://example.com/marketplace.json"
-              value={newMarketplace}
-              onChange={(e) => setNewMarketplace(e.target.value)}
-              className={`${INPUT_CLS} flex-1`}
-            />
-            <Button type="button" onClick={addMarketplace} variant="secondary">
-              Add
+        <section className="flex flex-col gap-6 mt-2">
+          <Toggle
+            label="Allow unverified installs"
+            help="Lets operators run `openneko install <pkg> --unverified` (bypasses every marketplace). Use only for plugin authoring or emergency hotfixes — integrity comes from npm on trust."
+            checked={policy.allowUnverified}
+            onChange={(v) => toggle("allowUnverified", v)}
+          />
+  
+          <Toggle
+            label="Allow community-skill installs from git URLs"
+            help="Lets operators run `openneko install <git-url>` to pull a skill directly from GitHub / GitLab / Codeberg. Skills run in-process with the worker by default — combine with the sandbox-escape switch below for untrusted sources."
+            checked={policy.allowGitUrlInstalls}
+            onChange={(v) => toggle("allowGitUrlInstalls", v)}
+          />
+  
+          <Toggle
+            label="Sandbox shell blocks of untrusted skills"
+            help="When installing a skill from a non-trusted source, run any shell blocks in its body inside a one-shot microVM. Slower but contained. Recommended when allowing git-URL installs."
+            checked={policy.allowSandboxedSkillEscape}
+            onChange={(v) => toggle("allowSandboxedSkillEscape", v)}
+          />
+  
+          <div className={FIELD_CLS}>
+            <label className={LABEL_CLS}>Allowed marketplaces</label>
+            <p className={HELP_CLS}>
+              Marketplaces this deployment trusts. The official OpenNeko
+              marketplace is always trusted. Add community marketplaces by
+              URL.
+            </p>
+            <ul className="flex flex-col gap-2 mt-1">
+              {policy.allowedMarketplaces.map((url) => (
+                <li
+                  key={url}
+                  className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-bg"
+                >
+                  <code className="flex-1 truncate text-[13px] text-text2">{url}</code>
+                  {url === OFFICIAL_MARKETPLACE_URL ? (
+                    <span className="text-[12px] text-text3">official</span>
+                  ) : (
+                    <button
+                      type="button"
+                      className="text-[12px] text-text2 underline"
+                      onClick={() => removeMarketplace(url)}
+                    >
+                      remove
+                    </button>
+                  )}
+                </li>
+              ))}
+            </ul>
+            <div className="flex gap-2 mt-2">
+              <input
+                type="url"
+                placeholder="https://example.com/marketplace.json"
+                value={newMarketplace}
+                onChange={(e) => setNewMarketplace(e.target.value)}
+                className={`${INPUT_CLS} flex-1`}
+              />
+              <Button type="button" onClick={addMarketplace} variant="secondary">
+                Add
+              </Button>
+            </div>
+          </div>
+  
+          <div className="flex justify-end mt-2">
+            <Button type="button" onClick={save} disabled={saving}>
+              {saving ? "Saving…" : "Save"}
             </Button>
           </div>
-        </div>
+        </section>
+      </div>
 
-        <div className="flex justify-end mt-2">
-          <Button type="button" onClick={save} disabled={saving}>
-            {saving ? "Saving…" : "Save"}
-          </Button>
-        </div>
-      </section>
-    </div>
+      <CreatorCredit />
+    </>
   );
 }
 

--- a/apps/web/src/app/styles/_responsive.css
+++ b/apps/web/src/app/styles/_responsive.css
@@ -45,11 +45,6 @@ body { overflow-x: hidden; }
   .work-thread-list { max-height: 38vh; }
   .work-bubble { max-width: 100%; }
 
-  .workflows-root:has(.workflow-drawer) .workflows-layout {
-    grid-template-columns: minmax(0, 1fr);
-  }
-  .workflow-drawer { position: static; max-height: none; }
-
   .builder-layout { grid-template-columns: minmax(0, 1fr); }
   .builder-card { position: static; }
 
@@ -62,6 +57,7 @@ body { overflow-x: hidden; }
   /* Hover-reveal actions are always visible — there is no hover. */
   .iactions, .work-bubble-actions { opacity: 1; }
   .work-thread-delete { opacity: 1; }
+  .workflows-row-delete { display: inline-flex; }
   .library-row-action { opacity: 1; pointer-events: auto; }
 }
 
@@ -173,7 +169,7 @@ body { overflow-x: hidden; }
   .act-row-actions { flex-wrap: wrap; row-gap: 8px; }
   .act-row-btn { flex: 1 1 auto; min-width: 0; text-align: center; }
 
-  .workflow-drawer { padding: 18px; border-radius: 14px; }
+  .workflow-detail { padding: 14px 16px 16px; }
   .workflow-drawer-actions { flex-wrap: wrap; }
   .workflow-drawer-btn { flex: 1 1 auto; }
 

--- a/apps/web/src/app/styles/_work.css
+++ b/apps/web/src/app/styles/_work.css
@@ -653,3 +653,57 @@
   padding: 14px 18px;
   box-shadow: var(--shadow);
 }
+
+/* ─── Confirmation card ─── */
+/* Emitted when the agent saves a workflow, trigger, or rule. Chat-scaled
+   chrome — deliberately NOT the dashboard .greet display heading. */
+.work-confirm {
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--success-mid) 7%, var(--card)) 0%,
+    var(--card) 52%
+  );
+  border: 1px solid color-mix(in srgb, var(--border) 70%, var(--success-mid) 22%);
+  border-radius: 16px;
+  padding: 13px 16px 14px;
+  box-shadow: var(--shadow);
+}
+.work-confirm-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.work-confirm-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 17px;
+  height: 17px;
+  border-radius: 50%;
+  background: var(--success-mid);
+  color: #fff;
+  flex-shrink: 0;
+}
+.work-confirm-check svg {
+  width: 10px;
+  height: 10px;
+}
+.work-confirm-label {
+  font-family: var(--font-display), 'Archivo', sans-serif;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--success-mid);
+}
+.work-confirm-title {
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.3;
+  letter-spacing: -0.012em;
+  color: var(--text);
+  margin-top: 5px;
+}
+.work-confirm-body {
+  margin-top: 9px;
+}

--- a/apps/web/src/app/styles/_workflows.css
+++ b/apps/web/src/app/styles/_workflows.css
@@ -23,36 +23,65 @@
   transform: translateY(-1px);
 }
 
-.workflows-layout {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: 24px;
-  align-items: start;
-}
-.workflows-root:has(.workflow-drawer) .workflows-layout {
-  grid-template-columns: minmax(0, 1fr) minmax(0, 380px);
-}
-
 .workflows-row {
+  position: relative;
   width: 100%;
-  display: block;
-  text-align: left;
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 14px;
-  padding: 14px 18px;
-  cursor: pointer;
   transition: border-color 0.18s, background 0.18s;
-  font: inherit;
-  color: inherit;
 }
 .workflows-row:hover {
   border-color: var(--text3);
 }
 .workflows-row.is-active {
   border-color: var(--accent);
-  background: var(--accent-soft);
 }
+
+.workflows-row-main {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: 0;
+  border-radius: 14px;
+  /* right padding leaves room for the hover delete button */
+  padding: 14px 44px 14px 18px;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+.workflows-row.is-active .workflows-row-main {
+  background: var(--accent-soft);
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.workflows-row-delete {
+  position: absolute;
+  top: 11px;
+  right: 11px;
+  width: 28px;
+  height: 28px;
+  border: 0;
+  background: transparent;
+  border-radius: 7px;
+  color: var(--text3);
+  cursor: pointer;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  transition: background 0.15s, color 0.15s;
+}
+.workflows-row:hover .workflows-row-delete,
+.workflows-row:focus-within .workflows-row-delete {
+  display: inline-flex;
+}
+.workflows-row-delete:hover {
+  background: rgba(220, 53, 69, 0.1);
+  color: #c0392b;
+}
+
 .workflows-row-meta {
   margin-top: 10px;
   display: flex;
@@ -63,26 +92,15 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
-/* ─── WORKFLOW DRAWER ─── */
-.workflow-drawer {
-  position: sticky;
-  top: 24px;
-  border: 1px solid var(--border);
-  background: var(--card);
-  border-radius: 16px;
-  padding: 20px;
-  min-width: 0;
-  max-height: calc(100vh - 48px);
-  overflow-y: auto;
+/* ─── WORKFLOW DETAIL (inline, expands beneath its row) ─── */
+.workflow-detail {
+  border-top: 1px solid var(--border);
+  padding: 16px 18px 18px;
+  animation: workflow-detail-in 0.16s ease;
 }
-.workflow-drawer-head {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 12px;
-  margin-bottom: 16px;
-  padding-bottom: 12px;
-  border-bottom: 1px solid var(--border);
+@keyframes workflow-detail-in {
+  from { opacity: 0; transform: translateY(-2px); }
+  to { opacity: 1; transform: none; }
 }
 
 .workflow-drawer-actions {
@@ -135,13 +153,6 @@
 }
 .workflow-drawer-run-link:hover .workflow-drawer-run-meta { color: var(--accent); }
 .workflow-drawer-run-link:hover .workflow-drawer-run-arrow { color: var(--accent); transform: translateX(2px); }
-
-@media (max-width: 900px) {
-  .workflows-root:has(.workflow-drawer) .workflows-layout {
-    grid-template-columns: minmax(0, 1fr);
-  }
-  .workflow-drawer { position: static; }
-}
 
 /* ─── WORKFLOW BUILDER (authoring chat) ─── */
 .builder-root { --page-width: 1000px; }

--- a/apps/worker/test/jobs/work-run.test.ts
+++ b/apps/worker/test/jobs/work-run.test.ts
@@ -395,10 +395,10 @@ describeIfDb("runChatTurn", () => {
     const components =
       payload.messages[1]?.updateComponents?.components ?? [];
     const root = components.find((c) => c.id === "root") as
-      | { greeting?: string; subtitle?: string }
+      | { label?: string; title?: string }
       | undefined;
-    expect(root?.greeting).toBe("Created workflow");
-    expect(root?.subtitle).toBe("APAC revenue dip check");
+    expect(root?.label).toBe("Created workflow");
+    expect(root?.title).toBe("APAC revenue dip check");
     const body = components.find((c) => c.id === "body");
     expect(body?.text).toContain("[Open detail](/workflows?id=");
 
@@ -484,10 +484,10 @@ describeIfDb("runChatTurn", () => {
     const components =
       payload.messages[1]?.updateComponents?.components ?? [];
     const root = components.find((c) => c.id === "root") as
-      | { greeting?: string; subtitle?: string }
+      | { label?: string; title?: string }
       | undefined;
-    expect(root?.greeting).toBe("Created rule");
-    expect(root?.subtitle).toBe("slack_revenue_alerts_autoapprove");
+    expect(root?.label).toBe("Created rule");
+    expect(root?.title).toBe("slack_revenue_alerts_autoapprove");
     const body = components.find((c) => c.id === "body");
     expect(body?.text).toContain("auto_approve");
     expect(body?.text).toContain("[Open detail](/settings/rules/");

--- a/packages/llm/src/graphjin/client.ts
+++ b/packages/llm/src/graphjin/client.ts
@@ -79,8 +79,27 @@ type WsMessage =
       payload: { query: string; variables?: unknown; operationName?: string };
     }
   | { type: "next"; id: string; payload: GraphjinSubscriptionMessage }
-  | { type: "error"; id: string; payload: Array<{ message: string }> }
+  | { type: "error"; id: string; payload?: unknown }
   | { type: "complete"; id: string };
+
+function errorMessageFromPayload(payload: unknown): string {
+  const list = Array.isArray(payload)
+    ? payload
+    : Array.isArray((payload as { errors?: unknown } | null)?.errors)
+      ? (payload as { errors: unknown[] }).errors
+      : null;
+  const joined = list
+    ?.map((e) =>
+      e && typeof e === "object" && "message" in e
+        ? String((e as { message: unknown }).message)
+        : String(e),
+    )
+    .filter(Boolean)
+    .join("; ");
+  if (joined) return joined;
+  if (typeof payload === "string" && payload) return payload;
+  return "subscription error";
+}
 
 /**
  * Subscribe to a GraphJin query via WebSocket using the
@@ -146,12 +165,7 @@ export function graphjinSubscribe<T = unknown>(
         return;
       case "error":
         if (parsed.id !== subId) return;
-        opts.onError?.(
-          new Error(
-            parsed.payload?.map((e) => e.message).join("; ") ||
-              "subscription error",
-          ),
-        );
+        opts.onError?.(new Error(errorMessageFromPayload(parsed.payload)));
         return;
       case "complete":
         if (parsed.id !== subId) return;

--- a/packages/llm/src/workflows/builder-cards.ts
+++ b/packages/llm/src/workflows/builder-cards.ts
@@ -3,10 +3,10 @@ import type { ActionPolicyRecord } from "./action-store";
 import type { SubscriptionRecord, WorkflowRecord } from "./store";
 import type { SourceChangeFilter } from "./subscription-query";
 
-function briefingCard(args: {
+function confirmationCard(args: {
   surfaceId: string;
-  greeting: string;
-  subtitle: string;
+  label: string;
+  title: string;
   body: string;
 }): AgentSurfaceMessage[] {
   return [
@@ -24,10 +24,9 @@ function briefingCard(args: {
         components: [
           {
             id: "root",
-            component: "Briefing",
-            greeting: args.greeting,
-            subtitle: args.subtitle,
-            role: "operator",
+            component: "Confirmation",
+            label: args.label,
+            title: args.title,
             children: ["body"],
           },
           { id: "body", component: "Markdown", text: args.body },
@@ -45,10 +44,10 @@ export function workflowSavedCard(args: {
   const cron = args.workflow.cron
     ? ` (cron \`${args.workflow.cron}\` ${args.workflow.cronTimezone})`
     : "";
-  return briefingCard({
+  return confirmationCard({
     surfaceId: `workflow-save-${args.workflow.id}`,
-    greeting: `${verb} workflow`,
-    subtitle: args.workflow.name,
+    label: `${verb} workflow`,
+    title: args.workflow.name,
     body: [
       `**${args.workflow.name}** — ${args.workflow.steps.length} step(s)${cron}.`,
       "",
@@ -74,10 +73,10 @@ export function subscriptionSavedCard(args: {
         Object.keys(filter.where as Record<string, unknown>).join("`, `") +
         "`"
       : "_(no filter)_";
-  return briefingCard({
+  return confirmationCard({
     surfaceId: `subscription-save-${args.subscription.id}`,
-    greeting: "Trigger added",
-    subtitle: args.workflowName,
+    label: "Trigger added",
+    title: args.workflowName,
     body: [
       `**${args.workflowName}** will fire on changes to \`${table}\` (pk: \`${pkList}\`).`,
       "",
@@ -103,10 +102,10 @@ export function policySavedCard(args: {
     args.policy.appliesToKinds.length > 0
       ? args.policy.appliesToKinds.map((k) => `\`${k}\``).join(", ")
       : "_(all kinds)_";
-  return briefingCard({
+  return confirmationCard({
     surfaceId: `policy-save-${args.policy.id}`,
-    greeting: `${verb} rule`,
-    subtitle: args.policy.name,
+    label: `${verb} rule`,
+    title: args.policy.name,
     body: [
       `**Mode:** \`${args.policy.mode}\` • **Scopes:** ${scopes} • **Priority:** ${args.policy.priority}`,
       "",

--- a/packages/llm/test/builder-cards.test.ts
+++ b/packages/llm/test/builder-cards.test.ts
@@ -92,10 +92,10 @@ describe("workflowSavedCard", () => {
   it("uses 'Created' vs 'Updated' verb based on the action", () => {
     const created = workflowSavedCard({ workflow: workflowFixture, action: "created" });
     const updated = workflowSavedCard({ workflow: workflowFixture, action: "updated" });
-    const createdRoot = (created[1].updateComponents as { components: Array<{ id: string; greeting?: string }> }).components.find((c) => c.id === "root");
-    const updatedRoot = (updated[1].updateComponents as { components: Array<{ id: string; greeting?: string }> }).components.find((c) => c.id === "root");
-    expect(createdRoot?.greeting).toBe("Created workflow");
-    expect(updatedRoot?.greeting).toBe("Updated workflow");
+    const createdRoot = (created[1].updateComponents as { components: Array<{ id: string; label?: string }> }).components.find((c) => c.id === "root");
+    const updatedRoot = (updated[1].updateComponents as { components: Array<{ id: string; label?: string }> }).components.find((c) => c.id === "root");
+    expect(createdRoot?.label).toBe("Created workflow");
+    expect(updatedRoot?.label).toBe("Updated workflow");
   });
 
   it("falls back to placeholder text when description is empty", () => {


### PR DESCRIPTION
Branch contains two commits — the previously-landed GraphJin defensive-parse fix (`7bf2962`) plus this session's work-surface improvements (`3282c07`). Summary of the new commit below.

## a2ui Confirmation card
- Dedicated `Confirmation` component for workflow/trigger/rule saves instead of reusing the dashboard `Briefing` display heading, which rendered a 52px greeting inside the chat timeline.
- Render-time remap of legacy persisted `Briefing`-as-confirmation events so existing threads pick up the new chrome. Renderer, catalog type, CSS, `builder-cards`, and both test files updated.

## Ask / work screen
- **New-thread landing:** `/work` (no threadId) is now the empty new-thread state — the composer creates a thread on first send — instead of redirecting to the most recent thread. The header **Ask** link and `?seed=` deep-links now open a fresh thread (and `?seed=` prefills the composer, which the old redirect threw away).
- **Duplicate-event guard:** resuming an in-flight run replayed its persisted events from `afterId=0` and appended them on top of the bundle's local copy, doubling tool rows and assistant text (and crashing with duplicate React keys). Now drops the local copy before replay and dedupes `tool_start` in the timeline builder.

## Workflows
- Detail is an **inline collapsible card** under each row instead of a drawer rendered below the whole list (which fell off-screen on narrow viewports).
- **Hover-reveal delete** that cascades — via FK `ON DELETE CASCADE` — to the workflow's triggers/subscriptions, runs, outputs, and proposed/executed actions (new `DELETE /api/workflows/[id]`).
- Moved the **New workflow** action to the header's right edge.

## Settings
- Dropped the always-green status pill from the **Rules** and **Security** cards (kept on Data source / Agent / Research, which reflect real config state).
- Matched the **Security** page chrome to **Rules**: back breadcrumb (`← Settings / Security`), display heading, and creator credit.

## Test plan
- `pnpm --filter @neko/web typecheck` — passes.
- `pnpm --filter @neko/llm exec vitest run test/builder-cards.test.ts` — 9/9 pass.
- Verified in-browser: workflow inline expand/collapse + deep-link, settings pill removal, Rules/Security chrome parity.

> Note: the branch name (`fix/graphjin-subscription-error-payload`) predates this session's broader scope. Happy to rename the branch / PR or split the work-surface commit out if you'd prefer a narrower PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)