### PR TITLE
ci: post-release smoke must pre-pull the OpenShell gateway image

### DIFF
--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -77,11 +77,16 @@ jobs:
         run: |
           set -euxo pipefail
           tag="${{ steps.ctx.outputs.tag }}"
+          # The OpenShell gateway/certgen image is part of every stack (SEC11/SEC9);
+          # with --pull never it must be pre-pulled too. Read the version off the
+          # compose pin so this list can't go stale.
+          gw_ver=$(grep -om1 'OPENSHELL_VERSION:-[0-9.]*' apps/openneko/assets/compose/openshell.yml | cut -d- -f2)
           refs=(
             "ghcr.io/open-neko/neko-web:${tag}"
             "ghcr.io/open-neko/neko-worker:${tag}"
             "ghcr.io/open-neko/neko-graphjin:${tag}"
             "ghcr.io/open-neko/neko-cli:${tag}"
+            "ghcr.io/nvidia/openshell/gateway:${gw_ver}"
             "pgvector/pgvector:pg16"
           )
           for ref in "${refs[@]}"; do


### PR DESCRIPTION
The first honest smoke (post-#105) caught a harness gap: `openneko start` runs with `--pull never`, and since SEC11/SEC9 the OpenShell gateway image (`ghcr.io/nvidia/openshell/gateway`, used by both the certgen and gateway services) is part of every stack — but it was never in the pre-pull list. The v2.0.0 smoke died on `No such image: ghcr.io/nvidia/openshell/gateway:0.0.54` and the (now-working) gate demoted v2.0.0 off Latest.

This is a smoke-harness gap, not a product bug — a normal `openneko start` without `--pull never` pulls the gateway automatically.

The fix derives the gateway version from the `OPENSHELL_VERSION` pin in `apps/openneko/assets/compose/openshell.yml` (extraction verified locally → `0.0.54`), so the pre-pull list tracks future pin bumps.

After merge: re-run the smoke against v2.0.0 (`gh workflow run post-release-smoke.yml -f version=v2.0.0`) and, once green, restore v2.0.0 to stable Latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)