### PR TITLE
fix(operability): make failures legible to a non-technical operator

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,14 +79,30 @@ jobs:
               export OPENNEKO_PLUGIN_INSTALL_DIR=/opt/neko/.plugins
               export OPENNEKO_PLUGINS_MANIFEST_PATH=/opt/neko/.plugins/openneko.plugins.json
               [ -f "$OPENNEKO_PLUGINS_MANIFEST_PATH" ] || openneko init
+              # These CLI ops proxy into the worker container via `docker exec`,
+              # which can return a spurious non-zero even when the operation
+              # succeeded. So we tolerate the exit code and assert the OUTCOME
+              # instead — a deploy must go red only when something is actually
+              # wrong, not when a write that worked reported a noisy exit.
               if [ -n "${SLACK_BOT_TOKEN:-}" ]; then
-                openneko secrets set @open-neko/plugin-slack SLACK_BOT_TOKEN "$SLACK_BOT_TOKEN"
-                echo "[deploy] SLACK_BOT_TOKEN saved"
+                openneko secrets set @open-neko/plugin-slack SLACK_BOT_TOKEN "$SLACK_BOT_TOKEN" || true
+                if printf '%s\n' "$(openneko secrets list 2>/dev/null || true)" | grep -q 'SLACK_BOT_TOKEN'; then
+                  echo "[deploy] SLACK_BOT_TOKEN saved"
+                else
+                  echo "[deploy] ERROR: SLACK_BOT_TOKEN not present after set" >&2
+                  exit 1
+                fi
               else
                 echo "[deploy] SLACK_BOT_TOKEN secret not set in CI; slack install will be skipped"
               fi
               if [ -n "${SLACK_BOT_TOKEN:-}" ]; then
-                openneko install @open-neko/plugin-slack --skip-host-check
+                openneko install @open-neko/plugin-slack --skip-host-check || true
+                if printf '%s\n' "$(openneko list 2>/dev/null || true)" | grep -q 'plugin-slack'; then
+                  echo "[deploy] plugin-slack installed"
+                else
+                  echo "[deploy] ERROR: plugin-slack not installed after install" >&2
+                  exit 1
+                fi
               fi
               if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -f /opt/neko/scripts/install-telegram-channel.sh ]; then
                 bash /opt/neko/scripts/install-telegram-channel.sh \

--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -1,5 +1,11 @@
 name: post-release smoke
 
+# Gate, not spectator. After a release builds, this actually installs the just-
+# published artifacts and asks `openneko status` whether the stack serves. If
+# the build FAILED, or the smoke fails, it demotes that release off "Latest"
+# (gh release edit --prerelease) so `releases/latest` falls back to the last
+# good version — a broken release never becomes the one users download.
+
 on:
   workflow_run:
     workflows: ["openneko release binaries"]
@@ -11,51 +17,65 @@ on:
         required: false
         default: "latest"
 
+permissions:
+  contents: write # needed to demote a bad release off "Latest"
+
 jobs:
   smoke:
     name: post-release supervisor smoke
     runs-on: ubuntu-22.04
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'workflow_run' &&
-       github.event.workflow_run.conclusion == 'success')
+    # Runs on BOTH success and failure of the release build: on failure we must
+    # still demote the half-published release.
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
+      - name: Resolve release tag + build outcome
+        id: ctx
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+            echo "stable=false" >> "$GITHUB_OUTPUT"
+            echo "build_ok=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          tag=$(gh api "repos/${{ github.repository }}/releases" \
+            --jq '.[] | select(.target_commitish=="main") | .tag_name' | head -1)
+          echo "tag=${tag:-}" >> "$GITHUB_OUTPUT"
+          # Only gate stable releases — a '-' marks a prerelease, which is never "Latest".
+          case "${tag:-}" in *-* | "") echo "stable=false" ;; *) echo "stable=true" ;; esac >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event.workflow_run.conclusion }}" = "success" ]; then
+            echo "build_ok=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "build_ok=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Fail fast if the release build did not succeed
+        if: ${{ steps.ctx.outputs.build_ok != 'true' }}
+        run: |
+          echo "::error::release build did not succeed for ${{ steps.ctx.outputs.tag }} — its artifacts are incomplete"
+          exit 1
+
       - uses: actions/setup-go@v5
