### PR TITLE
fix(worker): back off and dedupe inbound channel poll failures

### DIFF
--- a/apps/worker/src/channels/inbound-poll.ts
+++ b/apps/worker/src/channels/inbound-poll.ts
@@ -10,10 +10,10 @@
 // and are skipped here.
 import { getPluginRegistryInstance } from "../plugins/registry-instance.js";
 import { dispatchInboundIntent, ensureInboundBinding } from "./delivery.js";
+import { pollBackoffMs, shouldLogPollFailure } from "./poll-backoff.js";
 
 type IntentEvent = Parameters<typeof dispatchInboundIntent>[1];
 
-const POLL_INTERVAL_MS = 3_000;
 const msg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
 
@@ -41,6 +41,8 @@ export function startChannelInbound(orgId: string): { stop: () => void } {
   async function pollLoop(pluginName: string): Promise<void> {
     let cursor: string | undefined;
     let warnedUnsupported = false;
+    let failureStreak = 0;
+    let lastError: string | undefined;
     console.log(`[channel-inbound] ${pluginName}: polling for inbound (no public webhook URL)`);
     while (!stopped) {
       try {
@@ -59,6 +61,13 @@ export function startChannelInbound(orgId: string): { stop: () => void } {
             console.warn(`[channel-inbound] ${pluginName} dispatch error: ${msg(err)}`);
           }
         }
+        if (failureStreak > 0) {
+          console.log(
+            `[channel-inbound] ${pluginName}: poll recovered after ${failureStreak} failed attempt(s)`,
+          );
+          failureStreak = 0;
+          lastError = undefined;
+        }
       } catch (err) {
         const m = msg(err);
         if (m.includes("does not implement poll_inbound")) {
@@ -70,9 +79,16 @@ export function startChannelInbound(orgId: string): { stop: () => void } {
           }
           return; // can't be polled; retrying won't help
         }
-        if (!stopped) console.warn(`[channel-inbound] ${pluginName} poll error: ${m}`);
+        if (!stopped) {
+          failureStreak++;
+          if (shouldLogPollFailure(failureStreak, m !== lastError)) {
+            const attempt = failureStreak > 1 ? ` (attempt ${failureStreak})` : "";
+            console.warn(`[channel-inbound] ${pluginName} poll error${attempt}: ${m}`);
+          }
+          lastError = m;
+        }
       }
-      if (!stopped) await sleep(POLL_INTERVAL_MS);
+      if (!stopped) await sleep(pollBackoffMs(failureStreak));
     }
   }
 

--- a/apps/worker/src/channels/poll-backoff.ts
+++ b/apps/worker/src/channels/poll-backoff.ts
@@ -1,0 +1,27 @@
+// Backoff + log-gating policy for the inbound poll loop, factored out of
+// inbound-poll.ts so it can be unit-tested without the loop's registry and
+// delivery dependencies.
+
+export const POLL_INTERVAL_MS = 3_000;
+const MAX_BACKOFF_MS = 60_000;
+const REPEAT_LOG_EVERY = 10;
+
+/**
+ * Delay before the next poll. Healthy (streak 0) polls at the base interval;
+ * each consecutive failure doubles the delay up to a cap, so a downed channel
+ * stops hammering the plugin VM every 3s (and stops flooding the log).
+ */
+export function pollBackoffMs(failureStreak: number): number {
+  if (failureStreak <= 0) return POLL_INTERVAL_MS;
+  const exp = Math.min(failureStreak - 1, 6);
+  return Math.min(POLL_INTERVAL_MS * 2 ** exp, MAX_BACKOFF_MS);
+}
+
+/**
+ * Whether to log this poll failure: always for a new/changed error, otherwise
+ * only every REPEAT_LOG_EVERY-th identical repeat — so a persistent outage
+ * leaves a periodic breadcrumb instead of one line per cycle.
+ */
+export function shouldLogPollFailure(failureStreak: number, changed: boolean): boolean {
+  return changed || failureStreak % REPEAT_LOG_EVERY === 0;
+}

--- a/apps/worker/test/channels/poll-backoff.test.ts
+++ b/apps/worker/test/channels/poll-backoff.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+  POLL_INTERVAL_MS,
+  pollBackoffMs,
+  shouldLogPollFailure,
+} from "../../src/channels/poll-backoff.js";
+
+describe("pollBackoffMs", () => {
+  it("polls at the base interval while healthy", () => {
+    expect(pollBackoffMs(0)).toBe(POLL_INTERVAL_MS);
+    expect(pollBackoffMs(-1)).toBe(POLL_INTERVAL_MS);
+  });
+
+  it("doubles per consecutive failure", () => {
+    expect(pollBackoffMs(1)).toBe(3_000);
+    expect(pollBackoffMs(2)).toBe(6_000);
+    expect(pollBackoffMs(3)).toBe(12_000);
+    expect(pollBackoffMs(4)).toBe(24_000);
+    expect(pollBackoffMs(5)).toBe(48_000);
+  });
+
+  it("caps the backoff at 60s", () => {
+    expect(pollBackoffMs(6)).toBe(60_000);
+    expect(pollBackoffMs(7)).toBe(60_000);
+    expect(pollBackoffMs(100)).toBe(60_000);
+  });
+});
+
+describe("shouldLogPollFailure", () => {
+  it("logs whenever the error changes", () => {
+    expect(shouldLogPollFailure(1, true)).toBe(true);
+    expect(shouldLogPollFailure(7, true)).toBe(true);
+  });
+
+  it("suppresses identical repeats except every 10th", () => {
+    expect(shouldLogPollFailure(2, false)).toBe(false);
+    expect(shouldLogPollFailure(9, false)).toBe(false);
+    expect(shouldLogPollFailure(10, false)).toBe(true);
+    expect(shouldLogPollFailure(20, false)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why
A stuck Telegram channel on neko-vm exposed the inbound poll loop's behavior under sustained failure: it retried every 3s and logged a full warn line **every cycle**, so an outage (or a version-pin mismatch that makes `ensureVm` reject + tear down the plugin VM each poll) produced a wall of identical log lines and re-spawned the microVM every 3s — the kind of churn that can trip the microsandbox slot allocator.

## What
`inbound-poll.ts` now:
- **Backs off exponentially** on consecutive poll failures: 3s → 6s → 12s → … → **60s cap**, resetting to the base interval on the next success.
- **Dedupes logs**: a new/changed error logs immediately; identical repeats log only every 10th attempt (with an `(attempt N)` suffix), plus a one-line **recovery** log when polling succeeds again.

The backoff + log-gating policy is factored into `poll-backoff.ts` (no registry/delivery deps) so it's unit-testable in isolation.

## Tests
- `test/channels/poll-backoff.test.ts`: backoff curve (base / doubling / 60s cap) and the log-gating rule (changed → always; identical → every 10th).
- Worker typecheck clean; `test/channels/` **15/15 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)