### PR TITLE
ci: fix post-release smoke stuck testing v1.18.0-openshell.4

### DIFF
--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Resolve release tag + build outcome
         id: ctx
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -43,8 +41,11 @@ jobs:
             echo "build_ok=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          tag=$(gh api "repos/${{ github.repository }}/releases" \
-            --jq '.[] | select(.target_commitish=="main") | .tag_name' | head -1)
+          # The binaries workflow runs on tag push, so its head_branch IS the
+          # tag. Don't resolve via the releases API: release-please pins
+          # target_commitish to a SHA, so filtering on "main" matches only
+          # stale hand-made prereleases (this froze the smoke on v1.18.0-openshell.4).
+          tag="${{ github.event.workflow_run.head_branch }}"
           echo "tag=${tag:-}" >> "$GITHUB_OUTPUT"
           # Only gate stable releases — a '-' marks a prerelease, which is never "Latest".
           case "${tag:-}" in *-* | "") echo "stable=false" ;; *) echo "stable=true" ;; esac >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## The bug
The smoke resolved "the release to test" by filtering the releases API on `target_commitish == "main"`. But release-please pins `target_commitish` to the release **SHA**, so that filter has matched nothing but the stale hand-made `v1.18.0-openshell.4` prerelease since June 4. Consequences:

- Every smoke since v1.18.0 — including the green ones — pulled and tested **frozen `v1.18.0-openshell.4` images**, never the release that just built.
- The demote-off-Latest gate was defused: the resolved tag's `-openshell` suffix marks it prerelease → `stable=false` → broken releases (v1.22.0's lockfile desync, v1.23.0's GHCR 503) were never demoted off "Latest".
- Today's three failures (v1.21.0/v1.22.0/v1.23.0) all trace here: v1.21.0's smoke failed because the v1.21 CLI was driving 1.18-preview images; the other two correctly failed-fast on build failure but then demoted nothing.

## The fix
The binaries workflow runs on tag push, so its `workflow_run.head_branch` **is** the tag. Use it directly; drop the releases-API guess. `workflow_dispatch` path unchanged.

## Note on timing
`workflow_run` workflows execute the default-branch version of this file — merging this before the in-flight v2.0.0 binaries build completes means v2.0.0 gets the first honest smoke since June 4. If it lands after, trigger manually: `gh workflow run post-release-smoke.yml -f version=v2.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)