### PR TITLE
ci: derive the smoke pre-pull list from the prod compose files

### DIFF
--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -77,18 +77,19 @@ jobs:
         run: |
           set -euxo pipefail
           tag="${{ steps.ctx.outputs.tag }}"
-          # The OpenShell gateway/certgen image is part of every stack (SEC11/SEC9);
-          # with --pull never it must be pre-pulled too. Read the version off the
-          # compose pin so this list can't go stale.
-          gw_ver=$(grep -om1 'OPENSHELL_VERSION:-[0-9.]*' apps/openneko/assets/compose/openshell.yml | cut -d- -f2)
-          refs=(
-            "ghcr.io/open-neko/neko-web:${tag}"
-            "ghcr.io/open-neko/neko-worker:${tag}"
-            "ghcr.io/open-neko/neko-graphjin:${tag}"
-            "ghcr.io/open-neko/neko-cli:${tag}"
-            "ghcr.io/nvidia/openshell/gateway:${gw_ver}"
-            "pgvector/pgvector:pg16"
+          # With --pull never, any image the stack references but this list
+          # misses fails the boot — so derive the list from the compose files
+          # `--mode prod` actually runs instead of hand-maintaining it
+          # (busybox:latest for openshell-reg was the second one missed).
+          mapfile -t refs < <(
+            sed -n 's/^[[:space:]]*image:[[:space:]]*//p' \
+              apps/openneko/assets/compose/core.yml \
+              apps/openneko/assets/compose/openshell.yml \
+            | sed -e "s/\${OPENNEKO_VERSION:-latest}/${tag}/" \
+                  -e 's/\${OPENSHELL_VERSION:-\([0-9.][0-9.]*\)}/\1/' \
+            | sort -u
           )
+          echo "pre-pulling: ${refs[*]}"
           for ref in "${refs[@]}"; do
             for attempt in 1 2 3 4 5; do
               if docker pull "${ref}"; then


### PR DESCRIPTION
Second gap in the same list: after #106 fixed the gateway image, the v2.0.0 re-run got further and died on `No such image: busybox:latest` — the `openshell-reg` service (registration-writing is a separate busybox step because the gateway image is distroless, no shell).

Rather than a third hardcode, this derives the pre-pull list by parsing `image:` refs out of the compose files `--mode prod` actually boots (`core.yml` + `openshell.yml`), resolving `${OPENNEKO_VERSION}` to the tag under test and `${OPENSHELL_VERSION}` to its pinned default. Verified locally for v2.0.0 — yields exactly: busybox:latest, openshell/gateway:0.0.54, neko-cli, neko-graphjin, neko-web, neko-worker (all :v2.0.0), pgvector:pg16. Any service image added to the stack later is pre-pulled automatically.

(The agent sandbox image isn't compose-managed — the CLI pre-pulls it itself, which already works under `--pull never`.)

After merge: `gh workflow run post-release-smoke.yml -f version=v2.0.0`, then restore v2.0.0 to stable Latest once green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)