### PR TITLE
feat(web): surface hours-saved on the Ask thread + live dashboard sparkline

### DIFF
--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -114,6 +114,7 @@ import {
   type RailSource,
   type RailVital,
 } from "../work-shell-context";
+import { formatSavedShort } from "@/lib/hours-saved";
 
 type MessageRecord = {
   id: string;
@@ -130,6 +131,7 @@ type RunRecord = {
   error: string | null;
   createdAt: string;
   finishedAt: string | null;
+  analysisMinutesSaved?: number | null;
 };
 
 type WorkEvent =
@@ -484,8 +486,21 @@ export default function WorkScreen() {
       }
     }
     setRailArtifacts(arts);
+    // The run's self-estimated time saved (latest run wins) — surfaced as a
+    // rail vital so the value-prop is visible on the Ask surface, not only the
+    // dashboard. Prepended so it survives the 4-vital cap.
+    let savedMinutes: number | null = null;
+    for (const run of bundle.runs) {
+      if (typeof run.analysisMinutesSaved === "number") {
+        savedMinutes = run.analysisMinutesSaved;
+      }
+    }
+    const savedVital: RailVital | null =
+      savedMinutes && savedMinutes > 0
+        ? { label: "Time saved", value: formatSavedShort(savedMinutes) }
+        : null;
     setRailContext({
-      vitals: vitals.slice(0, 4),
+      vitals: (savedVital ? [savedVital, ...vitals] : vitals).slice(0, 4),
       sources: [...sourceMap.values()].slice(0, 6),
       followups,
     });

--- a/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
+++ b/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/cn";
 import { confirmDialog } from "@/components/ConfirmModal";
 import { describeSchedule } from "@/lib/cron-english";
 import { formatSavedShort } from "@/lib/hours-saved";
