### PR TITLE
fix: header compile-drop, responsive/UX/styling consistency, and workflow-run reliability

### DIFF
--- a/apps/web/src/app/(work)/memory/page.tsx
+++ b/apps/web/src/app/(work)/memory/page.tsx
@@ -186,7 +186,7 @@ export default function MemoryPage() {
                   onClick={() => void archive(memory.id)}
                   aria-label="Archive memory"
                   title="Archive memory"
-                  className="mt-1.5 mr-1.5 w-8 h-8 rounded-[9px] bg-transparent border-0 text-text3 inline-flex items-center justify-center transition opacity-0 pointer-events-none cursor-pointer hover:bg-[rgba(220,53,69,0.1)] hover:text-[#c0392b] disabled:opacity-50 disabled:cursor-not-allowed group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
+                  className="mt-1.5 mr-1.5 w-9 h-9 rounded-[9px] bg-transparent border-0 text-text3 inline-flex items-center justify-center transition opacity-0 pointer-events-none cursor-pointer hover:bg-[rgba(220,53,69,0.1)] hover:text-[var(--danger-hover)] disabled:opacity-50 disabled:cursor-not-allowed group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto"
                 >
                   <Trash2 size={14} strokeWidth={2} />
                 </button>

--- a/apps/web/src/app/(work)/skills/page.tsx
+++ b/apps/web/src/app/(work)/skills/page.tsx
@@ -100,7 +100,7 @@ export default function SkillsPage() {
                 onClick={() => void remove(skill.name)}
                 aria-label={`Delete skill ${skill.name}`}
                 title="Delete skill"
-                className="mt-1.5 mr-1.5 w-8 h-8 rounded-[9px] bg-transparent border-0 text-text3 inline-flex items-center justify-center transition opacity-0 pointer-events-none cursor-pointer hover:bg-[rgba(220,53,69,0.1)] hover:text-[#c0392b] disabled:opacity-50 disabled:cursor-not-allowed group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto"
+                className="mt-1.5 mr-1.5 w-9 h-9 rounded-[9px] bg-transparent border-0 text-text3 inline-flex items-center justify-center transition opacity-0 pointer-events-none cursor-pointer hover:bg-[rgba(220,53,69,0.1)] hover:text-[var(--danger-hover)] disabled:opacity-50 disabled:cursor-not-allowed group-hover:opacity-100 group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:pointer-events-auto [@media(hover:none)]:opacity-100 [@media(hover:none)]:pointer-events-auto"
               >
                 <Trash2 size={14} strokeWidth={2} />
               </button>

--- a/apps/web/src/app/(work)/work/WorkSidebar.tsx
+++ b/apps/web/src/app/(work)/work/WorkSidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Brain, Plus, Sparkles, Trash2, Workflow } from "lucide-react";
+import { Brain, ChevronDown, Plus, Sparkles, Trash2, Workflow } from "lucide-react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useCallback, useEffect, useState } from "react";
@@ -25,6 +25,12 @@ export default function WorkSidebar() {
   const [threads, setThreads] = useState<ThreadSummary[]>([]);
   const [loadingThreads, setLoadingThreads] = useState(true);
   const [pendingCount, setPendingCount] = useState(0);
+  // Collapsed on mobile while a thread is open so the conversation, not the
+  // thread list, is the first thing on screen. Desktop ignores this (CSS).
+  const [threadsExpanded, setThreadsExpanded] = useState(true);
+  useEffect(() => {
+    setThreadsExpanded(!activeThreadId);
+  }, [activeThreadId]);
 
   const refresh = useCallback(async () => {
     const res = await fetch("/api/work/threads", { cache: "no-store" });
@@ -92,10 +98,20 @@ export default function WorkSidebar() {
   return (
     <aside className="work-sidebar">
       <div className="work-sidebar-head">
-        <div className="work-sidebar-eyebrow">
+        <button
+          type="button"
+          className="work-sidebar-eyebrow work-threads-toggle"
+          onClick={() => setThreadsExpanded((v) => !v)}
+          aria-expanded={threadsExpanded}
+        >
           <span>Threads</span>
           <span className="work-sidebar-count">{threads.length}</span>
-        </div>
+          <ChevronDown
+            size={14}
+            strokeWidth={2}
+            className={`work-threads-chevron${threadsExpanded ? " is-open" : ""}`}
+          />
+        </button>
         <button
           className="work-icon-btn is-ghost"
           onClick={() => void createThread()}
@@ -106,7 +122,7 @@ export default function WorkSidebar() {
         </button>
       </div>
 
-      <div className="work-thread-list">
+      <div className={`work-thread-list${threadsExpanded ? "" : " is-collapsed"}`}>
         {loadingThreads ? (
           <div className="text-text3 text-[13px] py-3 px-1">Loading threads…</div>
         ) : threads.length === 0 ? (

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,5 +1,20 @@
 @import "tailwindcss";
 
+@import "./styles/_tokens.css";
+@import "./styles/_chrome.css";
+@import "./styles/_dashboard.css";
+@import "./styles/_work.css";
+@import "./styles/_composer.css";
+@import "./styles/_profile-review.css";
+@import "./styles/_toasts.css";
+@import "./styles/_library.css";
+@import "./styles/_modal.css";
+@import "./styles/_workflows.css";
+@import "./styles/_run-replay.css";
+@import "./styles/_actions.css";
+@import "./styles/_act-card.css";
+@import "./styles/_responsive.css";
+
 @theme {
   --color-bg: #FAFAF7;
   --color-card: #FFFFFF;
@@ -39,21 +54,6 @@
 @utility font-body {
   font-family: var(--font-body), 'Manrope', sans-serif;
 }
-
-@import "./styles/_tokens.css";
-@import "./styles/_chrome.css";
-@import "./styles/_dashboard.css";
-@import "./styles/_work.css";
-@import "./styles/_composer.css";
-@import "./styles/_profile-review.css";
-@import "./styles/_toasts.css";
-@import "./styles/_library.css";
-@import "./styles/_modal.css";
-@import "./styles/_workflows.css";
-@import "./styles/_run-replay.css";
-@import "./styles/_actions.css";
-@import "./styles/_act-card.css";
-@import "./styles/_responsive.css";
 
 /* ─── DENSITY LAYER (Comfortable ⇄ Compact, [data-density] on <html>) ─── */
 /* default (no attribute) = compact */

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -39,6 +39,9 @@
   --color-danger-soft: #FEECEC;
 
   --radius-card: 20px;
+  --radius-inner: 12px;
+  --radius-control: 10px;
+  --radius-2xl: 20px;
 
   --shadow-soft: 0 1px 3px rgba(20,18,12,0.04), 0 4px 16px rgba(20,18,12,0.03);
   --shadow-hover: 0 2px 8px rgba(20,18,12,0.06), 0 12px 36px -8px rgba(20,18,12,0.07);
@@ -111,7 +114,7 @@ html[data-density="comfortable"] {
 html[data-density="compact"] .workflows-root { --page-width: 1200px; }
 html[data-density="compact"] .wf-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(330px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(min(330px, 100%), 1fr));
   gap: 11px;
   align-items: start;
 }
@@ -128,7 +131,14 @@ html[data-density="compact"] .triage-layout {
   gap: 16px;
   align-items: start;
 }
-html[data-density="compact"] .triage-pane { display: block; position: sticky; top: 18px; }
+html[data-density="compact"] .triage-pane {
+  display: block; position: sticky; top: 18px;
+  max-height: calc(100vh - 36px); overflow-y: auto;
+}
+@media (max-width: 768px) {
+  html[data-density="compact"] .triage-layout { grid-template-columns: minmax(0, 1fr); }
+  html[data-density="compact"] .triage-pane { position: static; max-height: none; }
+}
 
 /* ── Ask: 3-pane (threads | conversation | context rail) in Compact ── */
 .work-rail { display: none; }

--- a/apps/web/src/app/runs/[workflowRunId]/page.tsx
+++ b/apps/web/src/app/runs/[workflowRunId]/page.tsx
@@ -472,7 +472,7 @@ export default function RunPage() {
                       <div className="flex gap-2 mt-2.5">
                         <button
                           type="button"
-                          className="px-3.5 py-[7px] rounded-[10px] border border-danger bg-danger text-white font-body text-[13px] font-semibold cursor-pointer hover:enabled:bg-[#c84545] hover:enabled:border-[#c84545] disabled:opacity-55 disabled:cursor-not-allowed"
+                          className="px-3.5 py-[7px] rounded-control border border-danger bg-danger text-white font-body text-[13px] font-semibold cursor-pointer hover:enabled:bg-[var(--danger-hover)] hover:enabled:border-[var(--danger-hover)] disabled:opacity-55 disabled:cursor-not-allowed"
                           disabled={actionBusyId === a.id}
                           onClick={() => void submitReject()}
                         >
@@ -492,7 +492,7 @@ export default function RunPage() {
                     <div className="flex gap-2 mt-2.5">
                       <button
                         type="button"
-                        className="px-3.5 py-[7px] rounded-[10px] border border-accent bg-accent text-white font-body text-[13px] font-semibold cursor-pointer hover:enabled:bg-[#5a4cd1] hover:enabled:border-[#5a4cd1] disabled:opacity-55 disabled:cursor-not-allowed"
+                        className="px-3.5 py-[7px] rounded-control border border-accent bg-accent text-white font-body text-[13px] font-semibold cursor-pointer hover:enabled:bg-[var(--accent-hover)] hover:enabled:border-[var(--accent-hover)] disabled:opacity-55 disabled:cursor-not-allowed"
                         disabled={actionBusyId === a.id}
                         onClick={() => void actOnRequest(a.id, "approve")}
                       >

--- a/apps/web/src/app/styles/_chrome.css
+++ b/apps/web/src/app/styles/_chrome.css
@@ -61,9 +61,9 @@ html {
   font-family: var(--font-body), 'Manrope', sans-serif;
   font-size: 11px;
   font-weight: 600;
-  color: #113719;
-  background: #6cff7f;
-  border: 1px solid #58f26c;
+  color: var(--success-ink);
+  background: var(--success);
+  border: 1px solid color-mix(in srgb, var(--success) 80%, var(--success-mid));
   text-decoration: none;
   letter-spacing: 0.1px;
   line-height: 1;
@@ -161,4 +161,26 @@ html {
 }
 .settings-backlink:hover .settings-backlink-arrow {
   transform: translateX(-3px);
+}
+
+/* ─── PILLS (segmented tab/selector — e.g. business-profile, role views) ─── */
+.pills { display: flex; flex-wrap: wrap; gap: 8px; }
+.pill {
+  font-family: var(--font-body), 'Manrope', sans-serif;
+  font-size: 13.5px;
+  font-weight: 600;
+  color: var(--text2);
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 8px 16px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.18s, background 0.18s, border-color 0.18s, transform 0.18s;
+}
+.pill:hover { border-color: var(--text3); color: var(--text); }
+.pill.on {
+  background: var(--text);
+  border-color: var(--text);
+  color: var(--bg);
 }

--- a/apps/web/src/app/styles/_chrome.css
+++ b/apps/web/src/app/styles/_chrome.css
@@ -49,55 +49,6 @@ html {
   border-bottom: 1px solid color-mix(in srgb, var(--border) 65%, transparent);
 }
 
-/* "Update available" chip beside the brand. Pulse animations would render
-   awkwardly as utility chains — kept as a single named class. */
-.brand-update {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  border: 1px solid color-mix(in srgb, var(--success-mid) 30%, var(--border));
-  background: var(--success-soft);
-  color: var(--success-ink);
-  font-family: var(--font-body), 'Manrope', sans-serif;
-  font-size: 11px;
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  padding: 6px 10px 6px 9px;
-  border-radius: 999px;
-  cursor: pointer;
-  line-height: 1;
-  height: 28px;
-  transition: background 0.18s, border-color 0.18s, transform 0.18s, box-shadow 0.18s;
-  animation: brand-update-in 0.4s ease both;
-}
-.brand-update:hover {
-  background: color-mix(in srgb, var(--success) 24%, var(--success-soft));
-  border-color: var(--success-mid);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 14px rgba(17, 55, 25, 0.10);
-}
-.brand-update:focus-visible {
-  outline: 2px solid var(--success-mid);
-  outline-offset: 2px;
-}
-.brand-update-dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 999px;
-  background: var(--success-mid);
-  box-shadow: 0 0 0 0 color-mix(in srgb, var(--success-mid) 55%, transparent);
-  animation: brand-update-pulse 1.8s ease-in-out infinite;
-  flex: 0 0 auto;
-}
-@keyframes brand-update-in {
-  from { opacity: 0; transform: translateY(-2px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-@keyframes brand-update-pulse {
-  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--success-mid) 55%, transparent); }
-  50% { box-shadow: 0 0 0 5px color-mix(in srgb, var(--success-mid) 0%, transparent); }
-}
-
 /* ─── CREATOR CREDIT ─── */
 /* Acid-green attribution chip fixed bottom-right; positioning gets
    responsive-aware in /work via body.work-shell. The math (work-shell
@@ -189,16 +140,6 @@ html {
   opacity: 0.55;
   cursor: not-allowed;
   pointer-events: none;
-}
-.section-nav-row {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  flex-wrap: wrap;
-  margin-top: -4px;
-  margin-bottom: 28px;
-  padding-bottom: 16px;
-  border-bottom: 1px solid var(--border);
 }
 .settings-backlink {
   display: inline-flex;

--- a/apps/web/src/app/styles/_dashboard.css
+++ b/apps/web/src/app/styles/_dashboard.css
@@ -34,7 +34,7 @@
   font-size: 11px;
   font-weight: 700;
   text-transform: uppercase;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.14em;
   color: var(--text3);
   margin-bottom: 12px;
 }
@@ -232,12 +232,12 @@
 .dash-call {
   margin: 0 0 36px;
   padding: 18px 18px 16px;
-  border: 1px solid rgba(233, 162, 59, 0.32);
+  border: 1px solid color-mix(in srgb, var(--watch) 32%, transparent);
   border-left: 3px solid var(--watch);
   border-radius: 14px;
   background:
-    linear-gradient(180deg, rgba(233, 162, 59, 0.07), rgba(233, 162, 59, 0.02));
-  box-shadow: 0 1px 0 rgba(233, 162, 59, 0.06), 0 12px 28px -16px rgba(233, 162, 59, 0.18);
+    linear-gradient(180deg, color-mix(in srgb, var(--watch) 7%, transparent), color-mix(in srgb, var(--watch) 2%, transparent));
+  box-shadow: 0 1px 0 color-mix(in srgb, var(--watch) 6%, transparent), 0 12px 28px -16px color-mix(in srgb, var(--watch) 18%, transparent);
 }
 .dash-call-eyebrow {
   display: flex;
@@ -246,7 +246,7 @@
   margin: 0 0 12px;
   font-family: var(--font-display), 'Archivo', sans-serif;
   font-size: 11px;
-  font-weight: 800;
+  font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
   color: var(--warn-ink);
@@ -256,12 +256,12 @@
   height: 8px;
   border-radius: 999px;
   background: var(--watch);
-  box-shadow: 0 0 0 4px rgba(233, 162, 59, 0.18);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--watch) 18%, transparent);
   animation: dash-call-pulse 2.4s ease-in-out infinite;
 }
 @keyframes dash-call-pulse {
-  0%, 100% { box-shadow: 0 0 0 4px rgba(233, 162, 59, 0.18); }
-  50%      { box-shadow: 0 0 0 7px rgba(233, 162, 59, 0.08); }
+  0%, 100% { box-shadow: 0 0 0 4px color-mix(in srgb, var(--watch) 18%, transparent); }
+  50%      { box-shadow: 0 0 0 7px color-mix(in srgb, var(--watch) 8%, transparent); }
 }
 .dash-call-label { color: var(--warn-ink); }
 .dash-call-count {
@@ -269,7 +269,7 @@
   padding: 1px 8px;
   border-radius: 999px;
   background: var(--watch);
-  color: #fff;
+  color: var(--on-accent);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0;
@@ -293,7 +293,7 @@
    amber wash doesn't seep through and muddy the contents. */
 .dash-call .act-card {
   background: var(--card);
-  border-color: rgba(233, 162, 59, 0.22);
+  border-color: color-mix(in srgb, var(--watch) 22%, transparent);
 }
 
 /* ─── DASH: THE PROOF (Act 3 — Fired disclosure) ─── */

--- a/apps/web/src/app/styles/_library.css
+++ b/apps/web/src/app/styles/_library.css
@@ -28,12 +28,12 @@
 .library-markdown code {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12.5px;
-  background: rgba(0,0,0,0.04);
+  background: var(--hover-wash);
   padding: 1px 6px;
   border-radius: 4px;
 }
 .library-markdown pre {
-  background: rgba(0,0,0,0.04);
+  background: var(--hover-wash);
   border-radius: 10px;
   padding: 12px 14px;
   overflow-x: auto;
@@ -66,3 +66,26 @@
   margin: 0.8em 0;
   color: var(--text2);
 }
+.library-markdown table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+  font-size: 0.95em;
+  margin: 0.8em 0;
+}
+.library-markdown thead th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--text2);
+  border-bottom: 1px solid var(--border);
+  padding: 6px 12px 6px 0;
+  white-space: nowrap;
+}
+.library-markdown tbody td {
+  padding: 8px 12px 8px 0;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.library-markdown tbody tr:last-child td { border-bottom: none; }

--- a/apps/web/src/app/styles/_profile-review.css
+++ b/apps/web/src/app/styles/_profile-review.css
@@ -1,11 +1,11 @@
 .profile-card {
   background: var(--card); border-radius: var(--radius); padding: 32px 36px;
-  margin-top: 28px; box-shadow: var(--shadow); border: 1.5px solid var(--border);
+  margin-top: 28px; box-shadow: var(--shadow); border: 1px solid var(--border);
 }
 .settings-card {
   background: linear-gradient(180deg, rgba(255,255,255,0.96), rgba(255,255,255,0.88));
-  border: 1.5px solid var(--border);
-  border-radius: 24px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
   padding: 26px 28px;
   box-shadow: var(--shadow);
   margin-top: 18px;

--- a/apps/web/src/app/styles/_responsive.css
+++ b/apps/web/src/app/styles/_responsive.css
@@ -7,7 +7,7 @@
    Typography choices and brand palette unchanged.
    ───────────────────────────────────────────────────────────── */
 
-html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; overflow-x: clip; }
 
 /* Prevent horizontal scroll caused by stray overflows. Long words
    (URLs, table-like content) wrap inside cards instead of pushing
@@ -36,13 +36,16 @@ body { overflow-x: hidden; }
   .approvals-root { --page-width: 100%; max-width: 100%; }
 
   .app-header { margin-bottom: 18px; }
-  .app-header-inner { padding: 0 18px; gap: 12px; }
 
-  /* Work + workflow drawer stacks. Sidebar gives up sticky; thread
-     list caps height so the main panel stays on screen. */
+  /* Work + workflow drawer stacks. Sidebar gives up sticky; the thread
+     list collapses by default on a thread page so the conversation is the
+     first thing on screen — the head toggle re-opens it. */
   .work-layout { grid-template-columns: minmax(0, 1fr); gap: 14px; }
   .work-sidebar { position: static; max-height: none; }
-  .work-thread-list { max-height: 38vh; }
+  .work-thread-list { max-height: 46vh; }
+  .work-thread-list.is-collapsed { display: none; }
+  .work-threads-toggle { cursor: pointer; }
+  .work-threads-chevron { display: inline-flex; }
   .work-bubble { max-width: 100%; }
 
   .builder-layout { grid-template-columns: minmax(0, 1fr); }
@@ -59,6 +62,10 @@ body { overflow-x: hidden; }
   .work-thread-delete { opacity: 1; }
   .workflows-row-delete { display: inline-flex; }
   .library-row-action { opacity: 1; pointer-events: auto; }
+
+  /* Real tap area for icon/delete buttons on touch. */
+  .work-thread-delete, .workflows-row-delete, .work-icon-btn.is-ghost { width: 36px; height: 36px; }
+  .work-bubble-actions button { padding: 9px; }
 }
 
 /* ── PHONE ── */
@@ -68,56 +75,7 @@ body { overflow-x: hidden; }
     padding-bottom: calc(116px + env(safe-area-inset-bottom, 0px));
   }
 
-  /* Header — brand on top, section nav on its own row below.
-     This avoids cramping the brand mark against a long nav and
-     gives the section strip the full viewport width to scroll in. */
   .app-header { margin-bottom: 14px; }
-  .app-header-inner {
-    flex-direction: column-reverse;
-    align-items: stretch;
-    padding: 0 16px;
-    gap: 14px;
-    min-height: 0;
-  }
-  .app-header .brand { align-self: flex-end; height: auto; }
-  .app-header-left { width: 100%; flex: none; min-width: 0; }
-  .brand-name { font-size: 16px; }
-  .brand-version { font-size: 10px; padding: 2px 5px; }
-  .brand-cluster { gap: 8px; }
-  .brand-update-label { display: none; }
-  .brand-update { padding: 6px 8px; height: 24px; }
-
-  /* Section nav as a horizontal scrollable tab strip — familiar
-     iOS sub-nav pattern, no awkward wraps, no clipped links. The
-     edge fade hints at scroll without a visible scrollbar. */
-  .section-nav-row {
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    overflow-y: visible;
-    scrollbar-width: none;
-    -ms-overflow-style: none;
-    margin-left: -16px;
-    margin-right: -16px;
-    padding: 0 16px 14px;
-    margin-bottom: 18px;
-    margin-top: 0;
-    gap: 6px;
-    scroll-snap-type: x proximity;
-    -webkit-overflow-scrolling: touch;
-    mask-image: linear-gradient(90deg, transparent 0, #000 16px, #000 calc(100% - 16px), transparent 100%);
-  }
-  .section-nav-row::-webkit-scrollbar { display: none; }
-  .section-nav-row .settings-link,
-  .section-nav-row .nav-link {
-    flex: 0 0 auto;
-    scroll-snap-align: start;
-  }
-  .section-nav-row .topbar-date {
-    margin-left: 0;
-    align-self: center;
-    flex: 0 0 auto;
-    padding-left: 4px;
-  }
 
   /* Dashboard role pills — comfortable wrap, no overflow. */
   .dash-meta { gap: 8px; margin-bottom: 24px; }

--- a/apps/web/src/app/styles/_run-replay.css
+++ b/apps/web/src/app/styles/_run-replay.css
@@ -42,3 +42,35 @@
 .run-evt-message strong { font-weight: 700; }
 .run-evt-message em { font-style: italic; }
 .run-evt-message a { color: var(--accent); }
+.run-evt-message pre {
+  background: var(--neutral);
+  border-radius: var(--radius-control);
+  padding: 10px 12px;
+  overflow-x: auto;
+  font-size: 12.5px;
+  line-height: 1.5;
+}
+.run-evt-message pre code { background: transparent; padding: 0; }
+.run-evt-message table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+  border-collapse: collapse;
+  font-size: 0.95em;
+  margin: 4px 0 8px;
+}
+.run-evt-message thead th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--text2);
+  border-bottom: 1px solid var(--border);
+  padding: 5px 12px 5px 0;
+  white-space: nowrap;
+}
+.run-evt-message tbody td {
+  padding: 6px 12px 6px 0;
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.run-evt-message tbody tr:last-child td { border-bottom: none; }

--- a/apps/web/src/app/styles/_tokens.css
+++ b/apps/web/src/app/styles/_tokens.css
@@ -21,7 +21,14 @@
   --warn-ink: #8A6D00;
   --danger: #E05656;
   --danger-soft: #FEECEC;
+  --accent-hover: #5A4CD1;
+  --danger-hover: #C0392B;
+  --on-accent: #FFFFFF;
+  --hover-wash: rgba(20,18,12,0.04);
+  --backdrop: rgba(20,18,12,0.45);
   --radius: 20px;
+  --radius-inner: 12px;
+  --radius-control: 10px;
   --shadow: 0 1px 3px rgba(20,18,12,0.04), 0 4px 16px rgba(20,18,12,0.03);
   --shadow-h: 0 2px 8px rgba(20,18,12,0.06), 0 12px 36px -8px rgba(20,18,12,0.07);
   --shadow-lift: 0 1px 2px rgba(20,18,12,0.04), 0 18px 48px -16px rgba(20,18,12,0.16);

--- a/apps/web/src/app/styles/_work.css
+++ b/apps/web/src/app/styles/_work.css
@@ -39,12 +39,22 @@
   letter-spacing: 0.1em;
   color: var(--text3);
 }
+.work-threads-toggle {
+  background: transparent;
+  border: 0;
+  margin: 0;
+  padding: 0;
+  font-family: inherit;
+  cursor: default;
+}
+.work-threads-chevron { display: none; transition: transform 0.18s; }
+.work-threads-chevron.is-open { transform: rotate(180deg); }
 .work-sidebar-count {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 10.5px;
   font-weight: 600;
   color: var(--text3);
-  background: rgba(0,0,0,0.04);
+  background: var(--hover-wash);
   padding: 1px 6px;
   border-radius: 999px;
   font-variant-numeric: tabular-nums;
@@ -57,7 +67,7 @@
   border: 1px solid transparent;
 }
 .work-icon-btn.is-ghost:hover {
-  background: rgba(0,0,0,0.04);
+  background: var(--hover-wash);
   border-color: var(--border);
   color: var(--text);
 }
@@ -193,7 +203,7 @@
   transition: background 0.15s, color 0.15s;
 }
 .work-sidebar-link:hover {
-  background: rgba(0,0,0,0.04);
+  background: var(--hover-wash);
   color: var(--text);
 }
 .work-sidebar-link svg {
@@ -380,8 +390,11 @@
   margin: 0;
 }
 .work-markdown table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
   border-collapse: collapse;
-  width: 100%;
   font-size: 0.95em;
 }
 .work-markdown thead th {

--- a/apps/web/src/app/styles/_work.css
+++ b/apps/web/src/app/styles/_work.css
@@ -155,12 +155,12 @@
   background: var(--accent);
 }
 .work-thread-dot.is-running {
-  background: #f5a623;
+  background: var(--watch);
   animation: work-pulse 1.4s ease-in-out infinite;
 }
 @keyframes work-pulse {
-  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(245, 166, 35, 0.4); }
-  50% { opacity: 0.6; box-shadow: 0 0 0 5px rgba(245, 166, 35, 0); }
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 color-mix(in srgb, var(--watch) 40%, transparent); }
+  50% { opacity: 0.6; box-shadow: 0 0 0 5px transparent; }
 }
 .work-thread-delete {
   width: 28px;
@@ -181,7 +181,7 @@
 }
 .work-thread-delete:hover {
   background: rgba(220, 53, 69, 0.1);
-  color: #c0392b;
+  color: var(--danger-hover);
 }
 .work-sidebar-footer {
   margin-top: auto;
@@ -516,8 +516,8 @@
   color: var(--accent);
 }
 .work-tool-group-badge.failed {
-  background: #fdecec;
-  color: #b42a2a;
+  background: var(--danger-soft);
+  color: var(--danger);
 }
 .work-tool-group-body {
   display: flex;
@@ -576,12 +576,12 @@
   color: var(--accent);
 }
 .work-tool-row-icon-done {
-  color: #2f8a4d;
-  background: #e6f4eb;
+  color: var(--success-mid);
+  background: var(--success-soft);
 }
 .work-tool-row-icon-failed {
-  color: #b42a2a;
-  background: #fdecec;
+  color: var(--danger);
+  background: var(--danger-soft);
 }
 .work-tool-row-name {
   font-weight: 600;
@@ -600,7 +600,7 @@
   flex: 1;
 }
 .work-tool-row-failed .work-tool-row-name {
-  color: #b42a2a;
+  color: var(--danger);
 }
 .work-tool-row-detail {
   padding: 4px 16px 14px 16px;

--- a/apps/web/src/app/styles/_workflows.css
+++ b/apps/web/src/app/styles/_workflows.css
@@ -273,7 +273,7 @@
 .rule-event-limits code {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 11.5px;
-  background: rgba(0,0,0,0.04);
+  background: var(--hover-wash);
   border-radius: 4px;
   padding: 1px 5px;
 }

--- a/apps/web/src/app/styles/_workflows.css
+++ b/apps/web/src/app/styles/_workflows.css
@@ -79,7 +79,7 @@
 }
 .workflows-row-delete:hover {
   background: rgba(220, 53, 69, 0.1);
-  color: #c0392b;
+  color: var(--danger-hover);
 }
 
 .workflows-row-meta {
@@ -134,8 +134,8 @@
   color: #fff;
 }
 .workflow-drawer-btn.is-primary:hover:not(:disabled) {
-  background: #5a4cd1;
-  border-color: #5a4cd1;
+  background: var(--accent-hover);
+  border-color: var(--accent-hover);
 }
 
 .workflow-drawer-run-link {
@@ -254,7 +254,7 @@
 .rule-event-eyebrow {
   font-family: var(--font-display), 'Archivo', sans-serif;
   font-size: 10.5px;
-  font-weight: 800;
+  font-weight: 700;
   letter-spacing: 0.13em;
   text-transform: uppercase;
   color: var(--success-ink);
@@ -293,7 +293,7 @@
 
 /* Action-request variant — amber accent (proposal awaiting policy/operator) */
 .action-event {
-  border-color: rgba(233, 162, 59, 0.45);
+  border-color: color-mix(in srgb, var(--watch) 45%, transparent);
   background: var(--watch-soft);
 }
 .action-event-tick {
@@ -312,7 +312,7 @@
   text-transform: uppercase;
 }
 .action-event-risk-low { background: var(--success-soft); color: var(--success-mid); }
-.action-event-risk-medium { background: var(--watch-soft); color: var(--warn-ink); border: 1px solid rgba(233,162,59,0.35); }
+.action-event-risk-medium { background: var(--watch-soft); color: var(--warn-ink); border: 1px solid color-mix(in srgb, var(--watch) 35%, transparent); }
 .action-event-risk-high { background: var(--danger-soft); color: var(--danger); }
 .action-event-risk-critical { background: var(--danger); color: #fff; }
 

--- a/apps/web/src/components/ActCard.tsx
+++ b/apps/web/src/components/ActCard.tsx
@@ -268,9 +268,9 @@ function RowButton({ tone, disabled, onClick, children }: RowButtonProps) {
         "disabled:opacity-55 disabled:cursor-not-allowed",
         !tone && "bg-card border-border text-text hover:not-disabled:border-text3",
         tone === "primary" &&
-          "bg-accent border-accent text-white hover:not-disabled:bg-[#5a4cd1] hover:not-disabled:border-[#5a4cd1]",
+          "bg-accent border-accent text-white hover:not-disabled:bg-[var(--accent-hover)] hover:not-disabled:border-[var(--accent-hover)]",
         tone === "destructive" &&
-          "bg-danger border-danger text-white hover:not-disabled:bg-[#c84545] hover:not-disabled:border-[#c84545]",
+          "bg-danger border-danger text-white hover:not-disabled:bg-[var(--danger-hover)] hover:not-disabled:border-[var(--danger-hover)]",
       )}
     >
       {children}

--- a/apps/web/src/components/ConfirmModal.tsx
+++ b/apps/web/src/components/ConfirmModal.tsx
@@ -90,13 +90,13 @@ function ConfirmDialog({
 
   return (
     <div
-      className="fixed inset-0 z-[1000] bg-[rgba(20,18,12,0.45)] backdrop-blur-[4px] flex items-center justify-center p-4 animate-[modal-fade_0.15s_ease-out]"
+      className="fixed inset-0 z-[1000] bg-[var(--backdrop)] backdrop-blur-[4px] flex items-center justify-center p-4 animate-[modal-fade_0.15s_ease-out]"
       onClick={onBackdrop}
       role="dialog"
       aria-modal="true"
       aria-labelledby="confirm-modal-title"
     >
-      <div className="w-full max-w-[420px] bg-card border border-border rounded-[18px] px-[22px] pt-[22px] pb-[18px] shadow-[0_8px_32px_rgba(20,18,12,0.18),0_24px_60px_rgba(20,18,12,0.10)] animate-[modal-rise_0.18s_cubic-bezier(0.16,1,0.3,1)]">
+      <div className="w-full max-w-[420px] bg-card border border-border rounded-card px-[22px] pt-[22px] pb-[18px] shadow-[0_8px_32px_rgba(20,18,12,0.18),0_24px_60px_rgba(20,18,12,0.10)] animate-[modal-rise_0.18s_cubic-bezier(0.16,1,0.3,1)]">
         <h2
           id="confirm-modal-title"
           className="font-display text-base font-bold leading-tight text-text m-0"
@@ -113,7 +113,7 @@ function ConfirmDialog({
             ref={cancelRef}
             type="button"
             onClick={() => onChoice(false)}
-            className="text-[13px] font-medium px-3.5 py-2 rounded-[10px] border border-border bg-card text-text cursor-pointer transition-all duration-150 hover:bg-black/5 hover:border-text3 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
+            className="text-[13px] font-medium px-3.5 py-2 rounded-control border border-border bg-card text-text cursor-pointer transition-all duration-150 hover:bg-black/5 hover:border-text3 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
           >
             {options.cancelLabel ?? "Cancel"}
           </button>
@@ -121,7 +121,7 @@ function ConfirmDialog({
             type="button"
             onClick={() => onChoice(true)}
             className={cn(
-              "text-[13px] font-medium px-3.5 py-2 rounded-[10px] border cursor-pointer transition-all duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2",
+              "text-[13px] font-medium px-3.5 py-2 rounded-control border cursor-pointer transition-all duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2",
               !options.destructive &&
                 "bg-text border-text text-bg hover:bg-[#1a1814] hover:border-[#1a1814]",
               options.destructive &&

--- a/apps/web/src/components/ConfirmModal.tsx
+++ b/apps/web/src/components/ConfirmModal.tsx
@@ -125,7 +125,7 @@ function ConfirmDialog({
               !options.destructive &&
                 "bg-text border-text text-bg hover:bg-[#1a1814] hover:border-[#1a1814]",
               options.destructive &&
-                "bg-[#c0392b] border-[#c0392b] text-white hover:bg-[#a83224] hover:border-[#a83224]",
+                "bg-danger border-danger text-white hover:bg-[var(--danger-hover)] hover:border-[var(--danger-hover)]",
             )}
           >
             {options.confirmLabel ?? "Confirm"}

--- a/apps/web/src/components/ui/Card.tsx
+++ b/apps/web/src/components/ui/Card.tsx
@@ -15,7 +15,7 @@ export function Card<T extends ElementType = "div">({
   return (
     <Component
       className={cn(
-        "bg-card border border-border rounded-2xl px-4 py-3.5",
+        "bg-card border border-border rounded-card shadow-soft px-4 py-3.5",
         className,
       )}
       {...props}

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -62,7 +62,10 @@ import { runWorkflowCronSweep } from "./jobs/workflow-cron-sweep.js";
 import { runWorkflowRunFire } from "./jobs/workflow-run-fire.js";
 import { runWorkflowOutputTtlSweep } from "./jobs/workflow-output-ttl-sweep.js";
 import { runActionExecute } from "./jobs/action-execute.js";
-import { reconcileStaleProcessingJobs } from "./reconciler.js";
+import {
+  reconcileStaleProcessingJobs,
+  reconcileStaleRuns,
+} from "./reconciler.js";
 
 const PORT: number = 4100;
 const MAX_JOB_RETRIES: number = 2;
@@ -382,6 +385,14 @@ const b = await boss();
       `[worker] reconciled processing_job rows on boot: succeeded=${summary.succeeded} failed=${summary.failed} requeued=${summary.requeued} lost=${summary.lost}`,
     );
   }
+  // At boot nothing this worker tracks is running yet, so any "running" run is
+  // a zombie left by a hard restart — cancel it instead of stranding it.
+  const runs = await reconcileStaleRuns();
+  if (runs.cancelled > 0) {
+    console.log(
+      `[worker] cancelled ${runs.cancelled} stale running run(s) on boot`,
+    );
+  }
 }
 
 for (const name of Object.values(QUEUE)) {
@@ -634,6 +645,19 @@ const reconcileTimer = setInterval(() => {
     .catch((e) => {
       console.warn(
         `[worker] reconcile sweep failed: ${e instanceof Error ? e.message : e}`,
+      );
+    });
+  reconcileStaleRuns({ minAgeMs: RECONCILE_SWEEP_MIN_AGE_MS })
+    .then((s) => {
+      if (s.cancelled > 0) {
+        console.log(
+          `[worker] reconcile sweep: cancelled ${s.cancelled} stale running run(s)`,
+        );
+      }
+    })
+    .catch((e) => {
+      console.warn(
+        `[worker] stale-run sweep failed: ${e instanceof Error ? e.message : e}`,
       );
     });
 }, RECONCILE_SWEEP_INTERVAL_MS);

--- a/apps/worker/src/jobs/workflow-run-fire.ts
+++ b/apps/worker/src/jobs/workflow-run-fire.ts
@@ -1,11 +1,20 @@
 import type { WorkflowRunFirePayload } from "@neko/db/jobs";
-import type { AgentEvent } from "@neko/llm";
+import { type AgentEvent, registerAgentCanceller } from "@neko/llm";
 import { appendWorkRunEvent, scrubAgentEvent } from "@neko/llm/work";
 import { prepareWorkflowRun, runWorkflowTurn } from "@neko/llm/workflows";
 import {
   getCurrentScrubber,
   getPluginRegistryInstance,
 } from "../plugins/registry-instance.js";
+
+// Thrown when worker shutdown cuts a headless run short, so the pg-boss handler
+// fails the job and a later worker retries it.
+export class WorkflowRunInterrupted extends Error {
+  constructor() {
+    super("Workflow run interrupted by worker shutdown");
+    this.name = "WorkflowRunInterrupted";
+  }
+}
 
 export async function runWorkflowRunFire(
   payload: WorkflowRunFirePayload,
@@ -37,11 +46,23 @@ export async function runWorkflowRunFire(
   const pluginActions =
     getPluginRegistryInstance()?.getRegisteredActionDescriptors() ?? [];
 
-  await runWorkflowTurn({
-    prepared,
-    userMessage: payload.userMessage,
-    mode: "headless",
-    emit,
-    pluginActions,
-  });
+  // SIGTERM aborts this signal, so an interrupted run finalizes as "cancelled"
+  // (not a hard failure with an opaque "ACP client disposed" error).
+  const abort = new AbortController();
+  const unregister = registerAgentCanceller(() => abort.abort());
+  let result;
+  try {
+    result = await runWorkflowTurn({
+      prepared,
+      userMessage: payload.userMessage,
+      mode: "headless",
+      emit,
+      signal: abort.signal,
+      pluginActions,
+    });
+  } finally {
+    unregister();
+  }
+
+  if (result.status === "cancelled") throw new WorkflowRunInterrupted();
 }

--- a/apps/worker/src/reconciler.ts
+++ b/apps/worker/src/reconciler.ts
@@ -7,6 +7,8 @@ import {
   metric,
   processing_job,
   sql,
+  work_run,
+  workflow_run,
 } from "@neko/db";
 
 export type ReconcileSummary = {
@@ -15,6 +17,51 @@ export type ReconcileSummary = {
   requeued: number;
   lost: number;
 };
+
+const STALE_RUN_REASON =
+  "Interrupted — the worker stopped before the run finished.";
+
+/**
+ * Cancel work_run / workflow_run rows stranded in "running" — a run that
+ * outlived the process tracking it (worker SIGKILLed mid-run, before its own
+ * finalizer could mark it cancelled). With minAgeMs past hermes' own timeout,
+ * a still-"running" row is provably dead. The processing_job reconciler above
+ * doesn't cover these tables.
+ */
+export async function reconcileStaleRuns(opts?: {
+  minAgeMs?: number;
+}): Promise<{ cancelled: number }> {
+  const cutoff = new Date(Date.now() - (opts?.minAgeMs ?? 0));
+  const now = new Date();
+
+  const stale = await db()
+    .update(work_run)
+    .set({
+      status: "cancelled",
+      error: STALE_RUN_REASON,
+      finished_at: now,
+      updated_at: now,
+    })
+    .where(and(eq(work_run.status, "running"), lte(work_run.updated_at, cutoff)))
+    .returning({ id: work_run.id });
+  if (stale.length === 0) return { cancelled: 0 };
+
+  await db()
+    .update(workflow_run)
+    .set({
+      status: "cancelled",
+      error: STALE_RUN_REASON,
+      finished_at: now,
+      updated_at: now,
+    })
+    .where(
+      and(
+        inArray(workflow_run.work_run_id, stale.map((r) => r.id)),
+        inArray(workflow_run.status, ["running", "queued"]),
+      ),
+    );
+  return { cancelled: stale.length };
+}
 
 type BossRow = {
   state: string;

--- a/apps/worker/test/reconciler.test.ts
+++ b/apps/worker/test/reconciler.test.ts
@@ -21,9 +21,16 @@ import {
   pool,
   processing_job,
   sql,
+  work_run,
+  work_thread,
+  workflow_definition,
+  workflow_run,
 } from "@neko/db";
 import { boss, QUEUE } from "@neko/db/jobs";
-import { reconcileStaleProcessingJobs } from "../src/reconciler";
+import {
+  reconcileStaleProcessingJobs,
+  reconcileStaleRuns,
+} from "../src/reconciler";
 
 const reachable = await dbReachable();
 const describeIfDb = reachable ? describe : describe.skip;
@@ -314,6 +321,87 @@ describeIfReady("reconcileStaleProcessingJobs", () => {
 
     const row = await readProcessingJob(jobId);
     expect(row.status).toBe("running");
+  });
+});
+
+describeIfDb("reconcileStaleRuns", () => {
+  let orgId: string;
+
+  beforeEach(async () => {
+    orgId = uniqueOrgId("stale-runs");
+    await createTestOrg(orgId);
+  });
+
+  afterEach(async () => {
+    await deleteTestOrg(orgId);
+  });
+
+  async function insertRunningRun(updatedAt: Date): Promise<{
+    threadId: string;
+    workRunId: string;
+  }> {
+    const [thread] = await db()
+      .insert(work_thread)
+      .values({ org_id: orgId, title: "t", channel: "workflow" })
+      .returning({ id: work_thread.id });
+    const [run] = await db()
+      .insert(work_run)
+      .values({
+        org_id: orgId,
+        thread_id: thread!.id,
+        backend: "hermes",
+        status: "running",
+        created_at: updatedAt,
+        updated_at: updatedAt,
+      })
+      .returning({ id: work_run.id });
+    return { threadId: thread!.id, workRunId: run!.id };
+  }
+
+  it("cancels a work_run + its workflow_run stranded in running past the age threshold", async () => {
+    const stale = new Date(Date.now() - 20 * 60_000);
+    const { threadId, workRunId } = await insertRunningRun(stale);
+    const [wf] = await db()
+      .insert(workflow_definition)
+      .values({ org_id: orgId, name: "zombie wf" })
+      .returning({ id: workflow_definition.id });
+    const [wfRun] = await db()
+      .insert(workflow_run)
+      .values({
+        org_id: orgId,
+        workflow_id: wf!.id,
+        thread_id: threadId,
+        work_run_id: workRunId,
+        trigger_kind: "subscription",
+        status: "running",
+      })
+      .returning({ id: workflow_run.id });
+
+    const res = await reconcileStaleRuns({ minAgeMs: 11 * 60_000 });
+    expect(res.cancelled).toBeGreaterThanOrEqual(1);
+
+    const wr = await db()
+      .select({ status: work_run.status, error: work_run.error })
+      .from(work_run)
+      .where(eq(work_run.id, workRunId));
+    expect(wr[0]?.status).toBe("cancelled");
+    expect(wr[0]?.error).toContain("Interrupted");
+
+    const wfr = await db()
+      .select({ status: workflow_run.status })
+      .from(workflow_run)
+      .where(eq(workflow_run.id, wfRun!.id));
+    expect(wfr[0]?.status).toBe("cancelled");
+  });
+
+  it("leaves a recently-updated running run alone (respects minAgeMs)", async () => {
+    const { workRunId } = await insertRunningRun(new Date());
+    await reconcileStaleRuns({ minAgeMs: 11 * 60_000 });
+    const wr = await db()
+      .select({ status: work_run.status })
+      .from(work_run)
+      .where(eq(work_run.id, workRunId));
+    expect(wr[0]?.status).toBe("running");
   });
 });
 

--- a/packages/llm/src/workflows/run-workflow-turn.ts
+++ b/packages/llm/src/workflows/run-workflow-turn.ts
@@ -92,9 +92,12 @@ export async function prepareWorkflowRun(
     throw new Error(`Workflow ${workflow.name} is disabled.`);
   }
   const backend = await resolveAgentBackend(opts.orgId);
+  // Trigger threads live on the "workflow" channel, never "web", so they can't
+  // surface in the human Ask sidebar — even as an orphan whose work_run never
+  // persisted (the sidebar lists only "web" threads).
   const threadId =
     opts.threadId ??
-    (await createWorkThread(opts.orgId, workflow.name)).id;
+    (await createWorkThread(opts.orgId, workflow.name, "workflow")).id;
   const created = await createWorkRun(opts.orgId, threadId, backend.id);
   const workflowRun = await createWorkflowRun({
     orgId: opts.orgId,

--- a/packages/llm/test/integration/run-workflow-turn.test.ts
+++ b/packages/llm/test/integration/run-workflow-turn.test.ts
@@ -232,4 +232,51 @@ describeIfDb("runWorkflowTurn", () => {
       expect(webIds).not.toContain(orphan.id);
     });
   });
+
+  // The failure mode behind the "ACP client disposed" run failures: worker
+  // shutdown aborts the run mid-flight. With a signal wired in, that must land
+  // as "cancelled" (no error), not a hard failure.
+  it("records a shutdown-interrupted run as cancelled, not failed", async () => {
+    await withTestOrg(async (orgId) => {
+      const { workflow } = await saveWorkflow({
+        orgId,
+        name: "interruptible workflow",
+        steps: [{ id: "s1", description: "work" }],
+      });
+
+      // Aborting the signal mid-run simulates cancelAllAgents() on SIGTERM;
+      // hermes then surfaces the SIGKILLed child as a disposed-client reject.
+      const controller = new AbortController();
+      const backend = fakeBackend(async () => {
+        controller.abort();
+        throw new Error("ACP client disposed before response");
+      });
+
+      const prepared = await prepareWorkflowRun(
+        { orgId, workflowId: workflow.id, triggerKind: "subscription" },
+        { resolveAgentBackend: async () => backend },
+      );
+
+      const result = await runWorkflowTurn(
+        {
+          prepared,
+          mode: "live",
+          emit: async () => {},
+          signal: controller.signal,
+        },
+        {
+          resolveAgentBackend: async () => backend,
+          formatGlobalMemoryPromptContext: async () => "",
+        },
+      );
+
+      expect(result.status).toBe("cancelled");
+      const rows = await db()
+        .select()
+        .from(workflow_run)
+        .where(eq(workflow_run.id, prepared.workflowRun.id));
+      expect(rows[0]?.status).toBe("cancelled");
+      expect(rows[0]?.error).toBeNull();
+    });
+  });
 });

--- a/packages/llm/test/integration/run-workflow-turn.test.ts
+++ b/packages/llm/test/integration/run-workflow-turn.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, describe, expect, it } from "vitest";
-import { db, eq, pool, workflow_output, workflow_run } from "@neko/db";
+import { db, eq, pool, work_thread, workflow_output, workflow_run } from "@neko/db";
 import { withTestOrg, dbReachable } from "@neko/db/test-helpers";
+import { createWorkThread, listWorkThreads } from "../../src/work/store";
 import type {
   AgentBackend,
   AgentEvent,
@@ -189,6 +190,46 @@ describeIfDb("runWorkflowTurn", () => {
       expect(rows[0]?.kind).toBe("finding");
       expect(rows[0]?.scope).toBe("test_scope");
       expect(rows[0]?.mood).toBe("watch");
+    });
+  });
+
+  // A trigger run reuses the work_thread plumbing for its transcript, but it is
+  // not a human chat — its thread must never appear in the web Ask sidebar.
+  it("creates its thread on the \"workflow\" channel, never \"web\"", async () => {
+    await withTestOrg(async (orgId) => {
+      const { workflow } = await saveWorkflow({
+        orgId,
+        name: "low stock slack alert",
+        steps: [{ id: "s1", description: "alert on slack" }],
+      });
+
+      const prepared = await prepareWorkflowRun(
+        { orgId, workflowId: workflow.id, triggerKind: "subscription" },
+        {
+          resolveAgentBackend: async () =>
+            fakeBackend(async () => ({ status: "completed", finalText: "" })),
+        },
+      );
+
+      const [thread] = await db()
+        .select()
+        .from(work_thread)
+        .where(eq(work_thread.id, prepared.threadId));
+      expect(thread?.channel).toBe("workflow");
+    });
+  });
+
+  it("keeps an orphaned trigger thread (no workflow_run) out of the Ask sidebar", async () => {
+    await withTestOrg(async (orgId) => {
+      // A genuine human Ask thread, plus a trigger thread whose workflow_run
+      // never persisted (a run-row insert that failed mid-trigger) — the leak
+      // the web sidebar's NOT EXISTS(workflow_run) filter cannot catch alone.
+      const ask = await createWorkThread(orgId, "what were our top products?", "web");
+      const orphan = await createWorkThread(orgId, "low stock slack alert", "workflow");
+
+      const webIds = (await listWorkThreads(orgId, "web")).map((t) => t.id);
+      expect(webIds).toContain(ask.id);
+      expect(webIds).not.toContain(orphan.id);
     });
   });
 });


### PR DESCRIPTION
Five fixes that accumulated on `fix/misc` — two backend/reliability fixes and three web-UI fixes (the bulk being a full responsive / UX / styling-consistency audit-and-fix pass).

## Backend / reliability

**`8b033a3` — keep workflow-trigger threads off the Ask sidebar**
Workflow/trigger runs reuse `work_thread` plumbing but were created on the default `web` channel, relying on a `NOT EXISTS(workflow_run)` filter to stay hidden. When a trigger's run rows failed to persist, the orphan thread leaked into the human Ask sidebar as a content-less chat. Trigger threads now land on a dedicated `workflow` channel so the sidebar filter excludes them structurally. *Tests added.*

**`97eeef4` — mark restart-interrupted runs cancelled, retry, sweep zombies**
Headless workflow/cron/subscription runs were recorded as hard FAILURES (`ACP client disposed before response`) whenever the worker restarted mid-run (dev file-watch, prod deploy/scale-down). The fire path now ties each run to the shutdown registry via an `AbortController` (interruption → `cancelled`, re-queued via pg-boss retry), and a new `reconcileStaleRuns` cancels `work_run`/`workflow_run` rows stranded in `running` past a staleness threshold (swept at boot + every 11 min). *Tests added.*

## Web UI

**`ed89e67` — hoist `@import` block so trailing `globals.css` rules aren't dropped**
The `@import "./styles/*.css"` statements sat after `@theme`/`@utility`, making them spec-invalid in position; the compiler silently discarded every plain rule written below them — the entire `.topbar-*` header chrome, the density system, and the `.wcr-*` rail. The header collapsed to an unstyled stacked column, in dev **and production builds**. Moving the imports to the top restores all of it (one logical change, no rule bodies touched).

**`32ec49f` — cross-page responsive, UX, and card-system consistency**
- **Responsive:** `html { overflow-x: clip }` (the old `body{overflow-x:hidden}` never worked — overflow escapes via `<html>`); markdown tables scroll inside their card across `.work-markdown`, `.library-markdown`, and run-replay (the last had no table styling at all); compact tile grid fits small phones; Actions triage stacks with a bounded sticky pane.
- **UX:** mobile thread list collapses to a head toggle while a thread is open (conversation first, not behind 38vh of threads); dead phone-header CSS removed (`.section-nav-row`/`.app-header-inner`/`.brand*` targeted classes that exist in no component); bigger touch targets + coarse-pointer reveal for archive buttons.
- **Consistency:** utility `<Card>`, ConfirmModal, and every `rounded-2xl` card resolve to the 20px `--radius-card` with the shared shadow (matching the dashboard); new `--radius-inner/-control`, `--hover-wash`, `--accent-hover`, `--danger-hover`, `--backdrop` tokens.

**`f55e041` — finish styling-consistency pass**
- Hardcoded colors routed through tokens (status hexes → `--watch`/`--success-*`/`--danger-*`; the amber `rgba(233,162,59,*)` family via `color-mix` — exact same color, no visual change; accent/danger button hovers unified).
- The two card border outliers (`.profile-card`, `.settings-card`) drop 1.5px → 1px; `.settings-card` 24px radius → token.
- Section eyebrows unified to 700 / 0.14em.
- **Bug:** `.pill`/`.pills` had no base CSS, so the Business-Profile tabs rendered as unstyled, touching buttons — given a proper pill style (dark active, 8px gap) matching the app's pattern.

## Verification
- `pnpm --filter @neko/web typecheck` clean after each UI batch; no console errors.
- Web changes driven and confirmed live in Chrome across desktop (1440) and phone (360–390): page horizontal overflow 329px → 0 on the table-heavy thread; tables scroll within their card; thread list collapses; desktop sidebar sticky/internal-scroll intact; ConfirmModal, Business-Profile pills, dashboard all re-checked.

### Intentionally left as-is (decided, not deferred)
- The failed-output dark error block (`#8a2a2a` on pale red) — no token matches that dark error ink; routing to `--danger` would cut contrast.
- Per-page content width and the distinct control types (segmented selector vs. filter tabs vs. section pills) — the intentional density system and semantically-distinct controls, not defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
