### PR TITLE
ci: fix Release Please auto-merge step breaking on apostrophes in release PR body

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,6 +28,7 @@ jobs:
         if: steps.release.outputs.prs_created == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PRS_JSON: ${{ steps.release.outputs.prs }}
         run: |
-          PR_NUMBER=$(echo '${{ steps.release.outputs.prs }}' | jq -r '.[0].number')
+          PR_NUMBER=$(echo "$PRS_JSON" | jq -r '.[0].number')
           gh pr merge --auto --squash "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"


### PR DESCRIPTION
## Problem
The **Release Please** workflow fails on the *Enable auto-merge on release PR* step whenever a release PR body contains an apostrophe. The step does:

```bash
PR_NUMBER=$(echo '${{ steps.release.outputs.prs }}' | jq -r '.[0].number')
```

GitHub Actions pastes the JSON literally inside the single quotes. A commit titled e.g. *"…rules aren't dropped"* puts `aren't` into the body, the `'` closes the shell string early, and the trailing `(` from the markdown commit links crashes bash:

```
syntax error near unexpected token '('
##[error]Process completed with exit code 2.
```

Observed red on the #88 and #90 merges. The release PR is still created — only the auto-merge-enable step fails — but the action goes red every release.

## Fix
Pass the JSON through an `env:` var and read it with `"$PRS_JSON"`. The runner sets the value verbatim, so the shell never re-parses its quotes — robust to apostrophes/parens, and the GitHub-recommended guard against script injection in `run:` blocks. No behavior change otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)