+import { Sparkline } from "@/components/Sparkline";
 
 type WorkflowListItem = {
   id: string;
@@ -127,44 +128,6 @@ function describeSubscription(s: Subscription): string {
   return `External events${f.provider ? ` from ${f.provider}` : ""}${
     f.topic ? ` on '${f.topic}'` : ""
   }.`;
-}
-
-function Sparkline({
-  values,
-  width = 88,
-  height = 16,
-}: {
-  values: number[];
-  width?: number;
-  height?: number;
-}) {
-  if (values.length === 0) return null;
-  const max = Math.max(1, ...values);
-  const barW = width / values.length;
-  return (
-    <svg
-      width={width}
-      height={height}
-      viewBox={`0 0 ${width} ${height}`}
-      aria-hidden="true"
-      style={{ display: "block" }}
-    >
-      {values.map((v, i) => {
-        const h = (v / max) * height;
-        return (
-          <rect
-            key={i}
-            x={i * barW + 0.5}
-            y={height - h}
-            width={Math.max(1, barW - 1)}
-            height={h}
-            fill="var(--text3)"
-            opacity={v === 0 ? 0.35 : 1}
-          />
-        );
-      })}
-    </svg>
-  );
 }
 
 export default function WorkflowsPage() {

--- a/apps/web/src/app/api/briefing/value/route.ts
+++ b/apps/web/src/app/api/briefing/value/route.ts
@@ -5,16 +5,19 @@ import {
   and,
   db,
   eq,
+  gte,
   organization,
   sql,
   work_run,
 } from "@neko/db";
 import { getOrgId } from "@/lib/db";
+import { fillDailySeries } from "@/lib/hours-saved";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 const WINDOW_HOURS = 24;
+const DAILY_DAYS = 7;
 
 // Realized hours saved = executed actions + completed-run analysis. Returns
 // the rolling-window total (for the dashboard line) and the cumulative total
@@ -30,6 +33,7 @@ export async function GET() {
       windowMin: sql<number>`coalesce(sum(${action_request.minutes_saved}) filter (where ${action_execution.finished_at} >= ${since}), 0)::int`,
       totalMin: sql<number>`coalesce(sum(${action_request.minutes_saved}), 0)::int`,
       windowTasks: sql<number>`count(*) filter (where ${action_execution.finished_at} >= ${since})::int`,
+      firstAt: sql<string | null>`min(${action_execution.finished_at})::text`,
     })
     .from(action_request)
     .innerJoin(
@@ -49,6 +53,7 @@ export async function GET() {
       windowMin: sql<number>`coalesce(sum(${work_run.analysis_minutes_saved}) filter (where ${work_run.finished_at} >= ${since}), 0)::int`,
       totalMin: sql<number>`coalesce(sum(${work_run.analysis_minutes_saved}), 0)::int`,
       windowTasks: sql<number>`count(*) filter (where ${work_run.finished_at} >= ${since} and ${work_run.analysis_minutes_saved} > 0)::int`,
+      firstAt: sql<string | null>`min(${work_run.finished_at}) filter (where ${work_run.analysis_minutes_saved} > 0)::text`,
     })
     .from(work_run)
     .where(and(eq(work_run.org_id, orgId), eq(work_run.status, "completed")));
@@ -58,6 +63,62 @@ export async function GET() {
     .from(organization)
     .where(eq(organization.id, orgId))
     .limit(1);
+
+  // Per-day minutes for the last 7 days — feeds the hero sparkline. Mirrors the
+  // workflow activity-sparkline bucketing.
+  const dayStart = new Date();
+  dayStart.setUTCHours(0, 0, 0, 0);
+  dayStart.setUTCDate(dayStart.getUTCDate() - (DAILY_DAYS - 1));
+
+  const actionDaily = await db()
+    .select({
+      day: sql<string>`date_trunc('day', ${action_execution.finished_at})::date::text`,
+      min: sql<number>`coalesce(sum(${action_request.minutes_saved}), 0)::int`,
+    })
+    .from(action_request)
+    .innerJoin(
+      action_execution,
+      eq(action_execution.action_request_id, action_request.id),
+    )
+    .where(
+      and(
+        eq(action_request.org_id, orgId),
+        eq(action_request.status, "executed"),
+        gte(action_execution.finished_at, dayStart),
+      ),
+    )
+    .groupBy(sql`date_trunc('day', ${action_execution.finished_at})`);
+
+  const analysisDaily = await db()
+    .select({
+      day: sql<string>`date_trunc('day', ${work_run.finished_at})::date::text`,
+      min: sql<number>`coalesce(sum(${work_run.analysis_minutes_saved}), 0)::int`,
+    })
+    .from(work_run)
+    .where(
+      and(
+        eq(work_run.org_id, orgId),
+        eq(work_run.status, "completed"),
+        gte(work_run.finished_at, dayStart),
+      ),
+    )
+    .groupBy(sql`date_trunc('day', ${work_run.finished_at})`);
+
+  const byDay = new Map<string, number>();
+  for (const r of [...actionDaily, ...analysisDaily]) {
+    byDay.set(r.day, (byDay.get(r.day) ?? 0) + r.min);
+  }
+  const dailyMinutes = fillDailySeries(byDay, dayStart, DAILY_DAYS);
+
+  // Honest "since": the first date we actually tracked a saved minute, not the
+  // org's install date (which would overstate the window for orgs that predate
+  // the feature). Falls back to install date when nothing is tracked yet.
+  const firstTracked = [actionAgg?.firstAt, analysisAgg?.firstAt]
+    .filter((s): s is string => typeof s === "string")
+    .map((s) => new Date(s))
+    .sort((a, b) => a.getTime() - b.getTime())[0];
+  const sinceISO =
+    (firstTracked ?? org?.createdAt ?? null)?.toISOString() ?? null;
 
   const windowMinutes = (actionAgg?.windowMin ?? 0) + (analysisAgg?.windowMin ?? 0);
   const totalMinutes = (actionAgg?.totalMin ?? 0) + (analysisAgg?.totalMin ?? 0);
@@ -69,6 +130,7 @@ export async function GET() {
     windowMinutes,
     totalMinutes,
     windowTasks,
-    sinceISO: org?.createdAt?.toISOString() ?? null,
+    dailyMinutes,
+    sinceISO,
   });
 }

--- a/apps/web/src/components/HoursSavedHero.tsx
+++ b/apps/web/src/components/HoursSavedHero.tsx
@@ -3,12 +3,14 @@
 import { useState } from "react";
 import { Clock } from "lucide-react";
 import { formatHours, formatSavedShort, sinceLabel } from "@/lib/hours-saved";
+import { Sparkline } from "@/components/Sparkline";
 
 export type HoursSavedValue = {
   windowHours: number;
   windowMinutes: number;
   totalMinutes: number;
   windowTasks: number;
+  dailyMinutes?: number[];
   sinceISO: string | null;
 };
 
