### PR TITLE
Information-dense Compact UI, hours-saved, per-channel rendering & Ask context rail

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/license-Apache_2.0-blue)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/open-neko/openneko)](https://github.com/open-neko/openneko/releases/latest)
 [![Self-hosted · Docker](https://img.shields.io/badge/self--hosted-Docker-2496ED?logo=docker&logoColor=white)](INSTALL.md)
-[![getneko.app](https://img.shields.io/badge/getneko.app-website-111111)](https://getneko.app)
+[![openneko.app](https://img.shields.io/badge/openneko.app-website-111111)](https://openneko.app)
 [![Stars](https://img.shields.io/github/stars/open-neko/openneko?style=social)](https://github.com/open-neko/openneko/stargazers)
 
 **OpenNeko watches your business data, flags what's worth a look, and drafts the next action — for you to approve.** Self-hosted, on your infrastructure, with whichever LLM you prefer.
@@ -112,4 +112,4 @@ OpenNeko is licensed under the [Apache License 2.0](LICENSE).
 
 ## Author
 
-Created by [Amit Deshmukh](https://getneko.app/#about).
+Created by [Amit Deshmukh](https://openneko.app/#about).

--- a/apps/openneko/.goreleaser.yml
+++ b/apps/openneko/.goreleaser.yml
@@ -55,7 +55,7 @@ homebrew_casks:
       owner: open-neko
       name: homebrew-tap
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
-    homepage: "https://getneko.app"
+    homepage: "https://openneko.app"
     description: "OpenNeko operator CLI — supervises the stack and manages plugins"
     # The binary isn't code-signed/notarized, so macOS quarantines it on
     # download. Strip the attribute on install so `openneko` runs without a

--- a/apps/openneko/assets/migrations/0024_hours_saved.sql
+++ b/apps/openneko/assets/migrations/0024_hours_saved.sql
@@ -1,0 +1,19 @@
+-- Human hours saved: agent-estimated minutes of human effort.
+-- Per-action estimate lives on action_request; per-run analysis estimate
+-- lives on work_run. Both are server-clamped before insert. Org/workflow
+-- rollups sum executed actions + completed-run analysis at query time.
+
+ALTER TABLE action_request
+  ADD COLUMN minutes_saved integer,
+  ADD COLUMN minutes_saved_basis text,
+  ADD COLUMN estimate_source text NOT NULL DEFAULT 'agent',
+  ADD COLUMN estimate_version integer NOT NULL DEFAULT 1;
+
+ALTER TABLE work_run
+  ADD COLUMN analysis_minutes_saved integer,
+  ADD COLUMN analysis_minutes_basis text,
+  ADD COLUMN estimate_version integer NOT NULL DEFAULT 1;
+
+-- Window + cumulative rollups filter completed runs by org and finish time.
+CREATE INDEX IF NOT EXISTS work_run_org_finished_idx
+  ON work_run (org_id, finished_at);

--- a/apps/openneko/assets/migrations/0025_thread_channel.sql
+++ b/apps/openneko/assets/migrations/0025_thread_channel.sql
@@ -1,0 +1,15 @@
+-- Channel isolation: record each work thread's origin channel so the web Ask
+-- UI lists only its own ("web") threads and other channels (Telegram, …) stay
+-- separate. See docs/PER_CHANNEL_RENDERING.md.
+
+ALTER TABLE work_thread
+  ADD COLUMN channel text NOT NULL DEFAULT 'web';
+
+-- Backfill the only non-web origin so far: Telegram inbound threads, which
+-- startChatRun titles "Telegram <ref>" (or bare "Telegram").
+UPDATE work_thread
+  SET channel = 'telegram'
+  WHERE title = 'Telegram' OR title LIKE 'Telegram %';
+
+CREATE INDEX IF NOT EXISTS work_thread_org_channel_recent_idx
+  ON work_thread (org_id, channel, last_message_at DESC);

--- a/apps/openneko/assets/migrations/0026_inbound_dedup.sql
+++ b/apps/openneko/assets/migrations/0026_inbound_dedup.sql
@@ -1,0 +1,32 @@
+-- Reliable inbound: persisted poll cursor + idempotency ledger. Together they
+-- make channel inbound exactly-once across worker restarts and provider retries.
+
+-- channel_poll_cursor: the last acknowledged poll offset per (org, channel).
+-- Restarting the worker resumes from here instead of re-polling from scratch.
+CREATE TABLE IF NOT EXISTS channel_poll_cursor (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id TEXT NOT NULL REFERENCES organization(id) ON DELETE CASCADE,
+  channel_plugin TEXT NOT NULL,
+  cursor TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS channel_poll_cursor_org_plugin_unique
+  ON channel_poll_cursor (org_id, channel_plugin);
+
+-- inbound_dedup: a claimed key per dispatched update. The re-poll window after a
+-- restart (and webhook retries) can re-deliver an update; claiming it here first
+-- makes dispatch exactly-once. Pruned on a TTL by the worker.
+CREATE TABLE IF NOT EXISTS inbound_dedup (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id TEXT NOT NULL REFERENCES organization(id) ON DELETE CASCADE,
+  channel_plugin TEXT NOT NULL,
+  update_key TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS inbound_dedup_org_plugin_key_unique
+  ON inbound_dedup (org_id, channel_plugin, update_key);
+
+CREATE INDEX IF NOT EXISTS inbound_dedup_created_idx
+  ON inbound_dedup (created_at);

--- a/apps/openneko/assets/migrations/0027_inbound_dead_letter.sql
+++ b/apps/openneko/assets/migrations/0027_inbound_dead_letter.sql
@@ -1,0 +1,19 @@
+-- Dead-letter support for inbound dispatch. A persistently-failing ("poison")
+-- update would otherwise hold the poll cursor forever, blocking every newer
+-- message behind it. Track per-update attempts; after MAX retries park the
+-- update as 'dead' (keeping its payload + last error for inspection) so the
+-- cursor can advance past it.
+--
+-- status: 'pending' (claimed, dispatch in progress / retrying)
+--       | 'done'    (dispatched OK — the dedup marker)
+--       | 'dead'    (gave up after MAX attempts — a dead letter)
+-- Existing rows are already-dispatched dedup markers, so they backfill to 'done'.
+ALTER TABLE inbound_dedup
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'done',
+  ADD COLUMN IF NOT EXISTS attempts INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_error TEXT,
+  ADD COLUMN IF NOT EXISTS payload JSONB,
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+-- Find dead letters fast for inspection / manual replay.
+CREATE INDEX IF NOT EXISTS inbound_dedup_status_idx ON inbound_dedup (status);

--- a/apps/openneko/assets/migrations/0028_work_memory_exact_search.sql
+++ b/apps/openneko/assets/migrations/0028_work_memory_exact_search.sql
@@ -1,0 +1,8 @@
+-- Drop the approximate IVFFlat index on work_memory.embedding in favour of an
+-- exact (sequential) cosine scan. work_memory is per-org and small (at most a
+-- few thousand rows), so scanning every row is sub-millisecond and gives 100%
+-- recall; the approximate index added no speedup at this scale and could skip a
+-- relevant memory (its centroids were also built on an empty table). The search
+-- SQL is unchanged. Re-add an HNSW index if a single org ever reaches tens of
+-- thousands of memories.
+DROP INDEX IF EXISTS work_memory_embedding_cosine_idx;

--- a/apps/web/dense-actions-prototype.html
+++ b/apps/web/dense-actions-prototype.html
@@ -1,0 +1,280 @@
+<!doctype html>
+<html lang="en" data-density="compact">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>OpenNeko · Actions — density study</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@500;600;700;800;900&family=Manrope:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+/* OpenNeko Actions — density study. Comfortable = today's stacked approval
+   cards. Compact = a triage queue: list left, full action detail in a
+   reading pane right (j/k to move, a/r to act — wiring already exists). */
+:root{
+  --bg:#FAFAF7;--card:#FFFFFF;--text:#2D2A24;--text2:#7A756A;--text3:#B0AA9F;
+  --border:#EEEBE4;--neutral:#F2EFE8;--neutral-soft:#F7F4ED;
+  --accent:#6B5CE7;--accent-soft:#EDE9FE;
+  --success:#6CFF7F;--success-ink:#113719;--success-soft:#E2FBE6;--success-mid:#4CAF82;
+  --watch:#E9A23B;--watch-soft:#FFF1D8;--warn-ink:#8A6D00;
+  --danger:#E05656;--danger-soft:#FEECEC;
+  --shadow:0 1px 3px rgba(20,18,12,.04),0 4px 16px rgba(20,18,12,.03);
+  --shadow-h:0 2px 8px rgba(20,18,12,.06),0 12px 36px -8px rgba(20,18,12,.07);
+  --display:'Archivo',sans-serif;--body:'Manrope',sans-serif;--mono:'Geist Mono',ui-monospace,monospace;
+}
+html[data-density="comfortable"]{--d-canvas:820px;--d-triage:none;--d-stack:flex}
+html[data-density="compact"]{--d-canvas:1180px;--d-triage:grid;--d-stack:none}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:var(--body);background:var(--bg);color:var(--text);line-height:1.5;-webkit-font-smoothing:antialiased;padding-bottom:60px}
+body::before{content:"";position:fixed;inset:0;pointer-events:none;z-index:0;
+  background-image:radial-gradient(circle at 15% 8%,rgba(107,92,231,.05),transparent 42%),radial-gradient(circle at 90% 4%,rgba(108,255,127,.05),transparent 40%)}
+.wrap{position:relative;z-index:1;max-width:var(--d-canvas);margin:0 auto;padding:24px 22px 0;transition:max-width .45s cubic-bezier(.4,0,.2,1)}
+a{color:inherit;text-decoration:none}
+.mono{font-family:var(--mono);font-variant-numeric:tabular-nums}
+
+/* top bar */
+.topbar{display:flex;align-items:center;gap:16px;margin-bottom:16px}
+.brand{display:inline-flex;align-items:center;gap:9px;font-family:var(--display);font-weight:800;font-size:17px;letter-spacing:-.02em}
+.brand .mark{width:19px;height:19px;border-radius:50%;background:conic-gradient(from 220deg,var(--text) 0 50%,transparent 50% 100%);border:1.5px solid var(--text)}
+.brand .ver{font-family:var(--body);font-weight:600;font-size:10.5px;color:var(--text2);background:var(--neutral);padding:2px 6px;border-radius:999px}
+.nav{display:flex;gap:2px;margin-left:6px}
+.nav a{font-size:13.5px;font-weight:500;color:var(--text2);padding:7px 12px;border-radius:999px;border:1px solid transparent}
+.nav a:hover{background:rgba(20,18,12,.04);color:var(--text)}
+.nav a.on{border-color:var(--border);color:var(--text);font-weight:600}
+.nav a.on::before{content:"";display:inline-block;width:5px;height:5px;border-radius:50%;background:var(--accent);margin-right:7px;vertical-align:2px}
+.spacer{flex:1}
+.seg{display:inline-flex;background:var(--neutral);border:1px solid var(--border);border-radius:999px;padding:3px;gap:2px}
+.seg button{font-family:var(--body);font-weight:600;font-size:12.5px;color:var(--text2);border:0;background:transparent;padding:6px 14px;border-radius:999px;cursor:pointer;display:inline-flex;align-items:center;gap:6px}
+.seg button .ic{width:13px;height:13px}
+.seg button[aria-pressed="true"]{background:var(--card);color:var(--text);box-shadow:0 1px 2px rgba(20,18,12,.08),0 2px 8px -2px rgba(20,18,12,.1)}
+
+/* head + tabs */
+.head{display:flex;align-items:baseline;gap:13px;margin-bottom:4px}
+.head h1{font-family:var(--display);font-size:28px;font-weight:800;letter-spacing:-.02em}
+.head .ct{font-family:var(--mono);font-size:13px;color:var(--text3)}
+.tabs{display:flex;gap:2px;border-bottom:1px solid var(--border);margin:6px 0 14px}
+.tabs button{font-size:13px;font-weight:600;color:var(--text3);background:0;border:0;border-bottom:2px solid transparent;margin-bottom:-1px;padding:8px 14px;cursor:pointer}
+.tabs button.on{color:var(--text);border-color:var(--accent)}
+.tabs button:hover:not(.on){color:var(--text2)}
+.khint{font-family:var(--mono);font-size:12px;color:var(--text3);margin-bottom:16px}
+.khint kbd{background:var(--neutral);border:1px solid var(--border);border-radius:4px;padding:1px 6px;color:var(--text2)}
+
+/* pills */
+.pill{font-family:var(--display);font-size:9.5px;font-weight:800;letter-spacing:.08em;text-transform:uppercase;padding:2px 8px;border-radius:999px;border:1px solid;white-space:nowrap}
+.pill.high{background:var(--danger-soft);color:var(--danger);border-color:rgba(224,86,86,.3)}
+.pill.med{background:var(--watch-soft);color:var(--warn-ink);border-color:rgba(233,162,59,.3)}
+.pill.low{background:var(--success-soft);color:var(--success-ink);border-color:rgba(76,175,130,.3)}
+
+/* ── TRIAGE (compact) ── */
+.triage{display:var(--d-triage);grid-template-columns:392px minmax(0,1fr);gap:14px;align-items:start}
+.queue{display:flex;flex-direction:column;gap:3px}
+.qrow{display:flex;gap:11px;padding:11px 13px;border-radius:13px;border:1px solid transparent;cursor:pointer;transition:background .14s,border-color .14s}
+.qrow:hover{background:var(--neutral-soft)}
+.qrow.sel{background:color-mix(in srgb,var(--accent-soft) 60%,transparent);border-color:color-mix(in srgb,var(--accent) 28%,var(--border))}
+.qrow .tone{width:9px;height:9px;border-radius:50%;margin-top:4px;flex:0 0 auto}
+.tone.action{background:var(--danger)}.tone.watch{background:var(--watch)}.tone.good{background:var(--success-mid)}
+.qrow .qb{min-width:0;flex:1}
+.qrow .qh{font-size:14px;font-weight:600;letter-spacing:-.005em;line-height:1.35;
+  display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+.qrow .qsub{font-size:11.5px;color:var(--text3);margin-top:3px;display:flex;align-items:center;gap:6px;flex-wrap:wrap}
+.qrow .qsub b{color:var(--text2);font-weight:600}
+.qrow .qrisk{flex:0 0 auto;align-self:flex-start;margin-top:1px}
+
+/* detail reading pane */
+.detail{position:sticky;top:18px;background:var(--card);border:1px solid var(--border);border-radius:18px;box-shadow:var(--shadow);padding:18px 20px 18px}
+.detail .drisk{display:flex;align-items:center;gap:9px;margin-bottom:10px}
+.detail .dkind{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--text3)}
+.detail h2{font-family:var(--display);font-size:20px;font-weight:800;letter-spacing:-.02em;line-height:1.18}
+.detail .dby{font-size:12.5px;color:var(--text2);margin-top:8px;line-height:1.5}
+.detail .dby b{color:var(--text);font-weight:600}
+.sect{margin-top:16px}
+.sect .sl{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--text3);margin-bottom:7px}
+.sect p{font-size:13.5px;line-height:1.55;color:var(--text)}
+.payload{background:var(--bg);border:1px solid var(--border);border-radius:12px;padding:11px 13px;display:grid;gap:6px}
+.payload .pr{display:flex;gap:12px;font-size:12.5px}
+.payload .pk{color:var(--text3);min-width:96px;flex:0 0 auto}
+.payload .pv{font-family:var(--mono);color:var(--text);font-variant-numeric:tabular-nums;word-break:break-word}
+.gate{display:flex;align-items:center;gap:10px;background:var(--watch-soft);border:1px solid rgba(233,162,59,.32);border-radius:12px;padding:10px 13px;font-size:12.5px;color:var(--warn-ink)}
+.gate .gk{font-weight:600}
+.gate .pill{margin-left:auto}
+.detail-acts{display:flex;align-items:center;gap:9px;margin-top:18px;padding-top:16px;border-top:1px solid var(--border)}
+.btn{font-family:var(--body);font-weight:700;font-size:13.5px;border-radius:11px;padding:10px 18px;cursor:pointer;border:1px solid transparent;transition:transform .15s,box-shadow .15s,background .15s}
+.btn:hover{transform:translateY(-1px)}
+.btn.ok{background:var(--text);color:var(--bg)}
+.btn.ok:hover{box-shadow:0 6px 18px -6px rgba(20,18,12,.3)}
+.btn.no{background:var(--card);border-color:var(--border);color:var(--text2)}
+.btn.no:hover{border-color:var(--danger);color:var(--danger)}
+.detail-acts .akbd{font-family:var(--mono);font-size:11px;color:var(--text3);margin-left:2px}
+.detail-acts .links{margin-left:auto;display:flex;gap:14px;font-size:12px;color:var(--accent)}
+.detail-acts .links a:hover{text-decoration:underline;text-underline-offset:2px}
+
+/* ── STACK (comfortable) — today's approval cards ── */
+.stack{display:var(--d-stack);flex-direction:column;gap:14px}
+.acard{background:var(--card);border:1px solid var(--border);border-radius:20px;box-shadow:var(--shadow);padding:16px 18px}
+.acard-head{display:flex;align-items:center;gap:10px;margin-bottom:12px}
+.acard-head .st{font-family:var(--display);font-size:9.5px;font-weight:800;letter-spacing:.1em;text-transform:uppercase;
+  background:var(--watch-soft);color:var(--warn-ink);border:1px solid rgba(233,162,59,.3);padding:3px 10px;border-radius:999px}
+.acard-head .tm{margin-left:auto;font-family:var(--mono);font-size:11px;color:var(--text3)}
+.acard .trigger{background:var(--watch-soft);border:1px solid rgba(233,162,59,.25);border-radius:11px;padding:9px 12px;font-size:12.5px;color:var(--text2);margin-bottom:11px}
+.arow{display:flex;gap:11px;padding:12px 13px;border:1px solid var(--border);border-radius:13px}
+.arow+.arow{margin-top:9px}
+.arow .tone{width:9px;height:9px;border-radius:50%;margin-top:4px;flex:0 0 auto}
+.arow .ab{flex:1;min-width:0}
+.arow .ah{font-size:14px;font-weight:600}
+.arow .at{font-family:var(--mono);font-size:11.5px;color:var(--text2);margin-top:2px}
+.arow .aa{display:flex;gap:8px;margin-top:10px;align-items:center}
+.arow .aa .why{margin-left:auto;font-size:11.5px;color:var(--text2)}
+
+@media (max-width:840px){
+  html[data-density="compact"]{--d-triage:none;--d-stack:flex;--d-canvas:100%}
+  .nav{display:none}
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="topbar">
+    <span class="brand"><span class="mark"></span>OpenNeko <span class="ver">1.17.2</span></span>
+    <nav class="nav"><a href="#">Dashboard</a><a href="#">Ask</a><a href="#" class="on">Actions</a><a href="#">Workflows</a></nav>
+    <span class="spacer"></span>
+    <div class="seg" role="group" aria-label="Density">
+      <button data-set="comfortable" aria-pressed="false"><svg class="ic" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="3" width="12" height="3.4" rx="1.2"/><rect x="2" y="9.6" width="12" height="3.4" rx="1.2"/></svg>Comfortable</button>
+      <button data-set="compact" aria-pressed="true"><svg class="ic" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="2.5" width="4" height="11" rx="1.2"/><rect x="7.5" y="2.5" width="6.5" height="11" rx="1.2"/></svg>Compact</button>
+    </div>
+  </div>
+
+  <div class="head"><h1>Actions</h1><span class="ct">5 pending</span></div>
+  <div class="tabs">
+    <button>Fired</button><button class="on">Awaiting you</button><button>Rejected</button><button>All</button>
+  </div>
+  <div class="khint"><kbd>a</kbd> approve · <kbd>r</kbd> reject · <kbd>j</kbd>/<kbd>k</kbd> navigate</div>
+
+  <!-- TRIAGE (compact) -->
+  <div class="triage">
+    <div class="queue" id="queue"></div>
+    <div class="detail" id="detail"></div>
+  </div>
+
+  <!-- STACK (comfortable) -->
+  <div class="stack" id="stack"></div>
+
+</div>
+
+<script>
+const ITEMS=[
+  {id:'a1',tone:'action',risk:'high',kind:'payment.refund',
+   headline:'Refund $4,200 to Acme Corp — disputed annual charge',
+   workflow:'Billing watch',trigger:'Acme flagged the annual renewal as a duplicate charge',time:'9:02a',
+   target:'stripe · ch_3PQ…91',
+   summary:'Acme was billed twice for the FY25 annual plan after a failed-then-retried payment. The agent reconciled both charges and proposes refunding the duplicate.',
+   payload:[['Amount','$4,200.00'],['Reason','duplicate_charge'],['Customer','Acme Corp · cus_Nf2…'],['Invoice','INV-4471'],['Charge','ch_3PQ…91']],
+   gate:'Refunds over $1,000 require approval',gatePill:'med'},
+  {id:'a2',tone:'watch',risk:'medium',kind:'email.send',
+   headline:'Send churn-risk note to Northwind, Globex, Initech',
+   workflow:'Churn-risk outreach',trigger:'Logins dropped >60% WoW across 3 enterprise accounts',time:'8:51a',
+   target:'gmail · 3 recipients',
+   summary:'Three enterprise accounts went quiet this week with no support tickets. The agent drafted a personalised check-in from their CSM to re-open the conversation.',
+   payload:[['To','3 recipients'],['From','csm@yourco.com'],['Subject','Quick check-in'],['Template','retention_v3'],['Attachments','none']],
+   gate:'External email to >2 recipients requires approval',gatePill:'med'},
+  {id:'a3',tone:'watch',risk:'medium',kind:'erp.purchase_order',
+   headline:'Create PO for 2 reorder SKUs ($18,400)',
+   workflow:'Inventory reorder',trigger:'SKU-0091 and SKU-0123 fell below reorder threshold',time:'8:22a',
+   target:'netsuite · vendor V-208',
+   summary:'Two fast-moving SKUs are below their reorder points with ~6 days of cover left. The agent sized a replenishment order against the preferred vendor\'s MOQ.',
+   payload:[['Vendor','Acme Supply (V-208)'],['SKU-0091','480 units · $9,600'],['SKU-0123','220 units · $8,800'],['Total','$18,400'],['ETA','7–9 days']],
+   gate:'Purchase orders over $10,000 require approval',gatePill:'med'},
+  {id:'a4',tone:'action',risk:'high',kind:'ads.pause_campaign',
+   headline:'Pause ad campaign “Q2-Brand” — CPA 3× target',
+   workflow:'Ad spend monitor',trigger:'Q2-Brand CPA hit $312 vs $100 target for 2 days',time:'7:40a',
+   target:'google-ads · camp 88123',
+   summary:'The Q2-Brand campaign has run 3× over target CPA for two consecutive days, burning ~$1,400/day with no conversions lift. The agent proposes pausing it pending review.',
+   payload:[['Campaign','Q2-Brand (88123)'],['Spend (48h)','$2,810'],['CPA','$312 (target $100)'],['Conversions','9'],['Action','pause']],
+   gate:'Spend-affecting actions require approval',gatePill:'med'},
+  {id:'a5',tone:'good',risk:'low',kind:'slack.post',
+   headline:'Post price-change notice to #leadership',
+   workflow:'Competitor radar',trigger:'Tracked competitor shipped usage-based pricing',time:'7:12a',
+   target:'slack · #leadership',
+   summary:'A tracked competitor moved to usage-based pricing overnight. The agent drafted a short heads-up summarising the change and its overlap with your mid-market segment.',
+   payload:[['Channel','#leadership'],['Length','94 words'],['Mentions','none'],['Links','1 (changelog)']],
+   gate:'Internal Slack posts auto-approve under rule "internal-notices"',gatePill:'low'},
+];
+
+let sel='a1';
+const q=document.getElementById('queue');
+function renderQueue(){
+  q.innerHTML=ITEMS.map(it=>`
+    <div class="qrow ${it.id===sel?'sel':''}" data-id="${it.id}">
+      <span class="tone ${it.tone}"></span>
+      <div class="qb">
+        <div class="qh">${it.headline}</div>
+        <div class="qsub">from <b>${it.workflow}</b> · <span class="mono">${it.time}</span></div>
+      </div>
+      <span class="pill ${it.risk==='high'?'high':it.risk==='medium'?'med':'low'} qrisk">${it.risk}</span>
+    </div>`).join('');
+  q.querySelectorAll('.qrow').forEach(r=>r.addEventListener('click',()=>{sel=r.dataset.id;renderQueue();renderDetail();}));
+}
+const d=document.getElementById('detail');
+function renderDetail(){
+  const it=ITEMS.find(x=>x.id===sel);
+  d.innerHTML=`
+    <div class="drisk">
+      <span class="pill ${it.risk==='high'?'high':it.risk==='medium'?'med':'low'}">${it.risk} risk</span>
+      <span class="dkind">${it.kind}</span>
+    </div>
+    <h2>${it.headline}</h2>
+    <div class="dby">Proposed by <b>${it.workflow}</b> · triggered by “${it.trigger}”</div>
+    <div class="sect"><div class="sl">Why</div><p>${it.summary}</p></div>
+    <div class="sect"><div class="sl">Target</div><p class="mono" style="font-size:12.5px;color:var(--text2)">${it.target}</p></div>
+    <div class="sect"><div class="sl">Payload</div>
+      <div class="payload">${it.payload.map(([k,v])=>`<div class="pr"><span class="pk">${k}</span><span class="pv">${v}</span></div>`).join('')}</div>
+    </div>
+    <div class="sect"><div class="sl">Gated by</div>
+      <div class="gate"><span class="gk">${it.gate}</span><span class="pill ${it.gatePill}">${it.gatePill==='low'?'auto':'approval'}</span></div>
+    </div>
+    <div class="detail-acts">
+      <button class="btn ok">Approve <span class="akbd">a</span></button>
+      <button class="btn no">Reject <span class="akbd">r</span></button>
+      <span class="links"><a href="#">why →</a><a href="#">view run →</a></span>
+    </div>`;
+}
+renderQueue();renderDetail();
+
+/* comfortable stack — today's grouped approval cards */
+document.getElementById('stack').innerHTML=ITEMS.slice(0,3).map(it=>`
+  <article class="acard">
+    <div class="acard-head"><span class="st">Awaiting you</span><span class="tm mono">${it.time}</span></div>
+    <div class="trigger">${it.trigger}</div>
+    <div class="arow">
+      <span class="tone ${it.tone}"></span>
+      <div class="ab">
+        <div class="ah">${it.headline}</div>
+        <div class="at">${it.target}</div>
+        <div class="aa">
+          <button class="btn ok" style="padding:6px 13px;font-size:12.5px">Approve</button>
+          <button class="btn no" style="padding:6px 13px;font-size:12.5px">Reject</button>
+          <a class="why" href="#">why →</a>
+        </div>
+      </div>
+    </div>
+  </article>`).join('');
+
+/* keyboard j/k + a/r on the triage queue */
+window.addEventListener('keydown',e=>{
+  if(document.documentElement.getAttribute('data-density')!=='compact')return;
+  const i=ITEMS.findIndex(x=>x.id===sel);
+  if(e.key==='j'||e.key==='ArrowDown'){e.preventDefault();sel=ITEMS[Math.min(ITEMS.length-1,i+1)].id;renderQueue();renderDetail();}
+  else if(e.key==='k'||e.key==='ArrowUp'){e.preventDefault();sel=ITEMS[Math.max(0,i-1)].id;renderQueue();renderDetail();}
+});
+
+const root=document.documentElement;
+document.querySelectorAll('.seg button').forEach(btn=>btn.addEventListener('click',()=>{
+  root.setAttribute('data-density',btn.dataset.set);
+  document.querySelectorAll('.seg button').forEach(b=>b.setAttribute('aria-pressed',String(b===btn)));
+}));
+document.querySelectorAll('.tabs button').forEach(b=>b.addEventListener('click',()=>{
+  document.querySelectorAll('.tabs button').forEach(x=>x.classList.remove('on'));b.classList.add('on');
+}));
+</script>
+</body>
+</html>

--- a/apps/web/dense-dashboard-prototype.html
+++ b/apps/web/dense-dashboard-prototype.html
@@ -1,0 +1,497 @@
+<!doctype html>
+<html lang="en" data-density="compact">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>OpenNeko · density study</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:ital,wght@0,500;0,600;0,700;0,800;0,900;1,500;1,600&family=Manrope:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+/* ───────────────────────────────────────────────────────────────
+   OpenNeko — Apple-Health-density study (standalone prototype)
+   Reuses the production tokens verbatim so this reads as "your app,
+   denser" rather than a different app. The whole point of interest
+   lives in [data-density="comfortable"] vs ["compact"]: one set of
+   --d-* variables flips canvas width, grid columns, padding, type
+   scale, and whether card detail is inlined. Toggle, top-right.
+   ─────────────────────────────────────────────────────────────── */
+
+:root{
+  /* ── production palette (globals.css) ── */
+  --bg:#FAFAF7; --card:#FFFFFF; --text:#2D2A24; --text2:#7A756A; --text3:#B0AA9F;
+  --border:#EEEBE4; --neutral:#F2EFE8; --neutral-soft:#F7F4ED;
+  --accent:#6B5CE7; --accent-soft:#EDE9FE;
+  --success:#6CFF7F; --success-ink:#113719; --success-soft:#E2FBE6; --success-mid:#4CAF82;
+  --watch:#E9A23B; --watch-soft:#FFF1D8;
+  --warn:#F0D97A; --warn-soft:#FFF4CC; --warn-ink:#8A6D00;
+  --danger:#E05656; --danger-soft:#FEECEC;
+
+  --shadow:0 1px 3px rgba(20,18,12,.04), 0 4px 16px rgba(20,18,12,.03);
+  --shadow-h:0 2px 8px rgba(20,18,12,.06), 0 12px 36px -8px rgba(20,18,12,.07);
+  --shadow-lift:0 1px 2px rgba(20,18,12,.04), 0 18px 48px -16px rgba(20,18,12,.16);
+
+  --display:'Archivo',sans-serif;
+  --body:'Manrope',sans-serif;
+  --mono:'Geist Mono',ui-monospace,monospace;
+}
+
+/* ── COMFORTABLE — today's feel: narrow reading column, roomy ── */
+html[data-density="comfortable"]{
+  --d-page:760px;
+  --d-grid:1fr;              /* one card per row            */
+  --d-gap:14px;
+  --d-pad:22px 24px 22px 28px;
+  --d-radius:20px;
+  --d-greet:46px;
+  --d-tile-metric:30px;
+  --d-itext:16.5px;
+  --d-vitals-min:210px;
+  --d-section-gap:34px;
+  --d-detail:block;         /* card detail always shown    */
+  --d-rail-spark:42px;
+}
+/* ── COMPACT — Apple-Health grid: wide canvas, tiled, scannable ── */
+html[data-density="compact"]{
+  --d-page:1180px;
+  --d-grid:repeat(auto-fill,minmax(296px,1fr));
+  --d-gap:12px;
+  --d-pad:15px 16px 15px 18px;
+  --d-radius:17px;
+  --d-greet:30px;
+  --d-tile-metric:23px;
+  --d-itext:14.5px;
+  --d-vitals-min:158px;
+  --d-section-gap:22px;
+  --d-detail:none;          /* detail tucked behind expand */
+  --d-rail-spark:30px;
+}
+
+*{box-sizing:border-box;margin:0;padding:0}
+html{-webkit-text-size-adjust:100%}
+body{
+  font-family:var(--body); background:var(--bg); color:var(--text);
+  line-height:1.5; -webkit-font-smoothing:antialiased;
+  padding-bottom:80px; min-height:100vh;
+}
+/* faint editorial paper texture (chrome.css) */
+body::before{
+  content:""; position:fixed; inset:0; pointer-events:none; z-index:0;
+  background-image:
+    radial-gradient(circle at 16% 10%, rgba(107,92,231,.05), transparent 42%),
+    radial-gradient(circle at 90% 4%,  rgba(108,255,127,.055), transparent 40%);
+}
+.wrap{position:relative;z-index:1;max-width:var(--d-page);margin:0 auto;
+  padding:26px 24px 0; transition:max-width .45s cubic-bezier(.4,0,.2,1)}
+
+a{color:inherit;text-decoration:none}
+.mono{font-family:var(--mono);font-variant-numeric:tabular-nums}
+.tnum{font-variant-numeric:tabular-nums}
+
+/* ─── TOP BAR ─── */
+.topbar{display:flex;align-items:center;gap:14px;margin-bottom:22px}
+.brand{display:inline-flex;align-items:center;gap:9px;font-family:var(--display);
+  font-weight:800;font-size:17px;letter-spacing:-.02em}
+.brand .mark{width:19px;height:19px;border-radius:50%;
+  background:conic-gradient(from 220deg, var(--text) 0 50%, transparent 50% 100%);
+  border:1.5px solid var(--text)}
+.brand .ver{font-family:var(--body);font-weight:600;font-size:10.5px;color:var(--text2);
+  background:var(--neutral);padding:2px 6px;border-radius:999px;letter-spacing:0}
+.spacer{flex:1}
+
+/* density segmented control — the headline of this study */
+.seg{display:inline-flex;background:var(--neutral);border:1px solid var(--border);
+  border-radius:999px;padding:3px;gap:2px}
+.seg button{font-family:var(--body);font-weight:600;font-size:12.5px;color:var(--text2);
+  border:0;background:transparent;padding:6px 14px;border-radius:999px;cursor:pointer;
+  display:inline-flex;align-items:center;gap:6px;transition:color .18s}
+.seg button .ic{width:13px;height:13px;display:block}
+.seg button[aria-pressed="true"]{background:var(--card);color:var(--text);
+  box-shadow:0 1px 2px rgba(20,18,12,.08), 0 2px 8px -2px rgba(20,18,12,.10)}
+
+/* ─── ROLE PILLS ─── */
+.roles{display:flex;gap:7px;flex-wrap:wrap;margin-bottom:20px}
+.role{font-family:var(--body);font-size:13.5px;font-weight:500;color:var(--text2);
+  background:rgba(255,255,255,.6);border:1.5px solid var(--border);
+  padding:8px 16px;border-radius:999px;cursor:pointer;
+  transition:color .2s,background .2s,border-color .2s,transform .2s,box-shadow .2s}
+.role:hover{border-color:var(--accent);color:var(--accent);background:var(--accent-soft);transform:translateY(-1px)}
+.role[aria-pressed="true"]{background:var(--text);border-color:var(--text);color:var(--bg);
+  box-shadow:0 2px 10px rgba(20,18,12,.18)}
+.role[aria-pressed="true"]::before{content:"";display:inline-block;width:6px;height:6px;
+  border-radius:50%;background:var(--success);margin-right:8px;vertical-align:1px;
+  box-shadow:0 0 0 3px rgba(108,255,127,.18)}
+
+/* ─── GREETING / SUMMARY ─── */
+.eyebrow{display:inline-flex;align-items:center;gap:10px;font-family:var(--display);
+  font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.16em;
+  color:var(--text3);margin-bottom:11px}
+.eyebrow .rule{width:26px;height:1px;background:currentColor;opacity:.45}
+.eyebrow .accent{color:var(--accent)}
+.greet{font-family:var(--display);font-weight:800;line-height:1.03;letter-spacing:-.035em;
+  font-size:var(--d-greet);margin-bottom:10px;transition:font-size .4s cubic-bezier(.4,0,.2,1)}
+.greet em{font-style:italic;font-weight:700;color:var(--accent)}
+.summary{font-size:15px;line-height:1.5;color:var(--text2);max-width:62ch;margin-bottom:6px}
+.summary b{color:var(--text);font-weight:600}
+.asof{font-family:var(--mono);font-size:11px;color:var(--text3);font-style:italic;margin-bottom:var(--d-section-gap)}
+
+/* ─── SECTION LABEL ─── */
+.label{display:flex;align-items:center;gap:10px;font-family:var(--display);
+  font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.16em;
+  color:var(--text3);margin:0 0 13px}
+.label::after{content:"";flex:1;height:1px;background:var(--border)}
+.label .ct{color:var(--text2);background:var(--neutral);border-radius:999px;
+  padding:1px 8px;font-size:10.5px;letter-spacing:.04em}
+section{margin-bottom:var(--d-section-gap)}
+
+/* ─── VITALS RAIL — compact KPI tiles w/ sparkline (Health "Summary") ─── */
+.vitals{display:grid;grid-template-columns:repeat(auto-fill,minmax(var(--d-vitals-min),1fr));gap:var(--d-gap)}
+.vital{background:var(--card);border:1px solid var(--border);border-radius:var(--d-radius);
+  padding:14px 15px 12px;box-shadow:var(--shadow);position:relative;overflow:hidden;
+  transition:box-shadow .25s,transform .25s,border-color .25s}
+.vital:hover{box-shadow:var(--shadow-h);transform:translateY(-1px)}
+.vital::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;
+  background:var(--m,var(--accent));opacity:.85}
+.vital .vk{font-family:var(--display);font-size:10px;font-weight:700;text-transform:uppercase;
+  letter-spacing:.12em;color:var(--text3);display:flex;align-items:center;gap:6px;margin-bottom:9px}
+.vital .vk i{width:6px;height:6px;border-radius:50%;background:var(--m,var(--accent));
+  box-shadow:0 0 0 3px var(--mt,transparent)}
+.vital .vrow{display:flex;align-items:flex-end;justify-content:space-between;gap:10px}
+.vital .vnum{font-family:var(--display);font-weight:800;font-size:var(--d-tile-metric);
+  line-height:1;letter-spacing:-.025em;font-variant-numeric:tabular-nums;transition:font-size .35s}
+.vital .vdelta{font-size:11.5px;font-weight:600;padding:2px 8px;border-radius:999px;
+  font-variant-numeric:tabular-nums;white-space:nowrap}
+.up{background:var(--success-soft);color:var(--success-ink)}
+.down{background:var(--watch-soft);color:var(--warn-ink)}
+.crash{background:var(--danger-soft);color:var(--danger)}
+.vital svg.spark{display:block;margin-top:10px;width:100%;height:var(--d-rail-spark);transition:height .35s}
+
+/* mood tints */
+.good{--m:var(--success-mid);--mt:var(--success-soft)}
+.watch{--m:var(--watch);--mt:var(--watch-soft)}
+.act{--m:var(--danger);--mt:var(--danger-soft)}
+.cool{--m:var(--accent);--mt:var(--accent-soft)}
+
+/* ─── "NEEDS YOUR CALL" — amber panel, compact rows ─── */
+.call{border:1px solid rgba(233,162,59,.32);border-left:3px solid var(--watch);
+  border-radius:14px;padding:15px 16px 13px;
+  background:linear-gradient(180deg,rgba(233,162,59,.07),rgba(233,162,59,.02));
+  box-shadow:0 1px 0 rgba(233,162,59,.06), 0 12px 28px -16px rgba(233,162,59,.18)}
+.call-head{display:flex;align-items:center;gap:10px;margin-bottom:11px;font-family:var(--display);
+  font-size:11px;font-weight:800;letter-spacing:.14em;text-transform:uppercase;color:var(--warn-ink)}
+.call-head .dot{width:8px;height:8px;border-radius:50%;background:var(--watch);
+  box-shadow:0 0 0 4px rgba(233,162,59,.18);animation:pulse 2.4s ease-in-out infinite}
+@keyframes pulse{0%,100%{box-shadow:0 0 0 4px rgba(233,162,59,.18)}50%{box-shadow:0 0 0 7px rgba(233,162,59,.08)}}
+.call-head .ct{margin-left:1px;padding:1px 8px;border-radius:999px;background:var(--watch);
+  color:#fff;font-size:11px;font-weight:700;letter-spacing:0}
+.call-head .skim{margin-left:auto;font-family:var(--body);font-size:12px;font-weight:600;
+  letter-spacing:0;text-transform:none;color:var(--warn-ink);opacity:.75}
+.call-head .skim:hover{opacity:1;text-decoration:underline;text-underline-offset:3px}
+.call-rows{display:grid;gap:8px}
+.crow{display:flex;align-items:flex-start;gap:11px;background:var(--card);
+  border:1px solid rgba(233,162,59,.22);border-radius:12px;padding:11px 13px}
+.crow .tone{width:9px;height:9px;border-radius:50%;margin-top:5px;flex:0 0 auto;background:var(--m)}
+.crow .body{flex:1;min-width:0}
+.crow .hl{font-size:14px;font-weight:600;letter-spacing:-.005em}
+.crow .tgt{font-family:var(--mono);font-size:11.5px;color:var(--text2);margin-top:2px}
+.crow .meta{font-size:11.5px;color:var(--text3);margin-top:3px}
+.crow .acts{display:flex;align-items:center;gap:7px;margin-top:9px}
+.btn{font-family:var(--body);font-size:12.5px;font-weight:600;border-radius:9px;
+  padding:6px 12px;cursor:pointer;border:1px solid transparent;transition:transform .15s,box-shadow .15s,background .15s}
+.btn:hover{transform:translateY(-1px)}
+.btn.ok{background:var(--success-ink);color:#fff}
+.btn.ok:hover{box-shadow:0 4px 12px rgba(17,55,25,.18)}
+.btn.no{background:var(--card);border-color:var(--border);color:var(--text2)}
+.btn.no:hover{border-color:var(--text3);color:var(--text)}
+.crow .why{margin-left:auto;font-size:11.5px;color:var(--text2);align-self:center}
+.crow .why:hover{color:var(--text);text-decoration:underline;text-underline-offset:2px}
+
+/* ─── BRIEFING — tiles in a grid (compact) / stacked (comfortable) ─── */
+.grid{display:grid;grid-template-columns:var(--d-grid);gap:var(--d-gap);
+  transition:grid-template-columns .1s}
+.icard{background:var(--card);border:1px solid var(--border);border-radius:var(--d-radius);
+  padding:var(--d-pad);box-shadow:var(--shadow);position:relative;overflow:hidden;cursor:pointer;
+  transition:box-shadow .3s cubic-bezier(.4,0,.2,1),transform .3s cubic-bezier(.4,0,.2,1),border-color .3s;
+  display:flex;flex-direction:column}
+.icard::before{content:"";position:absolute;left:0;top:0;bottom:0;width:4px;background:var(--m,var(--accent));opacity:.85}
+.icard::after{content:"";position:absolute;inset:0;pointer-events:none;
+  background:linear-gradient(135deg,var(--mt,transparent) 0%,transparent 45%);opacity:.5}
+.icard:hover{box-shadow:var(--shadow-h);transform:translateY(-1px);border-color:var(--m,var(--accent))}
+.itop{display:flex;align-items:flex-start;gap:13px;position:relative;z-index:1}
+.inum{font-family:var(--display);font-size:23px;font-weight:800;color:var(--m,var(--accent));
+  font-variant-numeric:tabular-nums;letter-spacing:-.025em;line-height:1;margin-top:-2px;
+  flex:0 0 auto;min-width:34px;opacity:.85}
+.icard:hover .inum{opacity:1}
+.icontent{flex:1;min-width:0}
+.imood{display:inline-flex;align-items:center;gap:6px;font-family:var(--display);font-size:10px;
+  font-weight:700;text-transform:uppercase;letter-spacing:.14em;color:var(--m,var(--text3));margin-bottom:7px}
+.imood i{width:6px;height:6px;border-radius:50%;background:currentColor;box-shadow:0 0 0 3px var(--mt,transparent)}
+.itext{font-size:var(--d-itext);font-weight:500;line-height:1.4;letter-spacing:-.005em;transition:font-size .35s}
+.kpi{display:flex;align-items:baseline;gap:12px;margin-top:9px;flex-wrap:wrap}
+.kpi .m{font-family:var(--display);font-weight:800;font-size:var(--d-tile-metric);line-height:1;
+  letter-spacing:-.025em;font-variant-numeric:tabular-nums;transition:font-size .35s}
+.kpi .l{font-size:11px;color:var(--text3);text-transform:uppercase;letter-spacing:.1em;font-weight:600}
+.kpi .vdelta{font-size:12px}
+/* inline sparkline lives in the tile header row in compact, full chart in detail */
+.icard .miniwrap{margin-top:11px;position:relative;z-index:1}
+.icard svg.spark{display:block;width:100%;height:46px}
+
+/* detail — shown inline in comfortable, on .open in compact */
+.idetail{display:var(--d-detail);margin-top:13px;padding-top:13px;border-top:1px dashed var(--border);position:relative;z-index:1}
+.icard.open .idetail{display:block;animation:reveal .3s ease}
+@keyframes reveal{from{opacity:0;transform:translateY(-4px)}to{opacity:1;transform:none}}
+.idetail .dtext{font-size:13.5px;line-height:1.55;color:var(--text2)}
+.idetail svg.spark{margin-top:12px;height:74px}
+.icard .expand{position:absolute;top:12px;right:13px;z-index:2;font-size:11px;color:var(--text3);
+  font-family:var(--mono);opacity:0;transition:opacity .2s}
+.icard:hover .expand{opacity:1}
+html[data-density="comfortable"] .icard .expand{display:none}
+
+/* ─── FINDINGS — dense rows ─── */
+.finds{display:grid;gap:9px}
+.find{background:var(--card);border:1px solid var(--border);border-radius:14px;
+  padding:12px 15px;cursor:pointer;transition:border-color .2s,transform .2s,box-shadow .2s}
+.find:hover{border-color:var(--text3);transform:translateY(-1px);box-shadow:var(--shadow)}
+.find-top{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:4px}
+.find h3{font-family:var(--display);font-size:15px;font-weight:700;letter-spacing:-.01em;line-height:1.3}
+.find p{font-size:13px;line-height:1.5;color:var(--text2);margin-bottom:6px}
+.find .fmeta{display:flex;align-items:center;gap:7px;font-size:11.5px;color:var(--text3)}
+.find .fmeta b{color:var(--text2);font-weight:600}
+.find .fmeta .go{margin-left:auto;color:var(--accent)}
+.find:hover .fmeta .go{text-decoration:underline;text-underline-offset:2px}
+
+/* status pill */
+.pill{font-family:var(--display);font-size:10px;font-weight:800;letter-spacing:.08em;
+  text-transform:uppercase;padding:3px 9px;border-radius:999px;border:1px solid;white-space:nowrap;flex:0 0 auto}
+.pill.good{background:var(--success-soft);color:var(--success-ink);border-color:rgba(76,175,130,.3)}
+.pill.watch{background:var(--watch-soft);color:var(--warn-ink);border-color:rgba(233,162,59,.3)}
+.pill.act{background:var(--danger-soft);color:var(--danger);border-color:rgba(224,86,86,.3)}
+.pill.cool{background:var(--accent-soft);color:var(--accent);border-color:rgba(107,92,231,.25)}
+
+/* ─── PROOF (fired on your behalf) ─── */
+.proof{border-top:1px dashed var(--border);padding-top:14px}
+.proof summary{display:flex;align-items:center;gap:11px;cursor:pointer;list-style:none;
+  font-size:14.5px;color:var(--text2);padding:6px 2px}
+.proof summary::-webkit-details-marker{display:none}
+.proof summary:hover{color:var(--text)}
+.proof .tick{color:var(--success-mid);font-size:18px;font-family:var(--mono)}
+.proof .ct{font-family:var(--display);font-size:17px;font-weight:800;color:var(--text);font-variant-numeric:tabular-nums}
+.proof .caret{margin-left:auto;color:var(--text3);font-size:12px;transition:transform .18s}
+.proof[open] .caret{transform:rotate(90deg)}
+.proof-body{margin-top:11px;display:grid;gap:8px}
+
+.note{font-size:13px;color:var(--text3);font-style:italic;margin-top:-6px}
+
+/* staggered load */
+@keyframes fadeUp{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:none}}
+.fu{animation:fadeUp .5s ease both}
+
+@media (max-width:680px){
+  html[data-density]{--d-page:100%;--d-grid:1fr;--d-greet:30px}
+  .wrap{padding:20px 16px 0}
+  .topbar{flex-wrap:wrap}
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <!-- TOP BAR -->
+  <div class="topbar">
+    <span class="brand"><span class="mark"></span>OpenNeko <span class="ver">1.17.2</span></span>
+    <span class="spacer"></span>
+    <div class="seg" role="group" aria-label="Information density">
+      <button data-set="comfortable" aria-pressed="false" title="Roomy single column">
+        <svg class="ic" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="3" width="12" height="3.4" rx="1.2"/><rect x="2" y="9.6" width="12" height="3.4" rx="1.2"/></svg>
+        Comfortable
+      </button>
+      <button data-set="compact" aria-pressed="true" title="Dense tile grid">
+        <svg class="ic" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="2.5" width="5" height="5" rx="1.2"/><rect x="9" y="2.5" width="5" height="5" rx="1.2"/><rect x="2" y="8.5" width="5" height="5" rx="1.2"/><rect x="9" y="8.5" width="5" height="5" rx="1.2"/></svg>
+        Compact
+      </button>
+    </div>
+  </div>
+
+  <!-- ROLES -->
+  <div class="roles">
+    <button class="role" aria-pressed="true">COO</button>
+    <button class="role" aria-pressed="false">CFO</button>
+    <button class="role" aria-pressed="false">Head of Sales</button>
+    <button class="role" aria-pressed="false">Support Lead</button>
+  </div>
+
+  <!-- GREETING -->
+  <div class="eyebrow fu"><span class="rule"></span><span class="accent">COO Briefing</span><span>·</span><span>Tue, June 3</span></div>
+  <h1 class="greet fu" style="animation-delay:.04s">Steady week, <em>two calls</em> waiting on you.</h1>
+  <p class="summary fu" style="animation-delay:.08s">Revenue is <b>up 6.2%</b> on the prior period and burn held flat. Support backlog crept past its threshold overnight — worth a glance. Everything else ran clean.</p>
+  <div class="asof fu" style="animation-delay:.1s">as of 9:14 AM</div>
+
+  <!-- VITALS RAIL -->
+  <section class="fu" style="animation-delay:.12s">
+    <div class="label">Vitals <span class="ct">6</span></div>
+    <div class="vitals" id="vitals"></div>
+  </section>
+
+  <!-- NEEDS YOUR CALL -->
+  <section class="fu" style="animation-delay:.16s">
+    <div class="call">
+      <div class="call-head">
+        <span class="dot"></span><span>Needs your call</span><span class="ct">2</span>
+        <a class="skim" href="#">open all →</a>
+      </div>
+      <div class="call-rows">
+        <div class="crow act">
+          <span class="tone"></span>
+          <div class="body">
+            <div class="hl">Refund $4,200 to Acme Corp — disputed annual charge</div>
+            <div class="tgt">stripe · ch_3PQ…91 · high risk</div>
+            <div class="acts">
+              <button class="btn ok">Approve</button>
+              <button class="btn no">Reject</button>
+              <a class="why" href="#">why →</a>
+            </div>
+          </div>
+        </div>
+        <div class="crow watch">
+          <span class="tone"></span>
+          <div class="body">
+            <div class="hl">Send churn-risk note to 3 enterprise accounts</div>
+            <div class="tgt">gmail · 3 recipients · medium risk</div>
+            <div class="acts">
+              <button class="btn ok">Approve</button>
+              <button class="btn no">Reject</button>
+              <a class="why" href="#">why →</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- BRIEFING GRID -->
+  <section class="fu" style="animation-delay:.2s">
+    <div class="label">Today's Briefing <span class="ct">6</span></div>
+    <div class="grid" id="briefing"></div>
+  </section>
+
+  <!-- FINDINGS -->
+  <section class="fu" style="animation-delay:.24s">
+    <div class="label">Worth your read <span class="ct">3</span></div>
+    <div class="finds" id="finds"></div>
+  </section>
+
+  <!-- PROOF -->
+  <section class="fu" style="animation-delay:.28s">
+    <details class="proof">
+      <summary><span class="tick">↳</span><span class="ct">14</span><span>fired on your behalf in the last 24h</span><span class="caret">▸</span></summary>
+      <div class="proof-body">
+        <div class="crow good"><span class="tone"></span><div class="body"><div class="hl">Renewed 9 expiring API keys</div><div class="meta">auto · billing-watch · 2:02 AM</div></div></div>
+        <div class="crow good"><span class="tone"></span><div class="body"><div class="hl">Tagged 41 inbound leads by ICP fit</div><div class="meta">rule "lead-triage" · 6:30 AM</div></div></div>
+        <div class="crow good"><span class="tone"></span><div class="body"><div class="hl">Posted weekly metrics to #leadership</div><div class="meta">you · Mon 5:00 PM · 8:00 AM</div></div></div>
+      </div>
+    </details>
+    <p class="note">12 healthy runs in the last 24h.</p>
+  </section>
+
+</div>
+
+<script>
+/* ── sparkline generator: smooth-ish area + line + end dot ──────────── */
+function spark(points,{w=120,h=46,stroke='var(--accent)',fill=true}={}){
+  const min=Math.min(...points),max=Math.max(...points),span=(max-min)||1;
+  const step=w/(points.length-1);
+  const xy=points.map((p,i)=>[i*step,h-((p-min)/span)*(h-7)-4]);
+  const line=xy.map((c,i)=>(i?'L':'M')+c[0].toFixed(1)+' '+c[1].toFixed(1)).join(' ');
+  const area=`${line} L ${w} ${h} L 0 ${h} Z`;
+  const [ex,ey]=xy[xy.length-1];
+  const id='g'+Math.round(min*97+max*13+points.length);
+  return `<svg class="spark" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none" aria-hidden="true">
+    <defs><linearGradient id="${id}" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="${stroke}" stop-opacity=".18"/>
+      <stop offset="1" stop-color="${stroke}" stop-opacity="0"/></linearGradient></defs>
+    ${fill?`<path d="${area}" fill="url(#${id})"/>`:''}
+    <path d="${line}" fill="none" stroke="${stroke}" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"/>
+    <circle cx="${ex.toFixed(1)}" cy="${ey.toFixed(1)}" r="2.6" fill="${stroke}"/>
+  </svg>`;
+}
+const C={good:'var(--success-mid)',watch:'var(--watch)',act:'var(--danger)',cool:'var(--accent)'};
+
+/* ── vitals data ── */
+const vitals=[
+  {k:'Net revenue',mood:'good',num:'$184.2k',delta:'▲ 6.2%',dc:'up',pts:[140,150,148,162,170,168,184]},
+  {k:'Monthly burn',mood:'good',num:'$96.4k',delta:'▼ 0.4%',dc:'up',pts:[101,99,100,98,97,97,96]},
+  {k:'Active orgs',mood:'good',num:'1,284',delta:'▲ 31',dc:'up',pts:[1180,1205,1220,1238,1251,1267,1284]},
+  {k:'Gross margin',mood:'cool',num:'71.8%',delta:'▲ 0.9pt',dc:'up',pts:[68,69,70,70,71,71,72]},
+  {k:'Support backlog',mood:'act',num:'37',delta:'▲ 14',dc:'crash',pts:[18,20,19,23,22,30,37]},
+  {k:'NRR',mood:'watch',num:'108%',delta:'▼ 3pt',dc:'down',pts:[114,113,112,111,110,109,108]},
+];
+document.getElementById('vitals').innerHTML=vitals.map(v=>`
+  <div class="vital ${v.mood}">
+    <div class="vk"><i></i>${v.k}</div>
+    <div class="vrow"><span class="vnum">${v.num}</span><span class="vdelta ${v.dc}">${v.delta}</span></div>
+    ${spark(v.pts,{stroke:C[v.mood]})}
+  </div>`).join('');
+
+/* ── briefing tiles ── */
+const briefing=[
+  {mood:'good',label:'On track',text:'Self-serve signups are pacing 18% ahead of last month, led by the API plan.',m:'+18%',l:'vs last mo',delta:'▲ strong',dc:'up',pts:[40,44,46,52,55,58,64],chart:[40,44,46,52,55,58,64],
+   detail:'API-plan signups (62% of new) are driving the lift; the new docs landing page is the top referrer. No paid spend change — this is organic.'},
+  {mood:'act',label:'Act now',text:'Support backlog crossed 35 tickets — first-response SLA is now at risk for 6 enterprise accounts.',m:'37',l:'open tickets',delta:'▲ +14',dc:'crash',pts:[18,20,19,23,22,30,37],
+   detail:'Spike began ~2 AM after the v3 rollout. 6 of 37 are enterprise (SLA: 1h). Suggest pulling one engineer onto triage and pausing non-critical deploys.'},
+  {mood:'good',label:'On track',text:'Cash runway holds at 19 months; burn flat despite the new hires.',m:'19 mo',l:'runway',delta:'▼ flat',dc:'up',pts:[20,20,19,19,19,19,19],
+   detail:'Two engineering hires offset by churned infra spend after the Graviton migration. No change to the raise timeline.'},
+  {mood:'watch',label:'Watch',text:'Net revenue retention slipped to 108% — third straight week of soft expansion.',m:'108%',l:'NRR',delta:'▼ −3pt',dc:'down',pts:[114,113,112,111,110,109,108],
+   detail:'Expansion MRR is the soft spot, not churn. Mid-market seats aren\'t upgrading post-trial. Worth a pricing-page experiment.'},
+  {mood:'good',label:'On track',text:'Lead-to-meeting rate up to 12.4% after the new ICP triage rule went live.',m:'12.4%',l:'lead→mtg',delta:'▲ +2.1pt',dc:'up',pts:[9,9.5,10,10.8,11.2,11.9,12.4],
+   detail:'The auto-triage rule is routing high-fit leads to AEs within 4 min on average (was 3.5h). Conversion lift concentrated in the >50-employee segment.'},
+  {mood:'cool',label:'Steady',text:'Infra cost per active org dropped 7% this month on the Graviton move.',m:'$0.74',l:'cost / org',delta:'▼ −7%',dc:'up',pts:[0.83,0.82,0.80,0.79,0.77,0.76,0.74],
+   detail:'Graviton migration completed for 80% of fleet. Remaining 20% (legacy x86 workers) scheduled for next sprint — projected to reach $0.69/org.'},
+];
+document.getElementById('briefing').innerHTML=briefing.map((b,i)=>`
+  <article class="icard ${b.mood}" data-i="${i}" style="animation:fadeUp .5s ease ${(.2+i*0.05).toFixed(2)}s both">
+    <span class="expand">expand ↕</span>
+    <div class="itop">
+      <span class="inum">${String(i+1).padStart(2,'0')}</span>
+      <div class="icontent">
+        <span class="imood"><i></i>${b.label}</span>
+        <div class="itext">${b.text}</div>
+        <div class="kpi"><span class="m">${b.m}</span><span class="l">${b.l}</span><span class="vdelta ${b.dc}">${b.delta}</span></div>
+        <div class="miniwrap">${spark(b.pts,{stroke:C[b.mood]})}</div>
+      </div>
+    </div>
+    <div class="idetail">
+      <div class="dtext">${b.detail}</div>
+    </div>
+  </article>`).join('');
+document.querySelectorAll('.icard').forEach(c=>c.addEventListener('click',()=>c.classList.toggle('open')));
+
+/* ── findings ── */
+const finds=[
+  {mood:'watch',pill:'watch',title:'Churn signal: 3 enterprise accounts went quiet',body:'Logins dropped >60% week-over-week for Northwind, Globex, and Initech. No support tickets — silent disengagement.',from:'churn-watch',ago:'22m ago',go:'drill in →'},
+  {mood:'cool',pill:'cool',title:'Competitor shipped usage-based pricing',body:'Tracked from their changelog this morning. Mirrors the model your mid-market prospects keep asking about.',from:'market-radar',ago:'1h ago',go:'drill in →'},
+  {mood:'good',pill:'good',title:'Docs revamp lifted activation 9 points',body:'Cohort that hit the new quickstart activated at 47% vs 38% baseline. Worth promoting it earlier in onboarding.',from:'activation-lab',ago:'3h ago',go:'drill in →'},
+];
+document.getElementById('finds').innerHTML=finds.map((f,i)=>`
+  <article class="find" style="animation:fadeUp .4s ease ${(.24+i*0.04).toFixed(2)}s both">
+    <div class="find-top"><h3>${f.title}</h3><span class="pill ${f.pill}">${f.pill==='cool'?'signal':f.pill}</span></div>
+    <p>${f.body}</p>
+    <div class="fmeta">from <b>${f.from}</b><span style="opacity:.5">·</span><span class="mono">${f.ago}</span><span class="go">${f.go}</span></div>
+  </article>`).join('');
+
+/* ── density toggle ── */
+const root=document.documentElement;
+document.querySelectorAll('.seg button').forEach(btn=>{
+  btn.addEventListener('click',()=>{
+    const mode=btn.dataset.set;
+    root.setAttribute('data-density',mode);
+    document.querySelectorAll('.seg button').forEach(b=>b.setAttribute('aria-pressed',String(b===btn)));
+  });
+});
+/* role toggle (visual) */
+document.querySelectorAll('.role').forEach(r=>r.addEventListener('click',()=>{
+  document.querySelectorAll('.role').forEach(x=>x.setAttribute('aria-pressed','false'));
+  r.setAttribute('aria-pressed','true');
+}));
+</script>
+</body>
+</html>

--- a/apps/web/dense-dashboard-prototype.html
+++ b/apps/web/dense-dashboard-prototype.html
@@ -133,7 +133,22 @@ a{color:inherit;text-decoration:none}
 .greet em{font-style:italic;font-weight:700;color:var(--accent)}
 .summary{font-size:15px;line-height:1.5;color:var(--text2);max-width:62ch;margin-bottom:6px}
 .summary b{color:var(--text);font-weight:600}
-.asof{font-family:var(--mono);font-size:11px;color:var(--text3);font-style:italic;margin-bottom:var(--d-section-gap)}
+.asof{font-family:var(--mono);font-size:11px;color:var(--text3);font-style:italic;margin-bottom:14px}
+
+/* hours-saved value-prop hero — the cumulative "look what we did" number */
+.valueprop{display:inline-flex;align-items:center;gap:13px;margin-bottom:var(--d-section-gap);
+  background:linear-gradient(135deg,var(--accent-soft),color-mix(in srgb,var(--success-soft) 55%,var(--accent-soft)));
+  border:1px solid color-mix(in srgb,var(--accent) 22%,var(--border));border-radius:14px;
+  padding:10px 16px 10px 13px;text-decoration:none;color:var(--text);
+  transition:transform .18s,box-shadow .18s,border-color .18s}
+.valueprop:hover{transform:translateY(-1px);box-shadow:var(--shadow-h);border-color:color-mix(in srgb,var(--accent) 42%,var(--border))}
+.vp-ic{width:32px;height:32px;border-radius:9px;background:var(--card);display:grid;place-items:center;font-size:16px;flex:0 0 auto;box-shadow:var(--shadow)}
+.vp-num{font-family:var(--display);font-weight:800;font-size:25px;letter-spacing:-.03em;line-height:1;color:var(--accent);font-variant-numeric:tabular-nums}
+.vp-num .vp-u{font-size:13px;margin-left:2px;opacity:.7}
+.vp-txt{font-size:12.5px;color:var(--text2);line-height:1.38}
+.vp-txt b{color:var(--success-ink);font-weight:700}
+.vp-how{margin-left:4px;font-size:11px;font-weight:600;color:var(--accent);opacity:.75;white-space:nowrap;font-family:var(--mono)}
+.valueprop:hover .vp-how{opacity:1}
 
 /* ─── SECTION LABEL ─── */
 .label{display:flex;align-items:center;gap:10px;font-family:var(--display);
@@ -333,9 +348,16 @@ section{margin-bottom:var(--d-section-gap)}
   <p class="summary fu" style="animation-delay:.08s">Revenue is <b>up 6.2%</b> on the prior period and burn held flat. Support backlog crept past its threshold overnight — worth a glance. Everything else ran clean.</p>
   <div class="asof fu" style="animation-delay:.1s">as of 9:14 AM</div>
 
+  <a class="valueprop fu" style="animation-delay:.11s" href="#" title="How hours saved is estimated">
+    <span class="vp-ic">⏱</span>
+    <span class="vp-num">142<span class="vp-u">hrs</span></span>
+    <span class="vp-txt">saved since you installed OpenNeko<br><b>+9.2h this week</b> · 38 tasks handled for you</span>
+    <span class="vp-how">how?&nbsp;→</span>
+  </a>
+
   <!-- VITALS RAIL -->
   <section class="fu" style="animation-delay:.12s">
-    <div class="label">Vitals <span class="ct">6</span></div>
+    <div class="label">Vitals <span class="ct">7</span></div>
     <div class="vitals" id="vitals"></div>
   </section>
 
@@ -390,7 +412,7 @@ section{margin-bottom:var(--d-section-gap)}
   <!-- PROOF -->
   <section class="fu" style="animation-delay:.28s">
     <details class="proof">
-      <summary><span class="tick">↳</span><span class="ct">14</span><span>fired on your behalf in the last 24h</span><span class="caret">▸</span></summary>
+      <summary><span class="tick">↳</span><span class="ct">14</span><span>fired on your behalf in the last 24h · saved you ~3.2h</span><span class="caret">▸</span></summary>
       <div class="proof-body">
         <div class="crow good"><span class="tone"></span><div class="body"><div class="hl">Renewed 9 expiring API keys</div><div class="meta">auto · billing-watch · 2:02 AM</div></div></div>
         <div class="crow good"><span class="tone"></span><div class="body"><div class="hl">Tagged 41 inbound leads by ICP fit</div><div class="meta">rule "lead-triage" · 6:30 AM</div></div></div>
@@ -425,6 +447,7 @@ const C={good:'var(--success-mid)',watch:'var(--watch)',act:'var(--danger)',cool
 
 /* ── vitals data ── */
 const vitals=[
+  {k:'Hours saved · wk',mood:'cool',num:'37h',delta:'▲ 9.2h',dc:'up',pts:[18,22,20,26,28,31,37]},
   {k:'Net revenue',mood:'good',num:'$184.2k',delta:'▲ 6.2%',dc:'up',pts:[140,150,148,162,170,168,184]},
   {k:'Monthly burn',mood:'good',num:'$96.4k',delta:'▼ 0.4%',dc:'up',pts:[101,99,100,98,97,97,96]},
   {k:'Active orgs',mood:'good',num:'1,284',delta:'▲ 31',dc:'up',pts:[1180,1205,1220,1238,1251,1267,1284]},

--- a/apps/web/dense-dashboard-prototype.html
+++ b/apps/web/dense-dashboard-prototype.html
@@ -242,10 +242,17 @@ section{margin-bottom:var(--d-section-gap)}
 @keyframes reveal{from{opacity:0;transform:translateY(-4px)}to{opacity:1;transform:none}}
 .idetail .dtext{font-size:13.5px;line-height:1.55;color:var(--text2)}
 .idetail svg.spark{margin-top:12px;height:74px}
-.icard .expand{position:absolute;top:12px;right:13px;z-index:2;font-size:11px;color:var(--text3);
-  font-family:var(--mono);opacity:0;transition:opacity .2s}
-.icard:hover .expand{opacity:1}
-html[data-density="comfortable"] .icard .expand{display:none}
+/* Card actions — retained from today's .iactions: deep-dive, retry, copy,
+   dismiss. Hover-revealed (always-on for touch in the real app). */
+.iacts{position:absolute;top:10px;right:11px;z-index:3;display:flex;gap:3px;
+  opacity:0;transition:opacity .18s}
+.icard:hover .iacts,.icard:focus-within .iacts{opacity:1}
+.iacts button{width:26px;height:26px;border-radius:8px;border:1px solid transparent;background:transparent;
+  color:var(--text3);display:grid;place-items:center;cursor:pointer;transition:background .15s,border-color .15s,color .15s}
+.iacts button:hover{background:var(--neutral);border-color:var(--border);color:var(--text)}
+.iacts button svg{width:13px;height:13px}
+.iacts button.deep:hover{color:var(--accent);border-color:color-mix(in srgb,var(--accent) 30%,var(--border));background:var(--accent-soft)}
+.iacts button.kill:hover{color:var(--danger);border-color:color-mix(in srgb,var(--danger) 30%,var(--border));background:var(--danger-soft)}
 
 /* ─── FINDINGS — dense rows ─── */
 .finds{display:grid;gap:9px}
@@ -449,7 +456,12 @@ const briefing=[
 ];
 document.getElementById('briefing').innerHTML=briefing.map((b,i)=>`
   <article class="icard ${b.mood}" data-i="${i}" style="animation:fadeUp .5s ease ${(.2+i*0.05).toFixed(2)}s both">
-    <span class="expand">expand ↕</span>
+    <div class="iacts">
+      <button class="deep" title="Deep dive in Work" aria-label="Deep dive"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7"><circle cx="7" cy="7" r="4.2"/><line x1="10.3" y1="10.3" x2="14" y2="14" stroke-linecap="round"/></svg></button>
+      <button title="Re-run this metric" aria-label="Retry"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"><path d="M12.8 8a4.8 4.8 0 1 1-1.5-3.5"/><path d="M12.9 2.8v2.4h-2.4"/></svg></button>
+      <button title="Copy card text" aria-label="Copy"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.55"><rect x="5.4" y="5.4" width="7.6" height="7.6" rx="1.7"/><path d="M10.4 5.4V4A1.5 1.5 0 0 0 8.9 2.5H4A1.5 1.5 0 0 0 2.5 4v4.9A1.5 1.5 0 0 0 4 10.4h1.4"/></svg></button>
+      <button class="kill" title="Dismiss" aria-label="Dismiss"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><line x1="4.2" y1="4.2" x2="11.8" y2="11.8"/><line x1="11.8" y1="4.2" x2="4.2" y2="11.8"/></svg></button>
+    </div>
     <div class="itop">
       <span class="inum">${String(i+1).padStart(2,'0')}</span>
       <div class="icontent">
@@ -464,6 +476,7 @@ document.getElementById('briefing').innerHTML=briefing.map((b,i)=>`
     </div>
   </article>`).join('');
 document.querySelectorAll('.icard').forEach(c=>c.addEventListener('click',()=>c.classList.toggle('open')));
+document.querySelectorAll('.iacts button').forEach(b=>b.addEventListener('click',e=>e.stopPropagation()));
 
 /* ── findings ── */
 const finds=[

--- a/apps/web/dense-work-prototype.html
+++ b/apps/web/dense-work-prototype.html
@@ -102,9 +102,6 @@ a{color:inherit;text-decoration:none}
 .convo{background:transparent;border:0;box-shadow:none;min-height:60vh;display:flex;flex-direction:column}
 .thread-title{font-family:var(--display);font-size:15px;font-weight:700;letter-spacing:-.01em;color:var(--text);
   padding:2px 4px 12px;border-bottom:1px solid var(--border);margin-bottom:18px;display:flex;align-items:center;gap:9px}
-.thread-title .src{margin-left:auto;font-family:var(--body);font-size:11px;font-weight:500;color:var(--text3);
-  display:inline-flex;align-items:center;gap:5px}
-.thread-title .src i{width:6px;height:6px;border-radius:50%;background:var(--success-mid)}
 .feed{display:flex;flex-direction:column;gap:var(--d-msg-gap);max-width:var(--d-bubble)}
 .umsg{align-self:flex-end;background:var(--neutral);border-radius:16px;padding:10px 14px;font-size:14px;max-width:80%}
 .amsg{display:flex;flex-direction:column;gap:11px}
@@ -279,7 +276,6 @@ table.data .bar{height:5px;border-radius:3px;background:var(--accent);opacity:.8
     <main class="convo">
       <div class="thread-title">
         <span>Top customers &amp; concentration</span>
-        <span class="src"><i></i>postgres · live</span>
       </div>
       <div class="feed">
         <div class="umsg">Who are our top 10 customers by revenue this year, and how concentrated is it?</div>

--- a/apps/web/dense-work-prototype.html
+++ b/apps/web/dense-work-prototype.html
@@ -158,8 +158,13 @@ table.data .bar{height:5px;border-radius:3px;background:var(--accent);opacity:.8
 .artifact{display:flex;align-items:center;gap:9px;padding:8px 10px;border:1px solid var(--border);border-radius:11px;background:var(--bg);cursor:pointer;transition:border-color .15s,transform .15s}
 .artifact+.artifact{margin-top:6px}
 .artifact:hover{border-color:var(--text3);transform:translateY(-1px)}
-.artifact .ic{width:30px;height:30px;border-radius:8px;display:grid;place-items:center;font-family:var(--display);font-weight:700;font-size:9px;color:#fff;flex:0 0 auto}
-.artifact .ic.csv{background:var(--success-mid)}.artifact .ic.png{background:var(--accent)}.artifact .ic.pdf{background:var(--danger)}
+.artifact .ic{width:30px;height:30px;border-radius:8px;display:grid;place-items:center;flex:0 0 auto}
+.artifact .ic svg{width:16px;height:16px;display:block}
+.artifact .ic.sheet{background:var(--success-soft);color:var(--success-mid)}
+.artifact .ic.image{background:var(--accent-soft);color:var(--accent)}
+.artifact .ic.doc{background:var(--danger-soft);color:var(--danger)}
+.artifact .ic.code{background:var(--watch-soft);color:var(--warn-ink)}
+.artifact .ic.file{background:var(--neutral);color:var(--text2)}
 .artifact .n{font-size:12.5px;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .artifact .meta{font-family:var(--mono);font-size:10.5px;color:var(--text3)}
 .artifact .dl{margin-left:auto;color:var(--text3);font-size:14px}
@@ -332,8 +337,9 @@ table.data .bar{height:5px;border-radius:3px;background:var(--accent);opacity:.8
       </section>
       <section>
         <h4>Artifacts</h4>
-        <div class="artifact"><span class="ic csv">CSV</span><div style="min-width:0"><div class="n">top-customers-ytd.csv</div><div class="meta">10 rows · 2 KB</div></div><span class="dl">↓</span></div>
-        <div class="artifact"><span class="ic png">PNG</span><div style="min-width:0"><div class="n">concentration.png</div><div class="meta">chart · 48 KB</div></div><span class="dl">↓</span></div>
+        <div class="artifact"><span class="ic sheet"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="M3 10h18M9 4v16"/></svg></span><div style="min-width:0"><div class="n">top-customers-ytd.csv</div><div class="meta">10 rows · 2 KB</div></div><span class="dl">↓</span></div>
+        <div class="artifact"><span class="ic image"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="9" r="1.7"/><path d="M21 16l-4.6-4.6L6 21"/></svg></span><div style="min-width:0"><div class="n">concentration.png</div><div class="meta">chart · 48 KB</div></div><span class="dl">↓</span></div>
+        <div class="artifact"><span class="ic doc"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14 3H7a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2V8z"/><path d="M14 3v5h5"/><path d="M9 13h6M9 17h4"/></svg></span><div style="min-width:0"><div class="n">board-summary.pdf</div><div class="meta">3 pages · 71 KB</div></div><span class="dl">↓</span></div>
       </section>
       <section>
         <h4>Sources touched</h4>

--- a/apps/web/dense-work-prototype.html
+++ b/apps/web/dense-work-prototype.html
@@ -1,0 +1,377 @@
+<!doctype html>
+<html lang="en" data-density="compact">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>OpenNeko · Ask — density study</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:ital,wght@0,500;0,600;0,700;0,800;0,900;1,600&family=Manrope:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+/* OpenNeko Ask/Work — density study. Comfortable = today's 2-pane
+   (threads + transcript). Compact = adds a right context rail so the
+   answer's data, sources and artifacts stay reachable without scrolling. */
+:root{
+  --bg:#FAFAF7; --card:#FFFFFF; --text:#2D2A24; --text2:#7A756A; --text3:#B0AA9F;
+  --border:#EEEBE4; --neutral:#F2EFE8; --neutral-soft:#F7F4ED;
+  --accent:#6B5CE7; --accent-soft:#EDE9FE;
+  --success:#6CFF7F; --success-ink:#113719; --success-soft:#E2FBE6; --success-mid:#4CAF82;
+  --watch:#E9A23B; --watch-soft:#FFF1D8; --warn-ink:#8A6D00;
+  --danger:#E05656; --danger-soft:#FEECEC;
+  --shadow:0 1px 3px rgba(20,18,12,.04), 0 4px 16px rgba(20,18,12,.03);
+  --shadow-h:0 2px 8px rgba(20,18,12,.06), 0 12px 36px -8px rgba(20,18,12,.07);
+  --display:'Archivo',sans-serif; --body:'Manrope',sans-serif;
+  --mono:'Geist Mono',ui-monospace,monospace;
+}
+html[data-density="comfortable"]{
+  --d-cols:264px minmax(0,1fr);
+  --d-rail:none; --d-canvas:1080px; --d-msg-gap:24px; --d-thread-prev:none; --d-bubble:760px;
+}
+html[data-density="compact"]{
+  --d-cols:248px minmax(0,1fr) 332px;
+  --d-rail:flex; --d-canvas:1320px; --d-msg-gap:16px; --d-thread-prev:block; --d-bubble:none;
+}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:var(--body);background:var(--bg);color:var(--text);line-height:1.5;
+  -webkit-font-smoothing:antialiased;min-height:100vh}
+body::before{content:"";position:fixed;inset:0;pointer-events:none;z-index:0;
+  background-image:radial-gradient(circle at 14% 8%,rgba(107,92,231,.05),transparent 42%),
+    radial-gradient(circle at 92% 4%,rgba(108,255,127,.05),transparent 40%)}
+.wrap{position:relative;z-index:1;max-width:var(--d-canvas);margin:0 auto;
+  padding:22px 22px 0;transition:max-width .45s cubic-bezier(.4,0,.2,1)}
+a{color:inherit;text-decoration:none}
+.mono{font-family:var(--mono);font-variant-numeric:tabular-nums}
+.tnum{font-variant-numeric:tabular-nums}
+
+/* top bar */
+.topbar{display:flex;align-items:center;gap:16px;margin-bottom:14px}
+.brand{display:inline-flex;align-items:center;gap:9px;font-family:var(--display);font-weight:800;font-size:17px;letter-spacing:-.02em}
+.brand .mark{width:19px;height:19px;border-radius:50%;
+  background:conic-gradient(from 220deg,var(--text) 0 50%,transparent 50% 100%);border:1.5px solid var(--text)}
+.brand .ver{font-family:var(--body);font-weight:600;font-size:10.5px;color:var(--text2);background:var(--neutral);padding:2px 6px;border-radius:999px}
+.nav{display:flex;gap:2px;margin-left:6px}
+.nav a{font-size:13.5px;font-weight:500;color:var(--text2);padding:7px 12px;border-radius:999px;border:1px solid transparent}
+.nav a:hover{background:rgba(20,18,12,.04);color:var(--text)}
+.nav a.on{border-color:var(--border);color:var(--text);font-weight:600}
+.nav a.on::before{content:"";display:inline-block;width:5px;height:5px;border-radius:50%;background:var(--accent);margin-right:7px;vertical-align:2px}
+.spacer{flex:1}
+.seg{display:inline-flex;background:var(--neutral);border:1px solid var(--border);border-radius:999px;padding:3px;gap:2px}
+.seg button{font-family:var(--body);font-weight:600;font-size:12.5px;color:var(--text2);border:0;background:transparent;
+  padding:6px 14px;border-radius:999px;cursor:pointer;display:inline-flex;align-items:center;gap:6px;transition:color .18s}
+.seg button .ic{width:13px;height:13px;display:block}
+.seg button[aria-pressed="true"]{background:var(--card);color:var(--text);box-shadow:0 1px 2px rgba(20,18,12,.08),0 2px 8px -2px rgba(20,18,12,.1)}
+
+/* 3-pane */
+.ask{display:grid;grid-template-columns:var(--d-cols);gap:14px;align-items:start;
+  transition:grid-template-columns .1s}
+.pane{background:rgba(255,255,255,.74);border:1px solid var(--border);border-radius:20px;box-shadow:var(--shadow)}
+
+/* ── threads ── */
+.threads{position:sticky;top:18px;display:flex;flex-direction:column;gap:8px;
+  padding:13px 11px 11px;max-height:calc(100vh - 36px)}
+.threads-head{display:flex;align-items:center;justify-content:space-between;padding:2px 5px 0}
+.threads-head .t{display:inline-flex;align-items:center;gap:8px;font-size:11px;font-weight:600;
+  text-transform:uppercase;letter-spacing:.1em;color:var(--text3)}
+.threads-head .ct{font-family:var(--mono);font-size:10.5px;color:var(--text3);background:rgba(0,0,0,.04);padding:1px 6px;border-radius:999px}
+.threads-head button{width:28px;height:28px;border-radius:8px;background:transparent;border:1px solid transparent;
+  color:var(--text2);cursor:pointer;display:grid;place-items:center;font-size:17px;line-height:1}
+.threads-head button:hover{background:rgba(0,0,0,.04);border-color:var(--border);color:var(--text)}
+.tgroup{font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--text3);padding:8px 7px 3px}
+.tlist{display:flex;flex-direction:column;gap:2px;overflow-y:auto;margin:0 -3px;padding:0 3px}
+.trow{position:relative;display:flex;gap:9px;padding:8px 10px;border-radius:11px;cursor:pointer;transition:background .15s}
+.trow:hover{background:rgba(0,0,0,.035)}
+.trow.on{background:color-mix(in srgb,var(--accent-soft) 55%,transparent)}
+.trow.on::before{content:"";position:absolute;left:0;top:7px;bottom:7px;width:2px;background:var(--accent);border-radius:0 2px 2px 0}
+.trow .dot{width:6px;height:6px;border-radius:50%;background:transparent;margin-top:5px;flex:0 0 auto}
+.trow.on .dot{background:var(--accent)}
+.trow .dot.run{background:#f5a623;animation:pulse 1.4s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;box-shadow:0 0 0 0 rgba(245,166,35,.4)}50%{opacity:.6;box-shadow:0 0 0 5px rgba(245,166,35,0)}}
+.trow .body{min-width:0;flex:1}
+.trow .ti{display:flex;align-items:center;gap:6px}
+.trow .title{font-size:13px;font-weight:500;color:var(--text);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.trow.on .title{font-weight:600;color:var(--accent)}
+.trow .time{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--text3);flex:0 0 auto}
+.trow .prev{display:var(--d-thread-prev);font-size:11.5px;line-height:1.4;color:var(--text3);
+  white-space:nowrap;overflow:hidden;text-overflow:ellipsis;margin-top:2px}
+.threads-foot{margin-top:auto;display:flex;flex-direction:column;gap:1px;padding-top:9px;border-top:1px solid var(--border)}
+.threads-foot a{display:flex;align-items:center;gap:9px;padding:7px 10px;border-radius:8px;font-size:12.5px;color:var(--text2)}
+.threads-foot a:hover{background:rgba(0,0,0,.04);color:var(--text)}
+.threads-foot a .badge{margin-left:auto;font-size:10.5px;font-weight:600;color:#fff;background:var(--accent);padding:1px 7px;border-radius:999px}
+
+/* ── conversation ── */
+.convo{background:transparent;border:0;box-shadow:none;min-height:60vh;display:flex;flex-direction:column}
+.thread-title{font-family:var(--display);font-size:15px;font-weight:700;letter-spacing:-.01em;color:var(--text);
+  padding:2px 4px 12px;border-bottom:1px solid var(--border);margin-bottom:18px;display:flex;align-items:center;gap:9px}
+.thread-title .src{margin-left:auto;font-family:var(--body);font-size:11px;font-weight:500;color:var(--text3);
+  display:inline-flex;align-items:center;gap:5px}
+.thread-title .src i{width:6px;height:6px;border-radius:50%;background:var(--success-mid)}
+.feed{display:flex;flex-direction:column;gap:var(--d-msg-gap);max-width:var(--d-bubble)}
+.umsg{align-self:flex-end;background:var(--neutral);border-radius:16px;padding:10px 14px;font-size:14px;max-width:80%}
+.amsg{display:flex;flex-direction:column;gap:11px}
+.toolpill{align-self:flex-start;display:inline-flex;align-items:center;gap:8px;background:color-mix(in srgb,var(--neutral-soft) 60%,transparent);
+  border:1px solid color-mix(in srgb,var(--border) 70%,transparent);border-radius:999px;padding:4px 12px 4px 9px;font-size:11.5px;color:var(--text3);cursor:pointer}
+.toolpill .tg{font-weight:600;color:var(--text)}
+.toolpill .ok{display:inline-flex;align-items:center;gap:5px;background:var(--accent-soft);color:var(--accent);
+  padding:2px 9px;border-radius:999px;font-size:11px}
+.prose{font-size:14.5px;line-height:1.6;color:var(--text)}
+.prose p+p{margin-top:10px}
+.prose b{font-weight:600}
+.answer{position:relative;background:linear-gradient(180deg,color-mix(in srgb,var(--accent) 4%,var(--card)) 0%,var(--card) 60%);
+  border:1px solid color-mix(in srgb,var(--border) 80%,var(--accent) 4%);border-radius:18px;padding:15px 18px;box-shadow:var(--shadow)}
+.kpi-inline{display:flex;align-items:baseline;gap:12px;margin:12px 0 4px;flex-wrap:wrap}
+.kpi-inline .m{font-family:var(--display);font-weight:800;font-size:30px;line-height:1;letter-spacing:-.025em;font-variant-numeric:tabular-nums}
+.kpi-inline .l{font-size:11px;color:var(--text3);text-transform:uppercase;letter-spacing:.1em;font-weight:600}
+.kpi-inline .d{font-size:12px;font-weight:600;padding:2px 9px;border-radius:999px;background:var(--success-soft);color:var(--success-ink)}
+table.data{border-collapse:collapse;width:100%;font-size:13px;margin-top:12px}
+table.data th{text-align:left;font-weight:600;color:var(--text2);border-bottom:1px solid var(--border);padding:6px 12px 6px 0;white-space:nowrap}
+table.data td{padding:7px 12px 7px 0;border-bottom:1px solid var(--border);vertical-align:middle}
+table.data tr:last-child td{border-bottom:0}
+table.data td.num{font-family:var(--mono);font-variant-numeric:tabular-nums;text-align:right;padding-right:0}
+table.data .bar{height:5px;border-radius:3px;background:var(--accent);opacity:.85}
+.confirm{align-self:flex-start;background:linear-gradient(180deg,color-mix(in srgb,var(--success-mid) 7%,var(--card)) 0%,var(--card) 52%);
+  border:1px solid color-mix(in srgb,var(--border) 70%,var(--success-mid) 22%);border-radius:16px;padding:12px 16px;box-shadow:var(--shadow)}
+.confirm .h{display:flex;align-items:center;gap:8px}
+.confirm .chk{width:17px;height:17px;border-radius:50%;background:var(--success-mid);color:#fff;display:grid;place-items:center;font-size:10px}
+.confirm .lab{font-family:var(--display);font-size:10.5px;font-weight:700;letter-spacing:.13em;text-transform:uppercase;color:var(--success-mid)}
+.confirm .ti{font-size:15px;font-weight:600;margin-top:5px}
+
+/* composer */
+.composer{position:sticky;bottom:14px;margin-top:18px;background:rgba(255,255,255,.92);backdrop-filter:blur(8px);
+  border:1px solid var(--border);border-radius:18px;box-shadow:var(--shadow-h);padding:11px 13px 9px}
+.composer textarea{width:100%;border:0;background:transparent;resize:none;font:inherit;font-size:14.5px;color:var(--text);outline:none}
+.composer .cbar{display:flex;align-items:center;gap:10px;margin-top:6px}
+.composer .attach{width:30px;height:30px;border-radius:9px;border:1px solid var(--border);background:var(--card);color:var(--text2);cursor:pointer;display:grid;place-items:center}
+.composer .hint{font-size:11.5px;color:var(--text3)}
+.composer .hint kbd{font-family:var(--mono);font-size:10.5px;background:var(--neutral);border:1px solid var(--border);border-radius:5px;padding:0 4px}
+.composer .send{margin-left:auto;display:inline-flex;align-items:center;gap:7px;background:var(--text);color:var(--bg);
+  border:0;border-radius:999px;padding:8px 15px;font-weight:600;font-size:13px;cursor:pointer}
+.composer .send:hover{transform:translateY(-1px)}
+
+/* ── context rail (compact only) ── */
+.rail{display:var(--d-rail);position:sticky;top:18px;flex-direction:column;gap:11px;padding:13px 13px 14px;max-height:calc(100vh - 36px);overflow-y:auto}
+.rail h4{font-family:var(--display);font-size:10px;font-weight:700;text-transform:uppercase;letter-spacing:.13em;color:var(--text3);
+  display:flex;align-items:center;gap:8px;margin-bottom:9px}
+.rail h4::after{content:"";flex:1;height:1px;background:var(--border)}
+.rail section+section{margin-top:6px}
+.minigrid{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+.mini{background:var(--bg);border:1px solid var(--border);border-radius:12px;padding:9px 10px}
+.mini .k{font-size:9.5px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--text3);margin-bottom:5px}
+.mini .v{font-family:var(--display);font-weight:800;font-size:18px;line-height:1;letter-spacing:-.02em;font-variant-numeric:tabular-nums}
+.mini .s{font-size:10.5px;color:var(--success-ink);margin-top:4px;font-weight:600}
+.artifact{display:flex;align-items:center;gap:9px;padding:8px 10px;border:1px solid var(--border);border-radius:11px;background:var(--bg);cursor:pointer;transition:border-color .15s,transform .15s}
+.artifact+.artifact{margin-top:6px}
+.artifact:hover{border-color:var(--text3);transform:translateY(-1px)}
+.artifact .ic{width:30px;height:30px;border-radius:8px;display:grid;place-items:center;font-family:var(--display);font-weight:700;font-size:9px;color:#fff;flex:0 0 auto}
+.artifact .ic.csv{background:var(--success-mid)}.artifact .ic.png{background:var(--accent)}.artifact .ic.pdf{background:var(--danger)}
+.artifact .n{font-size:12.5px;font-weight:500;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.artifact .meta{font-family:var(--mono);font-size:10.5px;color:var(--text3)}
+.artifact .dl{margin-left:auto;color:var(--text3);font-size:14px}
+.source{display:flex;align-items:center;gap:8px;padding:6px 2px;font-size:12.5px;color:var(--text2)}
+.source .sd{width:6px;height:6px;border-radius:2px;background:var(--accent);opacity:.7}
+.source .cnt{margin-left:auto;font-family:var(--mono);font-size:10.5px;color:var(--text3)}
+.chips{display:flex;flex-direction:column;gap:6px}
+.chip{text-align:left;background:var(--bg);border:1px solid var(--border);border-radius:11px;padding:9px 11px;cursor:pointer;
+  font:inherit;font-size:12.5px;color:var(--text2);transition:border-color .15s,background .15s,transform .15s;display:flex;gap:8px;align-items:center}
+.chip:hover{border-color:var(--accent);color:var(--accent);background:var(--accent-soft);transform:translateY(-1px)}
+.chip .arr{margin-left:auto;color:var(--text3)}
+.chip:hover .arr{color:var(--accent)}
+.memo{background:var(--bg);border:1px solid var(--border);border-left:2px solid var(--accent);border-radius:11px;padding:9px 11px;font-size:12px;line-height:1.45;color:var(--text2)}
+
+@media (max-width:1080px){
+  html[data-density="compact"]{--d-cols:248px minmax(0,1fr);--d-rail:none}
+}
+@media (max-width:680px){
+  html[data-density]{--d-cols:1fr;--d-rail:none;--d-canvas:100%}
+  .threads{position:static;max-height:38vh}.nav{display:none}
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="topbar">
+    <span class="brand"><span class="mark"></span>OpenNeko <span class="ver">1.17.2</span></span>
+    <nav class="nav">
+      <a href="#">Dashboard</a>
+      <a href="#" class="on">Ask</a>
+      <a href="#">Actions</a>
+      <a href="#">Workflows</a>
+    </nav>
+    <span class="spacer"></span>
+    <div class="seg" role="group" aria-label="Information density">
+      <button data-set="comfortable" aria-pressed="false">
+        <svg class="ic" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="3" width="12" height="3.4" rx="1.2"/><rect x="2" y="9.6" width="12" height="3.4" rx="1.2"/></svg>Comfortable</button>
+      <button data-set="compact" aria-pressed="true">
+        <svg class="ic" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="2.5" width="3.2" height="11" rx="1.1"/><rect x="6.4" y="2.5" width="3.2" height="11" rx="1.1"/><rect x="10.8" y="2.5" width="3.2" height="11" rx="1.1"/></svg>Compact</button>
+    </div>
+  </div>
+
+  <div class="ask">
+
+    <!-- THREADS -->
+    <aside class="pane threads">
+      <div class="threads-head">
+        <span class="t">Threads <span class="ct">9</span></span>
+        <button title="New thread">+</button>
+      </div>
+      <div class="tlist">
+        <div class="tgroup">Today</div>
+        <div class="trow on">
+          <span class="dot"></span>
+          <div class="body">
+            <div class="ti"><span class="title">Top customers & concentration</span><span class="time">9:14a</span></div>
+            <div class="prev">Top 10 are 48% of revenue — Acme leads at $1.2M…</div>
+          </div>
+        </div>
+        <div class="trow">
+          <span class="dot run"></span>
+          <div class="body">
+            <div class="ti"><span class="title">Q2 burn vs forecast</span><span class="time">8:51a</span></div>
+            <div class="prev">Running — reconciling AWS + payroll…</div>
+          </div>
+        </div>
+        <div class="trow">
+          <span class="dot"></span>
+          <div class="body">
+            <div class="ti"><span class="title">Reorder-risk SKUs</span><span class="time">8:22a</span></div>
+            <div class="prev">14 products below threshold; 3 critical.</div>
+          </div>
+        </div>
+        <div class="tgroup">Yesterday</div>
+        <div class="trow">
+          <span class="dot"></span>
+          <div class="body">
+            <div class="ti"><span class="title">Churn cohort breakdown</span><span class="time">Mon</span></div>
+            <div class="prev">Mid-market churn up 1.8pt after trial change.</div>
+          </div>
+        </div>
+        <div class="trow">
+          <span class="dot"></span>
+          <div class="body">
+            <div class="ti"><span class="title">Lead source ROI</span><span class="time">Mon</span></div>
+            <div class="prev">Organic docs page is the top converter.</div>
+          </div>
+        </div>
+        <div class="tgroup">Earlier</div>
+        <div class="trow">
+          <span class="dot"></span>
+          <div class="body">
+            <div class="ti"><span class="title">Pricing page experiment</span><span class="time">May 30</span></div>
+            <div class="prev">Usage-based variant lifted intent 9%.</div>
+          </div>
+        </div>
+        <div class="trow">
+          <span class="dot"></span>
+          <div class="body">
+            <div class="ti"><span class="title">Support SLA audit</span><span class="time">May 28</span></div>
+            <div class="prev">First-response median 42m, p90 3.1h.</div>
+          </div>
+        </div>
+      </div>
+      <div class="threads-foot">
+        <a href="#">▢ Workflows</a>
+        <a href="#">✦ Skills</a>
+        <a href="#">◐ Memory <span class="badge">2</span></a>
+      </div>
+    </aside>
+
+    <!-- CONVERSATION -->
+    <main class="convo">
+      <div class="thread-title">
+        <span>Top customers &amp; concentration</span>
+        <span class="src"><i></i>postgres · live</span>
+      </div>
+      <div class="feed">
+        <div class="umsg">Who are our top 10 customers by revenue this year, and how concentrated is it?</div>
+
+        <div class="amsg">
+          <button class="toolpill"><span class="mono">▸</span> Queried database <span class="tg">· 3 steps</span> <span class="ok">✓ done</span></button>
+          <div class="answer">
+            <div class="prose">
+              <p>Your top 10 customers account for <b>48% of YTD revenue</b> — moderately concentrated, but no single account is a cliff risk. <b>Acme Corp</b> leads at $1.2M (9.4% of total).</p>
+            </div>
+            <div class="kpi-inline">
+              <span class="m">48%</span><span class="l">top-10 share</span><span class="d">▲ healthy spread</span>
+            </div>
+            <table class="data">
+              <thead><tr><th>Customer</th><th>YTD revenue</th><th style="width:90px"></th><th class="num">Share</th></tr></thead>
+              <tbody>
+                <tr><td>Acme Corp</td><td class="num">$1,204k</td><td><div class="bar" style="width:100%"></div></td><td class="num">9.4%</td></tr>
+                <tr><td>Globex</td><td class="num">$842k</td><td><div class="bar" style="width:70%"></div></td><td class="num">6.6%</td></tr>
+                <tr><td>Initech</td><td class="num">$731k</td><td><div class="bar" style="width:61%"></div></td><td class="num">5.7%</td></tr>
+                <tr><td>Umbrella</td><td class="num">$655k</td><td><div class="bar" style="width:54%"></div></td><td class="num">5.1%</td></tr>
+                <tr><td>Soylent</td><td class="num">$598k</td><td><div class="bar" style="width:50%"></div></td><td class="num">4.7%</td></tr>
+                <tr><td>Hooli</td><td class="num">$540k</td><td><div class="bar" style="width:45%"></div></td><td class="num">4.2%</td></tr>
+              </tbody>
+            </table>
+            <div class="prose" style="margin-top:12px"><p>Concentration is <b>down from 53% last year</b> as mid-market revenue broadened the base. Full table saved to the rail →</p></div>
+          </div>
+          <div class="confirm">
+            <div class="h"><span class="chk">✓</span><span class="lab">Saved to memory</span></div>
+            <div class="ti">Revenue concentration tracked monthly</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="composer">
+        <textarea rows="1" placeholder="Ask a follow-up…"></textarea>
+        <div class="cbar">
+          <button class="attach" title="Attach">⎘</button>
+          <span class="hint">Enter <kbd>↵</kbd> to send · Shift <kbd>↵</kbd> for newline</span>
+          <button class="send">Send ↑</button>
+        </div>
+      </div>
+    </main>
+
+    <!-- CONTEXT RAIL (compact only) -->
+    <aside class="pane rail">
+      <section>
+        <h4>Answer vitals</h4>
+        <div class="minigrid">
+          <div class="mini"><div class="k">Top-10 share</div><div class="v">48%</div><div class="s">▼ from 53%</div></div>
+          <div class="mini"><div class="k">#1 account</div><div class="v">$1.2M</div><div class="s">Acme · 9.4%</div></div>
+          <div class="mini"><div class="k">Customers</div><div class="v">1,284</div><div class="s">▲ 31 MoM</div></div>
+          <div class="mini"><div class="k">YoY revenue</div><div class="v">+14%</div><div class="s">$12.8M YTD</div></div>
+        </div>
+      </section>
+      <section>
+        <h4>Artifacts</h4>
+        <div class="artifact"><span class="ic csv">CSV</span><div style="min-width:0"><div class="n">top-customers-ytd.csv</div><div class="meta">10 rows · 2 KB</div></div><span class="dl">↓</span></div>
+        <div class="artifact"><span class="ic png">PNG</span><div style="min-width:0"><div class="n">concentration.png</div><div class="meta">chart · 48 KB</div></div><span class="dl">↓</span></div>
+      </section>
+      <section>
+        <h4>Sources touched</h4>
+        <div class="source"><span class="sd"></span>orders<span class="cnt">3.2M rows</span></div>
+        <div class="source"><span class="sd"></span>customers<span class="cnt">1,284</span></div>
+        <div class="source"><span class="sd"></span>invoices<span class="cnt">41k</span></div>
+      </section>
+      <section>
+        <h4>Ask next</h4>
+        <div class="chips">
+          <button class="chip">Break down by region<span class="arr">→</span></button>
+          <button class="chip">Which top accounts are at churn risk?<span class="arr">→</span></button>
+          <button class="chip">Compare to last year by quarter<span class="arr">→</span></button>
+        </div>
+      </section>
+      <section>
+        <h4>Related memory</h4>
+        <div class="memo">Board cares about &lt;50% top-10 concentration as a health metric — flag if it climbs back.</div>
+      </section>
+    </aside>
+
+  </div>
+</div>
+
+<script>
+const root=document.documentElement;
+document.querySelectorAll('.seg button').forEach(btn=>btn.addEventListener('click',()=>{
+  root.setAttribute('data-density',btn.dataset.set);
+  document.querySelectorAll('.seg button').forEach(b=>b.setAttribute('aria-pressed',String(b===btn)));
+}));
+document.querySelectorAll('.trow').forEach(r=>r.addEventListener('click',()=>{
+  document.querySelectorAll('.trow').forEach(x=>x.classList.remove('on'));
+  r.classList.add('on');
+}));
+</script>
+</body>
+</html>

--- a/apps/web/dense-workflows-prototype.html
+++ b/apps/web/dense-workflows-prototype.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="en" data-density="compact">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>OpenNeko · Workflows — density study</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Archivo:wght@500;600;700;800;900&family=Manrope:wght@400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+/* OpenNeko Workflows — density study. Comfortable = today's single-column
+   rows (name + desc + schedule). Compact = tiled cards that surface each
+   watcher's vitals (next run, runs today, last status, pending) at a glance. */
+:root{
+  --bg:#FAFAF7;--card:#FFFFFF;--text:#2D2A24;--text2:#7A756A;--text3:#B0AA9F;
+  --border:#EEEBE4;--neutral:#F2EFE8;--neutral-soft:#F7F4ED;
+  --accent:#6B5CE7;--accent-soft:#EDE9FE;
+  --success:#6CFF7F;--success-ink:#113719;--success-soft:#E2FBE6;--success-mid:#4CAF82;
+  --watch:#E9A23B;--watch-soft:#FFF1D8;--warn-ink:#8A6D00;
+  --danger:#E05656;--danger-soft:#FEECEC;
+  --shadow:0 1px 3px rgba(20,18,12,.04),0 4px 16px rgba(20,18,12,.03);
+  --shadow-h:0 2px 8px rgba(20,18,12,.06),0 12px 36px -8px rgba(20,18,12,.07);
+  --display:'Archivo',sans-serif;--body:'Manrope',sans-serif;--mono:'Geist Mono',ui-monospace,monospace;
+}
+html[data-density="comfortable"]{--d-canvas:1000px;--d-grid:1fr;--d-meta:none;--d-pad:14px 18px;--d-radius:14px}
+html[data-density="compact"]{--d-canvas:1280px;--d-grid:repeat(auto-fill,minmax(340px,1fr));--d-meta:grid;--d-pad:13px 15px 14px;--d-radius:15px}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:var(--body);background:var(--bg);color:var(--text);line-height:1.5;-webkit-font-smoothing:antialiased;padding-bottom:60px}
+body::before{content:"";position:fixed;inset:0;pointer-events:none;z-index:0;
+  background-image:radial-gradient(circle at 15% 8%,rgba(107,92,231,.05),transparent 42%),radial-gradient(circle at 90% 4%,rgba(108,255,127,.05),transparent 40%)}
+.wrap{position:relative;z-index:1;max-width:var(--d-canvas);margin:0 auto;padding:24px 22px 0;transition:max-width .45s cubic-bezier(.4,0,.2,1)}
+a{color:inherit;text-decoration:none}
+.mono{font-family:var(--mono);font-variant-numeric:tabular-nums}
+
+/* top bar */
+.topbar{display:flex;align-items:center;gap:16px;margin-bottom:18px}
+.brand{display:inline-flex;align-items:center;gap:9px;font-family:var(--display);font-weight:800;font-size:17px;letter-spacing:-.02em}
+.brand .mark{width:19px;height:19px;border-radius:50%;background:conic-gradient(from 220deg,var(--text) 0 50%,transparent 50% 100%);border:1.5px solid var(--text)}
+.brand .ver{font-family:var(--body);font-weight:600;font-size:10.5px;color:var(--text2);background:var(--neutral);padding:2px 6px;border-radius:999px}
+.nav{display:flex;gap:2px;margin-left:6px}
+.nav a{font-size:13.5px;font-weight:500;color:var(--text2);padding:7px 12px;border-radius:999px;border:1px solid transparent}
+.nav a:hover{background:rgba(20,18,12,.04);color:var(--text)}
+.nav a.on{border-color:var(--border);color:var(--text);font-weight:600}
+.nav a.on::before{content:"";display:inline-block;width:5px;height:5px;border-radius:50%;background:var(--accent);margin-right:7px;vertical-align:2px}
+.spacer{flex:1}
+.seg{display:inline-flex;background:var(--neutral);border:1px solid var(--border);border-radius:999px;padding:3px;gap:2px}
+.seg button{font-family:var(--body);font-weight:600;font-size:12.5px;color:var(--text2);border:0;background:transparent;padding:6px 14px;border-radius:999px;cursor:pointer;display:inline-flex;align-items:center;gap:6px}
+.seg button .ic{width:13px;height:13px}
+.seg button[aria-pressed="true"]{background:var(--card);color:var(--text);box-shadow:0 1px 2px rgba(20,18,12,.08),0 2px 8px -2px rgba(20,18,12,.1)}
+
+/* page head */
+.head{display:flex;align-items:center;gap:13px;margin-bottom:22px}
+.head .ico{width:36px;height:36px;border-radius:11px;background:var(--accent-soft);color:var(--accent);display:grid;place-items:center;font-size:17px}
+.head h1{font-family:var(--display);font-size:24px;font-weight:800;letter-spacing:-.02em;line-height:1.1}
+.head .sub{font-size:13px;color:var(--text3);margin-top:1px}
+.head .new{margin-left:auto;font-size:14px;font-weight:600;color:var(--text2);background:rgba(255,255,255,.6);border:1.5px solid var(--border);border-radius:100px;padding:9px 16px;cursor:pointer;transition:border-color .18s,color .18s,background .18s,transform .18s}
+.head .new:hover{border-color:var(--accent);color:var(--accent);background:var(--accent-soft);transform:translateY(-1px)}
+
+/* group label */
+.glabel{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.12em;color:var(--text3);margin:0 0 12px;display:flex;align-items:center;gap:9px}
+.glabel::after{content:"";flex:1;height:1px;background:var(--border)}
+.glabel .ct{color:var(--text2);background:var(--neutral);border-radius:999px;padding:1px 8px;font-size:10.5px}
+section{margin-bottom:26px}
+
+/* grid + card */
+.grid{display:grid;grid-template-columns:var(--d-grid);gap:11px;transition:grid-template-columns .1s}
+.wf{position:relative;background:var(--card);border:1px solid var(--border);border-radius:var(--d-radius);padding:var(--d-pad);
+  cursor:pointer;transition:border-color .18s,transform .18s,box-shadow .18s;overflow:hidden}
+.wf:hover{border-color:var(--text3);transform:translateY(-1px);box-shadow:var(--shadow)}
+.wf.broken{border-color:rgba(224,86,86,.4)}
+.wf.broken::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--danger);opacity:.8}
+.wf.paused{opacity:.82}
+.wf-top{display:flex;align-items:center;gap:9px}
+.wf-dot{width:7px;height:7px;border-radius:50%;flex:0 0 auto}
+.wf.active .wf-dot{background:var(--success-mid);box-shadow:0 0 0 3px var(--success-soft)}
+.wf.paused .wf-dot{background:var(--text3)}
+.wf.broken .wf-dot{background:var(--danger);box-shadow:0 0 0 3px var(--danger-soft)}
+.wf-dot.run{background:var(--watch)!important;box-shadow:0 0 0 3px var(--watch-soft)!important;animation:pulse 1.5s ease-in-out infinite}
+@keyframes pulse{0%,100%{box-shadow:0 0 0 3px var(--watch-soft)}50%{box-shadow:0 0 0 6px transparent}}
+.wf-name{font-family:var(--display);font-size:15px;font-weight:700;letter-spacing:-.01em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+.wf-pending{margin-left:auto;flex:0 0 auto;font-size:10.5px;font-weight:700;color:#fff;background:var(--watch);padding:1px 8px;border-radius:999px;letter-spacing:.02em}
+.wf-del{margin-left:auto;flex:0 0 auto;width:24px;height:24px;border-radius:7px;border:0;background:transparent;color:var(--text3);cursor:pointer;display:none;place-items:center;font-size:13px}
+.wf:hover .wf-del{display:grid}
+.wf:hover .wf-pending+.wf-del{margin-left:6px}
+.wf-desc{font-size:12.5px;line-height:1.45;color:var(--text2);margin-top:7px;
+  display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}
+.wf-sched{font-family:var(--mono);font-size:11.5px;color:var(--text3);margin-top:9px;display:flex;align-items:center;gap:8px}
+.wf-bars{display:flex;align-items:flex-end;gap:1.5px;height:15px;margin-left:auto}
+.wf-bars i{width:3px;background:var(--text3);border-radius:1px;opacity:.85}
+
+/* vitals (compact only) */
+.wf-meta{display:var(--d-meta);grid-template-columns:1fr 1fr;gap:7px 12px;margin-top:11px;padding-top:11px;border-top:1px solid var(--border)}
+.wf-meta>div{min-width:0}
+.wf-meta .k{font-size:9px;font-weight:700;text-transform:uppercase;letter-spacing:.1em;color:var(--text3);margin-bottom:3px}
+.wf-meta .v{font-size:12.5px;font-weight:600;color:var(--text);font-variant-numeric:tabular-nums;display:flex;align-items:center;gap:6px}
+.wf-meta .v.ok{color:var(--success-mid)}
+.wf-meta .v.bad{color:var(--danger)}
+.wf-meta .v.warn{color:var(--warn-ink)}
+.budget{height:4px;border-radius:2px;background:var(--neutral);flex:1;min-width:28px;overflow:hidden;max-width:54px}
+.budget i{display:block;height:100%;background:var(--accent);border-radius:2px}
+.budget.hot i{background:var(--watch)}
+
+@media (max-width:680px){html[data-density]{--d-canvas:100%;--d-grid:1fr;--d-meta:grid}.nav{display:none}}
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <div class="topbar">
+    <span class="brand"><span class="mark"></span>OpenNeko <span class="ver">1.17.2</span></span>
+    <nav class="nav"><a href="#">Dashboard</a><a href="#">Ask</a><a href="#">Actions</a><a href="#" class="on">Workflows</a></nav>
+    <span class="spacer"></span>
+    <div class="seg" role="group" aria-label="Density">
+      <button data-set="comfortable" aria-pressed="false"><svg class="ic" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="3" width="12" height="3.4" rx="1.2"/><rect x="2" y="9.6" width="12" height="3.4" rx="1.2"/></svg>Comfortable</button>
+      <button data-set="compact" aria-pressed="true"><svg class="ic" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6"><rect x="2" y="2.5" width="5" height="5" rx="1.2"/><rect x="9" y="2.5" width="5" height="5" rx="1.2"/><rect x="2" y="8.5" width="5" height="5" rx="1.2"/><rect x="9" y="8.5" width="5" height="5" rx="1.2"/></svg>Compact</button>
+    </div>
+  </div>
+
+  <div class="head">
+    <span class="ico">▢</span>
+    <div><h1>Workflows</h1><div class="sub">8 watchers · 5 active</div></div>
+    <button class="new">+ New workflow</button>
+  </div>
+
+  <section>
+    <div class="glabel">Active <span class="ct">5</span></div>
+    <div class="grid" id="g-active"></div>
+  </section>
+  <section>
+    <div class="glabel">Paused <span class="ct">2</span></div>
+    <div class="grid" id="g-paused"></div>
+  </section>
+  <section>
+    <div class="glabel">Needs attention <span class="ct">1</span></div>
+    <div class="grid" id="g-broken"></div>
+  </section>
+
+</div>
+
+<script>
+function bars(values){const max=Math.max(1,...values);return `<span class="wf-bars">`+values.map(v=>{
+  const h=Math.max(2,Math.round((v/max)*15));return `<i style="height:${h}px;opacity:${v===0?.3:.85}"></i>`}).join('')+`</span>`}
+
+function metaCell(k,v,cls,extra){return `<div><div class="k">${k}</div><div class="v ${cls||''}">${v}${extra||''}</div></div>`}
+function budget(used,cap){const pct=Math.round(used/cap*100);return `<div class="budget ${pct>=80?'hot':''}"><i style="width:${pct}%"></i></div>`}
+
+const ACTIVE=[
+  {name:'Revenue concentration watch',state:'active',desc:'Tracks top-10 customer share daily and flags if concentration climbs back above 50%.',
+   sched:'Daily · 9:00a',next:'in 19h',used:1,cap:3,last:'✓ 2h ago',lastCls:'ok',pending:0,spark:[1,0,1,1,0,1,2,1,0,1,1,0,2,1]},
+  {name:'Churn-risk outreach',state:'active',running:true,desc:'Watches workflow outputs tagged "watch" and drafts retention notes to at-risk enterprise accounts.',
+   sched:'Every 6h',next:'running…',used:2,cap:8,last:'✓ 22m ago',lastCls:'ok',pending:3,spark:[2,1,3,2,4,2,3,5,2,3,4,3,2,4]},
+  {name:'Inventory reorder',state:'active',desc:'Compares stock against reorder thresholds and proposes purchase orders for at-risk SKUs.',
+   sched:'Daily · 7:00a',next:'in 17h',used:1,cap:2,last:'✓ 5h ago',lastCls:'ok',pending:2,spark:[1,1,0,1,2,1,1,0,1,1,2,1,1,1]},
+  {name:'Competitor radar',state:'active',desc:'Scans tracked competitors\' changelogs and pricing pages, summarising anything material.',
+   sched:'Daily · 6:00a',next:'in 16h',used:1,cap:1,last:'✓ 1h ago',lastCls:'ok',pending:0,spark:[0,1,0,0,1,0,1,0,0,1,0,0,1,0]},
+  {name:'Lead triage',state:'active',desc:'Fires on every inbound lead: scores ICP fit, tags, and routes high-fit leads to an AE.',
+   sched:'On new lead',next:'event-driven',used:41,cap:200,last:'✓ 4m ago',lastCls:'ok',pending:0,spark:[6,9,5,8,12,7,9,14,8,11,9,13,7,10]},
+];
+const PAUSED=[
+  {name:'Support SLA monitor',state:'paused',desc:'Hourly check on first-response times; pings #support when p90 crosses 3h.',
+   sched:'Hourly · paused',next:'—',used:0,cap:24,last:'✓ yesterday',lastCls:'',pending:0,spark:[1,1,2,1,0,1,1,2,1,1,0,1,1,1]},
+  {name:'Weekly board digest',state:'paused',desc:'Assembles the Monday metrics email for the leadership channel.',
+   sched:'Weekly · Mon 8:00a',next:'—',used:0,cap:1,last:'✓ Mon',lastCls:'',pending:0,spark:[0,0,0,0,0,0,1,0,0,0,0,0,0,1]},
+];
+const BROKEN=[
+  {name:'Invoice anomaly check',state:'broken',desc:'Flags invoices that deviate from historical patterns. Last run failed: GraphJin column ref error.',
+   sched:'Daily · 3:00a',next:'paused on error',used:0,cap:2,last:'✗ failed 3h ago',lastCls:'bad',pending:0,spark:[1,1,0,1,1,0,1,0,0,0,0,0,0,0]},
+];
+
+function card(w){
+  const running=w.running?' run':'';
+  const pend=w.pending>0?`<span class="wf-pending">${w.pending} pending</span>`:'';
+  return `<article class="wf ${w.state}">
+    <div class="wf-top">
+      <span class="wf-dot${running}"></span>
+      <span class="wf-name">${w.name}</span>
+      ${pend}
+      <button class="wf-del" title="Delete">🗑</button>
+    </div>
+    <div class="wf-desc">${w.desc}</div>
+    <div class="wf-sched"><span>${w.sched}</span>${bars(w.spark)}</div>
+    <div class="wf-meta">
+      ${metaCell('Next run',w.next)}
+      ${metaCell('Today',`${w.used}/${w.cap}`,'',budget(w.used,w.cap))}
+      ${metaCell('Last run',w.last,w.lastCls)}
+      ${metaCell('Pending',w.pending>0?`${w.pending} action${w.pending>1?'s':''}`:'none',w.pending>0?'warn':'')}
+    </div>
+  </article>`;
+}
+document.getElementById('g-active').innerHTML=ACTIVE.map(card).join('');
+document.getElementById('g-paused').innerHTML=PAUSED.map(card).join('');
+document.getElementById('g-broken').innerHTML=BROKEN.map(card).join('');
+document.querySelectorAll('.wf-del').forEach(b=>b.addEventListener('click',e=>e.stopPropagation()));
+
+const root=document.documentElement;
+document.querySelectorAll('.seg button').forEach(btn=>btn.addEventListener('click',()=>{
+  root.setAttribute('data-density',btn.dataset.set);
+  document.querySelectorAll('.seg button').forEach(b=>b.setAttribute('aria-pressed',String(b===btn)));
+}));
+</script>
+</body>
+</html>

--- a/apps/web/src/a2ui/renderer.tsx
+++ b/apps/web/src/a2ui/renderer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Fragment } from "react";
 import type { A2UIComponent, SurfaceState } from "./types";
 import type { BriefingCardProps, BriefingProps } from "./catalog";
 import { resolveComponent } from "./surface";
@@ -53,10 +54,13 @@ export function renderComponentsByType(
   context: RenderContext
 ): React.ReactNode[] {
   const nodes: React.ReactNode[] = [];
-  for (const [, comp] of surface.components) {
+  let i = 0;
+  for (const [id, comp] of surface.components) {
     if (comp.component === type) {
-      nodes.push(renderComponent(comp, context));
+      const node = renderComponent(comp, context);
+      if (node != null) nodes.push(<Fragment key={id || `c${i}`}>{node}</Fragment>);
     }
+    i += 1;
   }
   return nodes;
 }
@@ -67,10 +71,13 @@ export function renderChildren(
   context: RenderContext
 ): React.ReactNode[] {
   return childIds
-    .map((id) => {
+    .map((id, i) => {
       const comp = context.surface.components.get(id);
       if (!comp) return null;
-      return renderComponent(comp, context);
+      const node = renderComponent(comp, context);
+      // Components can arrive without an id; fall back to position so the list
+      // key is always present and unique.
+      return node == null ? null : <Fragment key={id || `c${i}`}>{node}</Fragment>;
     })
     .filter(Boolean);
 }

--- a/apps/web/src/app/(work)/layout.tsx
+++ b/apps/web/src/app/(work)/layout.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useEffect } from "react";
+import { usePathname } from "next/navigation";
 import AppHeader from "@/components/AppHeader";
 import CreatorCredit from "@/components/CreatorCredit";
 import SectionNav from "@/components/SectionNav";
 import WorkSidebar from "./work/WorkSidebar";
+import WorkContextRail from "./work/WorkContextRail";
 import { WorkShellProvider } from "./work-shell-context";
 
 export default function WorkShellLayout({
@@ -20,6 +22,11 @@ export default function WorkShellLayout({
     return () => document.body.classList.remove("work-shell");
   }, []);
 
+  // The context rail (3rd pane) belongs only to the Ask thread pages, not the
+  // other surfaces (workflows/skills/memory) that share this shell.
+  const pathname = usePathname();
+  const showRail = pathname === "/work" || pathname?.startsWith("/work/");
+
   return (
     <WorkShellProvider>
       <div className="root">
@@ -27,9 +34,10 @@ export default function WorkShellLayout({
           <SectionNav current="work" />
         </AppHeader>
 
-        <div className="work-layout">
+        <div className={`work-layout${showRail ? " has-rail" : ""}`}>
           <WorkSidebar />
           <section className="min-h-[72vh] flex flex-col gap-[18px]">{children}</section>
+          {showRail && <WorkContextRail />}
         </div>
       </div>
       <CreatorCredit />

--- a/apps/web/src/app/(work)/work-shell-context.tsx
+++ b/apps/web/src/app/(work)/work-shell-context.tsx
@@ -4,13 +4,15 @@ import { createContext, useContext, useMemo, useState } from "react";
 
 export type RailArtifact = { path: string; label: string; mimeType?: string };
 export type RailSource = { name: string; detail?: string };
+export type RailVital = { label: string; value: string; sub?: string };
 
 export type RailContext = {
+  vitals: RailVital[];
   sources: RailSource[];
   followups: string[];
 };
 
-const EMPTY_RAIL: RailContext = { sources: [], followups: [] };
+const EMPTY_RAIL: RailContext = { vitals: [], sources: [], followups: [] };
 
 type WorkShellContextValue = {
   activeRunId: string | null;
@@ -19,8 +21,9 @@ type WorkShellContextValue = {
   // the context rail (rendered up in the shell layout) can list them.
   railArtifacts: RailArtifact[];
   setRailArtifacts: (a: RailArtifact[]) => void;
-  // Right-rail context for the active thread: sources touched (derived from
-  // run telemetry) and LLM-generated follow-ups. Lifted from WorkScreen.
+  // Right-rail context for the active thread: the answer's headline vitals and
+  // follow-ups (channel-agnostic content the agent emits), plus sources touched
+  // (derived from run telemetry). Lifted from WorkScreen.
   railContext: RailContext;
   setRailContext: (c: RailContext) => void;
 };

--- a/apps/web/src/app/(work)/work-shell-context.tsx
+++ b/apps/web/src/app/(work)/work-shell-context.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { createContext, useContext, useMemo, useState } from "react";
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type MutableRefObject,
+} from "react";
 
 export type RailArtifact = { path: string; label: string; mimeType?: string };
 export type RailSource = { name: string; detail?: string };
@@ -26,6 +33,10 @@ type WorkShellContextValue = {
   // (derived from run telemetry). Lifted from WorkScreen.
   railContext: RailContext;
   setRailContext: (c: RailContext) => void;
+  // Imperative handle WorkScreen registers so the rail can drop an "Ask next"
+  // question into the CURRENT thread's composer (for the operator to edit),
+  // without the rail reaching into WorkScreen's draft state.
+  insertComposerRef: MutableRefObject<((q: string) => void) | null>;
 };
 
 const WorkShellContext = createContext<WorkShellContextValue>({
@@ -35,12 +46,14 @@ const WorkShellContext = createContext<WorkShellContextValue>({
   setRailArtifacts: () => {},
   railContext: EMPTY_RAIL,
   setRailContext: () => {},
+  insertComposerRef: { current: null },
 });
 
 export function WorkShellProvider({ children }: { children: React.ReactNode }) {
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
   const [railArtifacts, setRailArtifacts] = useState<RailArtifact[]>([]);
   const [railContext, setRailContext] = useState<RailContext>(EMPTY_RAIL);
+  const insertComposerRef = useRef<((q: string) => void) | null>(null);
   const value = useMemo(
     () => ({
       activeRunId,
@@ -49,6 +62,7 @@ export function WorkShellProvider({ children }: { children: React.ReactNode }) {
       setRailArtifacts,
       railContext,
       setRailContext,
+      insertComposerRef,
     }),
     [activeRunId, railArtifacts, railContext],
   );

--- a/apps/web/src/app/(work)/work-shell-context.tsx
+++ b/apps/web/src/app/(work)/work-shell-context.tsx
@@ -2,21 +2,30 @@
 
 import { createContext, useContext, useMemo, useState } from "react";
 
+export type RailArtifact = { path: string; label: string; mimeType?: string };
+
 type WorkShellContextValue = {
   activeRunId: string | null;
   setActiveRunId: (runId: string | null) => void;
+  // Artifacts produced by the active thread's runs, lifted from WorkScreen so
+  // the context rail (rendered up in the shell layout) can list them.
+  railArtifacts: RailArtifact[];
+  setRailArtifacts: (a: RailArtifact[]) => void;
 };
 
 const WorkShellContext = createContext<WorkShellContextValue>({
   activeRunId: null,
   setActiveRunId: () => {},
+  railArtifacts: [],
+  setRailArtifacts: () => {},
 });
 
 export function WorkShellProvider({ children }: { children: React.ReactNode }) {
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
+  const [railArtifacts, setRailArtifacts] = useState<RailArtifact[]>([]);
   const value = useMemo(
-    () => ({ activeRunId, setActiveRunId }),
-    [activeRunId],
+    () => ({ activeRunId, setActiveRunId, railArtifacts, setRailArtifacts }),
+    [activeRunId, railArtifacts],
   );
   return (
     <WorkShellContext.Provider value={value}>

--- a/apps/web/src/app/(work)/work-shell-context.tsx
+++ b/apps/web/src/app/(work)/work-shell-context.tsx
@@ -3,6 +3,16 @@
 import { createContext, useContext, useMemo, useState } from "react";
 
 export type RailArtifact = { path: string; label: string; mimeType?: string };
+export type RailVital = { label: string; value: string; sub?: string };
+export type RailSource = { name: string; detail?: string };
+
+export type RailContext = {
+  vitals: RailVital[];
+  sources: RailSource[];
+  followups: string[];
+};
+
+const EMPTY_RAIL: RailContext = { vitals: [], sources: [], followups: [] };
 
 type WorkShellContextValue = {
   activeRunId: string | null;
@@ -11,6 +21,10 @@ type WorkShellContextValue = {
   // the context rail (rendered up in the shell layout) can list them.
   railArtifacts: RailArtifact[];
   setRailArtifacts: (a: RailArtifact[]) => void;
+  // Agent-emitted right-rail context (vitals / sources / followups) for the
+  // active thread, lifted from the run's `ask_context` events.
+  railContext: RailContext;
+  setRailContext: (c: RailContext) => void;
 };
 
 const WorkShellContext = createContext<WorkShellContextValue>({
@@ -18,14 +32,24 @@ const WorkShellContext = createContext<WorkShellContextValue>({
   setActiveRunId: () => {},
   railArtifacts: [],
   setRailArtifacts: () => {},
+  railContext: EMPTY_RAIL,
+  setRailContext: () => {},
 });
 
 export function WorkShellProvider({ children }: { children: React.ReactNode }) {
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
   const [railArtifacts, setRailArtifacts] = useState<RailArtifact[]>([]);
+  const [railContext, setRailContext] = useState<RailContext>(EMPTY_RAIL);
   const value = useMemo(
-    () => ({ activeRunId, setActiveRunId, railArtifacts, setRailArtifacts }),
-    [activeRunId, railArtifacts],
+    () => ({
+      activeRunId,
+      setActiveRunId,
+      railArtifacts,
+      setRailArtifacts,
+      railContext,
+      setRailContext,
+    }),
+    [activeRunId, railArtifacts, railContext],
   );
   return (
     <WorkShellContext.Provider value={value}>

--- a/apps/web/src/app/(work)/work-shell-context.tsx
+++ b/apps/web/src/app/(work)/work-shell-context.tsx
@@ -3,16 +3,14 @@
 import { createContext, useContext, useMemo, useState } from "react";
 
 export type RailArtifact = { path: string; label: string; mimeType?: string };
-export type RailVital = { label: string; value: string; sub?: string };
 export type RailSource = { name: string; detail?: string };
 
 export type RailContext = {
-  vitals: RailVital[];
   sources: RailSource[];
   followups: string[];
 };
 
-const EMPTY_RAIL: RailContext = { vitals: [], sources: [], followups: [] };
+const EMPTY_RAIL: RailContext = { sources: [], followups: [] };
 
 type WorkShellContextValue = {
   activeRunId: string | null;
@@ -21,8 +19,8 @@ type WorkShellContextValue = {
   // the context rail (rendered up in the shell layout) can list them.
   railArtifacts: RailArtifact[];
   setRailArtifacts: (a: RailArtifact[]) => void;
-  // Agent-emitted right-rail context (vitals / sources / followups) for the
-  // active thread, lifted from the run's `ask_context` events.
+  // Right-rail context for the active thread: sources touched (derived from
+  // run telemetry) and LLM-generated follow-ups. Lifted from WorkScreen.
   railContext: RailContext;
   setRailContext: (c: RailContext) => void;
 };

--- a/apps/web/src/app/(work)/work/WorkContextRail.tsx
+++ b/apps/web/src/app/(work)/work/WorkContextRail.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import Link from "next/link";
 import { FileText, Image as ImageIcon, Sheet, File, ArrowRight } from "lucide-react";
 import { useWorkShell } from "../work-shell-context";
 
@@ -41,7 +40,7 @@ function ArtifactIcon({ name, mime }: { name: string; mime?: string }) {
 }
 
 export default function WorkContextRail() {
-  const { railArtifacts, railContext } = useWorkShell();
+  const { railArtifacts, railContext, insertComposerRef } = useWorkShell();
   const { vitals, sources, followups } = railContext;
   const [memory, setMemory] = useState<string | null>(null);
 
@@ -142,10 +141,15 @@ export default function WorkContextRail() {
           <h4 className="wcr-h">Ask next</h4>
           <div className="grid gap-1.5">
             {followups.map((q) => (
-              <Link key={q} href={`/work?seed=${encodeURIComponent(q)}`} className="wcr-chip">
-                <span className="min-w-0 truncate">{q}</span>
-                <ArrowRight size={13} strokeWidth={2} className="ml-auto flex-none opacity-60" />
-              </Link>
+              <button
+                key={q}
+                type="button"
+                onClick={() => insertComposerRef.current?.(q)}
+                className="wcr-chip"
+              >
+                <span className="min-w-0">{q}</span>
+                <ArrowRight size={13} strokeWidth={2} className="ml-auto mt-px flex-none opacity-60" />
+              </button>
             ))}
           </div>
         </section>

--- a/apps/web/src/app/(work)/work/WorkContextRail.tsx
+++ b/apps/web/src/app/(work)/work/WorkContextRail.tsx
@@ -1,18 +1,20 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import Link from "next/link";
 import { FileText, Image as ImageIcon, Sheet, File, ArrowRight } from "lucide-react";
 import { useWorkShell } from "../work-shell-context";
 
 // Right-hand context rail for the Ask page (Compact only — CSS hides it in
-// Comfortable). Surfaces the artifacts the agent produced this thread plus
-// quick follow-up prompts, so the answer's outputs stay reachable instead of
-// scrolling away. Hidden entirely when there's nothing to show.
+// Comfortable). Surfaces the answer's vitals, generated artifacts, the data
+// sources touched, follow-up prompts, and a relevant memory. The dynamic
+// panels (vitals / sources / followups) are agent-emitted via the
+// `neko_ask_context` fence and lifted through the shell context.
 
-const ASK_NEXT = [
-  "Break this down by region",
-  "Compare to last quarter",
-  "Which of these are at risk?",
+const FALLBACK_NEXT = [
+  "Break this down further",
+  "Compare to the prior period",
+  "What changed and why?",
 ];
 
 function ext(name: string): string {
@@ -35,12 +37,47 @@ function ArtifactIcon({ name, mime }: { name: string; mime?: string }) {
 }
 
 export default function WorkContextRail() {
-  const { railArtifacts } = useWorkShell();
-  const hasArtifacts = railArtifacts.length > 0;
+  const { railArtifacts, railContext } = useWorkShell();
+  const { vitals, sources, followups } = railContext;
+  const [memory, setMemory] = useState<string | null>(null);
+
+  // A relevant pinned memory, if any — real data from the work memory store.
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/work/memories", { cache: "no-store" })
+      .then((r) => (r.ok ? r.json() : { memories: [] }))
+      .then((d: { memories?: { text: string; pinned?: boolean }[] }) => {
+        if (cancelled) return;
+        const list = d.memories ?? [];
+        const pick = list.find((m) => m.pinned) ?? list[0];
+        setMemory(pick?.text ?? null);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const nextQuestions = followups.length > 0 ? followups : FALLBACK_NEXT;
 
   return (
     <aside className="work-rail">
-      {hasArtifacts && (
+      {vitals.length > 0 && (
+        <section className="wcr-sect">
+          <h4 className="wcr-h">Answer vitals</h4>
+          <div className="wcr-vitals">
+            {vitals.map((v, i) => (
+              <div key={i} className="wcr-vital">
+                <div className="wcr-vital-k">{v.label}</div>
+                <div className="wcr-vital-v">{v.value}</div>
+                {v.sub && <div className="wcr-vital-s">{v.sub}</div>}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {railArtifacts.length > 0 && (
         <section className="wcr-sect">
           <h4 className="wcr-h">Artifacts</h4>
           <div className="grid gap-1.5">
@@ -66,10 +103,25 @@ export default function WorkContextRail() {
         </section>
       )}
 
+      {sources.length > 0 && (
+        <section className="wcr-sect">
+          <h4 className="wcr-h">Sources touched</h4>
+          <div className="grid gap-px">
+            {sources.map((s, i) => (
+              <div key={i} className="wcr-source">
+                <span className="wcr-source-dot" aria-hidden="true" />
+                <span className="truncate">{s.name}</span>
+                {s.detail && <span className="ml-auto font-mono text-[10.5px] text-text3">{s.detail}</span>}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
       <section className="wcr-sect">
         <h4 className="wcr-h">Ask next</h4>
         <div className="grid gap-1.5">
-          {ASK_NEXT.map((q) => (
+          {nextQuestions.map((q) => (
             <Link key={q} href={`/work?seed=${encodeURIComponent(q)}`} className="wcr-chip">
               <span className="min-w-0 truncate">{q}</span>
               <ArrowRight size={13} strokeWidth={2} className="ml-auto flex-none opacity-60" />
@@ -77,6 +129,13 @@ export default function WorkContextRail() {
           ))}
         </div>
       </section>
+
+      {memory && (
+        <section className="wcr-sect">
+          <h4 className="wcr-h">Related memory</h4>
+          <div className="wcr-memo">{memory}</div>
+        </section>
+      )}
     </aside>
   );
 }

--- a/apps/web/src/app/(work)/work/WorkContextRail.tsx
+++ b/apps/web/src/app/(work)/work/WorkContextRail.tsx
@@ -53,8 +53,25 @@ export default function WorkContextRail() {
     };
   }, []);
 
+  const isEmpty =
+    vitals.length === 0 &&
+    railArtifacts.length === 0 &&
+    sources.length === 0 &&
+    followups.length === 0 &&
+    !memory;
+
   return (
     <aside className="work-rail">
+      {isEmpty && (
+        <section className="wcr-sect wcr-empty">
+          <h4 className="wcr-h">Context</h4>
+          <p className="wcr-empty-text">
+            Vitals, sources, and follow-ups surface here when the agent
+            highlights them for an answer.
+          </p>
+        </section>
+      )}
+
       {vitals.length > 0 && (
         <section className="wcr-sect">
           <h4 className="wcr-h">Answer vitals</h4>

--- a/apps/web/src/app/(work)/work/WorkContextRail.tsx
+++ b/apps/web/src/app/(work)/work/WorkContextRail.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import Link from "next/link";
+import { FileText, Image as ImageIcon, Sheet, File, ArrowRight } from "lucide-react";
+import { useWorkShell } from "../work-shell-context";
+
+// Right-hand context rail for the Ask page (Compact only — CSS hides it in
+// Comfortable). Surfaces the artifacts the agent produced this thread plus
+// quick follow-up prompts, so the answer's outputs stay reachable instead of
+// scrolling away. Hidden entirely when there's nothing to show.
+
+const ASK_NEXT = [
+  "Break this down by region",
+  "Compare to last quarter",
+  "Which of these are at risk?",
+];
+
+function ext(name: string): string {
+  const i = name.lastIndexOf(".");
+  return i > 0 ? name.slice(i + 1).toLowerCase() : "";
+}
+
+function ArtifactIcon({ name, mime }: { name: string; mime?: string }) {
+  const e = ext(name);
+  if (e === "csv" || e === "tsv" || e === "xlsx" || mime?.includes("spreadsheet")) {
+    return <span className="wcr-ic sheet"><Sheet size={15} strokeWidth={2} /></span>;
+  }
+  if (["png", "jpg", "jpeg", "gif", "webp", "svg"].includes(e) || mime?.startsWith("image/")) {
+    return <span className="wcr-ic image"><ImageIcon size={15} strokeWidth={2} /></span>;
+  }
+  if (e === "pdf" || e === "docx" || e === "md" || e === "txt" || e === "html" || e === "pptx") {
+    return <span className="wcr-ic doc"><FileText size={15} strokeWidth={2} /></span>;
+  }
+  return <span className="wcr-ic file"><File size={15} strokeWidth={2} /></span>;
+}
+
+export default function WorkContextRail() {
+  const { railArtifacts } = useWorkShell();
+  const hasArtifacts = railArtifacts.length > 0;
+
+  return (
+    <aside className="work-rail">
+      {hasArtifacts && (
+        <section className="wcr-sect">
+          <h4 className="wcr-h">Artifacts</h4>
+          <div className="grid gap-1.5">
+            {railArtifacts.map((a, i) => {
+              const fileName = a.label || a.path.split("/").slice(-1)[0];
+              return (
+                <a
+                  key={`${a.path}-${i}`}
+                  href={`/api/work/files/${a.path.replace(/^.*\/(runs|uploads|skills|memory)\//, "$1/")}`}
+                  className="wcr-artifact"
+                  title={a.path}
+                >
+                  <ArtifactIcon name={fileName} mime={a.mimeType} />
+                  <span className="min-w-0">
+                    <span className="block text-[12.5px] font-medium text-text truncate">{fileName}</span>
+                    {a.mimeType && <span className="block font-mono text-[10.5px] text-text3">{a.mimeType}</span>}
+                  </span>
+                  <span className="ml-auto text-text3 text-sm">↓</span>
+                </a>
+              );
+            })}
+          </div>
+        </section>
+      )}
+
+      <section className="wcr-sect">
+        <h4 className="wcr-h">Ask next</h4>
+        <div className="grid gap-1.5">
+          {ASK_NEXT.map((q) => (
+            <Link key={q} href={`/work?seed=${encodeURIComponent(q)}`} className="wcr-chip">
+              <span className="min-w-0 truncate">{q}</span>
+              <ArrowRight size={13} strokeWidth={2} className="ml-auto flex-none opacity-60" />
+            </Link>
+          ))}
+        </div>
+      </section>
+    </aside>
+  );
+}

--- a/apps/web/src/app/(work)/work/WorkContextRail.tsx
+++ b/apps/web/src/app/(work)/work/WorkContextRail.tsx
@@ -9,13 +9,8 @@ import { useWorkShell } from "../work-shell-context";
 // Comfortable). Surfaces the answer's vitals, generated artifacts, the data
 // sources touched, follow-up prompts, and a relevant memory. The dynamic
 // panels (vitals / sources / followups) are agent-emitted via the
-// `neko_ask_context` fence and lifted through the shell context.
-
-const FALLBACK_NEXT = [
-  "Break this down further",
-  "Compare to the prior period",
-  "What changed and why?",
-];
+// `neko_ask_context` fence and lifted through the shell context; each panel
+// only renders when its data is present.
 
 function ext(name: string): string {
   const i = name.lastIndexOf(".");
@@ -57,8 +52,6 @@ export default function WorkContextRail() {
       cancelled = true;
     };
   }, []);
-
-  const nextQuestions = followups.length > 0 ? followups : FALLBACK_NEXT;
 
   return (
     <aside className="work-rail">
@@ -118,17 +111,19 @@ export default function WorkContextRail() {
         </section>
       )}
 
-      <section className="wcr-sect">
-        <h4 className="wcr-h">Ask next</h4>
-        <div className="grid gap-1.5">
-          {nextQuestions.map((q) => (
-            <Link key={q} href={`/work?seed=${encodeURIComponent(q)}`} className="wcr-chip">
-              <span className="min-w-0 truncate">{q}</span>
-              <ArrowRight size={13} strokeWidth={2} className="ml-auto flex-none opacity-60" />
-            </Link>
-          ))}
-        </div>
-      </section>
+      {followups.length > 0 && (
+        <section className="wcr-sect">
+          <h4 className="wcr-h">Ask next</h4>
+          <div className="grid gap-1.5">
+            {followups.map((q) => (
+              <Link key={q} href={`/work?seed=${encodeURIComponent(q)}`} className="wcr-chip">
+                <span className="min-w-0 truncate">{q}</span>
+                <ArrowRight size={13} strokeWidth={2} className="ml-auto flex-none opacity-60" />
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
 
       {memory && (
         <section className="wcr-sect">

--- a/apps/web/src/app/(work)/work/WorkContextRail.tsx
+++ b/apps/web/src/app/(work)/work/WorkContextRail.tsx
@@ -6,11 +6,9 @@ import { FileText, Image as ImageIcon, Sheet, File, ArrowRight } from "lucide-re
 import { useWorkShell } from "../work-shell-context";
 
 // Right-hand context rail for the Ask page (Compact only — CSS hides it in
-// Comfortable). Surfaces the answer's vitals, generated artifacts, the data
-// sources touched, follow-up prompts, and a relevant memory. The dynamic
-// panels (vitals / sources / followups) are agent-emitted via the
-// `neko_ask_context` fence and lifted through the shell context; each panel
-// only renders when its data is present.
+// Comfortable). Surfaces the data sources touched, generated artifacts,
+// follow-up prompts, and a relevant memory — all derived from the run or
+// fetched, never model-authored UI. Each panel renders only when it has data.
 
 function ext(name: string): string {
   const i = name.lastIndexOf(".");
@@ -33,7 +31,7 @@ function ArtifactIcon({ name, mime }: { name: string; mime?: string }) {
 
 export default function WorkContextRail() {
   const { railArtifacts, railContext } = useWorkShell();
-  const { vitals, sources, followups } = railContext;
+  const { sources, followups } = railContext;
   const [memory, setMemory] = useState<string | null>(null);
 
   // A relevant pinned memory, if any — real data from the work memory store.
@@ -54,7 +52,6 @@ export default function WorkContextRail() {
   }, []);
 
   const isEmpty =
-    vitals.length === 0 &&
     railArtifacts.length === 0 &&
     sources.length === 0 &&
     followups.length === 0 &&
@@ -66,21 +63,21 @@ export default function WorkContextRail() {
         <section className="wcr-sect wcr-empty">
           <h4 className="wcr-h">Context</h4>
           <p className="wcr-empty-text">
-            Vitals, sources, and follow-ups surface here when the agent
-            highlights them for an answer.
+            Sources touched, artifacts, and follow-ups surface here once the
+            agent works through an answer.
           </p>
         </section>
       )}
 
-      {vitals.length > 0 && (
+      {sources.length > 0 && (
         <section className="wcr-sect">
-          <h4 className="wcr-h">Answer vitals</h4>
-          <div className="wcr-vitals">
-            {vitals.map((v, i) => (
-              <div key={i} className="wcr-vital">
-                <div className="wcr-vital-k">{v.label}</div>
-                <div className="wcr-vital-v">{v.value}</div>
-                {v.sub && <div className="wcr-vital-s">{v.sub}</div>}
+          <h4 className="wcr-h">Sources touched</h4>
+          <div className="grid gap-px">
+            {sources.map((s, i) => (
+              <div key={i} className="wcr-source">
+                <span className="wcr-source-dot" aria-hidden="true" />
+                <span className="truncate">{s.name}</span>
+                {s.detail && <span className="ml-auto font-mono text-[10.5px] text-text3">{s.detail}</span>}
               </div>
             ))}
           </div>
@@ -109,21 +106,6 @@ export default function WorkContextRail() {
                 </a>
               );
             })}
-          </div>
-        </section>
-      )}
-
-      {sources.length > 0 && (
-        <section className="wcr-sect">
-          <h4 className="wcr-h">Sources touched</h4>
-          <div className="grid gap-px">
-            {sources.map((s, i) => (
-              <div key={i} className="wcr-source">
-                <span className="wcr-source-dot" aria-hidden="true" />
-                <span className="truncate">{s.name}</span>
-                {s.detail && <span className="ml-auto font-mono text-[10.5px] text-text3">{s.detail}</span>}
-              </div>
-            ))}
           </div>
         </section>
       )}

--- a/apps/web/src/app/(work)/work/WorkContextRail.tsx
+++ b/apps/web/src/app/(work)/work/WorkContextRail.tsx
@@ -6,13 +6,24 @@ import { FileText, Image as ImageIcon, Sheet, File, ArrowRight } from "lucide-re
 import { useWorkShell } from "../work-shell-context";
 
 // Right-hand context rail for the Ask page (Compact only — CSS hides it in
-// Comfortable). Surfaces the data sources touched, generated artifacts,
-// follow-up prompts, and a relevant memory — all derived from the run or
-// fetched, never model-authored UI. Each panel renders only when it has data.
+// Comfortable). Surfaces the answer's headline vitals, generated artifacts, the
+// data sources touched, follow-up prompts, and a relevant memory. Vitals and
+// follow-ups are channel-agnostic CONTENT the agent emits — the web channel
+// renders them as pixels here; another channel could voice them. The rest is
+// derived from the run or fetched. Each panel renders only when it has data.
 
 function ext(name: string): string {
   const i = name.lastIndexOf(".");
   return i > 0 ? name.slice(i + 1).toLowerCase() : "";
+}
+
+// A terse, honest type label for an artifact — the file extension, or a short
+// form of its mime type. Never fabricates size/row counts we don't have.
+function artifactMeta(name: string, mime?: string): string {
+  const e = ext(name);
+  if (e) return e.toUpperCase();
+  if (mime) return mime.split("/").pop()?.toUpperCase() ?? mime;
+  return "file";
 }
 
 function ArtifactIcon({ name, mime }: { name: string; mime?: string }) {
@@ -31,7 +42,7 @@ function ArtifactIcon({ name, mime }: { name: string; mime?: string }) {
 
 export default function WorkContextRail() {
   const { railArtifacts, railContext } = useWorkShell();
-  const { sources, followups } = railContext;
+  const { vitals, sources, followups } = railContext;
   const [memory, setMemory] = useState<string | null>(null);
 
   // A relevant pinned memory, if any — real data from the work memory store.
@@ -52,6 +63,7 @@ export default function WorkContextRail() {
   }, []);
 
   const isEmpty =
+    vitals.length === 0 &&
     railArtifacts.length === 0 &&
     sources.length === 0 &&
     followups.length === 0 &&
@@ -69,15 +81,15 @@ export default function WorkContextRail() {
         </section>
       )}
 
-      {sources.length > 0 && (
+      {vitals.length > 0 && (
         <section className="wcr-sect">
-          <h4 className="wcr-h">Sources touched</h4>
-          <div className="grid gap-px">
-            {sources.map((s, i) => (
-              <div key={i} className="wcr-source">
-                <span className="wcr-source-dot" aria-hidden="true" />
-                <span className="truncate">{s.name}</span>
-                {s.detail && <span className="ml-auto font-mono text-[10.5px] text-text3">{s.detail}</span>}
+          <h4 className="wcr-h">Answer vitals</h4>
+          <div className="wcr-vitals">
+            {vitals.map((v, i) => (
+              <div key={i} className="wcr-vital">
+                <div className="wcr-vital-k">{v.label}</div>
+                <div className="wcr-vital-v">{v.value}</div>
+                {v.sub && <div className="wcr-vital-s">{v.sub}</div>}
               </div>
             ))}
           </div>
@@ -100,12 +112,27 @@ export default function WorkContextRail() {
                   <ArtifactIcon name={fileName} mime={a.mimeType} />
                   <span className="min-w-0">
                     <span className="block text-[12.5px] font-medium text-text truncate">{fileName}</span>
-                    {a.mimeType && <span className="block font-mono text-[10.5px] text-text3">{a.mimeType}</span>}
+                    <span className="block font-mono text-[10.5px] text-text3">{artifactMeta(fileName, a.mimeType)}</span>
                   </span>
                   <span className="ml-auto text-text3 text-sm">↓</span>
                 </a>
               );
             })}
+          </div>
+        </section>
+      )}
+
+      {sources.length > 0 && (
+        <section className="wcr-sect">
+          <h4 className="wcr-h">Sources touched</h4>
+          <div className="grid gap-px">
+            {sources.map((s, i) => (
+              <div key={i} className="wcr-source">
+                <span className="wcr-source-dot" aria-hidden="true" />
+                <span className="truncate">{s.name}</span>
+                {s.detail && <span className="ml-auto font-mono text-[10.5px] text-text3">{s.detail}</span>}
+              </div>
+            ))}
           </div>
         </section>
       )}

--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -1104,18 +1104,8 @@ export default function WorkScreen() {
                 {sending ? (
                   <span className="work-composer-pulse">Working</span>
                 ) : files.length > 0 ? (
-                  <>
-                    {files.length} of {MAX_ATTACHMENTS} attached
-                    <span className="work-composer-hint-sep">·</span>
-                    Enter <kbd>↵</kbd> to send
-                  </>
-                ) : (
-                  <>
-                    Enter <kbd>↵</kbd> to send
-                    <span className="work-composer-hint-sep">·</span>
-                    Shift <kbd>↵</kbd> for newline
-                  </>
-                )}
+                  <>{files.length} of {MAX_ATTACHMENTS} attached</>
+                ) : null}
               </span>
             </div>
             {sending ? (
@@ -1349,7 +1339,6 @@ function MessageBubble({
           />
         </div>
         <div className="work-bubble-edit-hint">
-          <span>Enter to send · Esc to cancel</span>
           <button type="button" onClick={cancel}>
             Cancel
           </button>
@@ -1771,7 +1760,7 @@ function ActionApprovalCard({
             type="button"
             disabled={busy}
             onClick={() => decide("approve")}
-            className="px-3 py-1.5 rounded-[10px] bg-text text-bg font-display font-bold text-[12px] tracking-[-0.01em] hover:opacity-90 disabled:opacity-50 cursor-pointer"
+            className="px-3 py-1.5 rounded-[10px] bg-success-ink text-white font-display font-bold text-[12px] tracking-[-0.01em] hover:bg-[#0b2912] disabled:opacity-50 cursor-pointer"
           >
             {busy ? "Approving…" : "Approve"}
           </button>

--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -111,7 +111,6 @@ import type { SurfaceState, A2UIMessage } from "@/a2ui/types";
 import {
   useWorkShell,
   type RailArtifact,
-  type RailVital,
   type RailSource,
 } from "../work-shell-context";
 
@@ -168,12 +167,7 @@ type WorkEvent =
       error?: string;
       rejection_reason?: string;
     }
-  | {
-      type: "ask_context";
-      vitals?: { label: string; value: string; sub?: string }[];
-      sources?: { name: string; detail?: string }[];
-      followups?: string[];
-    }
+  | { type: "followups"; items: string[] }
   | { type: "done"; result?: unknown };
 
 type ThreadBundle = {
@@ -408,36 +402,61 @@ export default function WorkScreen() {
     endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   }, [bundle, sending, activeRunId]);
 
-  // Lift this thread's generated artifacts into the shell context so the
-  // Compact context rail can list them.
+  // Derive this thread's rail context from the run's own telemetry — never
+  // from model-authored UI hints. Sources touched are parsed from the data
+  // tools the agent actually called (a fact about the run); artifacts come
+  // from artifact events; follow-ups are LLM-generated channel-agnostic
+  // content lifted from `followups` events. Vitals are a Dashboard concept
+  // and intentionally absent here.
   useEffect(() => {
     if (!bundle) {
       setRailArtifacts([]);
+      setRailContext({ sources: [], followups: [] });
       return;
     }
     const arts: RailArtifact[] = [];
-    const seen = new Set<string>();
-    let latestCtx: { vitals?: RailVital[]; sources?: RailSource[]; followups?: string[] } | null = null;
+    const seenArt = new Set<string>();
+    const sourceMap = new Map<string, RailSource>();
+    let followups: string[] = [];
+    const addSource = (raw: string) => {
+      const name = raw.trim().toLowerCase();
+      if (name.length < 2 || sourceMap.has(name)) return;
+      sourceMap.set(name, { name });
+    };
     for (const events of Object.values(bundle.eventsByRun)) {
       for (const ev of events) {
-        if (ev.type === "artifact" && ev.artifact && !seen.has(ev.artifact.path)) {
-          seen.add(ev.artifact.path);
+        if (ev.type === "artifact" && ev.artifact && !seenArt.has(ev.artifact.path)) {
+          seenArt.add(ev.artifact.path);
           arts.push({
             path: ev.artifact.path,
             label: ev.artifact.label,
             mimeType: ev.artifact.mimeType,
           });
-        } else if (ev.type === "ask_context") {
-          // Last context in the thread wins (the most recent answer's rail).
-          latestCtx = ev;
+        } else if (ev.type === "tool_start") {
+          const title =
+            typeof (ev.input as { title?: unknown })?.title === "string"
+              ? (ev.input as { title: string }).title
+              : "";
+          if (title) {
+            // graphjin table args: {"table":"x"} / {"from_table":"x"} / {"to_table":"x"}
+            for (const m of title.matchAll(
+              /"(?:from_table|to_table|table)"\s*:\s*"([a-z0-9_]+)"/gi,
+            )) {
+              addSource(m[1]);
+            }
+            // execute_graphql root field: {"query":"{ <table>( …
+            const q = title.match(/"query"\s*:\s*"\{\s*([a-z_][a-z0-9_]*)/i);
+            if (q) addSource(q[1]);
+          }
+        } else if (ev.type === "followups" && Array.isArray(ev.items)) {
+          followups = ev.items;
         }
       }
     }
     setRailArtifacts(arts);
     setRailContext({
-      vitals: latestCtx?.vitals ?? [],
-      sources: latestCtx?.sources ?? [],
-      followups: latestCtx?.followups ?? [],
+      sources: [...sourceMap.values()].slice(0, 6),
+      followups,
     });
   }, [bundle, setRailArtifacts, setRailContext]);
 

--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -305,7 +305,12 @@ export default function WorkScreen() {
   const searchParams = useSearchParams();
   const routeThreadId =
     typeof params?.threadId === "string" ? params.threadId : null;
-  const { setActiveRunId, setRailArtifacts, setRailContext } = useWorkShell();
+  const {
+    setActiveRunId,
+    setRailArtifacts,
+    setRailContext,
+    insertComposerRef,
+  } = useWorkShell();
   const [gateChecked, setGateChecked] = useState(false);
   const [gateError, setGateError] = useState<string | null>(null);
   const [activeThreadId, setActiveThreadId] = useState<string | null>(null);
@@ -403,6 +408,26 @@ export default function WorkScreen() {
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   }, [bundle, sending, activeRunId]);
+
+  // Register the handle the rail's "Ask next" chips call to drop a question
+  // into the composer (focused, caret at end) so the operator can edit it
+  // before sending — it never fires on its own. setDraft runs from the click,
+  // not synchronously inside this effect.
+  useEffect(() => {
+    insertComposerRef.current = (q: string) => {
+      setDraft(q);
+      requestAnimationFrame(() => {
+        const ta = textareaRef.current;
+        if (ta) {
+          ta.focus();
+          ta.setSelectionRange(ta.value.length, ta.value.length);
+        }
+      });
+    };
+    return () => {
+      insertComposerRef.current = null;
+    };
+  }, [insertComposerRef]);
 
   // Derive this thread's rail context from the run's own output. Vitals and
   // follow-ups are channel-agnostic CONTENT the agent emits (the web channel
@@ -1472,7 +1497,7 @@ type ApprovalItem = {
 
 type TimelineItem =
   | { kind: "text"; content: string }
-  | { kind: "tools"; tools: ToolItem[]; followedByText: boolean }
+  | { kind: "tools"; tools: ToolItem[] }
   | { kind: "approval"; approval: ApprovalItem }
   | { kind: "error"; message: string };
 
@@ -1498,9 +1523,6 @@ function buildRunTimeline(events: WorkEvent[]): {
   const flushTextSegment = () => {
     if (pendingText.trim()) {
       items.push({ kind: "text", content: pendingText });
-      for (const it of items) {
-        if (it.kind === "tools") it.followedByText = true;
-      }
     }
     pendingText = "";
   };
@@ -1537,7 +1559,7 @@ function buildRunTimeline(events: WorkEvent[]): {
         if (last && last.kind === "tools") {
           last.tools.push(item);
         } else {
-          items.push({ kind: "tools", tools: [item], followedByText: false });
+          items.push({ kind: "tools", tools: [item] });
         }
         break;
       }
@@ -1692,11 +1714,8 @@ function RunTimeline({
         }
         if (item.kind === "tools") {
           return (
-            <ToolGroup
-              key={`tools-${index}`}
-              tools={item.tools}
-              followedByText={item.followedByText}
-            />
+            <ToolGroup key={`tools-${index}`} tools={item.tools} />
+
           );
         }
         if (item.kind === "approval") {
@@ -1905,13 +1924,7 @@ function ActionResultStrip({
   );
 }
 
-function ToolGroup({
-  tools,
-  followedByText,
-}: {
-  tools: ToolItem[];
-  followedByText: boolean;
-}) {
+function ToolGroup({ tools }: { tools: ToolItem[] }) {
   const inflight = tools.filter((t) => !t.end).length;
   const failed = tools.filter((t) => t.end?.error).length;
   const showHeader = tools.length > 1;

--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -1760,7 +1760,7 @@ function ActionApprovalCard({
             type="button"
             disabled={busy}
             onClick={() => decide("approve")}
-            className="px-3 py-1.5 rounded-[10px] bg-success-ink text-white font-display font-bold text-[12px] tracking-[-0.01em] hover:bg-[#0b2912] disabled:opacity-50 cursor-pointer"
+            className="px-3 py-1.5 rounded-[10px] bg-accent text-white font-display font-bold text-[12px] tracking-[-0.01em] hover:bg-[#5a4cd1] disabled:opacity-50 cursor-pointer"
           >
             {busy ? "Approving…" : "Approve"}
           </button>

--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -108,7 +108,7 @@ import { parseBriefingCardMessage } from "@/lib/briefing-card-context";
 import { renderComponent, renderChildren } from "@/a2ui/renderer";
 import { applyMessage, getRootComponent } from "@/a2ui/surface";
 import type { SurfaceState, A2UIMessage } from "@/a2ui/types";
-import { useWorkShell } from "../work-shell-context";
+import { useWorkShell, type RailArtifact } from "../work-shell-context";
 
 type MessageRecord = {
   id: string;
@@ -298,7 +298,7 @@ export default function WorkScreen() {
   const searchParams = useSearchParams();
   const routeThreadId =
     typeof params?.threadId === "string" ? params.threadId : null;
-  const { setActiveRunId } = useWorkShell();
+  const { setActiveRunId, setRailArtifacts } = useWorkShell();
   const [gateChecked, setGateChecked] = useState(false);
   const [gateError, setGateError] = useState<string | null>(null);
   const [activeThreadId, setActiveThreadId] = useState<string | null>(null);
@@ -396,6 +396,30 @@ export default function WorkScreen() {
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   }, [bundle, sending, activeRunId]);
+
+  // Lift this thread's generated artifacts into the shell context so the
+  // Compact context rail can list them.
+  useEffect(() => {
+    if (!bundle) {
+      setRailArtifacts([]);
+      return;
+    }
+    const arts: RailArtifact[] = [];
+    const seen = new Set<string>();
+    for (const events of Object.values(bundle.eventsByRun)) {
+      for (const ev of events) {
+        if (ev.type === "artifact" && ev.artifact && !seen.has(ev.artifact.path)) {
+          seen.add(ev.artifact.path);
+          arts.push({
+            path: ev.artifact.path,
+            label: ev.artifact.label,
+            mimeType: ev.artifact.mimeType,
+          });
+        }
+      }
+    }
+    setRailArtifacts(arts);
+  }, [bundle, setRailArtifacts]);
 
   // Auto-grow the textarea up to its max-height (~9 lines); past that the
   // textarea scrolls internally. CSS alone can't do this — `rows={1}` is

--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -112,6 +112,7 @@ import {
   useWorkShell,
   type RailArtifact,
   type RailSource,
+  type RailVital,
 } from "../work-shell-context";
 
 type MessageRecord = {
@@ -168,6 +169,7 @@ type WorkEvent =
       rejection_reason?: string;
     }
   | { type: "followups"; items: string[] }
+  | { type: "vitals"; items: RailVital[] }
   | { type: "done"; result?: unknown };
 
 type ThreadBundle = {
@@ -402,21 +404,22 @@ export default function WorkScreen() {
     endRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
   }, [bundle, sending, activeRunId]);
 
-  // Derive this thread's rail context from the run's own telemetry — never
-  // from model-authored UI hints. Sources touched are parsed from the data
-  // tools the agent actually called (a fact about the run); artifacts come
-  // from artifact events; follow-ups are LLM-generated channel-agnostic
-  // content lifted from `followups` events. Vitals are a Dashboard concept
-  // and intentionally absent here.
+  // Derive this thread's rail context from the run's own output. Vitals and
+  // follow-ups are channel-agnostic CONTENT the agent emits (the web channel
+  // renders them as a tile grid / chips — another channel could read them
+  // aloud). Sources touched are parsed from the data tools the agent actually
+  // called (a fact about the run); artifacts come from artifact events. The
+  // latest answer in the thread wins for vitals and follow-ups.
   useEffect(() => {
     if (!bundle) {
       setRailArtifacts([]);
-      setRailContext({ sources: [], followups: [] });
+      setRailContext({ vitals: [], sources: [], followups: [] });
       return;
     }
     const arts: RailArtifact[] = [];
     const seenArt = new Set<string>();
     const sourceMap = new Map<string, RailSource>();
+    let vitals: RailVital[] = [];
     let followups: string[] = [];
     const addSource = (raw: string) => {
       const name = raw.trim().toLowerCase();
@@ -450,11 +453,14 @@ export default function WorkScreen() {
           }
         } else if (ev.type === "followups" && Array.isArray(ev.items)) {
           followups = ev.items;
+        } else if (ev.type === "vitals" && Array.isArray(ev.items)) {
+          vitals = ev.items;
         }
       }
     }
     setRailArtifacts(arts);
     setRailContext({
+      vitals: vitals.slice(0, 4),
       sources: [...sourceMap.values()].slice(0, 6),
       followups,
     });
@@ -1909,18 +1915,11 @@ function ToolGroup({
   const inflight = tools.filter((t) => !t.end).length;
   const failed = tools.filter((t) => t.end?.error).length;
   const showHeader = tools.length > 1;
-  // Auto-open once while work is in flight and the agent hasn't started
-  // talking yet — then leave the state alone. Re-deriving open from live
-  // inflight/text state caused the section to snap closed mid-stream as
-  // each tool finished or prose landed, which is visually jarring.
+  // Collapsed by default and left alone — the running/failed badges on the
+  // header carry live progress, so the body never expands on its own. An
+  // auto-open while in flight grew the transcript on every tool call and
+  // yanked the viewport down; the operator opens it only if they want detail.
   const [open, setOpen] = useState(false);
-  const autoOpenedRef = useRef(false);
-  useEffect(() => {
-    if (!autoOpenedRef.current && inflight > 0 && !followedByText) {
-      autoOpenedRef.current = true;
-      setOpen(true);
-    }
-  }, [inflight, followedByText]);
 
   if (!showHeader) {
     return (

--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -108,7 +108,12 @@ import { parseBriefingCardMessage } from "@/lib/briefing-card-context";
 import { renderComponent, renderChildren } from "@/a2ui/renderer";
 import { applyMessage, getRootComponent } from "@/a2ui/surface";
 import type { SurfaceState, A2UIMessage } from "@/a2ui/types";
-import { useWorkShell, type RailArtifact } from "../work-shell-context";
+import {
+  useWorkShell,
+  type RailArtifact,
+  type RailVital,
+  type RailSource,
+} from "../work-shell-context";
 
 type MessageRecord = {
   id: string;
@@ -162,6 +167,12 @@ type WorkEvent =
       };
       error?: string;
       rejection_reason?: string;
+    }
+  | {
+      type: "ask_context";
+      vitals?: { label: string; value: string; sub?: string }[];
+      sources?: { name: string; detail?: string }[];
+      followups?: string[];
     }
   | { type: "done"; result?: unknown };
 
@@ -298,7 +309,7 @@ export default function WorkScreen() {
   const searchParams = useSearchParams();
   const routeThreadId =
     typeof params?.threadId === "string" ? params.threadId : null;
-  const { setActiveRunId, setRailArtifacts } = useWorkShell();
+  const { setActiveRunId, setRailArtifacts, setRailContext } = useWorkShell();
   const [gateChecked, setGateChecked] = useState(false);
   const [gateError, setGateError] = useState<string | null>(null);
   const [activeThreadId, setActiveThreadId] = useState<string | null>(null);
@@ -406,6 +417,7 @@ export default function WorkScreen() {
     }
     const arts: RailArtifact[] = [];
     const seen = new Set<string>();
+    let latestCtx: { vitals?: RailVital[]; sources?: RailSource[]; followups?: string[] } | null = null;
     for (const events of Object.values(bundle.eventsByRun)) {
       for (const ev of events) {
         if (ev.type === "artifact" && ev.artifact && !seen.has(ev.artifact.path)) {
@@ -415,11 +427,19 @@ export default function WorkScreen() {
             label: ev.artifact.label,
             mimeType: ev.artifact.mimeType,
           });
+        } else if (ev.type === "ask_context") {
+          // Last context in the thread wins (the most recent answer's rail).
+          latestCtx = ev;
         }
       }
     }
     setRailArtifacts(arts);
-  }, [bundle, setRailArtifacts]);
+    setRailContext({
+      vitals: latestCtx?.vitals ?? [],
+      sources: latestCtx?.sources ?? [],
+      followups: latestCtx?.followups ?? [],
+    });
+  }, [bundle, setRailArtifacts, setRailContext]);
 
   // Auto-grow the textarea up to its max-height (~9 lines); past that the
   // textarea scrolls internally. CSS alone can't do this — `rows={1}` is

--- a/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
+++ b/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
@@ -365,7 +365,7 @@ function WorkflowGroup({
       <div className="text-[11px] font-bold tracking-[0.12em] uppercase text-text3 mb-2.5">
         {title} <span className="text-text3 font-semibold tracking-[0.06em] ml-0.5">({count})</span>
       </div>
-      <ul className="list-none flex flex-col gap-2">
+      <ul className="list-none flex flex-col gap-2 wf-grid">
         {items.map((w) => (
           <WorkflowRow
             key={w.id}

--- a/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
+++ b/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
@@ -6,6 +6,7 @@ import { Workflow, Trash2 } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { confirmDialog } from "@/components/ConfirmModal";
 import { describeSchedule } from "@/lib/cron-english";
+import { formatSavedShort } from "@/lib/hours-saved";
 
 type WorkflowListItem = {
   id: string;
@@ -59,6 +60,7 @@ type DrawerPayload = {
     systemPromptOverlay: string;
     dailyRunBudget: number | null;
     runsToday: number;
+    minutesSaved30d: number;
     createdByThreadId: string | null;
     createdByRunId: string | null;
   };
@@ -617,6 +619,19 @@ function WorkflowDetail({
           + Run now
         </button>
       </div>
+
+      {workflow.minutesSaved30d > 0 && (
+        <Section title="Hours saved (30d)">
+          <p className="leading-[1.55]">
+            <span className="font-display font-bold text-accent">
+              {formatSavedShort(workflow.minutesSaved30d)}
+            </span>{" "}
+            <span className="text-text2">
+              of human time, estimated across this workflow&apos;s runs and actions.
+            </span>
+          </p>
+        </Section>
+      )}
 
       {workflow.description && (
         <Section title="Description">

--- a/apps/web/src/app/actions/page.tsx
+++ b/apps/web/src/app/actions/page.tsx
@@ -26,6 +26,7 @@ type ActionRow = {
   summary: string;
   scope: string;
   status: string;
+  minutesSaved: number | null;
   approvedAt: string | null;
   approverKind: "operator" | "policy" | "auto" | null;
   approverLabel: string | null;
@@ -314,6 +315,7 @@ function ActionsPageInner() {
                     r.status === "rejected" ? r.rejectionReason : null,
                   approverPhrase: approverPhrase(r.approverKind, r.approverLabel),
                   status: r.status,
+                  minutesSaved: r.minutesSaved,
                 })),
               };
 

--- a/apps/web/src/app/actions/page.tsx
+++ b/apps/web/src/app/actions/page.tsx
@@ -209,33 +209,6 @@ function ActionsPageInner() {
   }, [rejectingId, rejectReason, act]);
 
   useEffect(() => {
-    if (filter !== "awaiting") return;
-    const handler = (e: KeyboardEvent) => {
-      if (!focusedId) return;
-      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
-      if (e.key === "a") {
-        e.preventDefault();
-        void act(focusedId, "approve");
-      } else if (e.key === "r") {
-        e.preventDefault();
-        beginReject(focusedId);
-      } else if (e.key === "j" || e.key === "ArrowDown") {
-        e.preventDefault();
-        const ids = data?.actions.map((a) => a.id) ?? [];
-        const idx = ids.indexOf(focusedId);
-        if (idx >= 0 && idx < ids.length - 1) setFocusedId(ids[idx + 1]);
-      } else if (e.key === "k" || e.key === "ArrowUp") {
-        e.preventDefault();
-        const ids = data?.actions.map((a) => a.id) ?? [];
-        const idx = ids.indexOf(focusedId);
-        if (idx > 0) setFocusedId(ids[idx - 1]);
-      }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [filter, focusedId, data, act, beginReject]);
-
-  useEffect(() => {
     if (!focusedId) return;
     rowRefs.current[focusedId]?.scrollIntoView({
       behavior: "smooth",
@@ -247,8 +220,6 @@ function ActionsPageInner() {
     () => (data ? groupActions(data.actions) : []),
     [data],
   );
-
-  const kbd = "font-mono bg-neutral border border-border rounded-[4px] px-1.5 py-px text-[11px] text-text2";
 
   return (
     <>
@@ -284,12 +255,6 @@ function ActionsPageInner() {
             );
           })}
         </div>
-
-        {filter === "awaiting" && data && data.actions.length > 0 && (
-          <div className="font-mono text-[12px] text-text3 mb-6">
-            <kbd className={kbd}>a</kbd> approve · <kbd className={kbd}>r</kbd> reject · <kbd className={kbd}>j</kbd>/<kbd className={kbd}>k</kbd> navigate
-          </div>
-        )}
 
         {error ? (
           <div className="py-[60px] text-center text-danger text-[14px]">{error}</div>
@@ -445,9 +410,9 @@ function ActionReadingPane({
             type="button"
             disabled={busy}
             onClick={onApprove}
-            className="px-[18px] py-2.5 rounded-[11px] bg-text text-bg font-display font-bold text-[13.5px] tracking-[-0.01em] hover:opacity-90 disabled:opacity-50 cursor-pointer"
+            className="px-[18px] py-2.5 rounded-[11px] bg-success-ink text-white font-display font-bold text-[13.5px] tracking-[-0.01em] hover:bg-[#0b2912] disabled:opacity-50 cursor-pointer"
           >
-            Approve <span className="font-mono text-[11px] opacity-70 ml-0.5">a</span>
+            Approve
           </button>
           <button
             type="button"
@@ -455,7 +420,7 @@ function ActionReadingPane({
             onClick={onReject}
             className="px-[18px] py-2.5 rounded-[11px] border border-border text-text2 font-semibold text-[13.5px] hover:border-danger hover:text-danger disabled:opacity-50 cursor-pointer"
           >
-            Reject <span className="font-mono text-[11px] opacity-70 ml-0.5">r</span>
+            Reject
           </button>
         </div>
       </div>

--- a/apps/web/src/app/actions/page.tsx
+++ b/apps/web/src/app/actions/page.tsx
@@ -11,6 +11,7 @@ import ActCard, {
   type ActRowTone,
 } from "@/components/ActCard";
 import { cn } from "@/lib/cn";
+import { formatSavedShort } from "@/lib/hours-saved";
 
 type Filter = "awaiting" | "fired" | "rejected" | "all";
 
@@ -297,7 +298,8 @@ function ActionsPageInner() {
         ) : data.actions.length === 0 ? (
           <EmptyState filter={filter} onBack={() => router.push("/")} />
         ) : (
-          <div className="act-list">
+          <div className="triage-layout">
+            <div className="act-list triage-queue">
             {groups.map((group, i) => {
               const cardData: ActCardData = {
                 runId: group.runId,
@@ -340,12 +342,124 @@ function ActionsPageInner() {
                 />
               );
             })}
+            </div>
+            {filter === "awaiting" && (
+              <ActionReadingPane
+                action={data.actions.find((a) => a.id === focusedId) ?? null}
+                busy={busyId !== null && busyId === focusedId}
+                onApprove={() => { if (focusedId) void act(focusedId, "approve"); }}
+                onReject={() => { if (focusedId) beginReject(focusedId); }}
+              />
+            )}
           </div>
         )}
       </div>
 
       <CreatorCredit />
     </>
+  );
+}
+
+const RISK_PILL: Record<string, string> = {
+  critical: "bg-danger text-white",
+  high: "bg-danger-soft text-danger border border-danger/30",
+  medium: "bg-watch-soft text-warn-ink border border-watch/30",
+  low: "bg-success-soft text-success-ink border border-success-mid/30",
+};
+
+// Reading pane for the triage queue (Compact). Shows the focused action's
+// full context — why, target, payload, value — beside the queue list.
+function ActionReadingPane({
+  action,
+  busy,
+  onApprove,
+  onReject,
+}: {
+  action: ActionRow | null;
+  busy: boolean;
+  onApprove: () => void;
+  onReject: () => void;
+}) {
+  if (!action) {
+    return (
+      <aside className="triage-pane">
+        <div className="bg-card border border-border rounded-2xl px-5 py-10 text-center text-[13px] text-text3 shadow-soft">
+          Select an action to review.
+        </div>
+      </aside>
+    );
+  }
+  const payloadEntries =
+    action.payload && typeof action.payload === "object" && !Array.isArray(action.payload)
+      ? Object.entries(action.payload as Record<string, unknown>).slice(0, 8)
+      : [];
+  const risk = action.riskLevel ?? "low";
+  return (
+    <aside className="triage-pane">
+      <div className="bg-card border border-border rounded-2xl px-5 py-[18px] shadow-soft">
+        <div className="flex items-center gap-2.5 mb-2.5">
+          <span className={cn("font-display text-[9.5px] font-extrabold tracking-[0.08em] uppercase px-2 py-0.5 rounded-full", RISK_PILL[risk] ?? RISK_PILL.low)}>
+            {risk} risk
+          </span>
+          <code className="ml-auto font-mono text-[11px] text-text3">{action.kind}</code>
+        </div>
+        <h2 className="font-display text-[19px] font-extrabold tracking-[-0.02em] leading-[1.2] text-text">
+          {action.summary || action.kind}
+        </h2>
+        <div className="text-[12.5px] text-text2 mt-2 leading-[1.5]">
+          Proposed by <span className="text-text font-semibold">{action.workflow.name}</span>
+          {action.triggeredByObservation ? <> · triggered by “{action.triggeredByObservation.title}”</> : null}
+        </div>
+
+        {action.target && (
+          <div className="mt-4">
+            <div className="text-[10px] font-bold tracking-[0.12em] uppercase text-text3 mb-1.5">Target</div>
+            <code className="font-mono text-[12px] text-text2 break-all">{action.target}</code>
+          </div>
+        )}
+
+        {payloadEntries.length > 0 && (
+          <div className="mt-4">
+            <div className="text-[10px] font-bold tracking-[0.12em] uppercase text-text3 mb-1.5">Payload</div>
+            <div className="bg-bg border border-border rounded-xl px-3 py-2.5 grid gap-1.5">
+              {payloadEntries.map(([k, v]) => (
+                <div key={k} className="flex gap-3 text-[12px]">
+                  <span className="text-text3 min-w-[88px] flex-none">{k}</span>
+                  <span className="font-mono text-text break-all">
+                    {typeof v === "object" ? JSON.stringify(v) : String(v)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {(action.minutesSaved ?? 0) > 0 && (
+          <div className="mt-4 text-[12.5px] text-text2">
+            Saves <span className="font-mono text-success-ink">{formatSavedShort(action.minutesSaved as number)}</span> of manual effort.
+          </div>
+        )}
+
+        <div className="flex items-center gap-2.5 mt-[18px] pt-4 border-t border-border">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onApprove}
+            className="px-[18px] py-2.5 rounded-[11px] bg-text text-bg font-display font-bold text-[13.5px] tracking-[-0.01em] hover:opacity-90 disabled:opacity-50 cursor-pointer"
+          >
+            Approve <span className="font-mono text-[11px] opacity-70 ml-0.5">a</span>
+          </button>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={onReject}
+            className="px-[18px] py-2.5 rounded-[11px] border border-border text-text2 font-semibold text-[13.5px] hover:border-danger hover:text-danger disabled:opacity-50 cursor-pointer"
+          >
+            Reject <span className="font-mono text-[11px] opacity-70 ml-0.5">r</span>
+          </button>
+        </div>
+      </div>
+    </aside>
   );
 }
 

--- a/apps/web/src/app/actions/page.tsx
+++ b/apps/web/src/app/actions/page.tsx
@@ -410,7 +410,7 @@ function ActionReadingPane({
             type="button"
             disabled={busy}
             onClick={onApprove}
-            className="px-[18px] py-2.5 rounded-[11px] bg-success-ink text-white font-display font-bold text-[13.5px] tracking-[-0.01em] hover:bg-[#0b2912] disabled:opacity-50 cursor-pointer"
+            className="px-[18px] py-2.5 rounded-[11px] bg-accent text-white font-display font-bold text-[13.5px] tracking-[-0.01em] hover:bg-[#5a4cd1] disabled:opacity-50 cursor-pointer"
           >
             Approve
           </button>

--- a/apps/web/src/app/api/approvals/route.ts
+++ b/apps/web/src/app/api/approvals/route.ts
@@ -80,6 +80,7 @@ export async function GET(request: NextRequest) {
       summary: action_request.summary,
       scope: action_request.scope,
       status: action_request.status,
+      minutesSaved: action_request.minutes_saved,
       approvedAt: action_request.approved_at,
       approvedByUserId: action_request.approved_by_user_id,
       policyId: action_request.policy_id,
@@ -141,6 +142,7 @@ export async function GET(request: NextRequest) {
       summary: r.summary,
       scope: r.scope,
       status: r.status,
+      minutesSaved: r.minutesSaved ?? null,
       approvedAt: r.approvedAt?.toISOString() ?? null,
       approverKind: r.approvedByUserId
         ? ("operator" as const)

--- a/apps/web/src/app/api/briefing/recent-actions/route.ts
+++ b/apps/web/src/app/api/briefing/recent-actions/route.ts
@@ -36,6 +36,8 @@ export async function GET() {
       scope: action_request.scope,
       riskLevel: action_request.risk_level,
       status: action_request.status,
+      minutesSaved: action_request.minutes_saved,
+      minutesSavedBasis: action_request.minutes_saved_basis,
       approvedAt: action_request.approved_at,
       approvedByUserId: action_request.approved_by_user_id,
       policyId: action_request.policy_id,
@@ -90,6 +92,8 @@ export async function GET() {
       status: r.status,
       executedAt: r.executedAt?.toISOString() ?? null,
       executionStatus: r.executionStatus,
+      minutesSaved: r.minutesSaved ?? null,
+      minutesSavedBasis: r.minutesSavedBasis ?? null,
       approverKind: r.approvedByUserId
         ? ("operator" as const)
         : r.policyId

--- a/apps/web/src/app/api/briefing/value/route.ts
+++ b/apps/web/src/app/api/briefing/value/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import {
+  action_execution,
+  action_request,
+  and,
+  db,
+  eq,
+  organization,
+  sql,
+  work_run,
+} from "@neko/db";
+import { getOrgId } from "@/lib/db";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const WINDOW_HOURS = 24;
+
+// Realized hours saved = executed actions + completed-run analysis. Returns
+// the rolling-window total (for the dashboard line) and the cumulative total
+// (the value-prop hero). Estimates are agent-produced and server-clamped at
+// write time; see docs/HOURS_SAVED_PLAN.md.
+export async function GET() {
+  const orgId = await getOrgId();
+  const since = new Date(Date.now() - WINDOW_HOURS * 3600 * 1000);
+
+  // Per-action minutes — counted once an action has actually executed.
+  const [actionAgg] = await db()
+    .select({
+      windowMin: sql<number>`coalesce(sum(${action_request.minutes_saved}) filter (where ${action_execution.finished_at} >= ${since}), 0)::int`,
+      totalMin: sql<number>`coalesce(sum(${action_request.minutes_saved}), 0)::int`,
+      windowTasks: sql<number>`count(*) filter (where ${action_execution.finished_at} >= ${since})::int`,
+    })
+    .from(action_request)
+    .innerJoin(
+      action_execution,
+      eq(action_execution.action_request_id, action_request.id),
+    )
+    .where(
+      and(
+        eq(action_request.org_id, orgId),
+        eq(action_request.status, "executed"),
+      ),
+    );
+
+  // Per-run analysis minutes — counted for completed runs (Ask + workflow).
+  const [analysisAgg] = await db()
+    .select({
+      windowMin: sql<number>`coalesce(sum(${work_run.analysis_minutes_saved}) filter (where ${work_run.finished_at} >= ${since}), 0)::int`,
+      totalMin: sql<number>`coalesce(sum(${work_run.analysis_minutes_saved}), 0)::int`,
+      windowTasks: sql<number>`count(*) filter (where ${work_run.finished_at} >= ${since} and ${work_run.analysis_minutes_saved} > 0)::int`,
+    })
+    .from(work_run)
+    .where(and(eq(work_run.org_id, orgId), eq(work_run.status, "completed")));
+
+  const [org] = await db()
+    .select({ createdAt: organization.created_at })
+    .from(organization)
+    .where(eq(organization.id, orgId))
+    .limit(1);
+
+  const windowMinutes = (actionAgg?.windowMin ?? 0) + (analysisAgg?.windowMin ?? 0);
+  const totalMinutes = (actionAgg?.totalMin ?? 0) + (analysisAgg?.totalMin ?? 0);
+  const windowTasks =
+    (actionAgg?.windowTasks ?? 0) + (analysisAgg?.windowTasks ?? 0);
+
+  return NextResponse.json({
+    windowHours: WINDOW_HOURS,
+    windowMinutes,
+    totalMinutes,
+    windowTasks,
+    sinceISO: org?.createdAt?.toISOString() ?? null,
+  });
+}

--- a/apps/web/src/app/api/work/threads/[threadId]/runs/route.ts
+++ b/apps/web/src/app/api/work/threads/[threadId]/runs/route.ts
@@ -99,6 +99,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       threadId,
       runId: run.id,
       message,
+      channel: "web",
       emit,
       signal: abortController.signal,
       pluginActions,

--- a/apps/web/src/app/api/workflows/[workflowId]/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/route.ts
@@ -7,6 +7,7 @@ import {
   eq,
   gte,
   sql,
+  work_run,
   workflow_definition,
   workflow_run,
 } from "@neko/db";
@@ -116,6 +117,39 @@ export async function GET(_request: Request, context: RouteContext) {
       ),
     );
 
+  // Hours saved over the last 30 days: completed-run analysis + executed
+  // action minutes, scoped to this workflow's runs.
+  const since30d = new Date(Date.now() - 30 * 24 * 3600 * 1000);
+  const [analysisAgg] = await db()
+    .select({
+      min: sql<number>`coalesce(sum(${work_run.analysis_minutes_saved}), 0)::int`,
+    })
+    .from(workflow_run)
+    .innerJoin(work_run, eq(workflow_run.work_run_id, work_run.id))
+    .where(
+      and(
+        eq(workflow_run.org_id, orgId),
+        eq(workflow_run.workflow_id, workflowId),
+        eq(work_run.status, "completed"),
+        gte(workflow_run.created_at, since30d),
+      ),
+    );
+  const [actionAgg] = await db()
+    .select({
+      min: sql<number>`coalesce(sum(${action_request.minutes_saved}), 0)::int`,
+    })
+    .from(action_request)
+    .innerJoin(workflow_run, eq(action_request.workflow_run_id, workflow_run.id))
+    .where(
+      and(
+        eq(workflow_run.org_id, orgId),
+        eq(workflow_run.workflow_id, workflowId),
+        eq(action_request.status, "executed"),
+        gte(action_request.created_at, since30d),
+      ),
+    );
+  const minutesSaved30d = (analysisAgg?.min ?? 0) + (actionAgg?.min ?? 0);
+
   return NextResponse.json({
     workflow: {
       id: workflow.id,
@@ -131,6 +165,7 @@ export async function GET(_request: Request, context: RouteContext) {
       cronEnabled: workflow.cronEnabled,
       dailyRunBudget: workflow.dailyRunBudget,
       runsToday: todayCount?.count ?? 0,
+      minutesSaved30d,
       createdByThreadId: workflow.createdByThreadId,
       createdByRunId: workflow.createdByRunId,
       createdAt: workflow.createdAt.toISOString(),

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -130,3 +130,47 @@ html[data-density="compact"] .triage-layout {
 }
 html[data-density="compact"] .triage-pane { display: block; position: sticky; top: 18px; }
 
+/* ── Ask: 3-pane (threads | conversation | context rail) in Compact ── */
+.work-rail { display: none; }
+.wcr-sect {
+  background: var(--card); border: 1px solid var(--border); border-radius: 18px;
+  padding: 13px 14px 14px; box-shadow: var(--shadow);
+}
+.wcr-h {
+  font-family: var(--font-display), 'Archivo', sans-serif; font-size: 10px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.13em; color: var(--text3);
+  margin: 0 0 9px; display: flex; align-items: center; gap: 8px;
+}
+.wcr-h::after { content: ""; flex: 1; height: 1px; background: var(--border); }
+.wcr-artifact {
+  display: flex; align-items: center; gap: 9px; padding: 8px 10px;
+  border: 1px solid var(--border); border-radius: 11px; background: var(--bg);
+  text-decoration: none; color: inherit; transition: border-color 0.15s, transform 0.15s;
+}
+.wcr-artifact:hover { border-color: var(--text3); transform: translateY(-1px); }
+.wcr-ic { width: 30px; height: 30px; border-radius: 8px; display: grid; place-items: center; flex: 0 0 auto; }
+.wcr-ic.sheet { background: var(--success-soft); color: var(--success-mid); }
+.wcr-ic.image { background: var(--accent-soft); color: var(--accent); }
+.wcr-ic.doc { background: var(--danger-soft); color: var(--danger); }
+.wcr-ic.file { background: var(--neutral); color: var(--text2); }
+.wcr-chip {
+  display: flex; align-items: center; gap: 8px; padding: 9px 11px;
+  border: 1px solid var(--border); border-radius: 11px; background: var(--bg);
+  text-decoration: none; color: var(--text2); font-size: 12.5px;
+  transition: border-color 0.15s, background 0.15s, color 0.15s, transform 0.15s;
+}
+.wcr-chip:hover { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); transform: translateY(-1px); }
+
+@media (min-width: 1100px) {
+  html[data-density="compact"] .work-layout.has-rail {
+    width: min(1340px, calc(100vw - 40px));
+    grid-template-columns: 248px minmax(0, 1fr) 312px;
+  }
+  html[data-density="compact"] .work-layout.has-rail .work-rail {
+    display: flex; flex-direction: column; gap: 12px;
+    position: sticky; top: 24px; align-self: start;
+    max-height: calc(100vh - 48px); overflow-y: auto;
+  }
+}
+
+

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -83,7 +83,7 @@ html[data-density="comfortable"] {
 }
 .density-seg button {
   font-family: var(--font-body), 'Manrope', sans-serif; font-weight: 600; font-size: 12.5px;
-  color: var(--text2); border: 0; background: transparent; padding: 6px 13px; border-radius: 999px;
+  color: var(--text2); border: 0; background: transparent; padding: 6px 14px; border-radius: 999px;
   cursor: pointer; display: inline-flex; align-items: center; gap: 6px; line-height: 1; transition: color 0.18s;
 }
 .density-seg button svg { width: 13px; height: 13px; }
@@ -172,5 +172,49 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
     max-height: calc(100vh - 48px); overflow-y: auto;
   }
 }
+
+/* ── TOP BAR (single-row chrome, matches the dense mockups) ── */
+.topbar-inner {
+  width: 100%; max-width: 1200px; padding: 0 20px;
+  display: flex; align-items: center; gap: 16px; min-height: 41px;
+}
+.topbar-brand { display: inline-flex; align-items: center; gap: 9px; text-decoration: none; color: var(--text); flex: 0 0 auto; transition: opacity 0.18s; }
+.topbar-brand:hover { opacity: 0.85; }
+.topbar-logo { width: 22px; height: 22px; object-fit: contain; display: block; flex: none; }
+.topbar-name { font-family: var(--font-display), 'Archivo', sans-serif; font-weight: 800; font-size: 17px; letter-spacing: -0.02em; line-height: 1; }
+.topbar-ver {
+  font-family: var(--font-body), 'Manrope', sans-serif; font-weight: 600; font-size: 10.5px;
+  color: var(--text2); background: var(--neutral); padding: 2px 6px; border-radius: 999px;
+  border: 0; line-height: 1.4; letter-spacing: 0;
+}
+.topbar-ver.is-update {
+  display: inline-flex; align-items: center; gap: 5px; cursor: pointer;
+  background: var(--success-soft); color: var(--success-ink);
+  border: 1px solid color-mix(in srgb, var(--success-mid) 30%, var(--border));
+}
+.topbar-ver.is-update:hover { background: color-mix(in srgb, var(--success) 22%, var(--success-soft)); }
+.topbar-ver-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--success-mid); }
+.topbar-nav { display: flex; align-items: center; gap: 2px; margin-left: 6px; flex-wrap: wrap; }
+.topbar-nav-link {
+  font-size: 13.5px; font-weight: 500; color: var(--text2); padding: 7px 12px; border-radius: 999px;
+  border: 1px solid transparent; text-decoration: none; white-space: nowrap; display: inline-flex; align-items: center;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.topbar-nav-link:hover { background: rgba(20, 18, 12, 0.04); color: var(--text); }
+.topbar-nav-link.is-active { border-color: var(--border); color: var(--text); font-weight: 600; }
+.topbar-nav-link.is-active::before {
+  content: ""; display: inline-block; width: 5px; height: 5px; border-radius: 50%;
+  background: var(--accent); margin-right: 7px;
+}
+.topbar-spacer { flex: 1; }
+.topbar-signout { background: transparent; border: 0; cursor: pointer; color: var(--text2); font-size: 12px; font-weight: 500; padding: 0; flex: 0 0 auto; white-space: nowrap; }
+.topbar-signout:hover { color: var(--text); }
+
+@media (max-width: 720px) {
+  .topbar-inner { flex-wrap: wrap; padding: 0 16px; gap: 10px 12px; }
+  .topbar-spacer { display: none; }
+  .topbar-nav { order: 3; width: 100%; overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; }
+}
+
 
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -54,3 +54,55 @@
 @import "./styles/_actions.css";
 @import "./styles/_act-card.css";
 @import "./styles/_responsive.css";
+
+/* ─── DENSITY LAYER (Comfortable ⇄ Compact, [data-density] on <html>) ─── */
+/* default (no attribute) = compact */
+:root,
+html[data-density="compact"] {
+  --d-dash-width: 1200px;
+  --d-brief-cols: repeat(auto-fill, minmax(300px, 1fr));
+  --d-brief-gap: 12px;
+  --d-greet: 30px;
+  --d-section-gap: 22px;
+  --d-icard-pad: 15px 16px 15px 20px;
+  --d-icard-detail: none;
+}
+html[data-density="comfortable"] {
+  --d-dash-width: 760px;
+  --d-brief-cols: 1fr;
+  --d-brief-gap: 12px;
+  --d-greet: 46px;
+  --d-section-gap: 32px;
+  --d-icard-pad: 22px 24px 22px 28px;
+  --d-icard-detail: block;
+}
+
+.density-seg {
+  display: inline-flex; background: var(--neutral); border: 1px solid var(--border);
+  border-radius: 999px; padding: 3px; gap: 2px; flex: 0 0 auto;
+}
+.density-seg button {
+  font-family: var(--font-body), 'Manrope', sans-serif; font-weight: 600; font-size: 12.5px;
+  color: var(--text2); border: 0; background: transparent; padding: 6px 13px; border-radius: 999px;
+  cursor: pointer; display: inline-flex; align-items: center; gap: 6px; line-height: 1; transition: color 0.18s;
+}
+.density-seg button svg { width: 13px; height: 13px; }
+.density-seg button[aria-pressed="true"] {
+  background: var(--card); color: var(--text);
+  box-shadow: 0 1px 2px rgba(20,18,12,0.08), 0 2px 8px -2px rgba(20,18,12,0.1);
+}
+@media (max-width: 680px) { .density-seg button span { display: none; } .density-seg button { padding: 7px 9px; } }
+
+.dash-root {
+  --page-width: var(--d-dash-width);
+  transition: max-width 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+.dash-root .greet { font-size: var(--d-greet); }
+
+.brief-grid {
+  display: grid; grid-template-columns: var(--d-brief-cols); gap: var(--d-brief-gap); align-items: start;
+}
+.brief-grid .icard { margin-bottom: 0; }
+.brief-grid .idetail { display: var(--d-icard-detail); }
+.brief-grid .icard.open .idetail { display: block; }
+.dash-root .icard { padding: var(--d-icard-pad); }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -160,6 +160,14 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
 .wcr-source-dot { width: 6px; height: 6px; border-radius: 2px; background: var(--accent); opacity: 0.7; flex: none; }
 .wcr-memo { background: var(--bg); border: 1px solid var(--border); border-left: 2px solid var(--accent); border-radius: 11px; padding: 9px 11px; font-size: 12px; line-height: 1.45; color: var(--text2); }
 .wcr-empty-text { margin: 0; font-size: 12px; line-height: 1.5; color: var(--text3); }
+.wcr-vitals { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.wcr-vital { background: var(--bg); border: 1px solid var(--border); border-radius: 12px; padding: 9px 10px; }
+.wcr-vital-k { font-size: 9.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text3); margin-bottom: 5px; }
+.wcr-vital-v {
+  font-family: var(--font-display), 'Archivo', sans-serif; font-weight: 800; font-size: 18px;
+  line-height: 1; letter-spacing: -0.02em; font-variant-numeric: tabular-nums; color: var(--text);
+}
+.wcr-vital-s { margin-top: 4px; font-size: 10.5px; font-weight: 600; color: var(--success-ink); }
 
 @media (min-width: 1100px) {
   html[data-density="compact"] .work-layout.has-rail {
@@ -225,6 +233,7 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
   .topbar-spacer { display: none; }
   .topbar-nav { order: 3; width: 100%; overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; }
 }
+
 
 
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -65,6 +65,10 @@ html[data-density="compact"] {
   --d-greet: 30px;
   --d-section-gap: 22px;
   --d-icard-pad: 15px 16px 15px 20px;
+  /* Sticky offset for the side panels — set to their resting top (sticky
+     header 62px + its 24px margin) so they pin from the first pixel of scroll
+     with zero travel: rock solid, never drifting with the page. */
+  --app-sticky-top: 86px;
 }
 html[data-density="comfortable"] {
   --d-dash-width: 760px;
@@ -150,9 +154,11 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
 .wcr-ic.doc { background: var(--danger-soft); color: var(--danger); }
 .wcr-ic.file { background: var(--neutral); color: var(--text2); }
 .wcr-chip {
-  display: flex; align-items: center; gap: 8px; padding: 9px 11px;
+  display: flex; align-items: flex-start; gap: 8px; padding: 9px 11px;
   border: 1px solid var(--border); border-radius: 11px; background: var(--bg);
-  text-decoration: none; color: var(--text2); font-size: 12.5px;
+  text-align: left; width: 100%; cursor: pointer;
+  font-family: var(--font-body), 'Manrope', sans-serif; font-size: 12.5px; line-height: 1.4;
+  color: var(--text2);
   transition: border-color 0.15s, background 0.15s, color 0.15s, transform 0.15s;
 }
 .wcr-chip:hover { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); transform: translateY(-1px); }
@@ -176,8 +182,8 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
   }
   html[data-density="compact"] .work-layout.has-rail .work-rail {
     display: flex; flex-direction: column; gap: 12px;
-    position: sticky; top: 24px; align-self: start;
-    max-height: calc(100vh - 48px); overflow-y: auto;
+    position: sticky; top: var(--app-sticky-top, 74px); align-self: start;
+    max-height: calc(100vh - var(--app-sticky-top, 74px) - 18px); overflow-y: auto;
   }
 }
 
@@ -233,6 +239,10 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
   .topbar-spacer { display: none; }
   .topbar-nav { order: 3; width: 100%; overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; }
 }
+
+
+
+
 
 
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -118,3 +118,15 @@ html[data-density="compact"] .wf-grid {
 html[data-density="compact"] .wf-grid > li:has(.workflows-row.is-active) {
   grid-column: 1 / -1;
 }
+
+/* ── Actions: triage queue (list + reading pane) in Compact ── */
+html[data-density="compact"] .approvals-root { --page-width: 1120px; }
+.triage-pane { display: none; }
+html[data-density="compact"] .triage-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 372px;
+  gap: 16px;
+  align-items: start;
+}
+html[data-density="compact"] .triage-pane { display: block; position: sticky; top: 18px; }
+

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -164,6 +164,7 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
 .wcr-source { display: flex; align-items: center; gap: 8px; padding: 6px 2px; font-size: 12.5px; color: var(--text2); }
 .wcr-source-dot { width: 6px; height: 6px; border-radius: 2px; background: var(--accent); opacity: 0.7; flex: none; }
 .wcr-memo { background: var(--bg); border: 1px solid var(--border); border-left: 2px solid var(--accent); border-radius: 11px; padding: 9px 11px; font-size: 12px; line-height: 1.45; color: var(--text2); }
+.wcr-empty-text { margin: 0; font-size: 12px; line-height: 1.5; color: var(--text3); }
 
 @media (min-width: 1100px) {
   html[data-density="compact"] .work-layout.has-rail {
@@ -229,6 +230,7 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
   .topbar-spacer { display: none; }
   .topbar-nav { order: 3; width: 100%; overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; }
 }
+
 
 
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -106,3 +106,15 @@ html[data-density="comfortable"] {
 .brief-grid .idetail { display: var(--d-icard-detail); }
 .brief-grid .icard.open .idetail { display: block; }
 .dash-root .icard { padding: var(--d-icard-pad); }
+
+/* ── Workflows: tile grid in Compact (expanded workflow spans full width) ── */
+html[data-density="compact"] .workflows-root { --page-width: 1200px; }
+html[data-density="compact"] .wf-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(330px, 1fr));
+  gap: 11px;
+  align-items: start;
+}
+html[data-density="compact"] .wf-grid > li:has(.workflows-row.is-active) {
+  grid-column: 1 / -1;
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -156,11 +156,6 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
   transition: border-color 0.15s, background 0.15s, color 0.15s, transform 0.15s;
 }
 .wcr-chip:hover { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); transform: translateY(-1px); }
-.wcr-vitals { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
-.wcr-vital { background: var(--bg); border: 1px solid var(--border); border-radius: 12px; padding: 9px 10px; }
-.wcr-vital-k { font-size: 9.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text3); margin-bottom: 5px; }
-.wcr-vital-v { font-family: var(--font-display), 'Archivo', sans-serif; font-weight: 800; font-size: 18px; line-height: 1; letter-spacing: -0.02em; font-variant-numeric: tabular-nums; }
-.wcr-vital-s { font-size: 10.5px; color: var(--success-ink); margin-top: 4px; font-weight: 600; }
 .wcr-source { display: flex; align-items: center; gap: 8px; padding: 6px 2px; font-size: 12.5px; color: var(--text2); }
 .wcr-source-dot { width: 6px; height: 6px; border-radius: 2px; background: var(--accent); opacity: 0.7; flex: none; }
 .wcr-memo { background: var(--bg); border: 1px solid var(--border); border-left: 2px solid var(--accent); border-radius: 11px; padding: 9px 11px; font-size: 12px; line-height: 1.45; color: var(--text2); }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -65,7 +65,6 @@ html[data-density="compact"] {
   --d-greet: 30px;
   --d-section-gap: 22px;
   --d-icard-pad: 15px 16px 15px 20px;
-  --d-icard-detail: none;
 }
 html[data-density="comfortable"] {
   --d-dash-width: 760px;
@@ -74,7 +73,6 @@ html[data-density="comfortable"] {
   --d-greet: 46px;
   --d-section-gap: 32px;
   --d-icard-pad: 22px 24px 22px 28px;
-  --d-icard-detail: block;
 }
 
 .density-seg {
@@ -103,10 +101,7 @@ html[data-density="comfortable"] {
   display: grid; grid-template-columns: var(--d-brief-cols); gap: var(--d-brief-gap); align-items: start;
 }
 .brief-grid .icard { margin-bottom: 0; }
-.brief-grid .idetail { display: var(--d-icard-detail); }
-.brief-grid .icard.open .idetail { display: block; }
-.dash-root .icard { padding: var(--d-icard-pad); }
-.icard .minispark { display: block; width: 100%; height: 30px; margin-top: 11px; }
+.dash-root .icard { padding: var(--d-icard-pad); cursor: default; }
 
 /* ── Workflows: tile grid in Compact (expanded workflow spans full width) ── */
 html[data-density="compact"] .workflows-root { --page-width: 1200px; }
@@ -210,12 +205,24 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
 .topbar-spacer { flex: 1; }
 .topbar-signout { background: transparent; border: 0; cursor: pointer; color: var(--text2); font-size: 12px; font-weight: 500; padding: 0; flex: 0 0 auto; white-space: nowrap; }
 .topbar-signout:hover { color: var(--text); }
+.topbar-credit {
+  display: inline-flex; align-items: center; flex: 0 0 auto;
+  font-family: var(--font-body), 'Manrope', sans-serif; font-size: 11px; font-weight: 600;
+  color: #113719; background: #6cff7f; border: 1px solid #58f26c; border-radius: 999px;
+  padding: 5px 10px; text-decoration: none; line-height: 1; white-space: nowrap;
+  transition: background 0.18s, transform 0.18s;
+}
+.topbar-credit:hover { background: #58f26c; transform: translateY(-1px); }
+/* The floating creator credit is replaced by the in-header one. */
+.creator-credit { display: none; }
 
 @media (max-width: 720px) {
   .topbar-inner { flex-wrap: wrap; padding: 0 16px; gap: 10px 12px; }
   .topbar-spacer { display: none; }
   .topbar-nav { order: 3; width: 100%; overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; }
 }
+
+
 
 
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -156,6 +156,14 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
   transition: border-color 0.15s, background 0.15s, color 0.15s, transform 0.15s;
 }
 .wcr-chip:hover { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); transform: translateY(-1px); }
+.wcr-vitals { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.wcr-vital { background: var(--bg); border: 1px solid var(--border); border-radius: 12px; padding: 9px 10px; }
+.wcr-vital-k { font-size: 9.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text3); margin-bottom: 5px; }
+.wcr-vital-v { font-family: var(--font-display), 'Archivo', sans-serif; font-weight: 800; font-size: 18px; line-height: 1; letter-spacing: -0.02em; font-variant-numeric: tabular-nums; }
+.wcr-vital-s { font-size: 10.5px; color: var(--success-ink); margin-top: 4px; font-weight: 600; }
+.wcr-source { display: flex; align-items: center; gap: 8px; padding: 6px 2px; font-size: 12.5px; color: var(--text2); }
+.wcr-source-dot { width: 6px; height: 6px; border-radius: 2px; background: var(--accent); opacity: 0.7; flex: none; }
+.wcr-memo { background: var(--bg); border: 1px solid var(--border); border-left: 2px solid var(--accent); border-radius: 11px; padding: 9px 11px; font-size: 12px; line-height: 1.45; color: var(--text2); }
 
 @media (min-width: 1100px) {
   html[data-density="compact"] .work-layout.has-rail {
@@ -221,6 +229,7 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
   .topbar-spacer { display: none; }
   .topbar-nav { order: 3; width: 100%; overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; }
 }
+
 
 
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -106,6 +106,7 @@ html[data-density="comfortable"] {
 .brief-grid .idetail { display: var(--d-icard-detail); }
 .brief-grid .icard.open .idetail { display: block; }
 .dash-root .icard { padding: var(--d-icard-pad); }
+.icard .minispark { display: block; width: 100%; height: 30px; margin-top: 11px; }
 
 /* ── Workflows: tile grid in Compact (expanded workflow spans full width) ── */
 html[data-density="compact"] .workflows-root { --page-width: 1200px; }
@@ -215,6 +216,7 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
   .topbar-spacer { display: none; }
   .topbar-nav { order: 3; width: 100%; overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; }
 }
+
 
 
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -179,8 +179,8 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
 
 /* ── TOP BAR (single-row chrome, matches the dense mockups) ── */
 .topbar-inner {
-  width: 100%; max-width: 1200px; padding: 0 20px;
-  display: flex; align-items: center; gap: 16px; min-height: 41px;
+  width: 100%; max-width: 1340px; padding: 0 20px;
+  display: flex; align-items: center; flex-wrap: nowrap; gap: 14px; min-height: 41px;
 }
 .topbar-brand { display: inline-flex; align-items: center; gap: 9px; text-decoration: none; color: var(--text); flex: 0 0 auto; transition: opacity 0.18s; }
 .topbar-brand:hover { opacity: 0.85; }
@@ -189,7 +189,7 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
 .topbar-ver {
   font-family: var(--font-body), 'Manrope', sans-serif; font-weight: 600; font-size: 10.5px;
   color: var(--text2); background: var(--neutral); padding: 2px 6px; border-radius: 999px;
-  border: 0; line-height: 1.4; letter-spacing: 0;
+  border: 0; line-height: 1.4; letter-spacing: 0; white-space: nowrap; flex: 0 0 auto;
 }
 .topbar-ver.is-update {
   display: inline-flex; align-items: center; gap: 5px; cursor: pointer;
@@ -198,7 +198,7 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
 }
 .topbar-ver.is-update:hover { background: color-mix(in srgb, var(--success) 22%, var(--success-soft)); }
 .topbar-ver-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--success-mid); }
-.topbar-nav { display: flex; align-items: center; gap: 2px; margin-left: 6px; flex-wrap: wrap; }
+.topbar-nav { display: flex; align-items: center; gap: 2px; margin-left: 6px; flex-wrap: nowrap; }
 .topbar-nav-link {
   font-size: 13.5px; font-weight: 500; color: var(--text2); padding: 7px 12px; border-radius: 999px;
   border: 1px solid transparent; text-decoration: none; white-space: nowrap; display: inline-flex; align-items: center;
@@ -215,12 +215,12 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
 .topbar-signout:hover { color: var(--text); }
 .topbar-credit {
   display: inline-flex; align-items: center; flex: 0 0 auto;
-  font-family: var(--font-body), 'Manrope', sans-serif; font-size: 11px; font-weight: 600;
-  color: #113719; background: #6cff7f; border: 1px solid #58f26c; border-radius: 999px;
-  padding: 5px 10px; text-decoration: none; line-height: 1; white-space: nowrap;
-  transition: background 0.18s, transform 0.18s;
+  font-family: var(--font-body), 'Manrope', sans-serif; font-size: 11.5px; font-weight: 500;
+  color: var(--text3); text-decoration: none; line-height: 1; white-space: nowrap;
+  padding-left: 14px; margin-left: 2px; border-left: 1px solid var(--border);
+  transition: color 0.18s;
 }
-.topbar-credit:hover { background: #58f26c; transform: translateY(-1px); }
+.topbar-credit:hover { color: var(--text2); }
 /* The floating creator credit is replaced by the in-header one. */
 .creator-credit { display: none; }
 
@@ -229,6 +229,8 @@ html[data-density="compact"] .triage-pane { display: block; position: sticky; to
   .topbar-spacer { display: none; }
   .topbar-nav { order: 3; width: 100%; overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; }
 }
+
+
 
 
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,7 +1,12 @@
 import type { Metadata, Viewport } from "next";
 import { Archivo, Manrope } from "next/font/google";
 import { Toaster } from "sonner";
+import { DensityProvider } from "@/components/DensityProvider";
 import "./globals.css";
+
+// Set data-density before paint from the persisted choice (default compact),
+// so the dense layout never flashes the comfortable one on load.
+const DENSITY_INIT = `(function(){try{var d=localStorage.getItem('neko-density');document.documentElement.setAttribute('data-density',d==='comfortable'?'comfortable':'compact');}catch(e){document.documentElement.setAttribute('data-density','compact');}})();`;
 
 const display = Archivo({
   variable: "--font-display",
@@ -32,9 +37,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${display.variable} ${body.variable}`}>
+    <html lang="en" data-density="compact" className={`${display.variable} ${body.variable}`}>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: DENSITY_INIT }} />
+      </head>
       <body>
-        {children}
+        <DensityProvider>{children}</DensityProvider>
         <Toaster
           position="bottom-right"
           expand

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -497,7 +497,7 @@ export default function Dashboard() {
 
   return (
     <>
-      <div className="root">
+      <div className="root dash-root">
         <AppHeader>
           <SectionNav current="dashboard" />
         </AppHeader>
@@ -710,16 +710,18 @@ export default function Dashboard() {
 
             <div className="mb-6">
               <div className="label">Today&apos;s Briefing</div>
-              {briefingCards.map((ins, i) => (
-                <BriefingCard
-                  key={ins.id}
-                  ins={ins}
-                  index={i}
-                  onDismiss={() => dismissCard(ins.metricId)}
-                  onRetry={retryCard}
-                  onDeepDive={deepDiveCard}
-                />
-              ))}
+              <div className="brief-grid">
+                {briefingCards.map((ins, i) => (
+                  <BriefingCard
+                    key={ins.id}
+                    ins={ins}
+                    index={i}
+                    onDismiss={() => dismissCard(ins.metricId)}
+                    onRetry={retryCard}
+                    onDeepDive={deepDiveCard}
+                  />
+                ))}
+              </div>
             </div>
 
             {recentActions && recentActions.receipts.length > 0 && (

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -16,6 +16,11 @@ import ActCard, {
 import AppHeader from "@/components/AppHeader";
 import CreatorCredit from "@/components/CreatorCredit";
 import SectionNav from "@/components/SectionNav";
+import HoursSavedHero, {
+  type HoursSavedItem,
+  type HoursSavedValue,
+} from "@/components/HoursSavedHero";
+import { formatSavedShort } from "@/lib/hours-saved";
 import { cn } from "@/lib/cn";
 
 type FindingsPayload = {
@@ -43,6 +48,8 @@ type ReceiptRow = {
   status: string;
   executedAt: string | null;
   executionStatus: string;
+  minutesSaved: number | null;
+  minutesSavedBasis: string | null;
   approverKind: "operator" | "policy" | "auto";
   approverLabel: string | null;
   workflowRunId: string | null;
@@ -155,6 +162,7 @@ function groupReceipts(
       target: r.summary ? r.target : null, // headline already includes target when summary is absent
       approverPhrase: approverPhrase(r.approverKind, r.approverLabel),
       status: r.status,
+      minutesSaved: r.minutesSaved,
     };
     const existing = groups.get(key);
     if (existing) {
@@ -234,6 +242,7 @@ export default function Dashboard() {
   const [recentActions, setRecentActions] =
     useState<RecentActionsPayload | null>(null);
   const [awaiting, setAwaiting] = useState<AwaitingPayload | null>(null);
+  const [hoursSaved, setHoursSaved] = useState<HoursSavedValue | null>(null);
 
   // Tributaries: workflow_output findings + pending approvals + live summary.
   // Polled alongside the KPI briefing so newly-produced findings appear
@@ -275,18 +284,31 @@ export default function Dashboard() {
     }
   }, []);
 
+  const fetchHoursSaved = useCallback(async () => {
+    try {
+      const res = await fetch("/api/briefing/value", { cache: "no-store" });
+      if (!res.ok) return;
+      const data = (await res.json()) as HoursSavedValue;
+      setHoursSaved(data);
+    } catch {
+      // best-effort; the page still renders without the value hero
+    }
+  }, []);
+
   useEffect(() => {
     if (!gateChecked) return;
     void fetchFindings();
     void fetchRecentActions();
     void fetchAwaiting();
+    void fetchHoursSaved();
     const id = setInterval(() => {
       void fetchFindings();
       void fetchRecentActions();
       void fetchAwaiting();
+      void fetchHoursSaved();
     }, 30_000);
     return () => clearInterval(id);
-  }, [gateChecked, fetchFindings, fetchRecentActions, fetchAwaiting]);
+  }, [gateChecked, fetchFindings, fetchRecentActions, fetchAwaiting, fetchHoursSaved]);
 
   const surfaceId = `briefing-${role.toLowerCase()}`;
   const surface = surfaces.get(surfaceId);
@@ -570,6 +592,19 @@ export default function Dashboard() {
               </div>
             )}
 
+            {hoursSaved && hoursSaved.totalMinutes > 0 && (
+              <HoursSavedHero
+                value={hoursSaved}
+                items={(recentActions?.receipts ?? [])
+                  .filter((r) => (r.minutesSaved ?? 0) > 0)
+                  .map<HoursSavedItem>((r) => ({
+                    label: r.summary || r.kind,
+                    minutes: r.minutesSaved ?? 0,
+                    basis: r.minutesSavedBasis,
+                  }))}
+              />
+            )}
+
             {awaiting && awaiting.actions.length > 0 && (
               <section
                 className="dash-call"
@@ -699,6 +734,9 @@ export default function Dashboard() {
                   </span>
                   <span className="dash-proof-label">
                     fired on your behalf in the last {recentActions.windowHours}h
+                    {hoursSaved && hoursSaved.windowMinutes > 0 && (
+                      <> · saved you {formatSavedShort(hoursSaved.windowMinutes)}</>
+                    )}
                   </span>
                   <span className="dash-proof-caret" aria-hidden="true">▸</span>
                 </summary>

--- a/apps/web/src/app/styles/_chrome.css
+++ b/apps/web/src/app/styles/_chrome.css
@@ -1,5 +1,5 @@
 /* ─── LAYOUT ─── */
-.root { --page-width: 740px; max-width: var(--page-width); margin: 0 auto; padding: 36px 20px 130px; min-height: 100vh; padding-bottom: calc(130px + env(safe-area-inset-bottom, 0px)); }
+.root { --page-width: 740px; max-width: var(--page-width); margin: 0 auto; padding: 0 20px 130px; min-height: 100vh; padding-bottom: calc(130px + env(safe-area-inset-bottom, 0px)); }
 
 /* Faint editorial paper texture — adds atmosphere without competing with content. */
 body::before {
@@ -20,13 +20,33 @@ body > * { position: relative; z-index: 1; }
    nav row sits at the same x-position regardless of which page you're on.
    Without this, the nav appears to "bounce" between pages with different
    .root widths (Briefing 740, Workflows 1000, Builder etc). */
+/* The page scrolls behind a sticky header (top) and a sticky composer
+   (bottom). scroll-padding keeps scrollIntoView (auto-follow during a run,
+   followup-chip jumps) clear of both, so the asked question and the live
+   "running" indicator never tuck behind the composer. */
+html {
+  scroll-padding-top: 78px;
+  scroll-padding-bottom: 152px;
+  /* Kill the elastic rubber-band past the top/bottom edge — it dragged the
+     sticky header down and made the page feel unanchored. */
+  overscroll-behavior-y: none;
+}
+
 .app-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
   margin-left: calc(-50vw + 50%);
   margin-right: calc(-50vw + 50%);
   width: 100vw;
   display: flex;
   justify-content: center;
   margin-bottom: 24px;
+  padding-block: 10px;
+  background: color-mix(in srgb, var(--bg) 90%, transparent);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
 }
 
 /* "Update available" chip beside the brand. Pulse animations would render

--- a/apps/web/src/app/styles/_work.css
+++ b/apps/web/src/app/styles/_work.css
@@ -15,12 +15,12 @@
   border-radius: 22px;
   box-shadow: var(--shadow);
   position: sticky;
-  top: 24px;
+  top: var(--app-sticky-top, 74px);
   padding: 14px 12px 12px;
   display: flex;
   flex-direction: column;
   gap: 10px;
-  max-height: calc(100vh - 48px);
+  max-height: calc(100vh - var(--app-sticky-top, 74px) - 18px);
 }
 .work-sidebar-head {
   display: flex;

--- a/apps/web/src/components/ActCard.tsx
+++ b/apps/web/src/components/ActCard.tsx
@@ -268,7 +268,7 @@ function RowButton({ tone, disabled, onClick, children }: RowButtonProps) {
         "disabled:opacity-55 disabled:cursor-not-allowed",
         !tone && "bg-card border-border text-text hover:not-disabled:border-text3",
         tone === "primary" &&
-          "bg-success-ink border-success-ink text-white hover:not-disabled:bg-[#0b2912] hover:not-disabled:border-[#0b2912]",
+          "bg-accent border-accent text-white hover:not-disabled:bg-[#5a4cd1] hover:not-disabled:border-[#5a4cd1]",
         tone === "destructive" &&
           "bg-danger border-danger text-white hover:not-disabled:bg-[#c84545] hover:not-disabled:border-[#c84545]",
       )}

--- a/apps/web/src/components/ActCard.tsx
+++ b/apps/web/src/components/ActCard.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation";
 import { Card } from "@/components/ui/Card";
 import { Pill, type PillVariant } from "@/components/ui/Pill";
 import { cn } from "@/lib/cn";
+import { formatSavedShort } from "@/lib/hours-saved";
 
 export type ActRowTone = "good" | "watch" | "action";
 
@@ -16,6 +17,8 @@ export type ActRowData = {
   rejectionReason?: string | null;
   approverPhrase?: string | null;
   status: string;
+  /** Realized minutes saved — shown on fired receipts that carry an estimate. */
+  minutesSaved?: number | null;
 };
 
 export type ActCardData = {
@@ -164,12 +167,24 @@ export default function ActCard({
                     {row.rejectionReason}
                   </p>
                 )}
-                {data.state === "live" && row.approverPhrase && (
-                  <p className="mt-1 text-[11.5px] text-text3">
-                    approved by{" "}
-                    <span className="text-text2 font-medium">
-                      {row.approverPhrase}
-                    </span>
+                {data.state === "live" && (row.approverPhrase || (row.minutesSaved ?? 0) > 0) && (
+                  <p className="mt-1 text-[11.5px] text-text3 flex items-center gap-2 flex-wrap">
+                    {row.approverPhrase && (
+                      <span>
+                        approved by{" "}
+                        <span className="text-text2 font-medium">
+                          {row.approverPhrase}
+                        </span>
+                      </span>
+                    )}
+                    {(row.minutesSaved ?? 0) > 0 && (
+                      <span
+                        className="font-mono text-success-ink bg-success-soft border border-success-mid/30 rounded-full px-1.5 py-px"
+                        title="Estimated human time saved"
+                      >
+                        {formatSavedShort(row.minutesSaved as number)} saved
+                      </span>
+                    )}
                   </p>
                 )}
 

--- a/apps/web/src/components/ActCard.tsx
+++ b/apps/web/src/components/ActCard.tsx
@@ -220,7 +220,7 @@ export default function ActCard({
                         onApproveRow?.(row.id);
                       }}
                     >
-                      [a] Approve
+                      Approve
                     </RowButton>
                     <RowButton
                       disabled={isBusy}
@@ -229,7 +229,7 @@ export default function ActCard({
                         onBeginRejectRow?.(row.id);
                       }}
                     >
-                      [r] Reject
+                      Reject
                     </RowButton>
                     <a
                       className="ml-auto self-center px-1.5 py-1 text-xs font-semibold text-text2 no-underline opacity-70 transition-opacity duration-150 hover:opacity-100 hover:text-text hover:underline underline-offset-2"

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { ArrowLeft } from "lucide-react";
+import DensityToggle from "@/components/DensityToggle";
 
 const MARKETING_URL = "https://getneko.app";
 const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "0.0.0";
@@ -89,6 +90,7 @@ export default function AppHeader({ back, children }: AppHeaderProps) {
         </div>
 
         <div className="inline-flex items-center gap-2.5 self-start">
+          <DensityToggle />
           <a
             href={MARKETING_URL}
             target="_blank"

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from "react";
 import { ArrowLeft } from "lucide-react";
 import DensityToggle from "@/components/DensityToggle";
 
-const MARKETING_URL = "https://getneko.app";
+const MARKETING_URL = "https://openneko.app";
 const APP_VERSION = process.env.NEXT_PUBLIC_APP_VERSION ?? "0.0.0";
 const VERSION_POLL_MS = 60_000;
 
@@ -116,7 +116,7 @@ export default function AppHeader({ back, children }: AppHeaderProps) {
 
         <a
           className="topbar-credit"
-          href="https://getneko.app/#about"
+          href="https://openneko.app/#about"
           target="_blank"
           rel="noreferrer"
         >

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -14,13 +14,13 @@ export type AppHeaderProps = {
   children?: React.ReactNode;
 };
 
+// Single top bar matching the dense mockups: brand + version pill (left),
+// section nav, then the density toggle (right). The "update available" state
+// folds into the version pill so the bar stays mockup-faithful.
 export default function AppHeader({ back, children }: AppHeaderProps) {
   const [latestVersion, setLatestVersion] = useState<string | null>(null);
   const [user, setUser] = useState<{ email: string } | null>(null);
 
-  // Quiet poll for the server's current version. When it diverges from the
-  // version baked into this client bundle at build time, a new deploy has
-  // landed — the brand chip turns into a reload button.
   useEffect(() => {
     let cancelled = false;
     const check = async () => {
@@ -42,10 +42,6 @@ export default function AppHeader({ back, children }: AppHeaderProps) {
     };
   }, []);
 
-  // Sign-out affordance is only meaningful when the user has a session
-  // (i.e. an SSO plugin is installed AND they've signed in). When no
-  // plugin is installed the proxy lets every request through and the
-  // session is always null, so nothing renders.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -78,63 +74,56 @@ export default function AppHeader({ back, children }: AppHeaderProps) {
 
   return (
     <header className="app-header">
-      <div className="w-full max-w-[1000px] px-5 flex items-start justify-between gap-4 min-h-[41px]">
-        <div className="flex items-center gap-2.5 flex-1 min-w-0 flex-wrap">
-          {back && (
-            <Link className="settings-backlink" href={back.href}>
-              <ArrowLeft size={14} strokeWidth={2.25} aria-hidden="true" className="settings-backlink-arrow" />
-              <span>{back.label}</span>
-            </Link>
-          )}
-          {children}
-        </div>
-
-        <div className="inline-flex items-center gap-2.5 self-start">
-          <DensityToggle />
-          <a
-            href={MARKETING_URL}
-            target="_blank"
-            rel="noreferrer"
-            className="hidden sm:inline-flex items-center gap-2 select-none text-text no-underline transition-opacity duration-200 hover:opacity-80 self-start h-[41px]"
-            aria-label="OpenNeko — open marketing site in a new tab"
-          >
-            <img className="w-6 h-6 object-contain block flex-none" src="/cat.png" alt="" width={24} height={24} />
-            <span className="font-display text-[17px] font-extrabold tracking-[-0.04em] leading-none">
-              OpenNeko
-            </span>
-            <span aria-hidden="true" className="text-text3 text-sm leading-none mx-0.5">·</span>
-            <span aria-hidden="true" className="font-mono text-[10.5px] font-semibold text-text3 tracking-wider lowercase bg-neutral px-1.5 py-0.5 rounded-full leading-none">
-              v{APP_VERSION}
-            </span>
-          </a>
-
-          {updateAvailable && (
+      <div className="topbar-inner">
+        <a
+          className="topbar-brand"
+          href={MARKETING_URL}
+          target="_blank"
+          rel="noreferrer"
+          aria-label="OpenNeko — open marketing site in a new tab"
+        >
+          <img className="topbar-logo" src="/cat.png" alt="" width={22} height={22} />
+          <span className="topbar-name">OpenNeko</span>
+          {updateAvailable ? (
             <button
               type="button"
-              className="brand-update"
+              className="topbar-ver is-update"
               onClick={() => window.location.reload()}
               aria-label={`Update available: v${latestVersion}. Reload to apply.`}
               title={`v${latestVersion} available — reload`}
             >
-              <span className="brand-update-dot" aria-hidden="true" />
-              <span className="brand-update-label">v{latestVersion} ready · reload</span>
+              <span className="topbar-ver-dot" aria-hidden="true" />
+              v{latestVersion} · reload
             </button>
+          ) : (
+            <span className="topbar-ver">{APP_VERSION}</span>
           )}
+        </a>
 
-          {user && (
-            <button
-              type="button"
-              onClick={handleSignOut}
-              aria-label={`Sign out ${user.email}`}
-              title={user.email}
-              className="inline-flex items-center gap-1.5 self-start h-[41px] bg-transparent border-0 p-0 cursor-pointer text-text2 hover:text-text text-[12px] font-medium leading-none"
-            >
-              <span className="hidden sm:inline truncate max-w-[160px]">{user.email}</span>
-              <span aria-hidden="true" className="text-text3 hidden sm:inline">·</span>
-              <span>Sign out</span>
-            </button>
-          )}
-        </div>
+        {back && (
+          <Link className="settings-backlink" href={back.href}>
+            <ArrowLeft size={14} strokeWidth={2.25} aria-hidden="true" className="settings-backlink-arrow" />
+            <span>{back.label}</span>
+          </Link>
+        )}
+
+        {children}
+
+        <span className="topbar-spacer" />
+
+        <DensityToggle />
+
+        {user && (
+          <button
+            type="button"
+            onClick={handleSignOut}
+            aria-label={`Sign out ${user.email}`}
+            title={user.email}
+            className="topbar-signout"
+          >
+            Sign out
+          </button>
+        )}
       </div>
     </header>
   );

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -86,19 +86,6 @@ export default function AppHeader({ back, children }: AppHeaderProps) {
           <span className="topbar-name">OpenNeko</span>
         </a>
 
-        {back && (
-          <Link className="settings-backlink" href={back.href}>
-            <ArrowLeft size={14} strokeWidth={2.25} aria-hidden="true" className="settings-backlink-arrow" />
-            <span>{back.label}</span>
-          </Link>
-        )}
-
-        {children}
-
-        <span className="topbar-spacer" />
-
-        <DensityToggle />
-
         {updateAvailable ? (
           <button
             type="button"
@@ -113,6 +100,19 @@ export default function AppHeader({ back, children }: AppHeaderProps) {
         ) : (
           <span className="topbar-ver" title="OpenNeko version">{APP_VERSION}</span>
         )}
+
+        {back && (
+          <Link className="settings-backlink" href={back.href}>
+            <ArrowLeft size={14} strokeWidth={2.25} aria-hidden="true" className="settings-backlink-arrow" />
+            <span>{back.label}</span>
+          </Link>
+        )}
+
+        {children}
+
+        <span className="topbar-spacer" />
+
+        <DensityToggle />
 
         <a
           className="topbar-credit"

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -84,20 +84,6 @@ export default function AppHeader({ back, children }: AppHeaderProps) {
         >
           <img className="topbar-logo" src="/cat.png" alt="" width={22} height={22} />
           <span className="topbar-name">OpenNeko</span>
-          {updateAvailable ? (
-            <button
-              type="button"
-              className="topbar-ver is-update"
-              onClick={() => window.location.reload()}
-              aria-label={`Update available: v${latestVersion}. Reload to apply.`}
-              title={`v${latestVersion} available — reload`}
-            >
-              <span className="topbar-ver-dot" aria-hidden="true" />
-              v{latestVersion} · reload
-            </button>
-          ) : (
-            <span className="topbar-ver">{APP_VERSION}</span>
-          )}
         </a>
 
         {back && (
@@ -112,6 +98,30 @@ export default function AppHeader({ back, children }: AppHeaderProps) {
         <span className="topbar-spacer" />
 
         <DensityToggle />
+
+        {updateAvailable ? (
+          <button
+            type="button"
+            className="topbar-ver is-update"
+            onClick={() => window.location.reload()}
+            aria-label={`Update available: v${latestVersion}. Reload to apply.`}
+            title={`v${latestVersion} available — reload`}
+          >
+            <span className="topbar-ver-dot" aria-hidden="true" />
+            v{latestVersion} · reload
+          </button>
+        ) : (
+          <span className="topbar-ver" title="OpenNeko version">{APP_VERSION}</span>
+        )}
+
+        <a
+          className="topbar-credit"
+          href="https://getneko.app/#about"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Built by Amit Deshmukh ↗
+        </a>
 
         {user && (
           <button

--- a/apps/web/src/components/BriefingCard.tsx
+++ b/apps/web/src/components/BriefingCard.tsx
@@ -34,6 +34,36 @@ const MOOD_CHART_ACCENT: Record<string, string> = {
   bad: "#E05656",
 };
 
+// Compact tiles carry a mini sparkline (the mockup look); the full chart only
+// appears on expand. Plots the chart series' `v` values, mood-coloured.
+function MiniSpark({ data, color }: { data: ChartDataPoint[]; color: string }) {
+  const pts = data.map((d) => d.v).filter((n): n is number => typeof n === "number");
+  if (pts.length < 2) return null;
+  const w = 120;
+  const h = 30;
+  const min = Math.min(...pts);
+  const max = Math.max(...pts);
+  const span = max - min || 1;
+  const step = w / (pts.length - 1);
+  const xy = pts.map((p, i) => [i * step, h - ((p - min) / span) * (h - 6) - 3] as const);
+  const line = xy.map((c, i) => `${i ? "L" : "M"}${c[0].toFixed(1)} ${c[1].toFixed(1)}`).join(" ");
+  const [ex, ey] = xy[xy.length - 1];
+  const gid = `ms${Math.round(min * 31 + max * 7 + pts.length)}`;
+  return (
+    <svg className="minispark" viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" aria-hidden="true">
+      <defs>
+        <linearGradient id={gid} x1="0" y1="0" x2="0" y2="1">
+          <stop offset="0" stopColor={color} stopOpacity="0.18" />
+          <stop offset="1" stopColor={color} stopOpacity="0" />
+        </linearGradient>
+      </defs>
+      <path d={`${line} L ${w} ${h} L 0 ${h} Z`} fill={`url(#${gid})`} />
+      <path d={line} fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" vectorEffect="non-scaling-stroke" />
+      <circle cx={ex.toFixed(1)} cy={ey.toFixed(1)} r="2.4" fill={color} />
+    </svg>
+  );
+}
+
 export type BriefingCardState = "ok" | "pending" | "failed";
 
 export interface BriefingCardData {
@@ -110,6 +140,12 @@ export default function BriefingCard({ ins, index, onDismiss, onRetry, onDeepDiv
               mood={moodKey}
             />
           ) : null}
+          {density === "compact" && state === "ok" && ins.chartData?.length > 1 && (
+            <MiniSpark
+              data={ins.chartData}
+              color={MOOD_CHART_ACCENT[moodKey] ?? "var(--color-accent)"}
+            />
+          )}
         </div>
       </div>
       <div className="iactions">

--- a/apps/web/src/components/BriefingCard.tsx
+++ b/apps/web/src/components/BriefingCard.tsx
@@ -5,7 +5,6 @@ import { Copy, RotateCw, Search, X } from "lucide-react";
 import Chart from "./Chart";
 import type { ChartDataPoint } from "./Chart";
 import KpiHeadline from "./KpiHeadline";
-import { useDensity } from "./DensityProvider";
 
 async function copyCardToClipboard(ins: BriefingCardData): Promise<void> {
   const lines: string[] = [];
@@ -34,36 +33,6 @@ const MOOD_CHART_ACCENT: Record<string, string> = {
   bad: "#E05656",
 };
 
-// Compact tiles carry a mini sparkline (the mockup look); the full chart only
-// appears on expand. Plots the chart series' `v` values, mood-coloured.
-function MiniSpark({ data, color }: { data: ChartDataPoint[]; color: string }) {
-  const pts = data.map((d) => d.v).filter((n): n is number => typeof n === "number");
-  if (pts.length < 2) return null;
-  const w = 120;
-  const h = 30;
-  const min = Math.min(...pts);
-  const max = Math.max(...pts);
-  const span = max - min || 1;
-  const step = w / (pts.length - 1);
-  const xy = pts.map((p, i) => [i * step, h - ((p - min) / span) * (h - 6) - 3] as const);
-  const line = xy.map((c, i) => `${i ? "L" : "M"}${c[0].toFixed(1)} ${c[1].toFixed(1)}`).join(" ");
-  const [ex, ey] = xy[xy.length - 1];
-  const gid = `ms${Math.round(min * 31 + max * 7 + pts.length)}`;
-  return (
-    <svg className="minispark" viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" aria-hidden="true">
-      <defs>
-        <linearGradient id={gid} x1="0" y1="0" x2="0" y2="1">
-          <stop offset="0" stopColor={color} stopOpacity="0.18" />
-          <stop offset="1" stopColor={color} stopOpacity="0" />
-        </linearGradient>
-      </defs>
-      <path d={`${line} L ${w} ${h} L 0 ${h} Z`} fill={`url(#${gid})`} />
-      <path d={line} fill="none" stroke={color} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" vectorEffect="non-scaling-stroke" />
-      <circle cx={ex.toFixed(1)} cy={ey.toFixed(1)} r="2.4" fill={color} />
-    </svg>
-  );
-}
-
 export type BriefingCardState = "ok" | "pending" | "failed";
 
 export interface BriefingCardData {
@@ -88,10 +57,8 @@ export default function BriefingCard({ ins, index, onDismiss, onRetry, onDeepDiv
   onRetry?: (metricId: string) => void;
   onDeepDive?: (metricId: string) => void;
 }) {
-  // Comfortable keeps today's always-expanded card; Compact starts the tile
-  // collapsed (metric only) and expands the detail + chart on click.
-  const { density } = useDensity();
-  const [open, setOpen] = useState(density === "comfortable");
+  // Briefing cards are always expanded — there is no collapse affordance.
+  const open = true;
   const [retrying, setRetrying] = useState(false);
   const state: BriefingCardState = ins.state ?? "ok";
   const moodKey = MOOD_LABELS[ins.mood] ? ins.mood : "good";
@@ -116,7 +83,6 @@ export default function BriefingCard({ ins, index, onDismiss, onRetry, onDeepDiv
       className={`icard${open ? " exp" : ""}${state === "failed" ? " icard-failed" : ""}${state === "pending" ? " icard-pending" : ""}`}
       data-mood={moodKey}
       style={{ animation: `fadeUp 0.5s ease ${index * 0.07}s both` }}
-      onClick={() => setOpen(!open)}
     >
       <div className="itop">
         <div className="inum">{numeral}</div>
@@ -140,12 +106,6 @@ export default function BriefingCard({ ins, index, onDismiss, onRetry, onDeepDiv
               mood={moodKey}
             />
           ) : null}
-          {density === "compact" && state === "ok" && ins.chartData?.length > 1 && (
-            <MiniSpark
-              data={ins.chartData}
-              color={MOOD_CHART_ACCENT[moodKey] ?? "var(--color-accent)"}
-            />
-          )}
         </div>
       </div>
       <div className="iactions">

--- a/apps/web/src/components/BriefingCard.tsx
+++ b/apps/web/src/components/BriefingCard.tsx
@@ -5,6 +5,7 @@ import { Copy, RotateCw, Search, X } from "lucide-react";
 import Chart from "./Chart";
 import type { ChartDataPoint } from "./Chart";
 import KpiHeadline from "./KpiHeadline";
+import { useDensity } from "./DensityProvider";
 
 async function copyCardToClipboard(ins: BriefingCardData): Promise<void> {
   const lines: string[] = [];
@@ -57,7 +58,10 @@ export default function BriefingCard({ ins, index, onDismiss, onRetry, onDeepDiv
   onRetry?: (metricId: string) => void;
   onDeepDive?: (metricId: string) => void;
 }) {
-  const [open, setOpen] = useState(true);
+  // Comfortable keeps today's always-expanded card; Compact starts the tile
+  // collapsed (metric only) and expands the detail + chart on click.
+  const { density } = useDensity();
+  const [open, setOpen] = useState(density === "comfortable");
   const [retrying, setRetrying] = useState(false);
   const state: BriefingCardState = ins.state ?? "ok";
   const moodKey = MOOD_LABELS[ins.mood] ? ins.mood : "good";

--- a/apps/web/src/components/CreatorCredit.tsx
+++ b/apps/web/src/components/CreatorCredit.tsx
@@ -4,7 +4,7 @@
  * link and the creator link don't sit on top of each other.
  */
 
-const CREATOR_URL = "https://getneko.app/#about";
+const CREATOR_URL = "https://openneko.app/#about";
 const CREATOR_NAME = "Amit Deshmukh";
 
 export default function CreatorCredit() {

--- a/apps/web/src/components/DensityProvider.tsx
+++ b/apps/web/src/components/DensityProvider.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+export type Density = "comfortable" | "compact";
+
+const STORAGE_KEY = "neko-density";
+const DEFAULT: Density = "compact";
+
+type DensityCtx = { density: Density; setDensity: (d: Density) => void };
+const Ctx = createContext<DensityCtx>({ density: DEFAULT, setDensity: () => {} });
+
+export function useDensity(): DensityCtx {
+  return useContext(Ctx);
+}
+
+// Drives the `data-density` attribute on <html>, which the density CSS keys
+// off (see styles/_density.css). Persists the operator's choice; defaults to
+// Compact. A pre-paint inline script (in layout.tsx) sets the attribute before
+// hydration so there's no flash of the wrong layout.
+export function DensityProvider({ children }: { children: React.ReactNode }) {
+  const [density, setDensityState] = useState<Density>(DEFAULT);
+
+  useEffect(() => {
+    const stored = (typeof window !== "undefined" &&
+      window.localStorage.getItem(STORAGE_KEY)) as Density | null;
+    if (stored === "comfortable" || stored === "compact") {
+      setDensityState(stored);
+      document.documentElement.setAttribute("data-density", stored);
+    }
+  }, []);
+
+  const setDensity = useCallback((d: Density) => {
+    setDensityState(d);
+    document.documentElement.setAttribute("data-density", d);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, d);
+    } catch {
+      // private mode / disabled storage — the attribute still applies for this session
+    }
+  }, []);
+
+  return <Ctx.Provider value={{ density, setDensity }}>{children}</Ctx.Provider>;
+}

--- a/apps/web/src/components/DensityToggle.tsx
+++ b/apps/web/src/components/DensityToggle.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useDensity } from "@/components/DensityProvider";
+
+// Comfortable / Compact segmented control. Lives in the app header; flips the
+// `data-density` attribute that the whole UI keys off.
+export default function DensityToggle() {
+  const { density, setDensity } = useDensity();
+  return (
+    <div className="density-seg" role="group" aria-label="Information density">
+      <button
+        type="button"
+        aria-pressed={density === "comfortable"}
+        onClick={() => setDensity("comfortable")}
+        title="Roomy — one column"
+      >
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" aria-hidden="true">
+          <rect x="2" y="3" width="12" height="3.4" rx="1.2" />
+          <rect x="2" y="9.6" width="12" height="3.4" rx="1.2" />
+        </svg>
+        <span>Comfortable</span>
+      </button>
+      <button
+        type="button"
+        aria-pressed={density === "compact"}
+        onClick={() => setDensity("compact")}
+        title="Dense — tiled grid"
+      >
+        <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" aria-hidden="true">
+          <rect x="2" y="2.5" width="5" height="5" rx="1.2" />
+          <rect x="9" y="2.5" width="5" height="5" rx="1.2" />
+          <rect x="2" y="8.5" width="5" height="5" rx="1.2" />
+          <rect x="9" y="8.5" width="5" height="5" rx="1.2" />
+        </svg>
+        <span>Compact</span>
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/components/HoursSavedHero.tsx
+++ b/apps/web/src/components/HoursSavedHero.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState } from "react";
+import { Clock } from "lucide-react";
+import { formatHours, formatSavedShort, sinceLabel } from "@/lib/hours-saved";
+
+export type HoursSavedValue = {
+  windowHours: number;
+  windowMinutes: number;
+  totalMinutes: number;
+  windowTasks: number;
+  sinceISO: string | null;
+};
+
+export type HoursSavedItem = {
+  label: string;
+  minutes: number;
+  basis: string | null;
+};
+
+// The cumulative "hours saved" value-prop, with a methodology disclosure.
+// Self-estimated numbers only earn trust when the reasoning is visible, so
+// the "how?" panel spells out the method and lists recent items + their
+// basis. See docs/HOURS_SAVED_PLAN.md.
+export default function HoursSavedHero({
+  value,
+  items,
+}: {
+  value: HoursSavedValue;
+  items: HoursSavedItem[];
+}) {
+  const [open, setOpen] = useState(false);
+  const hero = formatHours(value.totalMinutes);
+  const windowLabel = formatSavedShort(value.windowMinutes);
+  const detailed = items.filter((i) => i.minutes > 0).slice(0, 6);
+
+  return (
+    <div className="mb-7" style={{ animation: "fadeUp 0.5s ease 0.12s both" }}>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="group inline-flex items-center gap-3.5 bg-accent-soft border border-accent/25 rounded-2xl pl-3 pr-4 py-2.5 cursor-pointer transition-[transform,box-shadow,border-color] duration-200 hover:-translate-y-px hover:shadow-hover hover:border-accent/45 text-left"
+      >
+        <span className="grid place-items-center w-9 h-9 rounded-xl bg-card shadow-soft text-accent flex-none">
+          <Clock size={17} strokeWidth={2.25} />
+        </span>
+        <span className="font-display text-[26px] font-extrabold tracking-[-0.03em] text-accent tabular-nums leading-none">
+          {hero.value}
+          <span className="text-[13px] font-bold ml-1 opacity-70">{hero.unit}</span>
+        </span>
+        <span className="text-[12.5px] leading-[1.4] text-text2">
+          saved {sinceLabel(value.sinceISO)}
+          {windowLabel ? (
+            <>
+              <br />
+              <b className="text-success-ink font-bold">+{windowLabel} in the last {value.windowHours}h</b>
+              {value.windowTasks > 0 && (
+                <> · {value.windowTasks} task{value.windowTasks === 1 ? "" : "s"} handled for you</>
+              )}
+            </>
+          ) : null}
+        </span>
+        <span className="ml-1 font-mono text-[11px] font-semibold text-accent opacity-70 group-hover:opacity-100 whitespace-nowrap">
+          how? {open ? "▾" : "→"}
+        </span>
+      </button>
+
+      {open && (
+        <div className="mt-2.5 max-w-[640px] bg-card border border-border rounded-2xl px-5 py-4 shadow-soft text-[13.5px] leading-[1.55] text-text2">
+          <div className="font-display text-[11px] font-bold tracking-[0.13em] uppercase text-text3 mb-2.5">
+            How we estimate hours saved
+          </div>
+          <p className="m-0 mb-2.5">
+            Each time OpenNeko does something for you — sends a message, files a
+            refund, pulls a report — it estimates how long that task would take a
+            person to do by hand, and records a one-line reason. We estimate
+            conservatively and cap every task, so the total is a{" "}
+            <span className="text-text font-semibold">floor, not a flattering number</span>.
+          </p>
+          <p className="m-0">
+            We only count work that actually happened: actions that fired and
+            analyses we delivered — never anything still awaiting your approval.
+          </p>
+
+          {detailed.length > 0 && (
+            <div className="mt-3.5 pt-3.5 border-t border-border">
+              <div className="font-display text-[11px] font-bold tracking-[0.13em] uppercase text-text3 mb-2">
+                Recent
+              </div>
+              <ul className="list-none m-0 p-0 grid gap-1.5">
+                {detailed.map((item, i) => (
+                  <li key={i} className="flex items-baseline gap-2.5 text-[12.5px]">
+                    <span className="font-mono text-accent tabular-nums flex-none w-[58px]">
+                      {formatSavedShort(item.minutes)}
+                    </span>
+                    <span className="text-text2 min-w-0">
+                      <span className="text-text">{item.label}</span>
+                      {item.basis && (
+                        <span className="text-text3"> — {item.basis}</span>
+                      )}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/SectionNav.tsx
+++ b/apps/web/src/components/SectionNav.tsx
@@ -45,22 +45,22 @@ export default function SectionNav({
   }, []);
 
   return (
-    <div className="section-nav-row">
+    <nav className="topbar-nav">
       <Link
         href="/"
-        className={`settings-link nav-link${current === "dashboard" ? " is-active" : ""}`}
+        className={`topbar-nav-link${current === "dashboard" ? " is-active" : ""}`}
       >
         Dashboard
       </Link>
       <Link
         href="/work"
-        className={`settings-link nav-link${current === "work" ? " is-active" : ""}`}
+        className={`topbar-nav-link${current === "work" ? " is-active" : ""}`}
       >
         Ask
       </Link>
       <Link
         href="/actions"
-        className={`settings-link nav-link${current === "actions" ? " is-active" : ""}`}
+        className={`topbar-nav-link${current === "actions" ? " is-active" : ""}`}
       >
         Actions
         {pendingApprovals > 0 && (
@@ -69,17 +69,17 @@ export default function SectionNav({
       </Link>
       <Link
         href="/business-profile"
-        className={`settings-link nav-link${current === "business-profile" ? " is-active" : ""}`}
+        className={`topbar-nav-link${current === "business-profile" ? " is-active" : ""}`}
       >
         Business Profile
       </Link>
       <Link
         href="/settings"
-        className={`settings-link nav-link${current === "settings" ? " is-active" : ""}`}
+        className={`topbar-nav-link${current === "settings" ? " is-active" : ""}`}
       >
         Settings
       </Link>
       {children}
-    </div>
+    </nav>
   );
 }

--- a/apps/web/src/lib/hours-saved.ts
+++ b/apps/web/src/lib/hours-saved.ts
@@ -1,0 +1,30 @@
+// Formatting for the agent-estimated "hours saved" metric. Numbers are
+// approximate by nature (see docs/HOURS_SAVED_PLAN.md) — always rendered
+// with a "~" so the estimate framing is unmistakable.
+
+/** Compact per-item label, e.g. "~8 min", "~1.5h". */
+export function formatSavedShort(minutes: number): string {
+  if (!Number.isFinite(minutes) || minutes <= 0) return "";
+  if (minutes < 60) return `~${Math.round(minutes)} min`;
+  const hours = minutes / 60;
+  const rounded = hours >= 10 ? Math.round(hours) : Math.round(hours * 10) / 10;
+  return `~${rounded}h`;
+}
+
+/** Big hero figure split into value + unit, e.g. { value: "142", unit: "hrs" }. */
+export function formatHours(minutes: number): { value: string; unit: string } {
+  const hours = Math.max(0, minutes) / 60;
+  if (hours < 1) {
+    return { value: String(Math.round(minutes)), unit: minutes === 1 ? "min" : "min" };
+  }
+  const rounded = hours >= 10 ? Math.round(hours) : Math.round(hours * 10) / 10;
+  return { value: String(rounded), unit: rounded === 1 ? "hr" : "hrs" };
+}
+
+/** "since June 2026" style label from an ISO install date. */
+export function sinceLabel(iso: string | null): string {
+  if (!iso) return "since you installed OpenNeko";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "since you installed OpenNeko";
+  return `since ${d.toLocaleDateString("en-IN", { month: "long", year: "numeric" })}`;
+}

--- a/apps/worker/src/agent-sandbox/entry.ts
+++ b/apps/worker/src/agent-sandbox/entry.ts
@@ -33,6 +33,7 @@ interface SandboxJob {
   model?: string;
   backendState?: Record<string, unknown>;
   pluginActions?: RunAgentBackendInput["pluginActions"];
+  wantsCards?: boolean;
   workspace: AgentWorkspace;
 }
 
@@ -89,6 +90,7 @@ export async function main(): Promise<void> {
     workspace: job.workspace,
     backendState: job.backendState,
     pluginActions: job.pluginActions ?? [],
+    wantsCards: job.wantsCards ?? true,
     controlPlane,
     emit,
   });

--- a/apps/worker/src/channels/delivery.ts
+++ b/apps/worker/src/channels/delivery.ts
@@ -14,8 +14,19 @@ import {
   setWorkflowOutputDeliveryHook,
   type WorkflowOutputDeliveryHook,
 } from "@neko/llm/workflows";
-import { createWorkRun, createWorkThread } from "@neko/llm/work";
+import {
+  createWorkRun,
+  createWorkThread,
+  type RunChannel,
+} from "@neko/llm/work";
 import { getPluginRegistryInstance } from "../plugins/registry-instance.js";
+
+/** "@open-neko/channel-telegram" → "telegram". Channel-inbound runs are never
+ *  "web", so they get no a2ui rendering. See docs/PER_CHANNEL_RENDERING.md. */
+function channelFromPlugin(pluginName: string): RunChannel {
+  const m = pluginName.match(/channel-([a-z0-9-]+)$/i);
+  return (m ? m[1].toLowerCase() : pluginName) as RunChannel;
+}
 
 type IntentEvent =
   | { kind: "utterance"; threadRef?: string; text: string }
@@ -99,6 +110,7 @@ export async function ensureInboundBinding(
 export async function dispatchInboundIntent(
   orgId: string,
   intent: IntentEvent,
+  channelPlugin: string,
 ): Promise<void> {
   if (intent.kind === "decision") {
     const req = await getActionRequest(orgId, intent.decisionRef);
@@ -140,6 +152,7 @@ export async function dispatchInboundIntent(
     await startChatRun(
       orgId,
       message,
+      channelFromPlugin(channelPlugin),
       intent.kind === "utterance" ? intent.threadRef : undefined,
     );
     return;
@@ -152,6 +165,7 @@ export async function dispatchInboundIntent(
 async function startChatRun(
   orgId: string,
   message: string,
+  channel: RunChannel,
   threadRef?: string,
 ): Promise<void> {
   const thread = await createWorkThread(
@@ -178,6 +192,7 @@ async function startChatRun(
     runId: run.id,
     threadId: thread.id,
     message,
+    channel,
   });
   console.log(
     `[channel-inbound] started chat run ${run.id} for "${message.slice(0, 40)}"`,
@@ -205,7 +220,7 @@ export async function ingestInboundWebhook(
   if (recipient) await ensureInboundBinding(orgId, pluginName, recipient);
   for (const intent of intents) {
     try {
-      await dispatchInboundIntent(orgId, intent as IntentEvent);
+      await dispatchInboundIntent(orgId, intent as IntentEvent, pluginName);
     } catch (err) {
       console.warn(
         `[channel-inbound] dispatch error: ${err instanceof Error ? err.message : err}`,

--- a/apps/worker/src/channels/delivery.ts
+++ b/apps/worker/src/channels/delivery.ts
@@ -4,7 +4,7 @@
 // RPC. Inbound: an IntentEvent (parsed in-VM) routes to the SAME agent entry
 // points the web uses — approve/reject an action_request, or start a chat run.
 import { and, db, delivery_binding, eq, processing_job } from "@neko/db";
-import { enqueue, QUEUE } from "@neko/db/jobs";
+import { enqueue, QUEUE, type ChannelDeliverPayload } from "@neko/db/jobs";
 import { resolveAgentBackend } from "@neko/llm";
 import { outputRowToInteractionEvent, type OutputRow } from "@neko/llm/interaction";
 import type { InteractionEvent } from "@neko/interaction";
@@ -21,6 +21,12 @@ import {
   type RunChannel,
 } from "@neko/llm/work";
 import { getPluginRegistryInstance } from "../plugins/registry-instance.js";
+import {
+  beginInboundUpdate,
+  inboundUpdateKey,
+  markInboundDone,
+  recordInboundFailure,
+} from "./inbound-store.js";
 
 /** "@open-neko/channel-telegram" → "telegram". Channel-inbound runs are never
  *  "web", so they get no a2ui rendering. See docs/PER_CHANNEL_RENDERING.md. */
@@ -37,9 +43,50 @@ type IntentEvent =
 
 const MOODS = ["good", "watch", "act"] as const;
 
-const onOutput: WorkflowOutputDeliveryHook = async (orgId, output) => {
+// Outbound delivery retries: resilient to Telegram/Slack network blips and
+// worker restarts. The job is durable in pg-boss, so it survives a restart.
+const DELIVER_OPTS = { retryLimit: 8, retryDelay: 15, retryBackoff: true } as const;
+
+/**
+ * Enqueue a durable, retryable outbound delivery instead of sending inline.
+ * `idempotencyKey` is a pg-boss singletonKey — concurrent re-enqueues (e.g. a
+ * retried run job) collapse to one in-flight delivery.
+ */
+async function enqueueChannelDelivery(
+  orgId: string,
+  channelPlugin: string,
+  recipient: Record<string, unknown>,
+  events: unknown[],
+  idempotencyKey: string,
+): Promise<void> {
+  const payload: ChannelDeliverPayload = { orgId, channelPlugin, recipient, events };
+  await enqueue(QUEUE.CHANNEL_DELIVER, payload, {
+    ...DELIVER_OPTS,
+    singletonKey: idempotencyKey,
+  });
+}
+
+/**
+ * The CHANNEL_DELIVER job body: perform the actual send. Throwing makes
+ * pg-boss retry with backoff (network blips) and survives restarts.
+ */
+export async function runChannelDelivery(payload: ChannelDeliverPayload): Promise<void> {
   const reg = getPluginRegistryInstance();
-  if (!reg) return;
+  if (!reg) throw new Error("channel-delivery: plugin registry unavailable");
+  const res = await reg.deliverOnChannel(
+    payload.channelPlugin,
+    payload.recipient,
+    payload.events,
+  );
+  if (!res.delivered) {
+    throw new Error(`channel-delivery: ${payload.channelPlugin} reported delivered=false`);
+  }
+  console.log(
+    `[channel-delivery] ${payload.channelPlugin} delivered=true${res.ref ? ` ref=${res.ref}` : ""}`,
+  );
+}
+
+const onOutput: WorkflowOutputDeliveryHook = async (orgId, output) => {
   const bindings = await db()
     .select()
     .from(delivery_binding)
@@ -56,20 +103,13 @@ const onOutput: WorkflowOutputDeliveryHook = async (orgId, output) => {
   };
   const event = outputRowToInteractionEvent(row);
   for (const b of bindings) {
-    try {
-      const res = await reg.deliverOnChannel(
-        b.channel_plugin,
-        (b.recipient ?? {}) as Record<string, unknown>,
-        [event],
-      );
-      console.log(
-        `[channel-delivery] ${b.channel_plugin} output=${output.id} delivered=${res.delivered}${res.ref ? ` ref=${res.ref}` : ""}`,
-      );
-    } catch (err) {
-      console.warn(
-        `[channel-delivery] ${b.channel_plugin} output=${output.id} failed: ${err instanceof Error ? err.message : err}`,
-      );
-    }
+    await enqueueChannelDelivery(
+      orgId,
+      b.channel_plugin,
+      (b.recipient ?? {}) as Record<string, unknown>,
+      [event],
+      `output-${output.id}-${b.channel_plugin}`,
+    );
   }
 };
 
@@ -81,16 +121,17 @@ export function registerChannelOutputDelivery(): void {
 /**
  * Send a chat run's reply back to the channel that asked. Channel-initiated
  * runs (Telegram, …) have no other return path — the web UI streams its runs
- * over SSE, but a Telegram sender only hears back if we deliver here.
+ * over SSE, but a Telegram sender only hears back if we deliver here. Enqueued
+ * as a durable job so the reply survives network blips and restarts.
  */
 export async function deliverChatReply(
+  orgId: string,
   channelPlugin: string,
   recipient: Record<string, unknown>,
   runId: string,
   body: string,
 ): Promise<void> {
-  const reg = getPluginRegistryInstance();
-  if (!reg || !body.trim()) return;
+  if (!body.trim()) return;
   // A chat reply is the assistant's message, not a workflow-output card — use
   // `converse` so channels render the full text, not a summarized headline.
   const event: InteractionEvent = {
@@ -99,16 +140,7 @@ export async function deliverChatReply(
     role: "assistant",
     text: body,
   };
-  try {
-    const res = await reg.deliverOnChannel(channelPlugin, recipient, [event]);
-    console.log(
-      `[channel-delivery] ${channelPlugin} chat-reply run=${runId} delivered=${res.delivered}${res.ref ? ` ref=${res.ref}` : ""}`,
-    );
-  } catch (err) {
-    console.warn(
-      `[channel-delivery] ${channelPlugin} chat-reply run=${runId} failed: ${err instanceof Error ? err.message : err}`,
-    );
-  }
+  await enqueueChannelDelivery(orgId, channelPlugin, recipient, [event], `reply-${runId}`);
 }
 
 /**
@@ -241,7 +273,71 @@ async function startChatRun(
   );
 }
 
-/** Webhook ingest: verify (in-VM) → parse (in-VM) → dispatch. */
+// A persistently-failing update is retried up to this many times (with poll
+// backoff between attempts) before it's dead-lettered and the cursor advances
+// past it. The count is persisted, so the budget survives restarts.
+const MAX_INBOUND_ATTEMPTS = 30;
+
+/**
+ * Parse + dispatch one raw inbound update, exactly once. The update is claimed
+ * in the ledger first: a duplicate (restart re-poll, webhook retry) or a
+ * dead-lettered update is skipped. A transient failure is recorded and retried;
+ * after MAX_INBOUND_ATTEMPTS it's dead-lettered and consumed. Returns false
+ * ONLY while a failure is still retrying (caller holds the cursor); true once
+ * the update is done, duplicate, or dead-lettered. Shared by poll + webhook.
+ */
+export async function processInboundUpdate(
+  orgId: string,
+  pluginName: string,
+  raw: unknown,
+): Promise<boolean> {
+  const key = inboundUpdateKey(raw);
+  const begin = await beginInboundUpdate(orgId, pluginName, key);
+  if (!begin.proceed) {
+    console.log(
+      `[channel-inbound] ${pluginName}: skipping ${begin.dead ? "dead-lettered" : "duplicate"} inbound update`,
+    );
+    return true;
+  }
+  try {
+    const reg = getPluginRegistryInstance();
+    if (!reg) throw new Error("plugin registry unavailable");
+    const { intents, recipient } = await reg.parseInbound(pluginName, raw);
+    if (recipient) await ensureInboundBinding(orgId, pluginName, recipient);
+    for (const intent of intents) {
+      await dispatchInboundIntent(
+        orgId,
+        intent as IntentEvent,
+        pluginName,
+        recipient as Record<string, unknown> | undefined,
+      );
+    }
+    await markInboundDone(orgId, pluginName, key);
+    return true;
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    const { dead, attempts } = await recordInboundFailure(
+      orgId,
+      pluginName,
+      key,
+      MAX_INBOUND_ATTEMPTS,
+      raw,
+      errMsg,
+    );
+    if (dead) {
+      console.error(
+        `[channel-inbound] ${pluginName}: dead-lettered update after ${attempts} attempt(s): ${errMsg}`,
+      );
+      return true; // give up — advance past the poison update
+    }
+    console.warn(
+      `[channel-inbound] ${pluginName} dispatch error (attempt ${attempts}/${MAX_INBOUND_ATTEMPTS}): ${errMsg}`,
+    );
+    return false; // hold the cursor; retry next poll with backoff
+  }
+}
+
+/** Webhook ingest: verify (in-VM) → parse (in-VM) → dispatch, deduped. */
 export async function ingestInboundWebhook(
   orgId: string,
   pluginName: string,
@@ -258,21 +354,6 @@ export async function ingestInboundWebhook(
   } catch {
     return { ok: false, dispatched: 0 };
   }
-  const { intents, recipient } = await reg.parseInbound(pluginName, raw);
-  if (recipient) await ensureInboundBinding(orgId, pluginName, recipient);
-  for (const intent of intents) {
-    try {
-      await dispatchInboundIntent(
-        orgId,
-        intent as IntentEvent,
-        pluginName,
-        recipient as Record<string, unknown> | undefined,
-      );
-    } catch (err) {
-      console.warn(
-        `[channel-inbound] dispatch error: ${err instanceof Error ? err.message : err}`,
-      );
-    }
-  }
-  return { ok: true, dispatched: intents.length };
+  const ok = await processInboundUpdate(orgId, pluginName, raw);
+  return { ok, dispatched: ok ? 1 : 0 };
 }

--- a/apps/worker/src/channels/delivery.ts
+++ b/apps/worker/src/channels/delivery.ts
@@ -171,6 +171,7 @@ async function startChatRun(
   const thread = await createWorkThread(
     orgId,
     threadRef ? `Telegram ${threadRef}` : "Telegram",
+    channel,
   );
   const backend = await resolveAgentBackend(orgId);
   const run = await createWorkRun(orgId, thread.id, backend.id);

--- a/apps/worker/src/channels/delivery.ts
+++ b/apps/worker/src/channels/delivery.ts
@@ -7,6 +7,7 @@ import { and, db, delivery_binding, eq, processing_job } from "@neko/db";
 import { enqueue, QUEUE } from "@neko/db/jobs";
 import { resolveAgentBackend } from "@neko/llm";
 import { outputRowToInteractionEvent, type OutputRow } from "@neko/llm/interaction";
+import type { InteractionEvent } from "@neko/interaction";
 import {
   approveActionRequest,
   getActionRequest,
@@ -78,6 +79,39 @@ export function registerChannelOutputDelivery(): void {
 }
 
 /**
+ * Send a chat run's reply back to the channel that asked. Channel-initiated
+ * runs (Telegram, …) have no other return path — the web UI streams its runs
+ * over SSE, but a Telegram sender only hears back if we deliver here.
+ */
+export async function deliverChatReply(
+  channelPlugin: string,
+  recipient: Record<string, unknown>,
+  runId: string,
+  body: string,
+): Promise<void> {
+  const reg = getPluginRegistryInstance();
+  if (!reg || !body.trim()) return;
+  // A chat reply is the assistant's message, not a workflow-output card — use
+  // `converse` so channels render the full text, not a summarized headline.
+  const event: InteractionEvent = {
+    kind: "converse",
+    id: runId,
+    role: "assistant",
+    text: body,
+  };
+  try {
+    const res = await reg.deliverOnChannel(channelPlugin, recipient, [event]);
+    console.log(
+      `[channel-delivery] ${channelPlugin} chat-reply run=${runId} delivered=${res.delivered}${res.ref ? ` ref=${res.ref}` : ""}`,
+    );
+  } catch (err) {
+    console.warn(
+      `[channel-delivery] ${channelPlugin} chat-reply run=${runId} failed: ${err instanceof Error ? err.message : err}`,
+    );
+  }
+}
+
+/**
  * Auto-bind delivery to a sender on first inbound contact: the operator DMs the
  * bot once and starts receiving outputs there, never hand-writing a binding.
  * Idempotent — only writes when no binding for (org, channel) exists yet.
@@ -111,6 +145,7 @@ export async function dispatchInboundIntent(
   orgId: string,
   intent: IntentEvent,
   channelPlugin: string,
+  recipient?: Record<string, unknown>,
 ): Promise<void> {
   if (intent.kind === "decision") {
     const req = await getActionRequest(orgId, intent.decisionRef);
@@ -153,6 +188,8 @@ export async function dispatchInboundIntent(
       orgId,
       message,
       channelFromPlugin(channelPlugin),
+      channelPlugin,
+      recipient,
       intent.kind === "utterance" ? intent.threadRef : undefined,
     );
     return;
@@ -166,6 +203,8 @@ async function startChatRun(
   orgId: string,
   message: string,
   channel: RunChannel,
+  channelPlugin: string,
+  recipient: Record<string, unknown> | undefined,
   threadRef?: string,
 ): Promise<void> {
   const thread = await createWorkThread(
@@ -194,6 +233,8 @@ async function startChatRun(
     threadId: thread.id,
     message,
     channel,
+    channelPlugin,
+    recipient,
   });
   console.log(
     `[channel-inbound] started chat run ${run.id} for "${message.slice(0, 40)}"`,
@@ -221,7 +262,12 @@ export async function ingestInboundWebhook(
   if (recipient) await ensureInboundBinding(orgId, pluginName, recipient);
   for (const intent of intents) {
     try {
-      await dispatchInboundIntent(orgId, intent as IntentEvent, pluginName);
+      await dispatchInboundIntent(
+        orgId,
+        intent as IntentEvent,
+        pluginName,
+        recipient as Record<string, unknown> | undefined,
+      );
     } catch (err) {
       console.warn(
         `[channel-inbound] dispatch error: ${err instanceof Error ? err.message : err}`,

--- a/apps/worker/src/channels/inbound-poll.ts
+++ b/apps/worker/src/channels/inbound-poll.ts
@@ -1,27 +1,78 @@
 // Inbound transport for channels on hosts without a public webhook URL. For every
 // installed inbound-capable channel, the worker loops the plugin's poll_inbound
-// RPC (provider-agnostic — no Telegram-specific code here), normalizes each raw
-// update via parse_inbound, auto-binds delivery to the sender on first contact,
-// and dispatches the intents to the same agent entry points the web uses.
+// RPC (provider-agnostic — no Telegram-specific code here), then hands each raw
+// update to processInboundUpdate, which dedupes and dispatches it to the same
+// agent entry points the web uses.
+//
+// Reliability across restarts: the poll cursor is persisted per (org, channel),
+// so a restart resumes from the last acknowledged offset; the cursor only
+// advances when the whole batch dispatched cleanly, and the dedup ledger makes
+// re-polling a partially-processed batch safe (exactly-once dispatch).
 //
 // No env flag: a channel that declares an inbound direction is polled
 // automatically. Channels reachable by a public webhook (OPENNEKO_PUBLIC_URL set
 // + ingress="webhook") receive inbound via POST /channels/:plugin/inbound instead
 // and are skipped here.
 import { getPluginRegistryInstance } from "../plugins/registry-instance.js";
-import { dispatchInboundIntent, ensureInboundBinding } from "./delivery.js";
+import { processInboundUpdate } from "./delivery.js";
+import {
+  loadPollCursor,
+  pruneInboundDedup,
+  savePollCursor,
+} from "./inbound-store.js";
 import { pollBackoffMs, shouldLogPollFailure } from "./poll-backoff.js";
 
-type IntentEvent = Parameters<typeof dispatchInboundIntent>[1];
+const DEDUP_PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 
 const msg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
 const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+type Poller = {
+  pollInbound: (
+    pluginName: string,
+    cursor?: string,
+  ) => Promise<{ updates: unknown[]; cursor?: string }>;
+};
+
+/**
+ * One poll step: fetch a batch, dispatch each update exactly-once, and advance
+ * the cursor only when the whole batch settled (each update done, duplicate, or
+ * dead-lettered). A still-retrying update returns `held: true` with the cursor
+ * unchanged, so the batch is re-polled — the ledger skips updates that already
+ * settled, and the caller backs off before the next poll.
+ */
+export async function runPollIteration(
+  orgId: string,
+  pluginName: string,
+  cursor: string | undefined,
+  poller: Poller,
+): Promise<{ cursor: string | undefined; held: boolean }> {
+  const { updates, cursor: next } = await poller.pollInbound(pluginName, cursor);
+  let held = false;
+  for (const raw of updates) {
+    if (!(await processInboundUpdate(orgId, pluginName, raw))) held = true;
+  }
+  if (!held && next && next !== cursor) {
+    await savePollCursor(orgId, pluginName, next);
+    return { cursor: next, held: false };
+  }
+  return { cursor, held };
+}
 
 /** Start inbound transports for all installed inbound channels. Returns a stop handle. */
 export function startChannelInbound(orgId: string): { stop: () => void } {
   let stopped = false;
   const reg = getPluginRegistryInstance();
   if (!reg) return { stop: () => { stopped = true; } };
+
+  const pruneTimer = setInterval(() => {
+    void pruneInboundDedup(Date.now())
+      .then((n) => {
+        if (n > 0) console.log(`[channel-inbound] pruned ${n} expired dedup row(s)`);
+      })
+      .catch((e) => console.warn(`[channel-inbound] dedup prune error: ${msg(e)}`));
+  }, DEDUP_PRUNE_INTERVAL_MS);
+  pruneTimer.unref?.();
 
   const hasPublicWebhook = Boolean(process.env.OPENNEKO_PUBLIC_URL);
   const inboundProviders = reg
@@ -39,36 +90,31 @@ export function startChannelInbound(orgId: string): { stop: () => void } {
   }
 
   async function pollLoop(pluginName: string): Promise<void> {
-    let cursor: string | undefined;
+    let cursor = await loadPollCursor(orgId, pluginName);
     let warnedUnsupported = false;
     let failureStreak = 0;
     let lastError: string | undefined;
-    console.log(`[channel-inbound] ${pluginName}: polling for inbound (no public webhook URL)`);
+    console.log(
+      `[channel-inbound] ${pluginName}: polling for inbound (no public webhook URL)${cursor ? " — resumed from saved cursor" : ""}`,
+    );
     while (!stopped) {
       try {
         const r = getPluginRegistryInstance();
         if (!r) return;
-        const { updates, cursor: next } = await r.pollInbound(pluginName, cursor);
-        if (next) cursor = next;
-        for (const raw of updates) {
-          try {
-            const { intents, recipient } = await r.parseInbound(pluginName, raw);
-            if (recipient) await ensureInboundBinding(orgId, pluginName, recipient);
-            for (const intent of intents) {
-              await dispatchInboundIntent(
-                orgId,
-                intent as IntentEvent,
-                pluginName,
-                recipient as Record<string, unknown> | undefined,
-              );
-            }
-          } catch (err) {
-            console.warn(`[channel-inbound] ${pluginName} dispatch error: ${msg(err)}`);
+        const res = await runPollIteration(orgId, pluginName, cursor, r);
+        cursor = res.cursor;
+        if (res.held) {
+          // A still-retrying update holds the cursor; back off (shared streak)
+          // so we don't re-poll the failing batch every base interval.
+          failureStreak++;
+          if (shouldLogPollFailure(failureStreak, failureStreak === 1)) {
+            console.warn(
+              `[channel-inbound] ${pluginName}: holding cursor, retrying failed update(s) (attempt ${failureStreak})`,
+            );
           }
-        }
-        if (failureStreak > 0) {
+        } else if (failureStreak > 0) {
           console.log(
-            `[channel-inbound] ${pluginName}: poll recovered after ${failureStreak} failed attempt(s)`,
+            `[channel-inbound] ${pluginName}: recovered after ${failureStreak} held/failed attempt(s)`,
           );
           failureStreak = 0;
           lastError = undefined;
@@ -97,5 +143,10 @@ export function startChannelInbound(orgId: string): { stop: () => void } {
     }
   }
 
-  return { stop: () => { stopped = true; } };
+  return {
+    stop: () => {
+      stopped = true;
+      clearInterval(pruneTimer);
+    },
+  };
 }

--- a/apps/worker/src/channels/inbound-poll.ts
+++ b/apps/worker/src/channels/inbound-poll.ts
@@ -55,7 +55,12 @@ export function startChannelInbound(orgId: string): { stop: () => void } {
             const { intents, recipient } = await r.parseInbound(pluginName, raw);
             if (recipient) await ensureInboundBinding(orgId, pluginName, recipient);
             for (const intent of intents) {
-              await dispatchInboundIntent(orgId, intent as IntentEvent, pluginName);
+              await dispatchInboundIntent(
+                orgId,
+                intent as IntentEvent,
+                pluginName,
+                recipient as Record<string, unknown> | undefined,
+              );
             }
           } catch (err) {
             console.warn(`[channel-inbound] ${pluginName} dispatch error: ${msg(err)}`);

--- a/apps/worker/src/channels/inbound-poll.ts
+++ b/apps/worker/src/channels/inbound-poll.ts
@@ -55,7 +55,7 @@ export function startChannelInbound(orgId: string): { stop: () => void } {
             const { intents, recipient } = await r.parseInbound(pluginName, raw);
             if (recipient) await ensureInboundBinding(orgId, pluginName, recipient);
             for (const intent of intents) {
-              await dispatchInboundIntent(orgId, intent as IntentEvent);
+              await dispatchInboundIntent(orgId, intent as IntentEvent, pluginName);
             }
           } catch (err) {
             console.warn(`[channel-inbound] ${pluginName} dispatch error: ${msg(err)}`);

--- a/apps/worker/src/channels/inbound-store.ts
+++ b/apps/worker/src/channels/inbound-store.ts
@@ -1,0 +1,182 @@
+// Durable state for reliable inbound: a persisted poll cursor (resume point
+// across restarts) and a per-update ledger (exactly-once dispatch + dead-letter
+// after repeated failures). Both poll and webhook ingest drive an update
+// through begin → markDone | recordFailure here.
+import { createHash } from "node:crypto";
+import {
+  and,
+  channel_poll_cursor,
+  db,
+  eq,
+  inbound_dedup,
+  lt,
+  sql,
+} from "@neko/db";
+
+const DEDUP_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** Stable key for a raw inbound update: SHA-256 over canonical JSON (sorted
+ *  keys), so a re-fetched or retried duplicate hashes identically. */
+export function inboundUpdateKey(raw: unknown): string {
+  return createHash("sha256").update(canonical(raw)).digest("hex");
+}
+
+function canonical(v: unknown): string {
+  if (v === null || typeof v !== "object") return JSON.stringify(v) ?? "null";
+  if (Array.isArray(v)) return `[${v.map(canonical).join(",")}]`;
+  const keys = Object.keys(v as Record<string, unknown>).sort();
+  return `{${keys
+    .map((k) => `${JSON.stringify(k)}:${canonical((v as Record<string, unknown>)[k])}`)
+    .join(",")}}`;
+}
+
+export type BeginInboundResult = {
+  /** Dispatch this update? false ⇒ already done or dead-lettered (skip). */
+  proceed: boolean;
+  /** Failed-dispatch attempts recorded so far (0 on first sight). */
+  attempts: number;
+  /** The skip is because the update was dead-lettered (not a plain duplicate). */
+  dead: boolean;
+};
+
+/**
+ * Claim an update for dispatch, or report that it's already handled. A fresh
+ * update inserts a 'pending' row and proceeds; a 'pending' row (a retry, or a
+ * crash before completion) proceeds again; a 'done' or 'dead' row is skipped.
+ */
+export async function beginInboundUpdate(
+  orgId: string,
+  channelPlugin: string,
+  updateKey: string,
+): Promise<BeginInboundResult> {
+  const inserted = await db()
+    .insert(inbound_dedup)
+    .values({
+      org_id: orgId,
+      channel_plugin: channelPlugin,
+      update_key: updateKey,
+      status: "pending",
+      attempts: 0,
+    })
+    .onConflictDoNothing()
+    .returning({ attempts: inbound_dedup.attempts });
+  if (inserted.length > 0) {
+    return { proceed: true, attempts: inserted[0].attempts, dead: false };
+  }
+  const existing = await db()
+    .select({ status: inbound_dedup.status, attempts: inbound_dedup.attempts })
+    .from(inbound_dedup)
+    .where(
+      and(
+        eq(inbound_dedup.org_id, orgId),
+        eq(inbound_dedup.channel_plugin, channelPlugin),
+        eq(inbound_dedup.update_key, updateKey),
+      ),
+    )
+    .limit(1);
+  const row = existing[0];
+  if (!row) return { proceed: true, attempts: 0, dead: false };
+  if (row.status === "pending") {
+    return { proceed: true, attempts: row.attempts, dead: false };
+  }
+  return { proceed: false, attempts: row.attempts, dead: row.status === "dead" };
+}
+
+/** Mark an update successfully dispatched — the permanent dedup marker. */
+export async function markInboundDone(
+  orgId: string,
+  channelPlugin: string,
+  updateKey: string,
+): Promise<void> {
+  await db()
+    .update(inbound_dedup)
+    .set({ status: "done", updated_at: sql`now()` })
+    .where(
+      and(
+        eq(inbound_dedup.org_id, orgId),
+        eq(inbound_dedup.channel_plugin, channelPlugin),
+        eq(inbound_dedup.update_key, updateKey),
+      ),
+    );
+}
+
+/**
+ * Record a failed dispatch. Increments the attempt count; once it reaches
+ * `maxAttempts` the update is dead-lettered (status='dead', payload + error
+ * retained) so callers stop retrying and advance past it. Returns whether the
+ * update is now dead and the attempt number reached.
+ */
+export async function recordInboundFailure(
+  orgId: string,
+  channelPlugin: string,
+  updateKey: string,
+  maxAttempts: number,
+  rawPayload: unknown,
+  errorMessage: string,
+): Promise<{ dead: boolean; attempts: number }> {
+  const where = and(
+    eq(inbound_dedup.org_id, orgId),
+    eq(inbound_dedup.channel_plugin, channelPlugin),
+    eq(inbound_dedup.update_key, updateKey),
+  );
+  const rows = await db()
+    .update(inbound_dedup)
+    .set({
+      attempts: sql`${inbound_dedup.attempts} + 1`,
+      last_error: errorMessage,
+      updated_at: sql`now()`,
+    })
+    .where(where)
+    .returning({ attempts: inbound_dedup.attempts });
+  const attempts = rows[0]?.attempts ?? maxAttempts;
+  const dead = attempts >= maxAttempts;
+  if (dead) {
+    await db()
+      .update(inbound_dedup)
+      .set({ status: "dead", payload: rawPayload as Record<string, unknown> })
+      .where(where);
+  }
+  return { dead, attempts };
+}
+
+export async function loadPollCursor(
+  orgId: string,
+  channelPlugin: string,
+): Promise<string | undefined> {
+  const rows = await db()
+    .select({ cursor: channel_poll_cursor.cursor })
+    .from(channel_poll_cursor)
+    .where(
+      and(
+        eq(channel_poll_cursor.org_id, orgId),
+        eq(channel_poll_cursor.channel_plugin, channelPlugin),
+      ),
+    )
+    .limit(1);
+  return rows[0]?.cursor;
+}
+
+export async function savePollCursor(
+  orgId: string,
+  channelPlugin: string,
+  cursor: string,
+): Promise<void> {
+  await db()
+    .insert(channel_poll_cursor)
+    .values({ org_id: orgId, channel_plugin: channelPlugin, cursor })
+    .onConflictDoUpdate({
+      target: [channel_poll_cursor.org_id, channel_poll_cursor.channel_plugin],
+      set: { cursor, updated_at: sql`now()` },
+    });
+}
+
+/** Drop dispatched ('done') dedup rows past the TTL so the ledger stays bounded.
+ *  Dead letters are kept for inspection; pending rows are in-flight. */
+export async function pruneInboundDedup(nowMs: number): Promise<number> {
+  const cutoff = new Date(nowMs - DEDUP_TTL_MS);
+  const rows = await db()
+    .delete(inbound_dedup)
+    .where(and(eq(inbound_dedup.status, "done"), lt(inbound_dedup.created_at, cutoff)))
+    .returning({ id: inbound_dedup.id });
+  return rows.length;
+}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -413,6 +413,9 @@ const workRunHandler = makeHandler<WorkRunPayload>(
       runId: payload.runId,
       threadId: payload.threadId,
       message: payload.message,
+      channel: payload.channel,
+      channelPlugin: payload.channelPlugin,
+      recipient: payload.recipient,
     });
   },
 );

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -7,6 +7,7 @@ import {
   enqueue,
   QUEUE,
   type ActionExecutePayload,
+  type ChannelDeliverPayload,
   type ProcessingJobPayload,
   type WorkflowRunFirePayload,
   type WorkRunPayload,
@@ -48,6 +49,7 @@ import { setPluginRegistryInstance } from "./plugins/registry-instance.js";
 import {
   ingestInboundWebhook,
   registerChannelOutputDelivery,
+  runChannelDelivery,
 } from "./channels/delivery.js";
 import { startChannelInbound } from "./channels/inbound-poll.js";
 import type PgBossLib from "pg-boss";
@@ -475,6 +477,23 @@ await b.work(
       } catch (e) {
         console.warn(
           `[action-execute] job ${job.id} failed; pg-boss may retry: ${e instanceof Error ? e.message : e}`,
+        );
+        throw e;
+      }
+    }
+  },
+);
+
+await b.work(
+  QUEUE.CHANNEL_DELIVER,
+  { batchSize: 1, pollingIntervalSeconds: 0.5 },
+  async (jobs: PgBossLib.Job<ChannelDeliverPayload>[]) => {
+    for (const job of jobs) {
+      try {
+        await runChannelDelivery(job.data);
+      } catch (e) {
+        console.warn(
+          `[channel-deliver] job ${job.id} failed; pg-boss may retry: ${e instanceof Error ? e.message : e}`,
         );
         throw e;
       }

--- a/apps/worker/src/jobs/work-run.ts
+++ b/apps/worker/src/jobs/work-run.ts
@@ -12,6 +12,7 @@ import {
   getCurrentScrubber,
   getPluginRegistryInstance,
 } from "../plugins/registry-instance.js";
+import { deliverChatReply } from "../channels/delivery.js";
 
 export async function runWorkRun(
   _jobId: string,
@@ -21,9 +22,12 @@ export async function runWorkRun(
     threadId: string;
     message: string;
     channel?: RunChannel;
+    channelPlugin?: string;
+    recipient?: Record<string, unknown>;
   },
 ): Promise<void> {
-  const { runId, threadId, message, channel } = payload;
+  const { runId, threadId, message, channel, channelPlugin, recipient } =
+    payload;
 
   const run = await getWorkRun(orgId, runId);
   if (!run) {
@@ -52,7 +56,7 @@ export async function runWorkRun(
 
   const broker = await ensureAgentBroker();
 
-  await runChatTurn(
+  const result = await runChatTurn(
     {
       orgId,
       threadId,
@@ -64,4 +68,10 @@ export async function runWorkRun(
     },
     agentRuntimeDepsFromEnv(broker),
   );
+
+  // Channel-initiated runs have no other return path — send the reply back to
+  // the sender. Web runs (no channelPlugin) stream over SSE instead.
+  if (channelPlugin && recipient && result.status === "completed") {
+    await deliverChatReply(channelPlugin, recipient, runId, result.finalText);
+  }
 }

--- a/apps/worker/src/jobs/work-run.ts
+++ b/apps/worker/src/jobs/work-run.ts
@@ -6,6 +6,7 @@ import {
   getWorkRun,
   runChatTurn,
   scrubAgentEvent,
+  type RunChannel,
 } from "@neko/llm/work";
 import {
   getCurrentScrubber,
@@ -15,9 +16,14 @@ import {
 export async function runWorkRun(
   _jobId: string,
   orgId: string,
-  payload: { runId: string; threadId: string; message: string },
+  payload: {
+    runId: string;
+    threadId: string;
+    message: string;
+    channel?: RunChannel;
+  },
 ): Promise<void> {
-  const { runId, threadId, message } = payload;
+  const { runId, threadId, message, channel } = payload;
 
   const run = await getWorkRun(orgId, runId);
   if (!run) {
@@ -52,6 +58,7 @@ export async function runWorkRun(
       threadId,
       runId,
       message,
+      channel,
       emit,
       pluginActions,
     },

--- a/apps/worker/src/jobs/work-run.ts
+++ b/apps/worker/src/jobs/work-run.ts
@@ -72,6 +72,6 @@ export async function runWorkRun(
   // Channel-initiated runs have no other return path — send the reply back to
   // the sender. Web runs (no channelPlugin) stream over SSE instead.
   if (channelPlugin && recipient && result.status === "completed") {
-    await deliverChatReply(channelPlugin, recipient, runId, result.finalText);
+    await deliverChatReply(orgId, channelPlugin, recipient, runId, result.finalText);
   }
 }

--- a/apps/worker/test/channels/delivery.test.ts
+++ b/apps/worker/test/channels/delivery.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // delivery.ts wires several cross-package seams; mock them so the dispatch
-// logic (idempotency + routing) is tested in isolation.
+// logic (idempotency + routing), durable delivery, and inbound dedup are
+// tested in isolation.
 vi.mock("@neko/llm/workflows", () => ({
   getActionRequest: vi.fn(),
   approveActionRequest: vi.fn(async () => ({})),
@@ -10,11 +11,15 @@ vi.mock("@neko/llm/workflows", () => ({
 }));
 vi.mock("@neko/db/jobs", () => ({
   enqueue: vi.fn(async () => "job-1"),
-  QUEUE: { ACTION_EXECUTE: "action_execute", WORK_RUN: "work_run" },
+  QUEUE: {
+    ACTION_EXECUTE: "action_execute",
+    WORK_RUN: "work_run",
+    CHANNEL_DELIVER: "channel_deliver",
+  },
 }));
 const h = vi.hoisted(() => ({
   binds: [] as Array<Record<string, unknown>>,
-  existing: [] as unknown[],
+  selectRows: [] as unknown[],
 }));
 vi.mock("@neko/db", () => ({
   db: vi.fn(() => ({
@@ -24,7 +29,16 @@ vi.mock("@neko/db", () => ({
         return { returning: async () => [{ id: "pj-1" }] };
       },
     }),
-    select: () => ({ from: () => ({ where: () => ({ limit: async () => h.existing }) }) }),
+    select: () => ({
+      from: () => ({
+        // Awaitable (onOutput awaits .where() directly) AND chainable with
+        // .limit() (ensureInboundBinding uses .where().limit(1)).
+        where: () =>
+          Object.assign(Promise.resolve(h.selectRows), {
+            limit: async () => h.selectRows,
+          }),
+      }),
+    }),
   })),
   and: (...a: unknown[]) => a,
   eq: (...a: unknown[]) => a,
@@ -39,6 +53,12 @@ vi.mock("@neko/llm/work", () => ({
 vi.mock("@neko/llm/interaction", () => ({
   outputRowToInteractionEvent: (r: unknown) => ({ kind: "inform", ...(r as object) }),
 }));
+vi.mock("../../src/channels/inbound-store.js", () => ({
+  inboundUpdateKey: vi.fn(() => "update-key"),
+  beginInboundUpdate: vi.fn(async () => ({ proceed: true, attempts: 0, dead: false })),
+  markInboundDone: vi.fn(async () => {}),
+  recordInboundFailure: vi.fn(async () => ({ dead: false, attempts: 1 })),
+}));
 vi.mock("../../src/plugins/registry-instance.js", () => ({
   getPluginRegistryInstance: vi.fn(),
 }));
@@ -48,16 +68,29 @@ import {
   approveActionRequest,
   getActionRequest,
   rejectActionRequest,
+  setWorkflowOutputDeliveryHook,
 } from "@neko/llm/workflows";
 import { createWorkThread } from "@neko/llm/work";
 import {
+  deliverChatReply,
   dispatchInboundIntent,
   ensureInboundBinding,
   ingestInboundWebhook,
+  registerChannelOutputDelivery,
+  runChannelDelivery,
 } from "../../src/channels/delivery";
+import {
+  beginInboundUpdate,
+  markInboundDone,
+  recordInboundFailure,
+} from "../../src/channels/inbound-store.js";
 import { getPluginRegistryInstance } from "../../src/plugins/registry-instance.js";
 
-beforeEach(() => vi.clearAllMocks());
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(beginInboundUpdate).mockResolvedValue({ proceed: true, attempts: 0, dead: false });
+  vi.mocked(recordInboundFailure).mockResolvedValue({ dead: false, attempts: 1 });
+});
 afterEach(() => vi.clearAllMocks());
 
 describe("dispatchInboundIntent — decision", () => {
@@ -91,13 +124,112 @@ describe("dispatchInboundIntent — decision", () => {
 });
 
 describe("dispatchInboundIntent — utterance", () => {
-  it("starts a chat run (thread + WORK_RUN enqueue)", async () => {
-    await dispatchInboundIntent("org-1", { kind: "utterance", text: "how are sales?", threadRef: "42" });
+  it("starts a chat run (thread + WORK_RUN enqueue) carrying the channel + recipient", async () => {
+    await dispatchInboundIntent(
+      "org-1",
+      { kind: "utterance", text: "how are sales?", threadRef: "42" },
+      "@open-neko/channel-telegram",
+      { chatId: 7 },
+    );
     expect(createWorkThread).toHaveBeenCalled();
     expect(enqueue).toHaveBeenCalledWith(
       "work_run",
-      expect.objectContaining({ orgId: "org-1", message: "how are sales?", runId: "run-1", threadId: "thread-1" }),
+      expect.objectContaining({
+        orgId: "org-1",
+        message: "how are sales?",
+        runId: "run-1",
+        threadId: "thread-1",
+        channel: "telegram",
+        channelPlugin: "@open-neko/channel-telegram",
+        recipient: { chatId: 7 },
+      }),
     );
+  });
+});
+
+describe("runChannelDelivery (durable CHANNEL_DELIVER job body)", () => {
+  it("delivers via the plugin and resolves on delivered=true", async () => {
+    const deliverOnChannel = vi.fn(async () => ({ delivered: true, ref: "299" }));
+    vi.mocked(getPluginRegistryInstance).mockReturnValue({ deliverOnChannel } as never);
+    await runChannelDelivery({
+      orgId: "org-1",
+      channelPlugin: "@open-neko/channel-telegram",
+      recipient: { chatId: 7 },
+      events: [{ kind: "converse", text: "hi" }],
+    });
+    expect(deliverOnChannel).toHaveBeenCalledWith(
+      "@open-neko/channel-telegram",
+      { chatId: 7 },
+      [{ kind: "converse", text: "hi" }],
+    );
+  });
+
+  it("THROWS when the plugin reports delivered=false (so pg-boss retries)", async () => {
+    const deliverOnChannel = vi.fn(async () => ({ delivered: false }));
+    vi.mocked(getPluginRegistryInstance).mockReturnValue({ deliverOnChannel } as never);
+    await expect(
+      runChannelDelivery({ orgId: "o", channelPlugin: "p", recipient: {}, events: [] }),
+    ).rejects.toThrow(/delivered=false/);
+  });
+
+  it("THROWS when the registry is unavailable (retry rather than drop)", async () => {
+    vi.mocked(getPluginRegistryInstance).mockReturnValue(null);
+    await expect(
+      runChannelDelivery({ orgId: "o", channelPlugin: "p", recipient: {}, events: [] }),
+    ).rejects.toThrow(/registry unavailable/);
+  });
+});
+
+describe("deliverChatReply (channel reply path)", () => {
+  it("enqueues a durable converse delivery keyed by run id with backoff opts", async () => {
+    await deliverChatReply("org-1", "@open-neko/channel-telegram", { chatId: 7 }, "run-9", "We have 290 employees.");
+    expect(enqueue).toHaveBeenCalledTimes(1);
+    const [queue, payload, opts] = vi.mocked(enqueue).mock.calls[0];
+    expect(queue).toBe("channel_deliver");
+    expect(payload).toMatchObject({
+      orgId: "org-1",
+      channelPlugin: "@open-neko/channel-telegram",
+      recipient: { chatId: 7 },
+      events: [{ kind: "converse", id: "run-9", role: "assistant", text: "We have 290 employees." }],
+    });
+    expect(opts).toMatchObject({
+      singletonKey: "reply-run-9",
+      retryLimit: 8,
+      retryDelay: 15,
+      retryBackoff: true,
+    });
+  });
+
+  it("does not enqueue an empty reply", async () => {
+    await deliverChatReply("org-1", "p", {}, "run-9", "   ");
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+});
+
+describe("output → channel fan-out (registerChannelOutputDelivery)", () => {
+  it("enqueues one durable delivery per enabled binding, keyed by output+plugin", async () => {
+    h.selectRows = [
+      { channel_plugin: "@open-neko/channel-telegram", recipient: { chatId: 1 } },
+      { channel_plugin: "@open-neko/channel-slack", recipient: { chatId: 2 } },
+    ];
+    registerChannelOutputDelivery();
+    const hook = vi.mocked(setWorkflowOutputDeliveryHook).mock.calls[0][0];
+    await hook("org-1", { id: "o1", title: "Sales", body: "up 4%", mood: "good" } as never);
+    expect(enqueue).toHaveBeenCalledTimes(2);
+    const keys = vi.mocked(enqueue).mock.calls.map((c) => (c[2] as { singletonKey: string }).singletonKey);
+    expect(keys).toEqual([
+      "output-o1-@open-neko/channel-telegram",
+      "output-o1-@open-neko/channel-slack",
+    ]);
+    expect(vi.mocked(enqueue).mock.calls.every((c) => c[0] === "channel_deliver")).toBe(true);
+  });
+
+  it("no bindings → no deliveries", async () => {
+    h.selectRows = [];
+    registerChannelOutputDelivery();
+    const hook = vi.mocked(setWorkflowOutputDeliveryHook).mock.calls[0][0];
+    await hook("org-1", { id: "o1", title: "t", body: "b" } as never);
+    expect(enqueue).not.toHaveBeenCalled();
   });
 });
 
@@ -118,12 +250,50 @@ describe("ingestInboundWebhook", () => {
     vi.mocked(getActionRequest).mockResolvedValue({ id: "ar-1", status: "pending_approval", kind: "k" } as never);
   });
 
-  it("verifies, parses, and dispatches when the signature is valid", async () => {
+  it("verifies, parses, dispatches, and marks done when the signature is valid", async () => {
     const res = await ingestInboundWebhook("org-1", "@open-neko/channel-telegram", { "x-secret": "s" }, '{"callback_query":{}}');
     expect(res).toEqual({ ok: true, dispatched: 1 });
     expect(fakeReg.verifyInbound).toHaveBeenCalled();
     expect(fakeReg.parseInbound).toHaveBeenCalled();
     expect(approveActionRequest).toHaveBeenCalled();
+    expect(markInboundDone).toHaveBeenCalled();
+  });
+
+  it("DEDUPES a duplicate update — begin says skip ⇒ no parse, no dispatch, still ok", async () => {
+    vi.mocked(beginInboundUpdate).mockResolvedValue({ proceed: false, attempts: 1, dead: false });
+    const res = await ingestInboundWebhook("org-1", "@open-neko/channel-telegram", { "x-secret": "s" }, '{"callback_query":{}}');
+    expect(res).toEqual({ ok: true, dispatched: 1 });
+    expect(fakeReg.parseInbound).not.toHaveBeenCalled();
+    expect(approveActionRequest).not.toHaveBeenCalled();
+  });
+
+  it("SKIPS a dead-lettered update — never re-dispatches a poison message", async () => {
+    vi.mocked(beginInboundUpdate).mockResolvedValue({ proceed: false, attempts: 30, dead: true });
+    const res = await ingestInboundWebhook("org-1", "@open-neko/channel-telegram", { "x-secret": "s" }, '{"callback_query":{}}');
+    expect(res).toEqual({ ok: true, dispatched: 1 });
+    expect(fakeReg.parseInbound).not.toHaveBeenCalled();
+  });
+
+  it("records the failure + reports ok:false while still retrying (provider can redeliver)", async () => {
+    fakeReg.parseInbound.mockRejectedValue(new Error("VM down"));
+    vi.mocked(recordInboundFailure).mockResolvedValue({ dead: false, attempts: 3 });
+    const res = await ingestInboundWebhook("org-1", "@open-neko/channel-telegram", { "x-secret": "s" }, '{"callback_query":{}}');
+    expect(res).toEqual({ ok: false, dispatched: 0 });
+    expect(recordInboundFailure).toHaveBeenCalledWith(
+      "org-1",
+      "@open-neko/channel-telegram",
+      "update-key",
+      30,
+      expect.anything(),
+      "VM down",
+    );
+  });
+
+  it("DEAD-LETTERS after the attempt cap ⇒ consumed (ok:true), not retried again", async () => {
+    fakeReg.parseInbound.mockRejectedValue(new Error("still broken"));
+    vi.mocked(recordInboundFailure).mockResolvedValue({ dead: true, attempts: 30 });
+    const res = await ingestInboundWebhook("org-1", "@open-neko/channel-telegram", { "x-secret": "s" }, '{"callback_query":{}}');
+    expect(res).toEqual({ ok: true, dispatched: 1 });
   });
 
   it("refuses (no parse/dispatch) when verification fails", async () => {
@@ -144,7 +314,7 @@ describe("ingestInboundWebhook", () => {
 describe("ensureInboundBinding (auto-bind on first inbound)", () => {
   beforeEach(() => {
     h.binds.length = 0;
-    h.existing = [];
+    h.selectRows = [];
   });
 
   it("writes a binding when none exists for (org, channel)", async () => {
@@ -159,7 +329,7 @@ describe("ensureInboundBinding (auto-bind on first inbound)", () => {
   });
 
   it("is idempotent — skips writing when a binding already exists", async () => {
-    h.existing = [{ id: "b1" }];
+    h.selectRows = [{ id: "b1" }];
     await ensureInboundBinding("org-1", "@open-neko/channel-telegram", { kind: "telegram", chatId: 99 });
     expect(h.binds).toHaveLength(0);
   });

--- a/apps/worker/test/channels/inbound-poll.test.ts
+++ b/apps/worker/test/channels/inbound-poll.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// runPollIteration owns the restart-safety invariant: advance + persist the
+// cursor only when the whole batch settled, so a still-retrying batch is
+// re-polled (the ledger skips what already settled) and the caller backs off.
+// Mock the dispatch + cursor seams so that decision is tested in isolation.
+vi.mock("../../src/channels/delivery.js", () => ({
+  processInboundUpdate: vi.fn(async () => true),
+}));
+vi.mock("../../src/channels/inbound-store.js", () => ({
+  savePollCursor: vi.fn(async () => {}),
+  loadPollCursor: vi.fn(async () => undefined),
+  pruneInboundDedup: vi.fn(async () => 0),
+}));
+vi.mock("../../src/plugins/registry-instance.js", () => ({
+  getPluginRegistryInstance: vi.fn(),
+}));
+
+import { processInboundUpdate } from "../../src/channels/delivery.js";
+import { savePollCursor } from "../../src/channels/inbound-store.js";
+import { runPollIteration } from "../../src/channels/inbound-poll";
+
+const ORG = "org-1";
+const PLUGIN = "@open-neko/channel-telegram";
+
+function poller(updates: unknown[], next?: string) {
+  return { pollInbound: vi.fn(async () => ({ updates, ...(next ? { cursor: next } : {}) })) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(processInboundUpdate).mockResolvedValue(true);
+});
+
+describe("runPollIteration — cursor discipline", () => {
+  it("advances + persists the cursor when every update settles cleanly", async () => {
+    const p = poller([{ update_id: 1 }, { update_id: 2 }], "C2");
+    const res = await runPollIteration(ORG, PLUGIN, "C1", p);
+    expect(processInboundUpdate).toHaveBeenCalledTimes(2);
+    expect(savePollCursor).toHaveBeenCalledWith(ORG, PLUGIN, "C2");
+    expect(res).toEqual({ cursor: "C2", held: false });
+  });
+
+  it("HOLDS the cursor (held=true) when an update is still retrying", async () => {
+    vi.mocked(processInboundUpdate)
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false); // retrying dispatch failure on update 2
+    const p = poller([{ update_id: 1 }, { update_id: 2 }], "C2");
+    const res = await runPollIteration(ORG, PLUGIN, "C1", p);
+    expect(savePollCursor).not.toHaveBeenCalled();
+    expect(res).toEqual({ cursor: "C1", held: true }); // re-poll from here, back off
+  });
+
+  it("advances past a dead-lettered update (processInboundUpdate returns true)", async () => {
+    // A dead-letter is 'consumed' from the cursor's view — processInboundUpdate
+    // returns true even though dispatch ultimately failed, so the cursor moves on.
+    vi.mocked(processInboundUpdate).mockResolvedValue(true);
+    const p = poller([{ update_id: 1 }], "C2");
+    const res = await runPollIteration(ORG, PLUGIN, "C1", p);
+    expect(savePollCursor).toHaveBeenCalledWith(ORG, PLUGIN, "C2");
+    expect(res).toEqual({ cursor: "C2", held: false });
+  });
+
+  it("does not persist when the cursor is unchanged", async () => {
+    const p = poller([{ update_id: 1 }], "C1");
+    const res = await runPollIteration(ORG, PLUGIN, "C1", p);
+    expect(savePollCursor).not.toHaveBeenCalled();
+    expect(res).toEqual({ cursor: "C1", held: false });
+  });
+
+  it("does not persist on an empty batch with no new cursor", async () => {
+    const p = poller([]);
+    const res = await runPollIteration(ORG, PLUGIN, "C1", p);
+    expect(processInboundUpdate).not.toHaveBeenCalled();
+    expect(savePollCursor).not.toHaveBeenCalled();
+    expect(res).toEqual({ cursor: "C1", held: false });
+  });
+
+  it("resumes from an undefined cursor on first poll and adopts the provider's", async () => {
+    const p = poller([{ update_id: 1 }], "C1");
+    const res = await runPollIteration(ORG, PLUGIN, undefined, p);
+    expect(p.pollInbound).toHaveBeenCalledWith(PLUGIN, undefined);
+    expect(savePollCursor).toHaveBeenCalledWith(ORG, PLUGIN, "C1");
+    expect(res).toEqual({ cursor: "C1", held: false });
+  });
+});

--- a/apps/worker/test/channels/inbound-store.test.ts
+++ b/apps/worker/test/channels/inbound-store.test.ts
@@ -1,0 +1,153 @@
+// Integration test for the inbound ledger (dedup + dead-letter) + poll cursor.
+// The guarantees here are DB-enforced — a UNIQUE index + ON CONFLICT atomic
+// claim, an attempt counter, a dead-letter transition — so they're tested
+// against real Postgres; a hand-rolled mock would test the mock, not the SQL.
+//
+// Self-skips when no DB is reachable (e.g. CI without the compose stack), so
+// the suite stays green everywhere. inboundUpdateKey is pure and always runs.
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  channel_poll_cursor,
+  db,
+  eq,
+  inbound_dedup,
+  reconnectPool,
+  sql,
+} from "@neko/db";
+import {
+  beginInboundUpdate,
+  inboundUpdateKey,
+  loadPollCursor,
+  markInboundDone,
+  pruneInboundDedup,
+  recordInboundFailure,
+  savePollCursor,
+} from "../../src/channels/inbound-store";
+
+describe("inboundUpdateKey (pure)", () => {
+  it("is stable for the same value", () => {
+    const u = { update_id: 42, message: { text: "hi", chat: { id: 7 } } };
+    expect(inboundUpdateKey(u)).toBe(inboundUpdateKey({ ...u }));
+  });
+
+  it("is independent of key order (canonical JSON)", () => {
+    const a = { update_id: 1, message: { text: "hi", chat: { id: 7 } } };
+    const b = { message: { chat: { id: 7 }, text: "hi" }, update_id: 1 };
+    expect(inboundUpdateKey(a)).toBe(inboundUpdateKey(b));
+  });
+
+  it("differs when content differs", () => {
+    expect(inboundUpdateKey({ update_id: 1 })).not.toBe(inboundUpdateKey({ update_id: 2 }));
+  });
+
+  it("distinguishes nested + array differences", () => {
+    expect(inboundUpdateKey({ a: [1, 2] })).not.toBe(inboundUpdateKey({ a: [2, 1] }));
+    expect(inboundUpdateKey({ a: { b: 1 } })).not.toBe(inboundUpdateKey({ a: { b: 2 } }));
+  });
+});
+
+describe("inbound ledger + cursor (real Postgres)", () => {
+  let dbUp = false;
+  let orgId = "";
+  // Unique per run so parallel/repeat runs don't collide; rows are cleaned up.
+  const plugin = `@test/inbound-store-${Math.random().toString(36).slice(2)}`;
+  const keyOf = (id: number) => inboundUpdateKey({ update_id: id, plugin });
+
+  beforeAll(async () => {
+    try {
+      const rows = await db().execute<{ id: string }>(
+        sql`select id from organization limit 1`,
+      );
+      orgId = rows.rows[0]?.id ?? "";
+      dbUp = orgId !== "";
+    } catch {
+      dbUp = false;
+    }
+  });
+
+  afterAll(async () => {
+    if (dbUp) {
+      await db().delete(inbound_dedup).where(eq(inbound_dedup.channel_plugin, plugin));
+      await db()
+        .delete(channel_poll_cursor)
+        .where(eq(channel_poll_cursor.channel_plugin, plugin));
+    }
+    await reconnectPool();
+  });
+
+  it("claims once, allows a retry while pending, then dedups after done", async (ctx) => {
+    if (!dbUp) ctx.skip();
+    const key = keyOf(100);
+    expect(await beginInboundUpdate(orgId, plugin, key)).toMatchObject({ proceed: true, attempts: 0, dead: false });
+    // Still 'pending' (a crash before completion / a re-poll) ⇒ retry proceeds.
+    expect(await beginInboundUpdate(orgId, plugin, key)).toMatchObject({ proceed: true, dead: false });
+    await markInboundDone(orgId, plugin, key);
+    // Now dispatched ⇒ a duplicate (restart re-poll, webhook retry) is skipped.
+    expect(await beginInboundUpdate(orgId, plugin, key)).toMatchObject({ proceed: false, dead: false });
+  });
+
+  it("counts failures and dead-letters at the attempt cap, retaining payload + error", async (ctx) => {
+    if (!dbUp) ctx.skip();
+    const key = keyOf(200);
+    expect(await beginInboundUpdate(orgId, plugin, key)).toMatchObject({ proceed: true, attempts: 0 });
+
+    expect(await recordInboundFailure(orgId, plugin, key, 3, { update_id: 200 }, "boom-1")).toEqual({ dead: false, attempts: 1 });
+    // A retry still proceeds and carries the running attempt count.
+    expect(await beginInboundUpdate(orgId, plugin, key)).toMatchObject({ proceed: true, attempts: 1, dead: false });
+    expect(await recordInboundFailure(orgId, plugin, key, 3, { update_id: 200 }, "boom-2")).toEqual({ dead: false, attempts: 2 });
+    expect(await recordInboundFailure(orgId, plugin, key, 3, { update_id: 200 }, "boom-3")).toEqual({ dead: true, attempts: 3 });
+
+    // Dead-lettered ⇒ skipped, never re-dispatched; payload + last error kept.
+    expect(await beginInboundUpdate(orgId, plugin, key)).toMatchObject({ proceed: false, dead: true });
+    const row = await db()
+      .select({
+        status: inbound_dedup.status,
+        last_error: inbound_dedup.last_error,
+        payload: inbound_dedup.payload,
+      })
+      .from(inbound_dedup)
+      .where(eq(inbound_dedup.update_key, key))
+      .limit(1);
+    expect(row[0]).toMatchObject({ status: "dead", last_error: "boom-3", payload: { update_id: 200 } });
+  });
+
+  it("a successful dispatch after failures clears the retry (markInboundDone wins)", async (ctx) => {
+    if (!dbUp) ctx.skip();
+    const key = keyOf(250);
+    await beginInboundUpdate(orgId, plugin, key);
+    await recordInboundFailure(orgId, plugin, key, 30, { update_id: 250 }, "transient");
+    await markInboundDone(orgId, plugin, key);
+    expect(await beginInboundUpdate(orgId, plugin, key)).toMatchObject({ proceed: false, dead: false });
+  });
+
+  it("persists + resumes the poll cursor (upsert)", async (ctx) => {
+    if (!dbUp) ctx.skip();
+    expect(await loadPollCursor(orgId, plugin)).toBeUndefined();
+    await savePollCursor(orgId, plugin, "offset-1");
+    expect(await loadPollCursor(orgId, plugin)).toBe("offset-1");
+    await savePollCursor(orgId, plugin, "offset-2");
+    expect(await loadPollCursor(orgId, plugin)).toBe("offset-2");
+  });
+
+  it("prunes done rows past the TTL but keeps dead letters and fresh rows", async (ctx) => {
+    if (!dbUp) ctx.skip();
+    const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
+    const doneOld = keyOf(300);
+    const deadOld = keyOf(301);
+    const fresh = keyOf(302);
+    await db().insert(inbound_dedup).values([
+      { org_id: orgId, channel_plugin: plugin, update_key: doneOld, status: "done", created_at: old },
+      { org_id: orgId, channel_plugin: plugin, update_key: deadOld, status: "dead", created_at: old },
+    ]);
+    await beginInboundUpdate(orgId, plugin, fresh);
+    await markInboundDone(orgId, plugin, fresh);
+
+    await pruneInboundDedup(Date.now());
+
+    // Old 'done' pruned ⇒ claimable again; old 'dead' kept ⇒ still skipped;
+    // fresh 'done' kept ⇒ still deduped.
+    expect(await beginInboundUpdate(orgId, plugin, doneOld)).toMatchObject({ proceed: true });
+    expect(await beginInboundUpdate(orgId, plugin, deadOld)).toMatchObject({ proceed: false, dead: true });
+    expect(await beginInboundUpdate(orgId, plugin, fresh)).toMatchObject({ proceed: false, dead: false });
+  });
+});

--- a/db/migrations/0024_hours_saved.sql
+++ b/db/migrations/0024_hours_saved.sql
@@ -1,0 +1,19 @@
+-- Human hours saved: agent-estimated minutes of human effort.
+-- Per-action estimate lives on action_request; per-run analysis estimate
+-- lives on work_run. Both are server-clamped before insert. Org/workflow
+-- rollups sum executed actions + completed-run analysis at query time.
+
+ALTER TABLE action_request
+  ADD COLUMN minutes_saved integer,
+  ADD COLUMN minutes_saved_basis text,
+  ADD COLUMN estimate_source text NOT NULL DEFAULT 'agent',
+  ADD COLUMN estimate_version integer NOT NULL DEFAULT 1;
+
+ALTER TABLE work_run
+  ADD COLUMN analysis_minutes_saved integer,
+  ADD COLUMN analysis_minutes_basis text,
+  ADD COLUMN estimate_version integer NOT NULL DEFAULT 1;
+
+-- Window + cumulative rollups filter completed runs by org and finish time.
+CREATE INDEX IF NOT EXISTS work_run_org_finished_idx
+  ON work_run (org_id, finished_at);

--- a/db/migrations/0025_thread_channel.sql
+++ b/db/migrations/0025_thread_channel.sql
@@ -1,0 +1,15 @@
+-- Channel isolation: record each work thread's origin channel so the web Ask
+-- UI lists only its own ("web") threads and other channels (Telegram, …) stay
+-- separate. See docs/PER_CHANNEL_RENDERING.md.
+
+ALTER TABLE work_thread
+  ADD COLUMN channel text NOT NULL DEFAULT 'web';
+
+-- Backfill the only non-web origin so far: Telegram inbound threads, which
+-- startChatRun titles "Telegram <ref>" (or bare "Telegram").
+UPDATE work_thread
+  SET channel = 'telegram'
+  WHERE title = 'Telegram' OR title LIKE 'Telegram %';
+
+CREATE INDEX IF NOT EXISTS work_thread_org_channel_recent_idx
+  ON work_thread (org_id, channel, last_message_at DESC);

--- a/db/migrations/0026_inbound_dedup.sql
+++ b/db/migrations/0026_inbound_dedup.sql
@@ -1,0 +1,32 @@
+-- Reliable inbound: persisted poll cursor + idempotency ledger. Together they
+-- make channel inbound exactly-once across worker restarts and provider retries.
+
+-- channel_poll_cursor: the last acknowledged poll offset per (org, channel).
+-- Restarting the worker resumes from here instead of re-polling from scratch.
+CREATE TABLE IF NOT EXISTS channel_poll_cursor (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id TEXT NOT NULL REFERENCES organization(id) ON DELETE CASCADE,
+  channel_plugin TEXT NOT NULL,
+  cursor TEXT NOT NULL,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS channel_poll_cursor_org_plugin_unique
+  ON channel_poll_cursor (org_id, channel_plugin);
+
+-- inbound_dedup: a claimed key per dispatched update. The re-poll window after a
+-- restart (and webhook retries) can re-deliver an update; claiming it here first
+-- makes dispatch exactly-once. Pruned on a TTL by the worker.
+CREATE TABLE IF NOT EXISTS inbound_dedup (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id TEXT NOT NULL REFERENCES organization(id) ON DELETE CASCADE,
+  channel_plugin TEXT NOT NULL,
+  update_key TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS inbound_dedup_org_plugin_key_unique
+  ON inbound_dedup (org_id, channel_plugin, update_key);
+
+CREATE INDEX IF NOT EXISTS inbound_dedup_created_idx
+  ON inbound_dedup (created_at);

--- a/db/migrations/0027_inbound_dead_letter.sql
+++ b/db/migrations/0027_inbound_dead_letter.sql
@@ -1,0 +1,19 @@
+-- Dead-letter support for inbound dispatch. A persistently-failing ("poison")
+-- update would otherwise hold the poll cursor forever, blocking every newer
+-- message behind it. Track per-update attempts; after MAX retries park the
+-- update as 'dead' (keeping its payload + last error for inspection) so the
+-- cursor can advance past it.
+--
+-- status: 'pending' (claimed, dispatch in progress / retrying)
+--       | 'done'    (dispatched OK — the dedup marker)
+--       | 'dead'    (gave up after MAX attempts — a dead letter)
+-- Existing rows are already-dispatched dedup markers, so they backfill to 'done'.
+ALTER TABLE inbound_dedup
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'done',
+  ADD COLUMN IF NOT EXISTS attempts INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS last_error TEXT,
+  ADD COLUMN IF NOT EXISTS payload JSONB,
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+-- Find dead letters fast for inspection / manual replay.
+CREATE INDEX IF NOT EXISTS inbound_dedup_status_idx ON inbound_dedup (status);

--- a/db/migrations/0028_work_memory_exact_search.sql
+++ b/db/migrations/0028_work_memory_exact_search.sql
@@ -1,0 +1,8 @@
+-- Drop the approximate IVFFlat index on work_memory.embedding in favour of an
+-- exact (sequential) cosine scan. work_memory is per-org and small (at most a
+-- few thousand rows), so scanning every row is sub-millisecond and gives 100%
+-- recall; the approximate index added no speedup at this scale and could skip a
+-- relevant memory (its centroids were also built on an empty table). The search
+-- SQL is unchanged. Re-add an HNSW index if a single org ever reaches tens of
+-- thousands of memories.
+DROP INDEX IF EXISTS work_memory_embedding_cosine_idx;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "Apache-2.0",
   "author": "Amit Deshmukh (https://github.com/amitdeshmukh)",
-  "homepage": "https://getneko.app",
+  "homepage": "https://openneko.app",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/open-neko/openneko.git"

--- a/packages/channels/src/projections/slack.ts
+++ b/packages/channels/src/projections/slack.ts
@@ -81,6 +81,13 @@ export const slackProjection: Projection<SlackProjectionResult> = (events, profi
       blocks.push({ type: "context", elements: [{ type: "mrkdwn", text: `${mark} ${event.summary}` }] });
     } else if (event.kind === "offer") {
       blocks.push(section(`📎 ${event.label}`));
+    } else if (event.kind === "highlight") {
+      const fields = event.metrics.map((m) => ({
+        type: "mrkdwn",
+        text: `*${m.label}*\n${m.value}${m.sub ? ` _(${m.sub})_` : ""}`,
+      }));
+      blocks.push(section("*Key figures*", fields));
+      lines.push(event.metrics.map((m) => `${m.label} ${m.value}`).join(" · "));
     }
   }
   return { blocks, text: lines.join(" · ") };

--- a/packages/channels/src/projections/voice.ts
+++ b/packages/channels/src/projections/voice.ts
@@ -20,6 +20,11 @@ const utterance = (event: InteractionEvent): string => {
     return event.prompt;
   }
   if (event.kind === "resolve") return event.summary;
+  if (event.kind === "highlight") {
+    return event.metrics
+      .map((m) => `${m.label} is ${m.value}${m.sub ? `, ${m.sub}` : ""}.`)
+      .join(" ");
+  }
   return "";
 };
 

--- a/packages/channels/src/projections/web.ts
+++ b/packages/channels/src/projections/web.ts
@@ -50,6 +50,12 @@ const toComponent = (event: InteractionEvent): Component | null => {
   if (event.kind === "offer") {
     return { id: `o-${event.id}`, component: "Markdown", text: `[${event.label}](${event.artifactRef})` };
   }
+  if (event.kind === "highlight") {
+    const lines = event.metrics
+      .map((m) => `**${m.value}** ${m.label}${m.sub ? ` — ${m.sub}` : ""}`)
+      .join("  \n");
+    return { id: `h-${event.id}`, component: "Markdown", text: lines };
+  }
   return null;
 };
 

--- a/packages/channels/src/projections/whatsapp.ts
+++ b/packages/channels/src/projections/whatsapp.ts
@@ -46,6 +46,12 @@ export const whatsappProjection: Projection<WhatsappProjectionResult> = (events,
       parts.push(`${mark} ${event.summary}`);
     } else if (event.kind === "offer") {
       parts.push(`📎 ${event.label}`);
+    } else if (event.kind === "highlight") {
+      parts.push(
+        event.metrics
+          .map((m) => `${m.label}: ${m.value}${m.sub ? ` (${m.sub})` : ""}`)
+          .join("\n"),
+      );
     }
   }
   const body = clampChars(parts.join("\n\n"), profile.constraints.maxOutboundChars);

--- a/packages/channels/test/projections.test.ts
+++ b/packages/channels/test/projections.test.ts
@@ -34,6 +34,15 @@ const ask: InteractionEvent = {
   risk: "medium",
 };
 
+const highlight: InteractionEvent = {
+  kind: "highlight",
+  id: "h1",
+  metrics: [
+    { label: "Top-10 share", value: "48%", sub: "down from 53%" },
+    { label: "YoY revenue", value: "+14%" },
+  ],
+};
+
 const blockTypes = (blocks: SlackBlock[]): string[] => blocks.map((b) => String(b.type));
 
 describe("one inform, every substrate (degradation by profile)", () => {
@@ -70,6 +79,37 @@ describe("one inform, every substrate (degradation by profile)", () => {
     expect(ssml).toContain("Q3 revenue landed");
     expect(ssml).toContain("Revenue MTD is $4.7M");
     expect(ssml).not.toContain("Tue");
+  });
+});
+
+describe("one highlight, every substrate renders the figures its own way", () => {
+  it("web renders the figures as a markdown component", () => {
+    const { surfaces } = webProjection([highlight], WEB_PROFILE);
+    const update = surfaces[1] as { updateComponents: { components: Array<Record<string, unknown>> } };
+    const comp = update.updateComponents.components[0]!;
+    expect(comp.component).toBe("Markdown");
+    expect(String(comp.text)).toContain("**48%** Top-10 share — down from 53%");
+    expect(String(comp.text)).toContain("**+14%** YoY revenue");
+  });
+
+  it("slack renders the figures as section fields", () => {
+    const { blocks } = slackProjection([highlight], SLACK_PROFILE);
+    const json = JSON.stringify(blocks);
+    expect(json).toContain("Key figures");
+    expect(json).toContain("Top-10 share");
+    expect(json).toContain("down from 53%");
+  });
+
+  it("whatsapp renders the figures as plain lines", () => {
+    const { body } = whatsappProjection([highlight], WHATSAPP_PROFILE);
+    expect(body).toContain("Top-10 share: 48% (down from 53%)");
+    expect(body).toContain("YoY revenue: +14%");
+  });
+
+  it("voice reads the figures aloud, no sub when absent", () => {
+    const { ssml } = voiceProjection([highlight], VOICE_PROFILE);
+    expect(ssml).toContain("Top-10 share is 48%, down from 53%.");
+    expect(ssml).toContain("YoY revenue is +14%.");
   });
 });
 

--- a/packages/db/src/jobs.ts
+++ b/packages/db/src/jobs.ts
@@ -45,6 +45,10 @@ export type WorkRunPayload = ProcessingJobPayload & {
   /** Delivery channel ("web", "telegram", …). Omitted ⇒ "web". Gates a2ui
    *  rendering — see docs/PER_CHANNEL_RENDERING.md. */
   channel?: string;
+  /** For channel-initiated runs: the channel plugin + sender to deliver the
+   *  reply back to. Absent for web runs (the UI streams over SSE). */
+  channelPlugin?: string;
+  recipient?: Record<string, unknown>;
 };
 
 export type WorkflowRunFirePayload = {

--- a/packages/db/src/jobs.ts
+++ b/packages/db/src/jobs.ts
@@ -42,6 +42,9 @@ export type WorkRunPayload = ProcessingJobPayload & {
   threadId: string;
   /** The user message that kicked off this run. */
   message: string;
+  /** Delivery channel ("web", "telegram", …). Omitted ⇒ "web". Gates a2ui
+   *  rendering — see docs/PER_CHANNEL_RENDERING.md. */
+  channel?: string;
 };
 
 export type WorkflowRunFirePayload = {

--- a/packages/db/src/jobs.ts
+++ b/packages/db/src/jobs.ts
@@ -22,6 +22,7 @@ export const QUEUE = {
   WORKFLOW_RUN_FIRE: "workflow_run_fire",
   WORKFLOW_OUTPUT_TTL_SWEEP: "workflow_output_ttl_sweep",
   ACTION_EXECUTE: "action_execute",
+  CHANNEL_DELIVER: "channel_deliver",
 } as const;
 
 export type QueueName = (typeof QUEUE)[keyof typeof QUEUE];
@@ -49,6 +50,19 @@ export type WorkRunPayload = ProcessingJobPayload & {
    *  reply back to. Absent for web runs (the UI streams over SSE). */
   channelPlugin?: string;
   recipient?: Record<string, unknown>;
+};
+
+/**
+ * A durable, retryable outbound channel delivery. Enqueued (not delivered
+ * inline) so a transient network failure or a worker restart can't drop the
+ * message — pg-boss retries with backoff and the job survives restarts.
+ */
+export type ChannelDeliverPayload = {
+  orgId: string;
+  channelPlugin: string;
+  recipient: Record<string, unknown>;
+  /** InteractionEvent[] to deliver (serialized JSON). */
+  events: unknown[];
 };
 
 export type WorkflowRunFirePayload = {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -408,6 +408,9 @@ export const work_thread = pgTable(
       .notNull()
       .references(() => organization.id, { onDelete: "cascade" }),
     title: text("title").notNull().default(""),
+    // Origin channel ("web", "telegram", …). The web Ask UI lists only its own
+    // ("web") threads so channels stay isolated. See docs/PER_CHANNEL_RENDERING.md.
+    channel: text("channel").notNull().default("web"),
     backend_state: jsonb("backend_state").notNull().default(sql`'{}'::jsonb`),
     created_at: ts("created_at").notNull().defaultNow(),
     updated_at: ts("updated_at").notNull().defaultNow(),

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -800,6 +800,61 @@ export const delivery_binding = pgTable(
   }),
 );
 
+// Persisted poll offset per (org, channel). Inbound polling keeps an in-memory
+// cursor while running; persisting it means a restart resumes from the last
+// acknowledged offset instead of re-polling the provider from scratch.
+export const channel_poll_cursor = pgTable(
+  "channel_poll_cursor",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    org_id: text("org_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    channel_plugin: text("channel_plugin").notNull(),
+    cursor: text("cursor").notNull(),
+    updated_at: ts("updated_at").notNull().defaultNow(),
+  },
+  (t) => ({
+    org_plugin_unique: uniqueIndex("channel_poll_cursor_org_plugin_unique").on(
+      t.org_id,
+      t.channel_plugin,
+    ),
+  }),
+);
+
+// Per-update ledger for inbound dispatch. A poll restart (or webhook retry) can
+// re-deliver an update; claiming a stable per-update key here makes dispatch
+// exactly-once. `status` tracks the lifecycle: 'pending' (claimed, retrying),
+// 'done' (dispatched — the dedup marker), 'dead' (gave up after MAX attempts —
+// payload + last_error retained for inspection). 'done' rows are TTL-pruned;
+// 'dead' rows persist as a queryable dead-letter queue.
+export const inbound_dedup = pgTable(
+  "inbound_dedup",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    org_id: text("org_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    channel_plugin: text("channel_plugin").notNull(),
+    update_key: text("update_key").notNull(),
+    status: text("status").notNull().default("done"),
+    attempts: integer("attempts").notNull().default(0),
+    last_error: text("last_error"),
+    payload: jsonb("payload"),
+    created_at: ts("created_at").notNull().defaultNow(),
+    updated_at: ts("updated_at").notNull().defaultNow(),
+  },
+  (t) => ({
+    org_plugin_key_unique: uniqueIndex("inbound_dedup_org_plugin_key_unique").on(
+      t.org_id,
+      t.channel_plugin,
+      t.update_key,
+    ),
+    created_idx: index("inbound_dedup_created_idx").on(t.created_at),
+    status_idx: index("inbound_dedup_status_idx").on(t.status),
+  }),
+);
+
 export const subscription = pgTable(
   "subscription",
   {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -435,6 +435,12 @@ export const work_run = pgTable(
     backend: text("backend").notNull(),
     status: text("status").notNull().default("running"),
     error: text("error"),
+    // Agent-estimated minutes of human effort the run's ANALYSIS saved
+    // (excludes per-action work, which is tracked on action_request). Null
+    // until the run emits a value estimate; server-clamped before write.
+    analysis_minutes_saved: integer("analysis_minutes_saved"),
+    analysis_minutes_basis: text("analysis_minutes_basis"),
+    estimate_version: integer("estimate_version").notNull().default(1),
     created_at: ts("created_at").notNull().defaultNow(),
     updated_at: ts("updated_at").notNull().defaultNow(),
     finished_at: ts("finished_at"),
@@ -443,6 +449,10 @@ export const work_run = pgTable(
     thread_created_idx: index("work_run_thread_created_idx").on(
       t.thread_id,
       t.created_at.asc(),
+    ),
+    org_finished_idx: index("work_run_org_finished_idx").on(
+      t.org_id,
+      t.finished_at,
     ),
   }),
 );
@@ -958,6 +968,12 @@ export const action_request = pgTable(
     status: text("status").notNull().default("pending_approval"),
     summary: text("summary"),
     intent: text("intent"),
+    // Agent-estimated minutes of human effort this action saved, counted
+    // toward rollups only once status reaches "executed". Server-clamped.
+    minutes_saved: integer("minutes_saved"),
+    minutes_saved_basis: text("minutes_saved_basis"),
+    estimate_source: text("estimate_source").notNull().default("agent"),
+    estimate_version: integer("estimate_version").notNull().default(1),
     work_run_id: uuid("work_run_id").references(() => work_run.id, {
       onDelete: "set null",
     }),

--- a/packages/interaction/src/interaction-event.ts
+++ b/packages/interaction/src/interaction-event.ts
@@ -11,6 +11,8 @@ export type SeriesKind = "kpi" | "line" | "bar" | "area" | "donut";
 export interface Metric {
   label: string;
   value: string;
+  /** Optional one-line comparison or context, e.g. "down from 53%". */
+  sub?: string;
 }
 
 export interface SeriesPoint {
@@ -80,6 +82,10 @@ export type InteractionEvent =
       risk?: RiskLevel;
     }
   | { kind: "resolve"; id: string; ref: string; status: ResolveStatus; summary: string }
-  | { kind: "offer"; id: string; label: string; artifactRef: string; mime: string };
+  | { kind: "offer"; id: string; label: string; artifactRef: string; mime: string }
+  // The headline figures that carry an answer — modality-free content. Each
+  // channel renders them its own way: the web as metric tiles, an eyes-free
+  // channel by reading them aloud, a thin channel as plain lines.
+  | { kind: "highlight"; id: string; metrics: Metric[] };
 
 export type InteractionEventKind = InteractionEvent["kind"];

--- a/packages/llm/src/agent-backend.ts
+++ b/packages/llm/src/agent-backend.ts
@@ -134,6 +134,10 @@ export type AgentRunOptions = {
   onEvent?: (event: AgentEvent) => Promise<void> | void;
   backendState?: Record<string, unknown>;
   mcpServers?: Record<string, unknown>;
+  /** Web turn ⇒ the agent renders a2ui cards. Backends that can't take the
+   *  in-process SDK card server (hermes) wire their own render tool when set.
+   *  See docs/PER_CHANNEL_RENDERING.md. */
+  wantsCards?: boolean;
   outputSchema?: Record<string, unknown>;
   forkSession?: boolean;
   agents?: Record<string, unknown>;

--- a/packages/llm/src/agent-backend.ts
+++ b/packages/llm/src/agent-backend.ts
@@ -92,15 +92,10 @@ export type AgentEvent =
       rejection_reason?: string;
     }
   | { type: "needs_input"; question: string; options?: string[] }
-  // Structured context for the Ask page's right rail — emitted once at the
-  // end of a /work run via a `neko_ask_context` fence. All fields optional;
-  // the rail shows whichever sections are present.
-  | {
-      type: "ask_context";
-      vitals?: { label: string; value: string; sub?: string }[];
-      sources?: { name: string; detail?: string }[];
-      followups?: string[];
-    };
+  // Suggested follow-up questions — channel-agnostic content emitted once at
+  // the end of a /work run via a `neko_followups` fence. Any channel (the Ask
+  // rail, Telegram, Slack) can surface these as "ask next" prompts.
+  | { type: "followups"; items: string[] };
 
 export type AgentChatMessage = {
   id?: string;

--- a/packages/llm/src/agent-backend.ts
+++ b/packages/llm/src/agent-backend.ts
@@ -91,7 +91,16 @@ export type AgentEvent =
       /** Operator-supplied reason when the user rejected the request. */
       rejection_reason?: string;
     }
-  | { type: "needs_input"; question: string; options?: string[] };
+  | { type: "needs_input"; question: string; options?: string[] }
+  // Structured context for the Ask page's right rail — emitted once at the
+  // end of a /work run via a `neko_ask_context` fence. All fields optional;
+  // the rail shows whichever sections are present.
+  | {
+      type: "ask_context";
+      vitals?: { label: string; value: string; sub?: string }[];
+      sources?: { name: string; detail?: string }[];
+      followups?: string[];
+    };
 
 export type AgentChatMessage = {
   id?: string;

--- a/packages/llm/src/agent-backend.ts
+++ b/packages/llm/src/agent-backend.ts
@@ -95,7 +95,12 @@ export type AgentEvent =
   // Suggested follow-up questions — channel-agnostic content emitted once at
   // the end of a /work run via a `neko_followups` fence. Any channel (the Ask
   // rail, Telegram, Slack) can surface these as "ask next" prompts.
-  | { type: "followups"; items: string[] };
+  | { type: "followups"; items: string[] }
+  // The headline numbers that carry the answer — channel-agnostic content
+  // emitted once at the end of a /work run via a `neko_vitals` fence. Each
+  // channel renders them its own way (the web rail as a tile grid, a chat
+  // channel as a one-line recap, a voice channel by reading them aloud).
+  | { type: "vitals"; items: { label: string; value: string; sub?: string }[] };
 
 export type AgentChatMessage = {
   id?: string;

--- a/packages/llm/src/agent-backends/hermes.ts
+++ b/packages/llm/src/agent-backends/hermes.ts
@@ -1,6 +1,7 @@
 // Always session/new per turn — Hermes session/load replays history that the prompt already carries (see packages/llm/src/work/prompt.ts), double-counting context.
 
 import { spawn, type ChildProcess } from "node:child_process";
+import { writeFileSync } from "node:fs";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -17,9 +18,37 @@ import {
   type AcpClient,
   type AcpNotification,
 } from "./hermes-acp-client";
-import { extractSurfaceMessages } from "./surface";
+import { coerceSurfaceMessages, extractSurfaceMessages } from "./surface";
 
 export { extractSurfaceMessages } from "./surface";
+
+// ── Per-channel rendering (web): hand hermes a tiny stdio MCP server that
+// advertises `render_cards`, so the model can render a2ui cards instead of a
+// fence. The server is a sink (returns ok); the HOST emits the surface from the
+// tool_call notification's rawInput. See docs/PER_CHANNEL_RENDERING.md.
+const RENDER_MCP_SERVER_NAME = "neko_render";
+// hermes surfaces MCP tool calls as `mcp_<server>_<tool>` (verified via spike).
+const RENDER_TOOL_TITLE = `mcp_${RENDER_MCP_SERVER_NAME}_render_cards`;
+const RENDER_MCP_STUB_SOURCE = `let b="";
+process.stdin.on("data",c=>{b+=c;let i;while((i=b.indexOf("\\n"))>=0){
+const l=b.slice(0,i).trim();b=b.slice(i+1);if(!l)continue;
+let r;try{r=JSON.parse(l)}catch{continue}const{id,method}=r;
+if(typeof id==="undefined")continue;
+const w=o=>process.stdout.write(JSON.stringify({jsonrpc:"2.0",id,result:o})+"\\n");
+if(method==="initialize")w({protocolVersion:"2024-11-05",capabilities:{tools:{}},serverInfo:{name:"neko_render",version:"1"}});
+else if(method==="tools/list")w({tools:[{name:"render_cards",description:"Render your answer as cards and charts. Pass messages: an array of A2UI v0.9 messages (a createSurface then an updateComponents).",inputSchema:{type:"object",properties:{messages:{type:"array",items:{type:"object"}}},required:["messages"]}}]});
+else if(method==="tools/call")w({content:[{type:"text",text:'{"ok":true}'}]});
+else w({})}});
+`;
+let renderStubPath: string | null = null;
+function ensureRenderStub(): string {
+  if (!renderStubPath) {
+    const p = join(tmpdir(), "neko-render-mcp-server.mjs");
+    writeFileSync(p, RENDER_MCP_STUB_SOURCE);
+    renderStubPath = p;
+  }
+  return renderStubPath;
+}
 
 function killProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
   if (!child.pid) return;
@@ -159,6 +188,7 @@ export class HermesBackend implements AgentBackend {
       skills: _skills,
       signal,
       onEvent,
+      wantsCards = false,
       backendState = {},
     } = opts;
 
@@ -184,6 +214,7 @@ export class HermesBackend implements AgentBackend {
           workspace,
           signal,
           onEvent,
+          wantsCards,
         });
         if (out.error) {
           lastErr = new Error(out.error);
@@ -230,6 +261,7 @@ type RunOnceArgs = {
   workspace: AgentRunOptions["workspace"];
   signal: AbortSignal | undefined;
   onEvent: AgentRunOptions["onEvent"];
+  wantsCards: boolean;
 };
 
 type RunOnceOutcome = {
@@ -248,6 +280,7 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
     workspace,
     signal,
     onEvent,
+    wantsCards,
   } = args;
 
   let cwd: string;
@@ -342,9 +375,14 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
 
     // session/new per turn — see file header for the session/load double-count rationale.
     // TODO: verify whether Hermes ACP honors user-supplied mcpServers.
+    // session/new per turn — see file header for the session/load double-count rationale.
+    // Web turns get the render_cards MCP server so the model renders cards.
+    const mcpServers = wantsCards
+      ? [{ name: RENDER_MCP_SERVER_NAME, command: process.execPath, args: [ensureRenderStub()], env: [] }]
+      : [];
     const fresh = await client.request<{ sessionId: string }>("session/new", {
       cwd,
-      mcpServers: [],
+      mcpServers,
     });
     const sessionId = fresh.sessionId;
 
@@ -384,6 +422,18 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
         }
         case "tool_call": {
           if (!onEvent) return;
+          // A render_cards call IS the answer surface, not a tool step: pull the
+          // a2ui messages from the call input and emit them, skipping the pill.
+          if (update.title === RENDER_TOOL_TITLE) {
+            const messages = coerceSurfaceMessages(
+              (update.rawInput as { messages?: unknown } | undefined)?.messages,
+            );
+            if (messages.length > 0) {
+              surfaceEmittedDuringStream = true;
+              void onEvent({ type: "surface", messages });
+            }
+            return;
+          }
           void onEvent({
             type: "tool_start",
             id: update.toolCallId,

--- a/packages/llm/src/agent-backends/surface.ts
+++ b/packages/llm/src/agent-backends/surface.ts
@@ -17,6 +17,12 @@ function isValidA2UIMessage(m: unknown): m is AgentSurfaceMessage {
   );
 }
 
+// Validate an already-parsed messages value (e.g. a render_cards tool call's
+// `messages` argument) into surface messages. Returns [] when nothing valid.
+export function coerceSurfaceMessages(value: unknown): AgentSurfaceMessage[] {
+  return Array.isArray(value) ? value.filter(isValidA2UIMessage) : [];
+}
+
 export function extractSurfaceMessages(raw: string): {
   text: string;
   messages: AgentSurfaceMessage[];

--- a/packages/llm/src/interaction/from-agent-event.ts
+++ b/packages/llm/src/interaction/from-agent-event.ts
@@ -68,6 +68,10 @@ const mapOne = (event: AgentEvent, gen: IdGen): InteractionEvent[] => {
       return [informFromSurface(event.messages, gen())];
     case "artifact":
       return [{ kind: "offer", id: gen(), label: event.artifact.label, artifactRef: event.artifact.path, mime: event.artifact.mimeType ?? "application/octet-stream" }];
+    case "vitals":
+      return event.items.length
+        ? [{ kind: "highlight", id: gen(), metrics: event.items.map((m) => ({ label: m.label, value: m.value, ...(m.sub ? { sub: m.sub } : {}) })) }]
+        : [];
     case "action_request_emit":
       return event.decision === "pending_approval"
         ? [{ kind: "ask", id: event.action_request_id, ask: "approval", prompt: event.intent ?? event.summary ?? `Approve ${event.kind}?`, decisionRef: event.action_request_id, ...(isRisk(event.risk_level) ? { risk: event.risk_level } : {}) }]

--- a/packages/llm/src/work/agent-core.ts
+++ b/packages/llm/src/work/agent-core.ts
@@ -27,6 +27,9 @@ export interface RunAgentBackendInput {
   pluginActions: readonly PluginActionDescriptor[];
   /** In-process on the host; broker-backed inside the agent sandbox. */
   controlPlane?: AgentControlPlane;
+  /** Whether this channel renders a2ui cards (web). Default true. Gates the
+   *  neko_ui render server. See docs/PER_CHANNEL_RENDERING.md. */
+  wantsCards?: boolean;
   emit: (event: AgentEvent) => Promise<void>;
   signal?: AbortSignal;
 }
@@ -56,6 +59,7 @@ export async function runAgentBackend(
     backendState,
     pluginActions,
     controlPlane,
+    wantsCards = true,
     emit,
     signal,
   } = input;
@@ -74,7 +78,8 @@ export async function runAgentBackend(
 
   const mcpServers = mcp
     ? {
-        neko_ui: buildRenderCardsServer(emit),
+        // Rendering is per-channel: the card server only ships to web turns.
+        ...(wantsCards ? { neko_ui: buildRenderCardsServer(emit) } : {}),
         neko_skills: buildSkillBuilderServer(workspace.skillsRoot),
         neko_memory: buildWorkMemoryServer({ orgId, threadId, runId }, { controlPlane }),
         neko_workflow_builder: buildWorkflowBuilderServer({

--- a/packages/llm/src/work/agent-core.ts
+++ b/packages/llm/src/work/agent-core.ts
@@ -106,6 +106,7 @@ export async function runAgentBackend(
     backendState,
     onEvent: emit,
     mcpServers,
+    wantsCards,
     tag: `work ${runId}`,
     signal,
   });

--- a/packages/llm/src/work/index.ts
+++ b/packages/llm/src/work/index.ts
@@ -41,6 +41,7 @@ export { KNOWN_SKILL_DEPS, aggregateSkillDeps, type SkillDeps } from "./skill-de
 export { runAgentBackend, type RunAgentBackendInput } from "./agent-core";
 export { runChatTurn } from "./run-chat-turn";
 export type {
+  RunChannel,
   RunChatTurnDeps,
   RunChatTurnOptions,
   RunChatTurnResult,

--- a/packages/llm/src/work/prompt.ts
+++ b/packages/llm/src/work/prompt.ts
@@ -299,7 +299,7 @@ ${GRAPHJIN_DATE_RULE}
 // Closing contract shared by both backends: two JSON blocks the runtime parses
 // from the final output (hours-saved value + suggested follow-ups).
 const CLOSING_SECTION = `<closing>
-Always end your turn with these two JSON blocks, in this order.
+Always end your turn with these three JSON blocks, in this order.
 
 1. The time a data analyst or BI specialist would need to produce this answer
    from scratch — finding the right data, writing and validating the queries,
@@ -317,7 +317,20 @@ Always end your turn with these two JSON blocks, in this order.
    An action you propose (an email, a purchase order) carries its own
    \`minutes_saved\`.
 
-2. The three questions the operator is most likely to ask next, each specific
+2. The two to four numbers that carry this answer — the figures the operator
+   would repeat to their team. Give each a short label, the value with its
+   unit, and a one-line comparison or context where it sharpens the figure.
+   When the answer turns on no specific numbers, send an empty list:
+
+\`\`\`neko_vitals
+{ "vitals": [
+  { "label": "Top-10 share", "value": "48%", "sub": "down from 53%" },
+  { "label": "#1 account", "value": "$1.2M", "sub": "Acme · 9.4%" },
+  { "label": "YoY revenue", "value": "+14%", "sub": "$12.8M YTD" }
+] }
+\`\`\`
+
+3. The three questions the operator is most likely to ask next, each specific
    to the answer you just gave:
 
 \`\`\`neko_followups

--- a/packages/llm/src/work/prompt.ts
+++ b/packages/llm/src/work/prompt.ts
@@ -439,6 +439,9 @@ export function buildWorkPrompt(args: {
   currentUserMessage: string;
   memoryContext?: string;
   installedSkills?: InstalledSkill[];
+  /** Whether this channel renders a2ui cards (web). Default true. When false,
+   *  the prompt carries no rendering section and the agent answers in markdown. */
+  wantsCards?: boolean;
   supportsCardTool: boolean;
   supportsSkillTool: boolean;
   supportsMemoryTool: boolean;
@@ -458,6 +461,7 @@ export function buildWorkPrompt(args: {
     currentUserMessage,
     memoryContext,
     installedSkills,
+    wantsCards = true,
     supportsCardTool,
     supportsSkillTool,
     supportsMemoryTool,
@@ -477,7 +481,7 @@ behalf. This is the only chat surface — operators come here to do
 everything, from "what was last week's revenue?" to "set up a workflow
 that flags churn risk every Monday."
 </role>`,
-    buildRenderingSection(supportsCardTool),
+    wantsCards ? buildRenderingSection(supportsCardTool) : "",
     buildSkillsSection(supportsSkillTool, workspace, installedSkills),
     buildMemorySection({
       searchTool: supportsMemoryTool,

--- a/packages/llm/src/work/prompt.ts
+++ b/packages/llm/src/work/prompt.ts
@@ -311,46 +311,34 @@ const RULES_SECTION = `<conduct>
 ${GRAPHJIN_DATE_RULE}
 </conduct>`;
 
-// Closing contract shared by both backends. The runtime parses this fence
-// from the final output, clamps it, and surfaces it to the operator as
-// "hours saved." See docs/HOURS_SAVED_PLAN.md.
-const VALUE_SECTION = `<value>
-At the very end of your turn, emit exactly one fenced block estimating the
-human time your ANALYSIS saved — the report, answer, or finding you
-delivered. Exclude any actions you proposed; those carry their own estimate.
+// Closing contract shared by both backends: two JSON blocks the runtime parses
+// from the final output (hours-saved value + suggested follow-ups).
+const CLOSING_SECTION = `<closing>
+Always end your turn with these two JSON blocks, in this order.
+
+1. The time a data analyst or BI specialist would need to produce this answer
+   from scratch — finding the right data, writing and validating the queries,
+   and assembling the result. The operator got it from one plain-English
+   question instead of briefing a specialist and waiting on the report.
+   Estimate honestly in minutes, rounded down:
 
 \`\`\`neko_value
-{ "minutes_saved": 18, "basis": "Pulled and cross-checked a 3-table revenue report" }
+{ "minutes_saved": 90, "basis": "Joined orders to products, ranked by revenue, cross-checked against returns — a half-day BI request" }
 \`\`\`
 
-- Estimate the minutes a competent person would spend producing THIS
-  deliverable by hand — not your runtime, not wall-clock.
-- Be conservative; round DOWN when unsure.
-- Emit \`0\` when nothing was delivered a person would otherwise have done
-  (a check that found nothing, a clarifying question, an error).
-- Anchors (minutes): routine email 5-8 · CRM update 3-6 · refund 12-18 ·
-  purchase order 20-30 · multi-table report 20-40 · doc/changelog summary
-  10-20 · single-table lookup 3-8 · found nothing 0.
+   Anchors: a single metric lookup 15-30 · a multi-table breakdown or
+   drill-down 45-120 · a multi-step diagnostic like "why did revenue drop"
+   120-300. Use 0 for a clarifying question or a check that surfaced nothing.
+   An action you propose (an email, a purchase order) carries its own
+   \`minutes_saved\`.
 
-When you also propose an action, add \`minutes_saved\` (integer) and a short
-\`basis\` to that action too, estimated the same conservative way.
-</value>`;
-
-// Suggested follow-up questions. Channel-agnostic CONTENT — not UI: any
-// channel (the Ask rail, Telegram, Slack) can surface these as "ask next"
-// prompts. Parsed from a `neko_followups` fence.
-const FOLLOWUPS_SECTION = `<followups>
-After your answer, suggest up to 3 natural follow-up questions the operator is
-likely to ask next — the obvious next steps given what you just showed. Emit
-them as one fenced block at the very end:
+2. The three questions the operator is most likely to ask next, each specific
+   to the answer you just gave:
 
 \`\`\`neko_followups
 { "followups": ["Break this down by region", "Compare to last quarter", "Which products are declining?"] }
 \`\`\`
-
-- Make each one specific to this answer and a genuinely useful next step.
-- Omit the fence for a pure clarifying question or an error with no findings.
-</followups>`;
+</closing>`;
 
 export interface PluginActionPromptDescriptor {
   kind: string;
@@ -507,8 +495,7 @@ that flags churn risk every Monday."
     buildWorkspaceSection(workspace, shellTool),
     buildPluginActionsSection(pluginActions ?? [], !supportsCardTool),
     RULES_SECTION,
-    VALUE_SECTION,
-    FOLLOWUPS_SECTION,
+    CLOSING_SECTION,
   ].filter((s) => s.length > 0);
 
   if (inlineTranscript) {

--- a/packages/llm/src/work/prompt.ts
+++ b/packages/llm/src/work/prompt.ts
@@ -336,28 +336,21 @@ When you also propose an action, add \`minutes_saved\` (integer) and a short
 \`basis\` to that action too, estimated the same conservative way.
 </value>`;
 
-// Right-rail context for the Ask page. Optional but encouraged when the answer
-// has structured substance — the runtime parses it and renders the rail.
-const ASK_CONTEXT_SECTION = `<rail_context>
-When your answer carries structured substance, also emit one fenced block so
-the side rail can surface it. All fields optional; include what fits.
+// Suggested follow-up questions. Channel-agnostic CONTENT — not UI: any
+// channel (the Ask rail, Telegram, Slack) can surface these as "ask next"
+// prompts. Parsed from a `neko_followups` fence.
+const FOLLOWUPS_SECTION = `<followups>
+After your answer, suggest up to 3 natural follow-up questions the operator is
+likely to ask next — the obvious next steps given what you just showed. Emit
+them as one fenced block at the very end:
 
-\`\`\`neko_ask_context
-{
-  "vitals": [{ "label": "Top-10 share", "value": "48%", "sub": "▼ from 53%" }],
-  "sources": [{ "name": "orders", "detail": "3.2M rows" }, { "name": "customers", "detail": "1,284" }],
-  "followups": ["Break this down by region", "Compare to last quarter"]
-}
+\`\`\`neko_followups
+{ "followups": ["Break this down by region", "Compare to last quarter", "Which products are declining?"] }
 \`\`\`
 
-- \`vitals\`: up to 4 headline numbers from your answer (label + value, optional
-  sub like a delta). These are the figures worth pinning beside the chat.
-- \`sources\`: the data sources/tables you actually queried, with an optional
-  size/detail. Only list what you touched.
-- \`followups\`: up to 3 natural next questions the operator might ask.
-
-Emit at most once, at the end. Omit the fence entirely for trivial answers.
-</rail_context>`;
+- Make each one specific to this answer and a genuinely useful next step.
+- Omit the fence for a pure clarifying question or an error with no findings.
+</followups>`;
 
 export interface PluginActionPromptDescriptor {
   kind: string;
@@ -515,7 +508,7 @@ that flags churn risk every Monday."
     buildPluginActionsSection(pluginActions ?? [], !supportsCardTool),
     RULES_SECTION,
     VALUE_SECTION,
-    ASK_CONTEXT_SECTION,
+    FOLLOWUPS_SECTION,
   ].filter((s) => s.length > 0);
 
   if (inlineTranscript) {

--- a/packages/llm/src/work/prompt.ts
+++ b/packages/llm/src/work/prompt.ts
@@ -336,12 +336,11 @@ When you also propose an action, add \`minutes_saved\` (integer) and a short
 \`basis\` to that action too, estimated the same conservative way.
 </value>`;
 
-// Right-rail context for the Ask page. Required whenever the answer touched
-// data or contains numbers — the runtime parses it and renders the rail.
+// Right-rail context for the Ask page. Optional but encouraged when the answer
+// has structured substance — the runtime parses it and renders the rail.
 const ASK_CONTEXT_SECTION = `<rail_context>
-Whenever your answer touched data or states any number, you MUST emit one
-fenced block at the very end so the side rail can surface its context. Only
-omit it for a pure clarifying question or an error that produced no findings.
+When your answer carries structured substance, also emit one fenced block so
+the side rail can surface it. All fields optional; include what fits.
 
 \`\`\`neko_ask_context
 {
@@ -352,13 +351,12 @@ omit it for a pure clarifying question or an error that produced no findings.
 \`\`\`
 
 - \`vitals\`: up to 4 headline numbers from your answer (label + value, optional
-  sub like a delta). Include at least one whenever your answer states a number
-  — these are the figures worth pinning beside the chat.
-- \`sources\`: every data source/table you actually queried this turn, with an
-  optional size/detail. List what you touched — never invent one.
+  sub like a delta). These are the figures worth pinning beside the chat.
+- \`sources\`: the data sources/tables you actually queried, with an optional
+  size/detail. Only list what you touched.
 - \`followups\`: up to 3 natural next questions the operator might ask.
 
-Emit exactly once, at the very end, after the \`neko_value\` block.
+Emit at most once, at the end. Omit the fence entirely for trivial answers.
 </rail_context>`;
 
 export interface PluginActionPromptDescriptor {

--- a/packages/llm/src/work/prompt.ts
+++ b/packages/llm/src/work/prompt.ts
@@ -311,6 +311,31 @@ const RULES_SECTION = `<conduct>
 ${GRAPHJIN_DATE_RULE}
 </conduct>`;
 
+// Closing contract shared by both backends. The runtime parses this fence
+// from the final output, clamps it, and surfaces it to the operator as
+// "hours saved." See docs/HOURS_SAVED_PLAN.md.
+const VALUE_SECTION = `<value>
+At the very end of your turn, emit exactly one fenced block estimating the
+human time your ANALYSIS saved — the report, answer, or finding you
+delivered. Exclude any actions you proposed; those carry their own estimate.
+
+\`\`\`neko_value
+{ "minutes_saved": 18, "basis": "Pulled and cross-checked a 3-table revenue report" }
+\`\`\`
+
+- Estimate the minutes a competent person would spend producing THIS
+  deliverable by hand — not your runtime, not wall-clock.
+- Be conservative; round DOWN when unsure.
+- Emit \`0\` when nothing was delivered a person would otherwise have done
+  (a check that found nothing, a clarifying question, an error).
+- Anchors (minutes): routine email 5-8 · CRM update 3-6 · refund 12-18 ·
+  purchase order 20-30 · multi-table report 20-40 · doc/changelog summary
+  10-20 · single-table lookup 3-8 · found nothing 0.
+
+When you also propose an action, add \`minutes_saved\` (integer) and a short
+\`basis\` to that action too, estimated the same conservative way.
+</value>`;
+
 export interface PluginActionPromptDescriptor {
   kind: string;
   description: string;
@@ -466,6 +491,7 @@ that flags churn risk every Monday."
     buildWorkspaceSection(workspace, shellTool),
     buildPluginActionsSection(pluginActions ?? [], !supportsCardTool),
     RULES_SECTION,
+    VALUE_SECTION,
   ].filter((s) => s.length > 0);
 
   if (inlineTranscript) {

--- a/packages/llm/src/work/prompt.ts
+++ b/packages/llm/src/work/prompt.ts
@@ -336,11 +336,12 @@ When you also propose an action, add \`minutes_saved\` (integer) and a short
 \`basis\` to that action too, estimated the same conservative way.
 </value>`;
 
-// Right-rail context for the Ask page. Optional but encouraged when the answer
-// has structured substance — the runtime parses it and renders the rail.
+// Right-rail context for the Ask page. Required whenever the answer touched
+// data or contains numbers — the runtime parses it and renders the rail.
 const ASK_CONTEXT_SECTION = `<rail_context>
-When your answer carries structured substance, also emit one fenced block so
-the side rail can surface it. All fields optional; include what fits.
+Whenever your answer touched data or states any number, you MUST emit one
+fenced block at the very end so the side rail can surface its context. Only
+omit it for a pure clarifying question or an error that produced no findings.
 
 \`\`\`neko_ask_context
 {
@@ -351,12 +352,13 @@ the side rail can surface it. All fields optional; include what fits.
 \`\`\`
 
 - \`vitals\`: up to 4 headline numbers from your answer (label + value, optional
-  sub like a delta). These are the figures worth pinning beside the chat.
-- \`sources\`: the data sources/tables you actually queried, with an optional
-  size/detail. Only list what you touched.
+  sub like a delta). Include at least one whenever your answer states a number
+  — these are the figures worth pinning beside the chat.
+- \`sources\`: every data source/table you actually queried this turn, with an
+  optional size/detail. List what you touched — never invent one.
 - \`followups\`: up to 3 natural next questions the operator might ask.
 
-Emit at most once, at the end. Omit the fence entirely for trivial answers.
+Emit exactly once, at the very end, after the \`neko_value\` block.
 </rail_context>`;
 
 export interface PluginActionPromptDescriptor {

--- a/packages/llm/src/work/prompt.ts
+++ b/packages/llm/src/work/prompt.ts
@@ -21,59 +21,44 @@ function formatTranscript(messages: AgentChatMessage[]): string {
     .join("\n\n");
 }
 
-const A2UI_FENCE_EXAMPLE = `\`\`\`neko_a2ui
-[
+const RENDER_CARDS_EXAMPLE = `[
   {"version":"v0.9","createSurface":{"surfaceId":"s1","catalogId":"urn:app:catalog:briefing:v1"}},
   {"version":"v0.9","updateComponents":{"surfaceId":"s1","components":[
     {"id":"intro","component":"Markdown","text":"Brief 1-2 sentence intro to the answer."},
     {"id":"card1","component":"BriefingCard","metricId":"top-product","source":"chat","mood":"good","text":"Mountain-200 leads","metric":"$674,216","label":"Total Profit","detail":"Across all sales channels.","chartType":"kpi","chartData":[]},
     {"id":"detail","component":"Markdown","text":"Optional follow-up prose with tables, lists, etc."}
   ]}}
-]
-\`\`\``;
+]`;
 
+// Web-only (callers gate this behind wantsCards). Both backends render via a
+// `render_cards` tool — claude through the neko_ui MCP server, hermes through a
+// per-turn stdio render server. See docs/PER_CHANNEL_RENDERING.md.
 function buildRenderingSection(supportsCardTool: boolean): string {
-  if (supportsCardTool) {
-    return `<rendering>
-Every response to the user goes through \`mcp__neko_ui__render_cards\`.
-Wrap your prose in a \`Markdown\` component, and add KPI/Table/Chart
-cards alongside it when structured data helps the answer. Anything
-written outside the tool call is invisible to the UI — the tool call is
-the response.
-</rendering>`;
-  }
-
+  const tool = supportsCardTool ? "mcp__neko_ui__render_cards" : "render_cards";
   return `<rendering>
-Every response to the user is a single fenced \`\`\`neko_a2ui block
-containing A2UI v0.9 JSON messages. Anything written outside the fence
-is invisible to the UI — the fence is the entire response.
+Render your answer by calling the \`${tool}\` tool. Its \`messages\` argument is
+a JSON array of A2UI v0.9 messages — a \`createSurface\`, then an
+\`updateComponents\` whose \`components\` array holds flat component objects.
 
-The fence body is a JSON array (not JSX, not HTML, not bare component
-objects). Components are emitted flat inside
-\`updateComponents.components\` — every component is at the top level of
-that array, never nested inside another component's \`children\`.
+Component catalog (each component sets a \`component\` field):
 
-Component catalog (every component has a \`component\` field set to one
-of these):
-
-- \`Markdown\` — narrative text. Props: \`{ text: string }\` (markdown).
-  Use this for any prose.
+- \`Markdown\` — narrative text. Props: \`{ text: string }\` (markdown). Use this
+  for your prose.
 - \`BriefingCard\` — KPI card. Props:
   \`{ metricId: string, source: 'chat', mood: 'good'|'watch'|'act',
      text: string, metric: string, label: string, detail: string,
      chartType: 'kpi'|'line'|'bar'|'area'|'donut',
      chartData: Array<{d:string,v:number,t?:number}> | [] }\`.
 
-Each message has \`version: "v0.9"\` plus exactly one of
-\`createSurface\` or \`updateComponents\`. Most responses need just one
-of each.
+Each message sets \`version: "v0.9"\` and exactly one of \`createSurface\` or
+\`updateComponents\`.
 
 <example>
-${A2UI_FENCE_EXAMPLE}
+${tool}({ "messages": ${RENDER_CARDS_EXAMPLE} })
 </example>
 
-When the answer is purely prose with no metrics or cards, emit a single
-\`Markdown\` component inside \`updateComponents\`.
+Put your prose in \`Markdown\` components and add \`BriefingCard\`s for the key
+numbers. For a pure-prose answer, send one \`Markdown\` component.
 </rendering>`;
 }
 

--- a/packages/llm/src/work/prompt.ts
+++ b/packages/llm/src/work/prompt.ts
@@ -336,6 +336,29 @@ When you also propose an action, add \`minutes_saved\` (integer) and a short
 \`basis\` to that action too, estimated the same conservative way.
 </value>`;
 
+// Right-rail context for the Ask page. Optional but encouraged when the answer
+// has structured substance — the runtime parses it and renders the rail.
+const ASK_CONTEXT_SECTION = `<rail_context>
+When your answer carries structured substance, also emit one fenced block so
+the side rail can surface it. All fields optional; include what fits.
+
+\`\`\`neko_ask_context
+{
+  "vitals": [{ "label": "Top-10 share", "value": "48%", "sub": "▼ from 53%" }],
+  "sources": [{ "name": "orders", "detail": "3.2M rows" }, { "name": "customers", "detail": "1,284" }],
+  "followups": ["Break this down by region", "Compare to last quarter"]
+}
+\`\`\`
+
+- \`vitals\`: up to 4 headline numbers from your answer (label + value, optional
+  sub like a delta). These are the figures worth pinning beside the chat.
+- \`sources\`: the data sources/tables you actually queried, with an optional
+  size/detail. Only list what you touched.
+- \`followups\`: up to 3 natural next questions the operator might ask.
+
+Emit at most once, at the end. Omit the fence entirely for trivial answers.
+</rail_context>`;
+
 export interface PluginActionPromptDescriptor {
   kind: string;
   description: string;
@@ -492,6 +515,7 @@ that flags churn risk every Monday."
     buildPluginActionsSection(pluginActions ?? [], !supportsCardTool),
     RULES_SECTION,
     VALUE_SECTION,
+    ASK_CONTEXT_SECTION,
   ].filter((s) => s.length > 0);
 
   if (inlineTranscript) {

--- a/packages/llm/src/work/run-chat-turn.ts
+++ b/packages/llm/src/work/run-chat-turn.ts
@@ -4,6 +4,7 @@ import { resolveAgentBackend as defaultResolveAgentBackend } from "../agent-back
 import { extractMemoryFences } from "../agent-backends/memory-fence";
 import {
   extractActionRequestFences,
+  extractAskContextFence,
   extractRuleSaveFence,
   extractValueFence,
   extractWorkflowSaveFence,
@@ -397,6 +398,18 @@ export async function runChatTurn(
       }
     }
 
+    // Ask-page right-rail context (vitals / sources / followups). Parsed from
+    // the same source and emitted as an event the Ask UI lifts into the rail.
+    const askContext = extractAskContextFence(fenceSource);
+    if (askContext.payload) {
+      await wrappedEmit({
+        type: "ask_context",
+        vitals: askContext.payload.vitals,
+        sources: askContext.payload.sources,
+        followups: askContext.payload.followups,
+      });
+    }
+
     // Pull any neko_memory fences out of the raw agent response and persist
     // them. Backend-agnostic: works for Hermes (no MCP tool registry) and is
     // harmless for claude-agent (which would have used the MCP save tool).
@@ -428,6 +441,7 @@ export async function runChatTurn(
     persistedText = extractWorkflowSaveFence(persistedText).text;
     persistedText = extractRuleSaveFence(persistedText).text;
     persistedText = extractValueFence(persistedText).text;
+    persistedText = extractAskContextFence(persistedText).text;
     persistedText = extractMemoryFences(persistedText).text;
     if (persistedText) {
       await saveAssistantWorkMessage({

--- a/packages/llm/src/work/run-chat-turn.ts
+++ b/packages/llm/src/work/run-chat-turn.ts
@@ -4,7 +4,7 @@ import { resolveAgentBackend as defaultResolveAgentBackend } from "../agent-back
 import { extractMemoryFences } from "../agent-backends/memory-fence";
 import {
   extractActionRequestFences,
-  extractAskContextFence,
+  extractFollowupsFence,
   extractRuleSaveFence,
   extractValueFence,
   extractWorkflowSaveFence,
@@ -398,15 +398,13 @@ export async function runChatTurn(
       }
     }
 
-    // Ask-page right-rail context (vitals / sources / followups). Parsed from
-    // the same source and emitted as an event the Ask UI lifts into the rail.
-    const askContext = extractAskContextFence(fenceSource);
-    if (askContext.payload) {
+    // Suggested follow-up questions — channel-agnostic content, emitted as an
+    // event any channel (Ask rail, Telegram, …) can surface as "ask next".
+    const followups = extractFollowupsFence(fenceSource);
+    if (followups.payload) {
       await wrappedEmit({
-        type: "ask_context",
-        vitals: askContext.payload.vitals,
-        sources: askContext.payload.sources,
-        followups: askContext.payload.followups,
+        type: "followups",
+        items: followups.payload.followups,
       });
     }
 
@@ -441,7 +439,7 @@ export async function runChatTurn(
     persistedText = extractWorkflowSaveFence(persistedText).text;
     persistedText = extractRuleSaveFence(persistedText).text;
     persistedText = extractValueFence(persistedText).text;
-    persistedText = extractAskContextFence(persistedText).text;
+    persistedText = extractFollowupsFence(persistedText).text;
     persistedText = extractMemoryFences(persistedText).text;
     if (persistedText) {
       await saveAssistantWorkMessage({

--- a/packages/llm/src/work/run-chat-turn.ts
+++ b/packages/llm/src/work/run-chat-turn.ts
@@ -52,11 +52,20 @@ import {
   listInstalledSkills as defaultListInstalledSkills,
 } from "./workspace";
 
+/**
+ * Delivery channel for a run. "web" renders a2ui cards (the channel injects the
+ * render capability); other channels answer in plain markdown and may inject
+ * their own render tool later. See docs/PER_CHANNEL_RENDERING.md.
+ */
+export type RunChannel = "web" | "telegram" | "slack" | (string & {});
+
 export type RunChatTurnOptions = {
   orgId: string;
   threadId: string;
   runId: string;
   message: string;
+  /** Delivery channel; defaults to "web". Gates output rendering. */
+  channel?: RunChannel;
   emit: (event: AgentEvent) => Promise<void>;
   signal?: AbortSignal;
   /**
@@ -180,6 +189,10 @@ export async function runChatTurn(
       message: `Starting ${backendLabel(backend.id)}…`,
     });
 
+    // Rendering is a per-channel capability: only web turns get a2ui cards
+    // (via the render tool for claude, the fence for hermes). Other channels
+    // answer in plain markdown — no rendering vocabulary in their prompt.
+    const wantsCards = (opts.channel ?? "web") === "web";
     const supportsCardTool = backend.capabilities.mcpTools;
     const supportsSkillTool = backend.capabilities.mcpTools;
     const supportsMemoryTool = backend.capabilities.mcpTools;
@@ -216,6 +229,7 @@ export async function runChatTurn(
       currentUserMessage: message,
       memoryContext,
       installedSkills,
+      wantsCards,
       supportsCardTool,
       supportsSkillTool,
       supportsMemoryTool,
@@ -236,6 +250,7 @@ export async function runChatTurn(
       backendState: bundle.thread.backendState,
       pluginActions: opts.pluginActions ?? [],
       controlPlane: opts.controlPlane,
+      wantsCards,
       emit: wrappedEmit,
       signal,
     });

--- a/packages/llm/src/work/run-chat-turn.ts
+++ b/packages/llm/src/work/run-chat-turn.ts
@@ -5,8 +5,10 @@ import { extractMemoryFences } from "../agent-backends/memory-fence";
 import {
   extractActionRequestFences,
   extractRuleSaveFence,
+  extractValueFence,
   extractWorkflowSaveFence,
 } from "../workflows/fence-parsers";
+import { clampAnalysisMinutes } from "../workflows/value";
 import {
   handleWorkActionRequest,
   policySavedCard,
@@ -38,6 +40,7 @@ import {
   getWorkThreadBundle,
   markWorkRunRunning,
   saveAssistantWorkMessage,
+  setWorkRunValue,
   setWorkThreadBackendState,
 } from "./store";
 import type { PluginActionDescriptor } from "./tools";
@@ -375,6 +378,25 @@ export async function runChatTurn(
       });
     }
 
+    // Per-run analysis value estimate (the human time the answer saved,
+    // excluding any actions which carry their own estimate). Parsed from the
+    // same raw source, server-clamped, persisted, and echoed in `done` so the
+    // UI can show it live. Best-effort: a missing/invalid fence leaves it null.
+    const valueFence = extractValueFence(fenceSource);
+    const analysisMinutes = clampAnalysisMinutes(valueFence.payload?.minutes_saved);
+    if (valueFence.payload) {
+      try {
+        await setWorkRunValue(runId, {
+          minutes: analysisMinutes,
+          basis: valueFence.payload.basis ?? null,
+        });
+      } catch (err) {
+        console.warn(
+          `[work-run] setWorkRunValue failed: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+
     // Pull any neko_memory fences out of the raw agent response and persist
     // them. Backend-agnostic: works for Hermes (no MCP tool registry) and is
     // harmless for claude-agent (which would have used the MCP save tool).
@@ -405,6 +427,7 @@ export async function runChatTurn(
     let persistedText = extractActionRequestFences(result.finalText.trim()).text;
     persistedText = extractWorkflowSaveFence(persistedText).text;
     persistedText = extractRuleSaveFence(persistedText).text;
+    persistedText = extractValueFence(persistedText).text;
     persistedText = extractMemoryFences(persistedText).text;
     if (persistedText) {
       await saveAssistantWorkMessage({
@@ -415,7 +438,10 @@ export async function runChatTurn(
       });
     }
 
-    await wrappedEmit({ type: "done", result: { status: result.status } });
+    await wrappedEmit({
+      type: "done",
+      result: { status: result.status, minutesSaved: analysisMinutes ?? 0 },
+    });
 
     return {
       status: result.status,

--- a/packages/llm/src/work/run-chat-turn.ts
+++ b/packages/llm/src/work/run-chat-turn.ts
@@ -7,6 +7,7 @@ import {
   extractFollowupsFence,
   extractRuleSaveFence,
   extractValueFence,
+  extractVitalsFence,
   extractWorkflowSaveFence,
 } from "../workflows/fence-parsers";
 import { clampAnalysisMinutes } from "../workflows/value";
@@ -423,6 +424,16 @@ export async function runChatTurn(
       });
     }
 
+    // The answer's headline numbers — channel-agnostic content, emitted as an
+    // event each channel renders its own way (the web rail as a tile grid).
+    const vitals = extractVitalsFence(fenceSource);
+    if (vitals.payload && vitals.payload.vitals.length > 0) {
+      await wrappedEmit({
+        type: "vitals",
+        items: vitals.payload.vitals,
+      });
+    }
+
     // Pull any neko_memory fences out of the raw agent response and persist
     // them. Backend-agnostic: works for Hermes (no MCP tool registry) and is
     // harmless for claude-agent (which would have used the MCP save tool).
@@ -455,6 +466,7 @@ export async function runChatTurn(
     persistedText = extractRuleSaveFence(persistedText).text;
     persistedText = extractValueFence(persistedText).text;
     persistedText = extractFollowupsFence(persistedText).text;
+    persistedText = extractVitalsFence(persistedText).text;
     persistedText = extractMemoryFences(persistedText).text;
     if (persistedText) {
       await saveAssistantWorkMessage({

--- a/packages/llm/src/work/sandbox-launcher.ts
+++ b/packages/llm/src/work/sandbox-launcher.ts
@@ -125,6 +125,9 @@ export function makeSandboxRunCore(opts: SandboxLauncherOptions): RunCore {
       model: input.backend.model,
       backendState: input.backendState,
       pluginActions: input.pluginActions,
+      // Channel render intent — gates the in-box render tool (see
+      // docs/PER_CHANNEL_RENDERING.md). Default true if absent.
+      wantsCards: input.wantsCards ?? true,
       workspace: boxWorkspace,
     };
 

--- a/packages/llm/src/work/store.ts
+++ b/packages/llm/src/work/store.ts
@@ -54,18 +54,25 @@ export type WorkThreadBundle = {
   eventsByRun: Record<string, AgentEvent[]>;
 };
 
-export async function listWorkThreads(orgId: string): Promise<WorkThreadSummary[]> {
+export async function listWorkThreads(
+  orgId: string,
+  channel = "web",
+): Promise<WorkThreadSummary[]> {
   // Workflow runs reuse the work_thread / work_run plumbing for their
   // transcripts (so they get the same surface, events, memory hooks).
   // But /work (Ask) is strictly human ↔ agent — its sidebar must not
   // surface threads created by a workflow trigger. Exclude any thread
   // that has a workflow_run pointing at it.
+  //
+  // Channels are isolated: a surface lists only its own threads (the web Ask
+  // UI passes "web"), so Telegram/Slack conversations never appear here.
   const rows = await db()
     .select()
     .from(work_thread)
     .where(
       and(
         eq(work_thread.org_id, orgId),
+        eq(work_thread.channel, channel),
         sql`NOT EXISTS (SELECT 1 FROM ${workflow_run} wr WHERE wr.thread_id = ${work_thread.id})`,
       ),
     )
@@ -79,12 +86,17 @@ export async function listWorkThreads(orgId: string): Promise<WorkThreadSummary[
   }));
 }
 
-export async function createWorkThread(orgId: string, title = "") {
+export async function createWorkThread(
+  orgId: string,
+  title = "",
+  channel = "web",
+) {
   const rows = await db()
     .insert(work_thread)
     .values({
       org_id: orgId,
       title,
+      channel,
     })
     .returning();
   return rows[0];

--- a/packages/llm/src/work/store.ts
+++ b/packages/llm/src/work/store.ts
@@ -227,6 +227,23 @@ export async function finishWorkRun(
     .where(eq(work_run.id, runId));
 }
 
+// Persist a run's agent-estimated analysis value (server-clamped minutes +
+// the one-line basis). Separate from finishWorkRun because the estimate is
+// parsed from the run's value fence after the run is marked finished.
+export async function setWorkRunValue(
+  runId: string,
+  args: { minutes: number | null; basis: string | null },
+) {
+  await db()
+    .update(work_run)
+    .set({
+      analysis_minutes_saved: args.minutes,
+      analysis_minutes_basis: args.basis,
+      updated_at: new Date(),
+    })
+    .where(eq(work_run.id, runId));
+}
+
 export async function createWorkMessage(args: {
   orgId: string;
   threadId: string;

--- a/packages/llm/src/workflows/action-server.ts
+++ b/packages/llm/src/workflows/action-server.ts
@@ -19,6 +19,7 @@ import {
   evaluateActionPolicy,
   type PolicyDecision,
 } from "./policy-engine";
+import { clampActionMinutes } from "./value";
 
 export type WorkflowActionContext = {
   orgId: string;
@@ -135,6 +136,8 @@ export async function handleActionRequest(
     payload: args.payload ?? {},
     riskLevel: (args.risk_level as RiskLevel | undefined) ?? null,
     summary: args.summary,
+    minutesSaved: clampActionMinutes(args.minutes_saved),
+    minutesSavedBasis: args.basis ?? null,
     status,
   });
 
@@ -246,6 +249,8 @@ export async function handleWorkActionRequest(
     riskLevel: (args.risk_level as RiskLevel | undefined) ?? null,
     summary: args.summary,
     intent: intent ?? null,
+    minutesSaved: clampActionMinutes(args.minutes_saved),
+    minutesSavedBasis: args.basis ?? null,
     status,
   });
 

--- a/packages/llm/src/workflows/action-store.ts
+++ b/packages/llm/src/workflows/action-store.ts
@@ -261,6 +261,9 @@ export type ActionRequestRecord = {
    * for auto-mode and pre-intent legacy rows.
    */
   intent: string | null;
+  /** Agent-estimated, server-clamped minutes of human effort saved. */
+  minutesSaved: number | null;
+  minutesSavedBasis: string | null;
   /**
    * /work run id this request was emitted from. Lets the worker's
    * runActionExecute emit an action_request_result event into the
@@ -293,6 +296,8 @@ function toRequestRecord(
     status: row.status as ActionRequestStatus,
     summary: row.summary,
     intent: row.intent ?? null,
+    minutesSaved: row.minutes_saved ?? null,
+    minutesSavedBasis: row.minutes_saved_basis ?? null,
     workRunId: row.work_run_id ?? null,
     requestedByRunId: row.requested_by_run_id,
     approvedByUserId: row.approved_by_user_id,
@@ -320,6 +325,9 @@ export type CreateActionRequestInput = {
   /** /work run id this request was emitted from (omit for workflow paths). */
   workRunId?: string | null;
   requestedByRunId?: string | null;
+  /** Agent-estimated, server-clamped minutes of human effort this saves. */
+  minutesSaved?: number | null;
+  minutesSavedBasis?: string | null;
 };
 
 export async function createActionRequest(
@@ -340,6 +348,8 @@ export async function createActionRequest(
       status: input.status,
       summary: input.summary ?? null,
       intent: input.intent ?? null,
+      minutes_saved: input.minutesSaved ?? null,
+      minutes_saved_basis: input.minutesSavedBasis ?? null,
       work_run_id: input.workRunId ?? null,
       requested_by_run_id: input.requestedByRunId ?? null,
     })

--- a/packages/llm/src/workflows/fence-parsers.ts
+++ b/packages/llm/src/workflows/fence-parsers.ts
@@ -1,10 +1,12 @@
 import {
   ACTION_REQUEST_SCHEMA,
+  ASK_CONTEXT_SCHEMA,
   POLICY_SAVE_SCHEMA,
   VALUE_ESTIMATE_SCHEMA,
   WORKFLOW_OUTPUT_SCHEMA,
   WORKFLOW_SAVE_SCHEMA,
   type ActionRequestPayload,
+  type AskContextPayload,
   type PolicySavePayload,
   type ValueEstimatePayload,
   type WorkflowOutputPayload,
@@ -16,6 +18,7 @@ const OUTPUT_FENCE_RE = /```neko_workflow_output\s*([\s\S]*?)```/gi;
 const ACTION_FENCE_RE = /```neko_action_request\s*([\s\S]*?)```/gi;
 const RULE_FENCE_RE = /```neko_rule_save\s*([\s\S]*?)```/gi;
 const VALUE_FENCE_RE = /```neko_value\s*([\s\S]*?)```/gi;
+const ASK_CONTEXT_FENCE_RE = /```neko_ask_context\s*([\s\S]*?)```/gi;
 
 export type FenceParseError = {
   raw: string;
@@ -49,6 +52,12 @@ export type PolicySaveFenceResult = {
 export type ValueFenceResult = {
   text: string;
   payload: ValueEstimatePayload | null;
+  errors: FenceParseError[];
+};
+
+export type AskContextFenceResult = {
+  text: string;
+  payload: AskContextPayload | null;
   errors: FenceParseError[];
 };
 
@@ -201,6 +210,34 @@ export function extractValueFence(raw: string): ValueFenceResult {
 
   return {
     text: stripAllFences(raw, VALUE_FENCE_RE),
+    payload,
+    errors,
+  };
+}
+
+// Ask-page right-rail context (vitals / sources / followups). Last valid
+// fence wins; everything optional.
+export function extractAskContextFence(raw: string): AskContextFenceResult {
+  const matches = [...raw.matchAll(ASK_CONTEXT_FENCE_RE)];
+  const errors: FenceParseError[] = [];
+  let payload: AskContextPayload | null = null;
+
+  for (const m of matches) {
+    const parsed = tryParse(m[1]);
+    if (!parsed.ok) {
+      errors.push({ raw: m[0], reason: parsed.reason });
+      continue;
+    }
+    const validated = ASK_CONTEXT_SCHEMA.safeParse(parsed.value);
+    if (!validated.success) {
+      errors.push({ raw: m[0], reason: validated.error.message });
+      continue;
+    }
+    payload = validated.data;
+  }
+
+  return {
+    text: stripAllFences(raw, ASK_CONTEXT_FENCE_RE),
     payload,
     errors,
   };

--- a/packages/llm/src/workflows/fence-parsers.ts
+++ b/packages/llm/src/workflows/fence-parsers.ts
@@ -3,12 +3,14 @@ import {
   FOLLOWUPS_SCHEMA,
   POLICY_SAVE_SCHEMA,
   VALUE_ESTIMATE_SCHEMA,
+  VITALS_SCHEMA,
   WORKFLOW_OUTPUT_SCHEMA,
   WORKFLOW_SAVE_SCHEMA,
   type ActionRequestPayload,
   type FollowupsPayload,
   type PolicySavePayload,
   type ValueEstimatePayload,
+  type VitalsPayload,
   type WorkflowOutputPayload,
   type WorkflowSavePayload,
 } from "./fence-schemas";
@@ -19,6 +21,7 @@ const ACTION_FENCE_RE = /```neko_action_request\s*([\s\S]*?)```/gi;
 const RULE_FENCE_RE = /```neko_rule_save\s*([\s\S]*?)```/gi;
 const VALUE_FENCE_RE = /```neko_value\s*([\s\S]*?)```/gi;
 const FOLLOWUPS_FENCE_RE = /```neko_followups\s*([\s\S]*?)```/gi;
+const VITALS_FENCE_RE = /```neko_vitals\s*([\s\S]*?)```/gi;
 
 export type FenceParseError = {
   raw: string;
@@ -58,6 +61,12 @@ export type ValueFenceResult = {
 export type FollowupsFenceResult = {
   text: string;
   payload: FollowupsPayload | null;
+  errors: FenceParseError[];
+};
+
+export type VitalsFenceResult = {
+  text: string;
+  payload: VitalsPayload | null;
   errors: FenceParseError[];
 };
 
@@ -238,6 +247,34 @@ export function extractFollowupsFence(raw: string): FollowupsFenceResult {
 
   return {
     text: stripAllFences(raw, FOLLOWUPS_FENCE_RE),
+    payload,
+    errors,
+  };
+}
+
+// Headline numbers that carry the answer (channel-agnostic content). Last valid
+// fence wins.
+export function extractVitalsFence(raw: string): VitalsFenceResult {
+  const matches = [...raw.matchAll(VITALS_FENCE_RE)];
+  const errors: FenceParseError[] = [];
+  let payload: VitalsPayload | null = null;
+
+  for (const m of matches) {
+    const parsed = tryParse(m[1]);
+    if (!parsed.ok) {
+      errors.push({ raw: m[0], reason: parsed.reason });
+      continue;
+    }
+    const validated = VITALS_SCHEMA.safeParse(parsed.value);
+    if (!validated.success) {
+      errors.push({ raw: m[0], reason: validated.error.message });
+      continue;
+    }
+    payload = validated.data;
+  }
+
+  return {
+    text: stripAllFences(raw, VITALS_FENCE_RE),
     payload,
     errors,
   };

--- a/packages/llm/src/workflows/fence-parsers.ts
+++ b/packages/llm/src/workflows/fence-parsers.ts
@@ -1,10 +1,12 @@
 import {
   ACTION_REQUEST_SCHEMA,
   POLICY_SAVE_SCHEMA,
+  VALUE_ESTIMATE_SCHEMA,
   WORKFLOW_OUTPUT_SCHEMA,
   WORKFLOW_SAVE_SCHEMA,
   type ActionRequestPayload,
   type PolicySavePayload,
+  type ValueEstimatePayload,
   type WorkflowOutputPayload,
   type WorkflowSavePayload,
 } from "./fence-schemas";
@@ -13,6 +15,7 @@ const SAVE_FENCE_RE = /```neko_workflow_save\s*([\s\S]*?)```/gi;
 const OUTPUT_FENCE_RE = /```neko_workflow_output\s*([\s\S]*?)```/gi;
 const ACTION_FENCE_RE = /```neko_action_request\s*([\s\S]*?)```/gi;
 const RULE_FENCE_RE = /```neko_rule_save\s*([\s\S]*?)```/gi;
+const VALUE_FENCE_RE = /```neko_value\s*([\s\S]*?)```/gi;
 
 export type FenceParseError = {
   raw: string;
@@ -40,6 +43,12 @@ export type ActionRequestFenceResult = {
 export type PolicySaveFenceResult = {
   text: string;
   payload: PolicySavePayload | null;
+  errors: FenceParseError[];
+};
+
+export type ValueFenceResult = {
+  text: string;
+  payload: ValueEstimatePayload | null;
   errors: FenceParseError[];
 };
 
@@ -164,6 +173,34 @@ export function extractRuleSaveFence(raw: string): PolicySaveFenceResult {
 
   return {
     text: stripAllFences(raw, RULE_FENCE_RE),
+    payload,
+    errors,
+  };
+}
+
+// Per-run analysis value estimate. Last fence wins (the agent emits one at
+// the very end of the turn), so iterate and keep the last valid payload.
+export function extractValueFence(raw: string): ValueFenceResult {
+  const matches = [...raw.matchAll(VALUE_FENCE_RE)];
+  const errors: FenceParseError[] = [];
+  let payload: ValueEstimatePayload | null = null;
+
+  for (const m of matches) {
+    const parsed = tryParse(m[1]);
+    if (!parsed.ok) {
+      errors.push({ raw: m[0], reason: parsed.reason });
+      continue;
+    }
+    const validated = VALUE_ESTIMATE_SCHEMA.safeParse(parsed.value);
+    if (!validated.success) {
+      errors.push({ raw: m[0], reason: validated.error.message });
+      continue;
+    }
+    payload = validated.data;
+  }
+
+  return {
+    text: stripAllFences(raw, VALUE_FENCE_RE),
     payload,
     errors,
   };

--- a/packages/llm/src/workflows/fence-parsers.ts
+++ b/packages/llm/src/workflows/fence-parsers.ts
@@ -1,12 +1,12 @@
 import {
   ACTION_REQUEST_SCHEMA,
-  ASK_CONTEXT_SCHEMA,
+  FOLLOWUPS_SCHEMA,
   POLICY_SAVE_SCHEMA,
   VALUE_ESTIMATE_SCHEMA,
   WORKFLOW_OUTPUT_SCHEMA,
   WORKFLOW_SAVE_SCHEMA,
   type ActionRequestPayload,
-  type AskContextPayload,
+  type FollowupsPayload,
   type PolicySavePayload,
   type ValueEstimatePayload,
   type WorkflowOutputPayload,
@@ -18,7 +18,7 @@ const OUTPUT_FENCE_RE = /```neko_workflow_output\s*([\s\S]*?)```/gi;
 const ACTION_FENCE_RE = /```neko_action_request\s*([\s\S]*?)```/gi;
 const RULE_FENCE_RE = /```neko_rule_save\s*([\s\S]*?)```/gi;
 const VALUE_FENCE_RE = /```neko_value\s*([\s\S]*?)```/gi;
-const ASK_CONTEXT_FENCE_RE = /```neko_ask_context\s*([\s\S]*?)```/gi;
+const FOLLOWUPS_FENCE_RE = /```neko_followups\s*([\s\S]*?)```/gi;
 
 export type FenceParseError = {
   raw: string;
@@ -55,9 +55,9 @@ export type ValueFenceResult = {
   errors: FenceParseError[];
 };
 
-export type AskContextFenceResult = {
+export type FollowupsFenceResult = {
   text: string;
-  payload: AskContextPayload | null;
+  payload: FollowupsPayload | null;
   errors: FenceParseError[];
 };
 
@@ -215,12 +215,12 @@ export function extractValueFence(raw: string): ValueFenceResult {
   };
 }
 
-// Ask-page right-rail context (vitals / sources / followups). Last valid
-// fence wins; everything optional.
-export function extractAskContextFence(raw: string): AskContextFenceResult {
-  const matches = [...raw.matchAll(ASK_CONTEXT_FENCE_RE)];
+// Suggested follow-up questions (channel-agnostic content). Last valid fence
+// wins.
+export function extractFollowupsFence(raw: string): FollowupsFenceResult {
+  const matches = [...raw.matchAll(FOLLOWUPS_FENCE_RE)];
   const errors: FenceParseError[] = [];
-  let payload: AskContextPayload | null = null;
+  let payload: FollowupsPayload | null = null;
 
   for (const m of matches) {
     const parsed = tryParse(m[1]);
@@ -228,7 +228,7 @@ export function extractAskContextFence(raw: string): AskContextFenceResult {
       errors.push({ raw: m[0], reason: parsed.reason });
       continue;
     }
-    const validated = ASK_CONTEXT_SCHEMA.safeParse(parsed.value);
+    const validated = FOLLOWUPS_SCHEMA.safeParse(parsed.value);
     if (!validated.success) {
       errors.push({ raw: m[0], reason: validated.error.message });
       continue;
@@ -237,7 +237,7 @@ export function extractAskContextFence(raw: string): AskContextFenceResult {
   }
 
   return {
-    text: stripAllFences(raw, ASK_CONTEXT_FENCE_RE),
+    text: stripAllFences(raw, FOLLOWUPS_FENCE_RE),
     payload,
     errors,
   };

--- a/packages/llm/src/workflows/fence-schemas.ts
+++ b/packages/llm/src/workflows/fence-schemas.ts
@@ -119,6 +119,31 @@ export const ACTION_REQUEST_SCHEMA = z.object({
   payload: z.record(z.string(), z.unknown()).optional(),
   risk_level: z.enum(RISK_LEVELS).optional(),
   summary: z.string().trim().min(1).max(2000),
+  minutes_saved: z
+    .number()
+    .int()
+    .min(0)
+    .max(600)
+    .optional()
+    .describe(
+      "Conservative estimate of the minutes a competent human would spend doing this one action by hand (e.g. send email ~8, file refund ~15). Omit if unsure.",
+    ),
+  basis: z
+    .string()
+    .trim()
+    .max(160)
+    .optional()
+    .describe("One short line naming why minutes_saved is what it is."),
 });
 
 export type ActionRequestPayload = z.infer<typeof ACTION_REQUEST_SCHEMA>;
+
+// Per-run analysis value estimate. Emitted once at the end of every run via
+// a `neko_value` fence (excludes per-action work, which carries its own
+// estimate). Server-clamped before persisting. See docs/HOURS_SAVED_PLAN.md.
+export const VALUE_ESTIMATE_SCHEMA = z.object({
+  minutes_saved: z.number().int().min(0).max(600),
+  basis: z.string().trim().max(160).optional(),
+});
+
+export type ValueEstimatePayload = z.infer<typeof VALUE_ESTIMATE_SCHEMA>;

--- a/packages/llm/src/workflows/fence-schemas.ts
+++ b/packages/llm/src/workflows/fence-schemas.ts
@@ -147,3 +147,31 @@ export const VALUE_ESTIMATE_SCHEMA = z.object({
 });
 
 export type ValueEstimatePayload = z.infer<typeof VALUE_ESTIMATE_SCHEMA>;
+
+// Structured context for the Ask page's right rail. Emitted once at the end of
+// a /work run via a `neko_ask_context` fence. Everything optional — the rail
+// renders whichever sections are present.
+export const ASK_CONTEXT_SCHEMA = z.object({
+  vitals: z
+    .array(
+      z.object({
+        label: z.string().trim().min(1).max(40),
+        value: z.string().trim().min(1).max(40),
+        sub: z.string().trim().max(40).optional(),
+      }),
+    )
+    .max(4)
+    .optional(),
+  sources: z
+    .array(
+      z.object({
+        name: z.string().trim().min(1).max(80),
+        detail: z.string().trim().max(40).optional(),
+      }),
+    )
+    .max(8)
+    .optional(),
+  followups: z.array(z.string().trim().min(1).max(120)).max(4).optional(),
+});
+
+export type AskContextPayload = z.infer<typeof ASK_CONTEXT_SCHEMA>;

--- a/packages/llm/src/workflows/fence-schemas.ts
+++ b/packages/llm/src/workflows/fence-schemas.ts
@@ -148,30 +148,11 @@ export const VALUE_ESTIMATE_SCHEMA = z.object({
 
 export type ValueEstimatePayload = z.infer<typeof VALUE_ESTIMATE_SCHEMA>;
 
-// Structured context for the Ask page's right rail. Emitted once at the end of
-// a /work run via a `neko_ask_context` fence. Everything optional — the rail
-// renders whichever sections are present.
-export const ASK_CONTEXT_SCHEMA = z.object({
-  vitals: z
-    .array(
-      z.object({
-        label: z.string().trim().min(1).max(40),
-        value: z.string().trim().min(1).max(40),
-        sub: z.string().trim().max(40).optional(),
-      }),
-    )
-    .max(4)
-    .optional(),
-  sources: z
-    .array(
-      z.object({
-        name: z.string().trim().min(1).max(80),
-        detail: z.string().trim().max(40).optional(),
-      }),
-    )
-    .max(8)
-    .optional(),
-  followups: z.array(z.string().trim().min(1).max(120)).max(4).optional(),
+// Suggested follow-up questions — channel-agnostic CONTENT, not UI. The model
+// emits a `neko_followups` fence at the end of a /work run; any channel (the
+// Ask rail, Telegram, Slack) can surface these as "ask next" prompts.
+export const FOLLOWUPS_SCHEMA = z.object({
+  followups: z.array(z.string().trim().min(1).max(120)).max(3),
 });
 
-export type AskContextPayload = z.infer<typeof ASK_CONTEXT_SCHEMA>;
+export type FollowupsPayload = z.infer<typeof FOLLOWUPS_SCHEMA>;

--- a/packages/llm/src/workflows/fence-schemas.ts
+++ b/packages/llm/src/workflows/fence-schemas.ts
@@ -156,3 +156,21 @@ export const FOLLOWUPS_SCHEMA = z.object({
 });
 
 export type FollowupsPayload = z.infer<typeof FOLLOWUPS_SCHEMA>;
+
+// The few headline numbers that carry an answer — channel-agnostic CONTENT,
+// not UI. The model emits a `neko_vitals` fence at the end of a /work run; each
+// channel renders the figures its own way (the web rail as a tile grid, a chat
+// channel as a one-line recap, a voice channel by reading them aloud).
+export const VITALS_SCHEMA = z.object({
+  vitals: z
+    .array(
+      z.object({
+        label: z.string().trim().min(1).max(28),
+        value: z.string().trim().min(1).max(18),
+        sub: z.string().trim().max(36).optional(),
+      }),
+    )
+    .max(4),
+});
+
+export type VitalsPayload = z.infer<typeof VITALS_SCHEMA>;

--- a/packages/llm/src/workflows/index.ts
+++ b/packages/llm/src/workflows/index.ts
@@ -8,10 +8,12 @@ export {
 export {
   extractActionRequestFences,
   extractRuleSaveFence,
+  extractValueFence,
   extractWorkflowOutputFences,
   extractWorkflowSaveFence,
   type ActionRequestFenceResult,
   type PolicySaveFenceResult,
+  type ValueFenceResult,
   type WorkflowOutputFenceResult,
   type WorkflowSaveFenceResult,
 } from "./fence-parsers";
@@ -24,14 +26,21 @@ export {
   POLICY_SAVE_SCHEMA,
   RISK_LEVELS,
   SOURCE_CHANGE_TRIGGER_SCHEMA,
+  VALUE_ESTIMATE_SCHEMA,
   WORKFLOW_OUTPUT_SCHEMA,
   WORKFLOW_SAVE_SCHEMA,
   type ActionRequestPayload,
   type PolicySavePayload,
   type SourceChangeTriggerPayload,
+  type ValueEstimatePayload,
   type WorkflowOutputPayload,
   type WorkflowSavePayload,
 } from "./fence-schemas";
+export {
+  HOURS_SAVED,
+  clampActionMinutes,
+  clampAnalysisMinutes,
+} from "./value";
 export {
   buildWorkflowBuilderServer,
   type WorkflowBuilderContext,

--- a/packages/llm/src/workflows/run-workflow-turn.ts
+++ b/packages/llm/src/workflows/run-workflow-turn.ts
@@ -15,6 +15,7 @@ import {
   finishWorkRun,
   markWorkRunRunning,
   saveAssistantWorkMessage,
+  setWorkRunValue,
 } from "../work/store";
 import { buildWorkMemoryServer } from "../work/tools";
 import { ensureWorkWorkspace } from "../work/workspace";
@@ -24,8 +25,10 @@ import {
 } from "./action-server";
 import {
   extractActionRequestFences,
+  extractValueFence,
   extractWorkflowOutputFences,
 } from "./fence-parsers";
+import { clampAnalysisMinutes } from "./value";
 import {
   buildWorkflowOutputServer,
   handleWorkflowOutput,
@@ -313,7 +316,26 @@ export async function runWorkflowTurn(
       });
     }
 
+    // Per-run analysis value estimate (works for both backends — the
+    // `neko_value` fence rides in the agent's final text). Parse, clamp,
+    // strip from the persisted text so it never shows in the summary.
+    const valueFence = extractValueFence(persistedText);
+    persistedText = valueFence.text;
+    const analysisMinutes = clampAnalysisMinutes(valueFence.payload?.minutes_saved);
+
     await finishWorkRun(workRunId, result.status, result.error ?? null);
+    if (valueFence.payload) {
+      try {
+        await setWorkRunValue(workRunId, {
+          minutes: analysisMinutes,
+          basis: valueFence.payload.basis ?? null,
+        });
+      } catch (err) {
+        console.warn(
+          `[workflow-run] setWorkRunValue failed: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
     const summary =
       persistedText.slice(0, 4000) ||
       (result.status === "completed"
@@ -335,7 +357,10 @@ export async function runWorkflowTurn(
       });
     }
 
-    await wrappedEmit({ type: "done", result: { status: result.status } });
+    await wrappedEmit({
+      type: "done",
+      result: { status: result.status, minutesSaved: analysisMinutes ?? 0 },
+    });
 
     return {
       status: result.status,

--- a/packages/llm/src/workflows/runner-prompt.ts
+++ b/packages/llm/src/workflows/runner-prompt.ts
@@ -284,7 +284,20 @@ ${memorySection}
 
 <finishing>
 After producing your output(s), send one short final assistant message
-summarising what you did, then end the run.
+summarising what you did. Then emit exactly one fenced block estimating the
+human time this run's ANALYSIS saved (exclude any actions you proposed —
+those carry their own estimate):
+
+\`\`\`neko_value
+{ "minutes_saved": 12, "basis": "Checked reorder thresholds across 40 SKUs" }
+\`\`\`
+
+Estimate the minutes a competent person would spend on this by hand; be
+conservative and round DOWN. Emit \`0\` when the run found nothing a person
+would otherwise have acted on. Anchors (minutes): routine email 5-8 · CRM
+update 3-6 · refund 12-18 · purchase order 20-30 · multi-table report 20-40 ·
+summary 10-20 · single-table lookup 3-8 · found nothing 0. When you propose an
+action, add \`minutes_saved\` + a short \`basis\` to it too.
 </finishing>
 
 ${mode === "headless" ? HEADLESS_TAIL : LIVE_TAIL}`;

--- a/packages/llm/src/workflows/value.ts
+++ b/packages/llm/src/workflows/value.ts
@@ -1,0 +1,33 @@
+// Human-hours-saved estimate guardrails. The agent self-estimates the
+// minutes a competent human would spend on a task; these caps make the
+// number safe to surface — one hallucinated estimate can't poison a total.
+// See docs/HOURS_SAVED_PLAN.md.
+
+export const HOURS_SAVED = {
+  /** Max minutes credited to a single action. */
+  perActionCapMin: 120,
+  /** Max minutes credited to a single run's analysis. */
+  perAnalysisCapMin: 180,
+  /** Methodology revision stamped on every estimate row. */
+  estimateVersion: 1,
+} as const;
+
+function clamp(raw: number | null | undefined, capMin: number): number | null {
+  if (raw == null || typeof raw !== "number" || !Number.isFinite(raw)) {
+    return null;
+  }
+  if (raw < 0) return 0;
+  return Math.min(Math.round(raw), capMin);
+}
+
+/** Clamp an agent's per-action minutes estimate. Null when unusable. */
+export function clampActionMinutes(raw: number | null | undefined): number | null {
+  return clamp(raw, HOURS_SAVED.perActionCapMin);
+}
+
+/** Clamp an agent's per-run analysis minutes estimate. Null when unusable. */
+export function clampAnalysisMinutes(
+  raw: number | null | undefined,
+): number | null {
+  return clamp(raw, HOURS_SAVED.perAnalysisCapMin);
+}

--- a/packages/llm/test/fence-parsers.test.ts
+++ b/packages/llm/test/fence-parsers.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   extractActionRequestFences,
   extractRuleSaveFence,
+  extractVitalsFence,
   extractWorkflowOutputFences,
   extractWorkflowSaveFence,
 } from "../src/workflows/fence-parsers";
@@ -348,5 +349,78 @@ describe("extractRuleSaveFence", () => {
     const r = extractRuleSaveFence(raw);
     expect(r.payload?.name).toBe("first");
     expect(r.text).not.toContain("neko_rule_save");
+  });
+});
+
+describe("extractVitalsFence", () => {
+  it("returns null payload when no fence is present", () => {
+    const r = extractVitalsFence("just the prose answer, no numbers fenced");
+    expect(r.payload).toBeNull();
+    expect(r.errors).toEqual([]);
+    expect(r.text).toBe("just the prose answer, no numbers fenced");
+  });
+
+  it("parses headline vitals and strips the fence from text", () => {
+    const raw = [
+      "Your top 10 customers are 48% of YTD revenue.",
+      "```neko_vitals",
+      JSON.stringify({
+        vitals: [
+          { label: "Top-10 share", value: "48%", sub: "down from 53%" },
+          { label: "#1 account", value: "$1.2M", sub: "Acme · 9.4%" },
+          { label: "YoY revenue", value: "+14%" },
+        ],
+      }),
+      "```",
+    ].join("\n");
+    const r = extractVitalsFence(raw);
+    expect(r.payload?.vitals).toHaveLength(3);
+    expect(r.payload?.vitals[0]).toEqual({
+      label: "Top-10 share",
+      value: "48%",
+      sub: "down from 53%",
+    });
+    expect(r.payload?.vitals[2].sub).toBeUndefined();
+    expect(r.text).toContain("Your top 10 customers");
+    expect(r.text).not.toContain("neko_vitals");
+  });
+
+  it("rejects more than four vitals without throwing", () => {
+    const raw = [
+      "```neko_vitals",
+      JSON.stringify({
+        vitals: Array.from({ length: 5 }, (_, i) => ({
+          label: `m${i}`,
+          value: `${i}`,
+        })),
+      }),
+      "```",
+    ].join("\n");
+    const r = extractVitalsFence(raw);
+    expect(r.payload).toBeNull();
+    expect(r.errors).toHaveLength(1);
+  });
+
+  it("reports parse errors for invalid JSON without throwing", () => {
+    const raw = "Prose.\n```neko_vitals\n{not valid}\n```\nMore prose.";
+    const r = extractVitalsFence(raw);
+    expect(r.payload).toBeNull();
+    expect(r.errors).toHaveLength(1);
+    expect(r.text).toContain("Prose.");
+    expect(r.text).toContain("More prose.");
+  });
+
+  it("lets the last valid fence win when an agent emits two", () => {
+    const raw = [
+      "```neko_vitals",
+      JSON.stringify({ vitals: [{ label: "first", value: "1" }] }),
+      "```",
+      "```neko_vitals",
+      JSON.stringify({ vitals: [{ label: "second", value: "2" }] }),
+      "```",
+    ].join("\n");
+    const r = extractVitalsFence(raw);
+    expect(r.payload?.vitals[0].label).toBe("second");
+    expect(r.text).not.toContain("neko_vitals");
   });
 });

--- a/packages/llm/test/hermes-backend-acp.test.ts
+++ b/packages/llm/test/hermes-backend-acp.test.ts
@@ -295,4 +295,71 @@ describe("HermesBackend ACP behavior", () => {
     expect(result.error).toContain("Provider gemini returned 503");
     expect(events.find((e) => e.type === "error")).toBeDefined();
   });
+
+  it("web turn: offers the render MCP server and turns a render_cards call into a surface", async () => {
+    const cap = captureRequests();
+    const sessionId = "sess-render";
+    const a2ui = [
+      { version: "v0.9", createSurface: { surfaceId: "s1", catalogId: "urn:app:catalog:briefing:v1" } },
+      { version: "v0.9", updateComponents: { surfaceId: "s1", components: [{ id: "k", component: "BriefingCard", metric: "42", label: "Test" }] } },
+    ];
+    controller.setScript({
+      responders: {
+        "session/new": (p) => { cap.record("session/new", p); return { sessionId }; },
+        "session/prompt": (_p, ctx) => {
+          ctx.emitNotification({
+            jsonrpc: "2.0",
+            method: "session/update",
+            params: {
+              sessionId,
+              update: {
+                sessionUpdate: "tool_call",
+                toolCallId: "tc-render",
+                kind: "other",
+                title: "mcp_neko_render_render_cards",
+                rawInput: { messages: a2ui },
+              },
+            },
+          });
+          return { stopReason: "end_turn" };
+        },
+      },
+    });
+    const events: Array<{ type: string; messages?: unknown[] }> = [];
+    const backend = new HermesBackend();
+    await backend.run({
+      prompt: "p",
+      workspace: FAKE_WORKSPACE,
+      wantsCards: true,
+      onEvent: (e) => { events.push(e as { type: string; messages?: unknown[] }); },
+    });
+
+    // The render server is handed to hermes via session/new.mcpServers.
+    const sn = cap.seen.find((s) => s.method === "session/new");
+    expect(JSON.stringify(sn?.params)).toContain("neko_render");
+
+    // The render_cards call became the answer surface — not a tool pill.
+    const surfaces = events.filter((e) => e.type === "surface");
+    expect(surfaces).toHaveLength(1);
+    expect(surfaces[0].messages).toHaveLength(2);
+    expect(events.some((e) => e.type === "tool_start")).toBe(false);
+  });
+
+  it("non-web turn: does not offer the render MCP server", async () => {
+    const cap = captureRequests();
+    controller.setScript({
+      responders: {
+        "session/new": (p) => { cap.record("session/new", p); return { sessionId: "s" }; },
+        "session/prompt": (_p, ctx) => {
+          ctx.emitNotification(chunkNotification("s", "hi"));
+          return { stopReason: "end_turn" };
+        },
+      },
+    });
+    const backend = new HermesBackend();
+    await backend.run({ prompt: "p", workspace: FAKE_WORKSPACE }); // wantsCards defaults false
+    const sn = cap.seen.find((s) => s.method === "session/new");
+    expect((sn?.params as { mcpServers?: unknown[] }).mcpServers).toEqual([]);
+    expect(JSON.stringify(sn?.params)).not.toContain("neko_render");
+  });
 });

--- a/packages/llm/test/interaction-from-agent-event.test.ts
+++ b/packages/llm/test/interaction-from-agent-event.test.ts
@@ -124,4 +124,28 @@ describe("toInteractionEvents", () => {
       { kind: "inform", id: "ie-1", mood: "act", title: "Something went wrong", body: "boom" },
     ]);
   });
+
+  it("maps vitals to a modality-free highlight, dropping a sub when absent", () => {
+    const vitals: AgentEvent = {
+      type: "vitals",
+      items: [
+        { label: "Top-10 share", value: "48%", sub: "down from 53%" },
+        { label: "YoY revenue", value: "+14%" },
+      ],
+    };
+    expect(toInteractionEvents([vitals])).toEqual([
+      {
+        kind: "highlight",
+        id: "ie-1",
+        metrics: [
+          { label: "Top-10 share", value: "48%", sub: "down from 53%" },
+          { label: "YoY revenue", value: "+14%" },
+        ],
+      },
+    ]);
+  });
+
+  it("drops an empty vitals event entirely", () => {
+    expect(toInteractionEvents([{ type: "vitals", items: [] }])).toEqual([]);
+  });
 });

--- a/packages/llm/test/value-estimate.test.ts
+++ b/packages/llm/test/value-estimate.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { extractValueFence } from "../src/workflows/fence-parsers";
+import {
+  HOURS_SAVED,
+  clampActionMinutes,
+  clampAnalysisMinutes,
+} from "../src/workflows/value";
+
+describe("extractValueFence", () => {
+  it("returns null payload when no fence is present", () => {
+    const r = extractValueFence("just an answer, nothing else");
+    expect(r.payload).toBeNull();
+    expect(r.errors).toEqual([]);
+    expect(r.text).toBe("just an answer, nothing else");
+  });
+
+  it("parses a valid value fence and strips it from text", () => {
+    const raw = [
+      "Here's the revenue report.",
+      "",
+      "```neko_value",
+      JSON.stringify({ minutes_saved: 18, basis: "Cross-checked a 3-table report" }),
+      "```",
+    ].join("\n");
+    const r = extractValueFence(raw);
+    expect(r.payload?.minutes_saved).toBe(18);
+    expect(r.payload?.basis).toBe("Cross-checked a 3-table report");
+    expect(r.text).toBe("Here's the revenue report.");
+  });
+
+  it("accepts a zero estimate (no-op runs report 0)", () => {
+    const raw = '```neko_value\n{ "minutes_saved": 0 }\n```';
+    const r = extractValueFence(raw);
+    expect(r.payload?.minutes_saved).toBe(0);
+  });
+
+  it("rejects a negative estimate as invalid", () => {
+    const raw = '```neko_value\n{ "minutes_saved": -5 }\n```';
+    const r = extractValueFence(raw);
+    expect(r.payload).toBeNull();
+    expect(r.errors.length).toBe(1);
+  });
+
+  it("keeps the last fence when several are emitted", () => {
+    const raw = [
+      '```neko_value\n{ "minutes_saved": 5 }\n```',
+      '```neko_value\n{ "minutes_saved": 30 }\n```',
+    ].join("\n\n");
+    const r = extractValueFence(raw);
+    expect(r.payload?.minutes_saved).toBe(30);
+  });
+});
+
+describe("clamping", () => {
+  it("caps an over-eager action estimate", () => {
+    expect(clampActionMinutes(99999)).toBe(HOURS_SAVED.perActionCapMin);
+  });
+
+  it("caps an over-eager analysis estimate", () => {
+    expect(clampAnalysisMinutes(99999)).toBe(HOURS_SAVED.perAnalysisCapMin);
+  });
+
+  it("floors negatives at 0 and drops non-numbers", () => {
+    expect(clampActionMinutes(-10)).toBe(0);
+    expect(clampActionMinutes(null)).toBeNull();
+    expect(clampActionMinutes(undefined)).toBeNull();
+    expect(clampActionMinutes(Number.NaN)).toBeNull();
+  });
+
+  it("rounds and passes through values within the cap", () => {
+    expect(clampAnalysisMinutes(17.6)).toBe(18);
+    expect(clampActionMinutes(8)).toBe(8);
+  });
+});

--- a/packages/llm/test/work-prompt.test.ts
+++ b/packages/llm/test/work-prompt.test.ts
@@ -28,6 +28,7 @@ const knowledge: KnowledgePackContents = {
 function build(
   backend: "claude-agent" | "hermes",
   overrides: {
+    wantsCards?: boolean;
     supportsCardTool?: boolean;
     supportsSkillTool?: boolean;
     supportsMemoryTool?: boolean;
@@ -41,6 +42,7 @@ function build(
     knowledge,
     messages: [],
     currentUserMessage: "test",
+    wantsCards: overrides.wantsCards ?? true,
     supportsCardTool: overrides.supportsCardTool ?? false,
     supportsSkillTool: overrides.supportsSkillTool ?? false,
     supportsMemoryTool: overrides.supportsMemoryTool ?? false,
@@ -76,6 +78,27 @@ describe("buildWorkPrompt attachments guidance", () => {
     // explicitly say to read them.
     expect(prompt).not.toMatch(/Uploaded files are auxiliary/);
     expect(prompt).toMatch(/read the file/i);
+  });
+});
+
+describe("per-channel rendering gate", () => {
+  it("includes the rendering section on web turns (wantsCards)", () => {
+    const claudeWeb = build("claude-agent", { wantsCards: true, supportsCardTool: true });
+    expect(claudeWeb).toContain("<rendering>");
+    expect(claudeWeb).toContain("render_cards");
+
+    const hermesWeb = build("hermes", { wantsCards: true, supportsCardTool: false });
+    expect(hermesWeb).toContain("<rendering>");
+    expect(hermesWeb).toContain("neko_a2ui");
+  });
+
+  it("omits all rendering vocabulary on non-web turns", () => {
+    for (const backend of ["claude-agent", "hermes"] as const) {
+      const prompt = build(backend, { wantsCards: false, supportsCardTool: backend === "claude-agent" });
+      expect(prompt).not.toContain("<rendering>");
+      expect(prompt).not.toContain("neko_a2ui");
+      expect(prompt).not.toContain("render_cards");
+    }
   });
 });
 

--- a/packages/llm/test/work-prompt.test.ts
+++ b/packages/llm/test/work-prompt.test.ts
@@ -82,14 +82,17 @@ describe("buildWorkPrompt attachments guidance", () => {
 });
 
 describe("per-channel rendering gate", () => {
-  it("includes the rendering section on web turns (wantsCards)", () => {
+  it("renders via the render_cards tool on web turns (wantsCards)", () => {
+    // claude → the neko_ui MCP tool; hermes → its stdio render server tool.
     const claudeWeb = build("claude-agent", { wantsCards: true, supportsCardTool: true });
     expect(claudeWeb).toContain("<rendering>");
-    expect(claudeWeb).toContain("render_cards");
+    expect(claudeWeb).toContain("mcp__neko_ui__render_cards");
 
     const hermesWeb = build("hermes", { wantsCards: true, supportsCardTool: false });
     expect(hermesWeb).toContain("<rendering>");
-    expect(hermesWeb).toContain("neko_a2ui");
+    expect(hermesWeb).toContain("render_cards");
+    // The web-UI-coupled fence is gone from the prompt entirely.
+    expect(hermesWeb).not.toContain("neko_a2ui");
   });
 
   it("omits all rendering vocabulary on non-web turns", () => {

--- a/scripts/neko-vm-setup.sh
+++ b/scripts/neko-vm-setup.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# One-time setup for the neko-vm host (demo.getneko.app).
+# One-time setup for the neko-vm host (demo.openneko.app).
 # Run as root (or via sudo) on the VM. Idempotent — re-running is safe.
 #
 # Usage:  sudo bash scripts/neko-vm-setup.sh [DEPLOY_USER]


### PR DESCRIPTION
Large feature branch (34 commits) bringing the information-dense **Compact** UI study into the live app, plus the channel-agnostic rendering/output work and the Ask context rail it enables.

## Density UI (Comfortable ⇄ Compact toggle, default Compact)
- `DensityProvider` (localStorage + pre-paint script) and a `DensityToggle` in the header; CSS variable system keyed on `[data-density]`.
- Compact ports across all surfaces: Dashboard (wide canvas + briefing tile grid, mini sparklines), Workflows (tile grid), Actions (triage queue + reading pane), Ask (3-pane: threads | conversation | context rail).
- Header rebuilt as the mockup's single top bar, pixel-aligned.

## Hours-saved value prop
- Agent-estimated "human hours saved" end to end — dashboard hero + per-receipt chips, derived from a server-clamped `neko_value` fence.

## Per-channel rendering (channel-agnostic by construction)
- a2ui card rendering is channel-gated; the base prompt stays channel-neutral. Hermes renders via a real `render_cards` MCP tool.
- Channels are isolated (web Ask lists only its own threads) and chat replies are delivered back to the origin channel.
- Reliable, deduped, dead-lettered delivery.

## Ask context rail + channel-agnostic vitals
- Rail surfaces the answer's **Answer vitals**, **Artifacts**, **Sources touched**, **Ask next**, and a related **memory** — faithful to the dense work prototype.
- Vitals and follow-ups are channel-agnostic **content** (not UI): the model emits `neko_vitals` / `neko_followups` fences; the web channel renders pixels, while the `InteractionEvent` waist carries vitals as a `highlight` event that voice/slack/whatsapp each render their own way. Sources are derived from run telemetry.

## Ask-page UX hardening
- Sticky frosted header (always visible), rock-solid pinned sidebar + rail (zero scroll travel), `scroll-padding` + `overscroll-behavior:none` so the live "running" indicator stays above the composer and the header can't be dragged.
- Tool-call groups collapsed by default; Ask-next chips drop the question into the composer (focused) for editing rather than starting a new thread; a2ui list-key fix for id-less components.

## Backend / DB
- LLM turn-closing prompt rewritten as positive demands; `neko_ask_context` replaced by `neko_followups`.
- DB: exact memory vector search (dropped a misconfigured IVFFlat index).

## Testing
New tests at every layer of the channel-agnostic path (fence parsers, agent-event→interaction mapping, channel projections); web suite green (223 tests). web / channels / interaction typecheck clean. Verified live end-to-end on localhost: fresh `/work` runs emit vitals and the minigrid renders faithfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)