+        if: ${{ steps.ctx.outputs.build_ok == 'true' }}
         with:
           go-version: "1.24"
           cache-dependency-path: apps/openneko/go.sum
 
-      - name: Resolve image tag
-        id: tag
-        run: |
-          set -euxo pipefail
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          tag=$(gh api "repos/${{ github.repository }}/releases" \
-            --jq '.[] | select(.target_commitish=="main") | .tag_name' \
-            | head -1)
-          if [ -z "$tag" ]; then
-            echo "no release tag found; defaulting to :latest"
-            tag="latest"
-          fi
-          echo "tag=$tag" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build openneko binary
+        if: ${{ steps.ctx.outputs.build_ok == 'true' }}
         working-directory: apps/openneko
         run: go build -o /usr/local/bin/openneko ./cmd/openneko
 
       - name: Pre-pull images with retry
+        if: ${{ steps.ctx.outputs.build_ok == 'true' }}
         run: |
           set -euxo pipefail
-          tag="${{ steps.tag.outputs.tag }}"
+          tag="${{ steps.ctx.outputs.tag }}"
           refs=(
             "ghcr.io/open-neko/neko-web:${tag}"
             "ghcr.io/open-neko/neko-worker:${tag}"
@@ -78,31 +98,45 @@ jobs:
           done
 
       - name: openneko start (detached) against pre-pulled images
+        if: ${{ steps.ctx.outputs.build_ok == 'true' }}
         env:
-          OPENNEKO_VERSION: ${{ steps.tag.outputs.tag }}
+          OPENNEKO_VERSION: ${{ steps.ctx.outputs.tag }}
         run: |
           set -euxo pipefail
           openneko start --mode prod --detach --pull never
 
-      - name: openneko status (poll until healthy)
+      - name: openneko status (poll until serving)
+        if: ${{ steps.ctx.outputs.build_ok == 'true' }}
         env:
-          OPENNEKO_VERSION: ${{ steps.tag.outputs.tag }}
+          OPENNEKO_VERSION: ${{ steps.ctx.outputs.tag }}
         run: |
-          set -euxo pipefail
+          set -euo pipefail
           for i in $(seq 1 60); do
-            if openneko status | grep -E "running|healthy"; then
-              echo "stack is up after ${i} polls"
+            if openneko status; then
+              echo "stack is serving after ${i} polls"
               exit 0
             fi
             sleep 2
           done
-          echo "stack did not come up within 120s — final state:"
-          openneko status || true
+          echo "stack did not reach 'serving' within 120s — final state:"
+          openneko status -v || true
           openneko logs || true
           exit 1
 
-      - name: openneko stop --volumes
-        if: always()
+      # Any failure above — build incomplete OR the stack never served — demotes
+      # the release so installers fall back to the last good version.
+      - name: Demote release off "Latest" on failure
+        if: ${{ failure() && steps.ctx.outputs.stable == 'true' && steps.ctx.outputs.tag != '' }}
         env:
-          OPENNEKO_VERSION: ${{ steps.tag.outputs.tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "::error::${{ steps.ctx.outputs.tag }} failed post-release smoke — demoting off 'Latest' so installs fall back to the last good release"
+          gh release edit "${{ steps.ctx.outputs.tag }}" \
+            --prerelease --latest=false \
+            --repo "${{ github.repository }}" || true
+
+      - name: openneko stop --volumes
+        if: ${{ always() && steps.ctx.outputs.build_ok == 'true' }}
+        env:
+          OPENNEKO_VERSION: ${{ steps.ctx.outputs.tag }}
         run: openneko stop --volumes || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@
 FROM node:22-bookworm-slim AS base
 ENV PNPM_HOME=/pnpm
 ENV PATH=$PNPM_HOME:$PATH
+# Retry transient apt mirror hiccups instead of hard-failing the image build.
+RUN printf 'Acquire::Retries "5";\nAcquire::http::Timeout "30";\n' > /etc/apt/apt.conf.d/80-retries
 RUN corepack enable && corepack prepare pnpm@9.14.1 --activate
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl tini \
@@ -40,12 +42,12 @@ ARG TARGETARCH
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git unzip postgresql-client openssh-client \
     && rm -rf /var/lib/apt/lists/*
-RUN curl -fsSL -o /tmp/graphjin.tgz \
+RUN curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/graphjin.tgz \
       "https://github.com/dosco/graphjin/releases/download/v${GRAPHJIN_VERSION}/graphjin_${GRAPHJIN_VERSION}_linux_${TARGETARCH}.tar.gz" \
     && tar -xzf /tmp/graphjin.tgz -C /usr/local/bin graphjin \
     && rm /tmp/graphjin.tgz \
     && graphjin version
-RUN curl -LsSf https://astral.sh/uv/install.sh \
+RUN curl -LsSf --retry 5 --retry-delay 5 --retry-all-errors https://astral.sh/uv/install.sh \
       | env UV_INSTALL_DIR=/usr/local/bin sh -s -- --no-modify-path \
     && UV_TOOL_DIR=/usr/local/uv/tools \
        UV_TOOL_BIN_DIR=/usr/local/bin \

--- a/apps/openneko/assets/compose/core.yml
+++ b/apps/openneko/assets/compose/core.yml
@@ -84,7 +84,9 @@ services:
     ports:
       - "${OPENNEKO_GRAPHJIN_PORT:-8089}:8089"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8089/health"]
+      # graphjin serves no /health route (it 500s); the GraphQL endpoint
+      # answering is the honest readiness signal.
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8089/api/v1/graphql"]
       interval: 10s
       timeout: 3s
       retries: 5

--- a/apps/openneko/internal/cli/status.go
+++ b/apps/openneko/internal/cli/status.go
@@ -2,7 +2,14 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"os/exec"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -10,10 +17,29 @@ import (
 	"github.com/open-neko/neko/apps/openneko/internal/compose"
 )
 
+// composeService is the subset of `docker compose ps --format json` we read.
+type composeService struct {
+	Service  string `json:"Service"`
+	State    string `json:"State"`
+	Health   string `json:"Health"`
+	ExitCode int    `json:"ExitCode"`
+}
+
+// health is the single honest answer status gives: is the stack actually
+// usable right now, partly usable, or not.
+type health int
+
+const (
+	serving  health = iota // everything a user needs is up
+	degraded               // up but something is starting/unhealthy
+	down                   // a required service is not running
+)
+
 func newStatusCmd() *cobra.Command {
-	return &cobra.Command{
+	var verbose bool
+	cmd := &cobra.Command{
 		Use:   "status",
-		Short: "Show service health for the running stack",
+		Short: "Is the stack serving, degraded, or down?",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			sup := compose.New(assets.ComposeFS)
@@ -25,14 +51,157 @@ func newStatusCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			code, err := sup.Run(context.Background(), project, files, []string{"ps"}, os.Stdout, os.Stderr)
+			if verbose {
+				code, err := sup.Run(context.Background(), project, files, []string{"ps"}, os.Stdout, os.Stderr)
+				if err != nil {
+					return err
+				}
+				if code != 0 {
+					return WithExit(code, nil)
+				}
+				return nil
+			}
+			services, err := composePs(project, files)
 			if err != nil {
 				return err
 			}
-			if code != 0 {
-				return WithExit(code, nil)
+			state, lines := classifyStack(services)
+			writeStatus(cmd.OutOrStdout(), state, lines, probeWeb())
+			if state == serving {
+				return nil
 			}
-			return nil
+			return WithExit(1, nil)
 		},
+	}
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "Show raw `docker compose ps` output")
+	return cmd
+}
+
+func composePs(project string, files []string) ([]composeService, error) {
+	args := []string{"compose"}
+	if project != "" {
+		args = append(args, "-p", project)
+	}
+	for _, f := range files {
+		args = append(args, "-f", f)
+	}
+	args = append(args, "ps", "-a", "--format", "json")
+	out, err := exec.Command("docker", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("docker compose ps failed: %w", err)
+	}
+	return parseComposePs(out)
+}
+
+// parseComposePs handles both shapes docker compose emits: a JSON array
+// (newer) and newline-delimited objects (older / single service).
+func parseComposePs(out []byte) ([]composeService, error) {
+	trimmed := strings.TrimSpace(string(out))
+	if trimmed == "" {
+		return nil, nil
+	}
+	var arr []composeService
+	if json.Unmarshal([]byte(trimmed), &arr) == nil {
+		return arr, nil
+	}
+	var svcs []composeService
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var s composeService
+		if err := json.Unmarshal([]byte(line), &s); err != nil {
+			return nil, fmt.Errorf("parse `docker compose ps` json: %w", err)
+		}
+		svcs = append(svcs, s)
+	}
+	return svcs, nil
+}
+
+// classifyStack reduces raw service states to one honest verdict plus a
+// human-readable line per service. A one-shot job that exited 0 (e.g.
+// neko-migrate) is a success, not a failure — that distinction is the whole
+// point of this command.
+func classifyStack(services []composeService) (health, []string) {
+	if len(services) == 0 {
+		return down, []string{"no services are running — start them with `openneko start`"}
+	}
+	worst := serving
+	var lines []string
+	for _, s := range services {
+		state := strings.ToLower(strings.TrimSpace(s.State))
+		hl := strings.ToLower(strings.TrimSpace(s.Health))
+		switch {
+		case state == "running" && (hl == "" || hl == "healthy"):
+			lines = append(lines, fmt.Sprintf("  ✅ %s — serving", s.Service))
+		case state == "running" && hl == "starting":
+			lines = append(lines, fmt.Sprintf("  ⏳ %s — starting up", s.Service))
+			if worst < degraded {
+				worst = degraded
+			}
+		case state == "running" && hl == "unhealthy":
+			lines = append(lines, fmt.Sprintf("  ⚠️  %s — running but failing its health check", s.Service))
+			if worst < degraded {
+				worst = degraded
+			}
+		case state == "exited" && s.ExitCode == 0:
+			lines = append(lines, fmt.Sprintf("  ✅ %s — completed", s.Service))
+		default:
+			lines = append(lines, fmt.Sprintf("  ❌ %s — %s", s.Service, describeState(s)))
+			worst = down
+		}
+	}
+	return worst, lines
+}
+
+func describeState(s composeService) string {
+	state := strings.TrimSpace(s.State)
+	if strings.EqualFold(state, "exited") {
+		return fmt.Sprintf("exited (code %d)", s.ExitCode)
+	}
+	if state == "" {
+		return "not running"
+	}
+	return state
+}
+
+// probeWeb is a best-effort "is the front door open?" check against the
+// published web port. It never fails status on its own — it's an extra
+// human signal alongside the container verdict.
+func probeWeb() string {
+	port := strings.TrimSpace(os.Getenv("OPENNEKO_PORT"))
+	if port == "" {
+		port = "3000"
+	}
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get("http://localhost:" + port + "/")
+	if err != nil {
+		return fmt.Sprintf("  ·  web front door (localhost:%s): not answering yet", port)
+	}
+	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
+	return fmt.Sprintf("  ·  web front door (localhost:%s): answering (HTTP %d)", port, resp.StatusCode)
+}
+
+func writeStatus(w io.Writer, state health, lines []string, webLine string) {
+	switch state {
+	case serving:
+		fmt.Fprintln(w, "✅ serving — the stack is up and usable")
+	case degraded:
+		fmt.Fprintln(w, "⚠️  degraded — up, but something is still coming up or unhealthy")
+	case down:
+		fmt.Fprintln(w, "❌ down — a required service is not running")
+	}
+	for _, l := range lines {
+		fmt.Fprintln(w, l)
+	}
+	if webLine != "" {
+		fmt.Fprintln(w, webLine)
+	}
+	switch state {
+	case degraded:
+		fmt.Fprintln(w, "\nGive it a moment, then re-run `openneko status`. Details: `openneko status -v` / `openneko logs`.")
+	case down:
+		fmt.Fprintln(w, "\nSee why with `openneko logs`, or (re)start with `openneko start`.")
 	}
 }

--- a/apps/openneko/internal/cli/status_test.go
+++ b/apps/openneko/internal/cli/status_test.go
@@ -1,0 +1,80 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestClassifyStack(t *testing.T) {
+	tests := []struct {
+		name     string
+		services []composeService
+		want     health
+	}{
+		{"empty is down", nil, down},
+		{"all up + one-shot migrate done", []composeService{
+			{Service: "web", State: "running", Health: "healthy"},
+			{Service: "worker", State: "running", Health: "healthy"},
+			{Service: "neko-graphjin", State: "running", Health: "healthy"},
+			{Service: "neko-db", State: "running", Health: "healthy"},
+			{Service: "neko-migrate", State: "exited", ExitCode: 0},
+		}, serving},
+		{"running without a healthcheck counts as serving", []composeService{
+			{Service: "web", State: "running", Health: ""},
+		}, serving},
+		{"unhealthy is degraded, not down", []composeService{
+			{Service: "web", State: "running", Health: "healthy"},
+			{Service: "neko-graphjin", State: "running", Health: "unhealthy"},
+		}, degraded},
+		{"starting is degraded", []composeService{
+			{Service: "worker", State: "running", Health: "starting"},
+		}, degraded},
+		{"exited non-zero is down", []composeService{
+			{Service: "worker", State: "exited", ExitCode: 1},
+		}, down},
+		{"down outranks degraded", []composeService{
+			{Service: "web", State: "running", Health: "starting"},
+			{Service: "worker", State: "exited", ExitCode: 1},
+		}, down},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, lines := classifyStack(tc.services)
+			if got != tc.want {
+				t.Fatalf("classifyStack = %v, want %v", got, tc.want)
+			}
+			if len(tc.services) > 0 && len(lines) != len(tc.services) {
+				t.Fatalf("expected one line per service, got %d for %d", len(lines), len(tc.services))
+			}
+		})
+	}
+}
+
+func TestParseComposePs(t *testing.T) {
+	arr := `[{"Service":"web","State":"running","Health":"healthy"},{"Service":"worker","State":"exited","ExitCode":0}]`
+	if svcs, err := parseComposePs([]byte(arr)); err != nil || len(svcs) != 2 {
+		t.Fatalf("array form: got %v err %v", svcs, err)
+	}
+
+	nd := `{"Service":"web","State":"running","Health":"healthy"}` + "\n" +
+		`{"Service":"worker","State":"running","Health":"starting"}`
+	svcs, err := parseComposePs([]byte(nd))
+	if err != nil || len(svcs) != 2 || svcs[1].Health != "starting" {
+		t.Fatalf("ndjson form: got %+v err %v", svcs, err)
+	}
+
+	if svcs, err := parseComposePs([]byte("   ")); err != nil || svcs != nil {
+		t.Fatalf("empty: got %v err %v", svcs, err)
+	}
+}
+
+func TestWriteStatusEmitsVerdictWord(t *testing.T) {
+	for state, want := range map[health]string{serving: "serving", degraded: "degraded", down: "down"} {
+		var b bytes.Buffer
+		writeStatus(&b, state, []string{"  ✅ web — serving"}, "")
+		if !strings.Contains(b.String(), want) {
+			t.Fatalf("state %v output missing %q: %s", state, want, b.String())
+		}
+	}
+}

--- a/apps/openneko/internal/dockerproxy/proxy.go
+++ b/apps/openneko/internal/dockerproxy/proxy.go
@@ -12,6 +12,7 @@
 package dockerproxy
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -49,24 +50,33 @@ func FindRunningWorker() string {
 }
 
 // ProxyToWorker re-executes `openneko <args>` inside the named container,
-// forwarding stdin/stdout/stderr and propagating the exit code. The `-t`
-// docker flag is added only when stdin is a TTY (so non-interactive flows
-// — scripts, CI — don't fail).
+// forwarding stdout/stderr and propagating the exit code.
+//
+// Stdin is attached only when it can carry useful input: an interactive TTY,
+// or a pipe/regular file being redirected in (e.g. `echo val | openneko …`).
+// A terminal-less stdin — the common CI/script case where the value is passed
+// as an argument — is NOT attached, because `docker exec -i` draining such a
+// stream can surface a spurious non-zero exit even when the inner command
+// succeeded. `-t` is added only for an interactive TTY.
 func ProxyToWorker(container string, args []string) int {
-	dockerArgs := []string{"exec", "-i"}
-	if term.IsTerminal(int(os.Stdin.Fd())) {
-		dockerArgs = append(dockerArgs, "-t")
+	isTTY := term.IsTerminal(int(os.Stdin.Fd()))
+	attachStdin := isTTY
+	if !isTTY {
+		if fi, err := os.Stdin.Stat(); err == nil {
+			attachStdin = shouldAttachStdin(false, fi.Mode())
+		}
 	}
-	dockerArgs = append(dockerArgs, "-e", EnvMarker+"=1", container, "openneko")
-	dockerArgs = append(dockerArgs, args...)
+	dockerArgs := dockerExecArgs(container, args, attachStdin, isTTY)
 	fmt.Fprintf(os.Stderr, "[openneko] proxying into %s …\n", container)
 	cmd := exec.Command("docker", dockerArgs...)
-	cmd.Stdin = os.Stdin
+	if attachStdin {
+		cmd.Stdin = os.Stdin
+	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		var exitErr *exec.ExitError
-		if ok := errAs(err, &exitErr); ok {
+		if errors.As(err, &exitErr) {
 			return exitErr.ExitCode()
 		}
 		fmt.Fprintf(os.Stderr, "[openneko] proxy failed: %v\n", err)
@@ -75,15 +85,24 @@ func ProxyToWorker(container string, args []string) int {
 	return 0
 }
 
-// errAs is a tiny errors.As wrapper that avoids the import cycle/double
-// import for the one place this package needs it.
-func errAs(err error, target **exec.ExitError) bool {
-	if err == nil {
-		return false
-	}
-	if e, ok := err.(*exec.ExitError); ok {
-		*target = e
+// shouldAttachStdin decides whether to forward stdin to `docker exec`: yes for
+// an interactive TTY or redirected pipe/regular-file input; no for a
+// terminal-less device (e.g. /dev/null, an inherited non-tty).
+func shouldAttachStdin(isTTY bool, mode os.FileMode) bool {
+	if isTTY {
 		return true
 	}
-	return false
+	return mode&os.ModeNamedPipe != 0 || mode.IsRegular()
+}
+
+func dockerExecArgs(container string, args []string, attachStdin, isTTY bool) []string {
+	out := []string{"exec"}
+	if attachStdin {
+		out = append(out, "-i")
+	}
+	if isTTY {
+		out = append(out, "-t")
+	}
+	out = append(out, "-e", EnvMarker+"=1", container, "openneko")
+	return append(out, args...)
 }

--- a/apps/openneko/internal/dockerproxy/proxy_test.go
+++ b/apps/openneko/internal/dockerproxy/proxy_test.go
@@ -30,3 +30,66 @@ func TestEnvMarkerConstant(t *testing.T) {
 	}
 	_ = os.Environ // keep import
 }
+
+func TestShouldAttachStdin(t *testing.T) {
+	cases := []struct {
+		name string
+		tty  bool
+		mode os.FileMode
+		want bool
+	}{
+		{"interactive tty", true, os.ModeCharDevice, true},
+		{"piped input", false, os.ModeNamedPipe, true},
+		{"redirected file", false, 0, true}, // regular file
+		{"dev/null char device", false, os.ModeDevice | os.ModeCharDevice, false},
+		{"non-tty char device", false, os.ModeCharDevice, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := shouldAttachStdin(tc.tty, tc.mode); got != tc.want {
+				t.Fatalf("shouldAttachStdin(%v, %v) = %v, want %v", tc.tty, tc.mode, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDockerExecArgs(t *testing.T) {
+	// Non-interactive, no stdin (the CI/script path that triggered the spurious
+	// exit): neither -i nor -t.
+	got := dockerExecArgs("w-1", []string{"secrets", "list"}, false, false)
+	want := []string{"exec", "-e", EnvMarker + "=1", "w-1", "openneko", "secrets", "list"}
+	if !equalStrings(got, want) {
+		t.Fatalf("non-interactive args = %v, want %v", got, want)
+	}
+	// Interactive: -i and -t.
+	got = dockerExecArgs("w-1", []string{"secrets", "set", "p", "K"}, true, true)
+	if !contains(got, "-i") || !contains(got, "-t") {
+		t.Fatalf("interactive args missing -i/-t: %v", got)
+	}
+	// Piped (attach but not a tty): -i, no -t.
+	got = dockerExecArgs("w-1", []string{"x"}, true, false)
+	if !contains(got, "-i") || contains(got, "-t") {
+		t.Fatalf("piped args want -i without -t: %v", got)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(s []string, v string) bool {
+	for _, x := range s {
+		if x == v {
+			return true
+		}
+	}
+	return false
+}

--- a/compose.yml
+++ b/compose.yml
@@ -95,7 +95,9 @@ services:
     ports:
       - "${OPENNEKO_GRAPHJIN_PORT:-8089}:8089"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8089/health"]
+      # graphjin serves no /health route (it 500s); the GraphQL endpoint
+      # answering is the honest readiness signal.
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8089/api/v1/graphql"]
       interval: 10s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
## Why
Debugging the v1.18.0 release showed the real product gap: **every failure was either *cosmetic shown as fatal* or *transient with no recovery*, and a non-technical operator can't tell either from a genuine outage** without reading source and SSHing into the box. These seven fixes make the system tell the truth about its own state.

## The seven fixes (each → the failure it prevents)

| # | Change | Prevents |
|---|--------|----------|
| **1 + 6** | `post-release-smoke` is now a **gate**: runs on build-failure too, and on a failed build *or* failed smoke it demotes the release off "Latest" (`gh release edit --prerelease`). | A broken release (like v1.18.0) staying "Latest" with no installable binaries → `install` 404s. |
| **2** | graphjin healthcheck `/health` (500) → the GraphQL endpoint that actually answers (verified `200`). | The false `unhealthy` that made a working service look broken. |
| **3** | deploy asserts **outcomes** (`secrets list`/`list` grep) instead of trusting the worker-proxy exit code under `set -e`. | A deploy going red on a `secrets set` that actually succeeded. |
| **5** | `ProxyToWorker` attaches stdin only for a TTY or redirected pipe/file — never a terminal-less CI stdin to `docker exec -i` (the likeliest source of the spurious exit-1); `errors.As` for exit propagation. **+ tests** | The root lie behind #3. |
| **7** | `openneko status` was bare `docker compose ps`; now **one honest verdict** — `serving` / `degraded` / `down` — distinguishing one-shot jobs (completed) from services, unhealthy (degraded) from stopped (down), with a web front-door probe + remediation hints. Exit 0 only when serving. **+ tests** | The operator having no single, truthful "is it working?" signal. |
| **4** | apt retries config + `curl --retry` on the graphjin/uv downloads (prewarm already resilient via #84). | A registry/mirror hiccup hard-failing an image build. |

## Validation
- **Go:** full `apps/openneko` suite green; new tests for `classifyStack`/`parseComposePs` (status) and `shouldAttachStdin`/`dockerExecArgs` (proxy); `go vet` + `gofmt` clean.
- **Live:** `openneko status` run against a real local stack — correctly reports `serving`/`completed`/`degraded` per service, probes the web front door (`HTTP 200`), and exits non-zero on degraded.
- **graphjin endpoint:** `GET /api/v1/graphql → 200` verified on the running prod container (vs `/health → 500`).
- **Compose + workflow YAML:** parse clean.
- **Needs a release to fully exercise:** the #1/#6 gate + #4 build resilience — logic/syntax validated here; the real proof is the next tag cutting cleanly (or correctly self-demoting on a forced failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)