@@ -33,6 +35,8 @@ export default function HoursSavedHero({
   const hero = formatHours(value.totalMinutes);
   const windowLabel = formatSavedShort(value.windowMinutes);
   const detailed = items.filter((i) => i.minutes > 0).slice(0, 6);
+  const daily = value.dailyMinutes ?? [];
+  const hasTrend = daily.some((d) => d > 0);
 
   return (
     <div className="mb-7" style={{ animation: "fadeUp 0.5s ease 0.12s both" }}>
@@ -61,6 +65,14 @@ export default function HoursSavedHero({
             </>
           ) : null}
         </span>
+        {hasTrend && (
+          <span
+            className="ml-1 flex-none self-center text-accent/70"
+            title="Time saved per day, last 7 days"
+          >
+            <Sparkline values={daily} width={64} height={18} />
+          </span>
+        )}
         <span className="ml-1 font-mono text-[11px] font-semibold text-accent opacity-70 group-hover:opacity-100 whitespace-nowrap">
           how? {open ? "▾" : "→"}
         </span>

--- a/apps/web/src/components/Sparkline.tsx
+++ b/apps/web/src/components/Sparkline.tsx
@@ -1,0 +1,40 @@
+// Tiny bar sparkline — shared by the workflows list and the hours-saved hero.
+// Pure presentational: bars scaled to the series max, faded for zero days.
+
+export function Sparkline({
+  values,
+  width = 88,
+  height = 16,
+}: {
+  values: number[];
+  width?: number;
+  height?: number;
+}) {
+  if (values.length === 0) return null;
+  const max = Math.max(1, ...values);
+  const barW = width / values.length;
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      aria-hidden="true"
+      style={{ display: "block" }}
+    >
+      {values.map((v, i) => {
+        const h = (v / max) * height;
+        return (
+          <rect
+            key={i}
+            x={i * barW + 0.5}
+            y={height - h}
+            width={Math.max(1, barW - 1)}
+            height={h}
+            fill="var(--text3)"
+            opacity={v === 0 ? 0.35 : 1}
+          />
+        );
+      })}
+    </svg>
+  );
+}

--- a/apps/web/src/lib/hours-saved.ts
+++ b/apps/web/src/lib/hours-saved.ts
@@ -28,3 +28,22 @@ export function sinceLabel(iso: string | null): string {
   if (Number.isNaN(d.getTime())) return "since you installed OpenNeko";
   return `since ${d.toLocaleDateString("en-IN", { month: "long", year: "numeric" })}`;
 }
+
+/**
+ * Fill a fixed-length daily series (oldest → newest) from a "YYYY-MM-DD" → value
+ * map. `since` is the UTC-midnight start day; produces `days` entries, 0 where a
+ * day has no data.
+ */
+export function fillDailySeries(
+  byDay: Map<string, number>,
+  since: Date,
+  days: number,
+): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < days; i += 1) {
+    const d = new Date(since);
+    d.setUTCDate(since.getUTCDate() + i);
+    out.push(byDay.get(d.toISOString().slice(0, 10)) ?? 0);
+  }
+  return out;
+}

--- a/apps/web/test/lib/hours-saved.test.ts
+++ b/apps/web/test/lib/hours-saved.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { fillDailySeries, formatSavedShort } from "@/lib/hours-saved";
+
+describe("fillDailySeries", () => {
+  const since = new Date("2026-06-03T00:00:00.000Z");
+
+  it("returns a zero-filled series of the requested length", () => {
+    expect(fillDailySeries(new Map(), since, 7)).toEqual([0, 0, 0, 0, 0, 0, 0]);
+  });
+
+  it("places day values oldest → newest and zero-fills gaps", () => {
+    const byDay = new Map<string, number>([
+      ["2026-06-03", 10],
+      ["2026-06-05", 25],
+      ["2026-06-09", 40],
+    ]);
+    expect(fillDailySeries(byDay, since, 7)).toEqual([10, 0, 25, 0, 0, 0, 40]);
+  });
+
+  it("ignores days outside the window", () => {
+    const byDay = new Map<string, number>([
+      ["2026-06-01", 99], // before `since`
+      ["2026-06-04", 12],
+    ]);
+    expect(fillDailySeries(byDay, since, 7)).toEqual([0, 12, 0, 0, 0, 0, 0]);
+  });
+});
+
+describe("formatSavedShort", () => {
+  it("renders minutes under an hour", () => {
+    expect(formatSavedShort(18)).toBe("~18 min");
+  });
+  it("renders hours with one decimal under 10h", () => {
+    expect(formatSavedShort(150)).toBe("~2.5h");
+  });
+  it("renders empty for non-positive", () => {
+    expect(formatSavedShort(0)).toBe("");
+  });
+});

--- a/apps/worker/test/channels/inbound-store.test.ts
+++ b/apps/worker/test/channels/inbound-store.test.ts
@@ -6,14 +6,13 @@
 // Self-skips when no DB is reachable (e.g. CI without the compose stack), so
 // the suite stays green everywhere. inboundUpdateKey is pure and always runs.
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { db, eq, inbound_dedup, reconnectPool } from "@neko/db";
 import {
-  channel_poll_cursor,
-  db,
-  eq,
-  inbound_dedup,
-  reconnectPool,
-  sql,
-} from "@neko/db";
+  createTestOrg,
+  dbReachable,
+  deleteTestOrg,
+  uniqueOrgId,
+} from "@neko/db/test-helpers";
 import {
   beginInboundUpdate,
   inboundUpdateKey,
@@ -49,29 +48,22 @@ describe("inboundUpdateKey (pure)", () => {
 describe("inbound ledger + cursor (real Postgres)", () => {
   let dbUp = false;
   let orgId = "";
-  // Unique per run so parallel/repeat runs don't collide; rows are cleaned up.
+  // Own a unique org per run. Borrowing the first existing row races a
+  // concurrent test file that creates+deletes its own org, FK-breaking our
+  // inserts; cascade FKs clean up our child rows on teardown.
   const plugin = `@test/inbound-store-${Math.random().toString(36).slice(2)}`;
   const keyOf = (id: number) => inboundUpdateKey({ update_id: id, plugin });
 
   beforeAll(async () => {
-    try {
-      const rows = await db().execute<{ id: string }>(
-        sql`select id from organization limit 1`,
-      );
-      orgId = rows.rows[0]?.id ?? "";
-      dbUp = orgId !== "";
-    } catch {
-      dbUp = false;
+    dbUp = await dbReachable();
+    if (dbUp) {
+      orgId = uniqueOrgId("inbound-store");
+      await createTestOrg(orgId);
     }
   });
 
   afterAll(async () => {
-    if (dbUp) {
-      await db().delete(inbound_dedup).where(eq(inbound_dedup.channel_plugin, plugin));
-      await db()
-        .delete(channel_poll_cursor)
-        .where(eq(channel_poll_cursor.channel_plugin, plugin));
-    }
+    if (dbUp) await deleteTestOrg(orgId);
     await reconnectPool();
   });
 

--- a/packages/llm/src/work/store.ts
+++ b/packages/llm/src/work/store.ts
@@ -38,6 +38,8 @@ export type WorkRunRecord = {
   error: string | null;
   createdAt: string;
   finishedAt: string | null;
+  analysisMinutesSaved: number | null;
+  analysisMinutesBasis: string | null;
 };
 
 export type WorkThreadBundle = {
@@ -479,6 +481,8 @@ export async function getWorkThreadBundle(
       error: row.error,
       createdAt: row.created_at.toISOString(),
       finishedAt: row.finished_at ? row.finished_at.toISOString() : null,
+      analysisMinutesSaved: row.analysis_minutes_saved,
+      analysisMinutesBasis: row.analysis_minutes_basis,
     })),
     messages: messages.map((row) => ({
       id: row.id,


### PR DESCRIPTION
Completes the hours-saved **surfaces** that were left unbuilt after the backend (fence/clamps/columns + Hero) landed.

## What's in this PR
- **Ask thread vital** — the run's `analysisMinutesSaved` now rides the work bundle (`store.ts`) and is prepended as a **"Time saved"** tile in the Ask context rail, ahead of the 4-vital cap so it always shows. Reads from the persisted run (survives reload), not the transient `done` event.
- **Live dashboard sparkline** — `/api/briefing/value` returns a **7-day `dailyMinutes`** series (action + analysis minutes, day-bucketed) plus an **honest `sinceISO`** derived from the first *actually-tracked* minute (falling back to org-created). `HoursSavedHero` renders it via a new shared **`components/Sparkline.tsx`**, retiring the hardcoded prototype tile. `WorkflowsPage` drops its duplicate local `Sparkline`.

## Deliberately deferred (no migration)
- `minutes_saved_raw` calibration columns and the `total_minutes_saved` denorm. The denorm would be **silently wrong** under async action execution (actions can execute *after* a run finalizes), and the value API already rolls up correctly on read. Tracked in `docs/HOURS_SAVED_PLAN.md`.

## Verification
- `apps/web` typecheck: 0 errors
- New unit test (`test/lib/hours-saved.test.ts`): 6/6 — covers `fillDailySeries` zero-fill/windowing and `formatSavedShort`

🤖 Generated with [Claude Code](https://claude.com/claude-code)