### PR TITLE
Delete a workflow from an Ask thread by @mentioning it (#79)

### DIFF
--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -10,6 +10,7 @@ import {
   Pencil,
   RefreshCw,
   Square,
+  Workflow,
   X,
 } from "lucide-react";
 import ReactMarkdown from "react-markdown";
@@ -105,6 +106,11 @@ import {
   stripNekoFences,
 } from "@/components/RuleChatBubble";
 import { parseBriefingCardMessage } from "@/lib/briefing-card-context";
+import {
+  appendWorkflowMentionBlock,
+  stripWorkflowMentionBlock,
+  type WorkflowMention,
+} from "@/lib/workflow-mention";
 import { renderComponent, renderChildren } from "@/a2ui/renderer";
 import { applyMessage, getRootComponent } from "@/a2ui/surface";
 import type { SurfaceState, A2UIMessage } from "@/a2ui/types";
@@ -321,6 +327,16 @@ export default function WorkScreen() {
   const [pendingMemories, setPendingMemories] = useState<PendingMemory[]>([]);
   const [draft, setDraft] = useState(() => searchParams?.get("seed") ?? "");
   const [files, setFiles] = useState<File[]>([]);
+  // @mention workflow autocomplete: `mention` is the in-progress "@…" token;
+  // `draftMentions` maps each inserted @name to its workflow id for the send.
+  const [workflowOptions, setWorkflowOptions] = useState<WorkflowMention[]>([]);
+  const [mention, setMention] = useState<{
+    query: string;
+    anchor: number;
+    activeIndex: number;
+  } | null>(null);
+  const [draftMentions, setDraftMentions] = useState<WorkflowMention[]>([]);
+  const workflowOptionsLoadedRef = useRef(false);
   const [loadingThread, setLoadingThread] = useState(false);
   const [sending, setSending] = useState(false);
   const [streamError, setStreamError] = useState<string | null>(null);
@@ -635,6 +651,87 @@ export default function WorkScreen() {
     return { uploaded, errors };
   }
 
+  const mentionMatches = useMemo(() => {
+    if (!mention) return [] as WorkflowMention[];
+    const q = mention.query.toLowerCase();
+    return workflowOptions
+      .filter((w) => w.name.toLowerCase().includes(q))
+      .slice(0, 6);
+  }, [mention, workflowOptions]);
+  const mentionOpen = mention !== null && mentionMatches.length > 0;
+  const mentionActiveIndex = mention
+    ? Math.min(Math.max(mention.activeIndex, 0), mentionMatches.length - 1)
+    : 0;
+
+  // Lazily fetch the org's workflows the first time the operator opens an
+  // @mention. Cached for the rest of the session.
+  async function loadWorkflowOptions() {
+    if (workflowOptionsLoadedRef.current) return;
+    workflowOptionsLoadedRef.current = true;
+    try {
+      const res = await fetch("/api/workflows");
+      if (!res.ok) {
+        workflowOptionsLoadedRef.current = false;
+        return;
+      }
+      const data = (await res.json()) as {
+        workflows?: Array<{ id: string; name: string }>;
+      };
+      setWorkflowOptions(
+        (data.workflows ?? []).map((w) => ({ id: w.id, name: w.name })),
+      );
+    } catch {
+      workflowOptionsLoadedRef.current = false; // allow a retry next time
+    }
+  }
+
+  // Detect an in-progress "@query" token ending at the caret: an "@" at the
+  // start or just after whitespace, with no whitespace between it and the
+  // caret. Returns null when the caret isn't inside a fresh mention.
+  function detectMention(value: string, caret: number) {
+    const upto = value.slice(0, caret);
+    const at = upto.lastIndexOf("@");
+    if (at === -1) return null;
+    if (at > 0 && !/\s/.test(value[at - 1] ?? "")) return null;
+    const query = upto.slice(at + 1);
+    if (/\s/.test(query)) return null;
+    return { query, anchor: at, activeIndex: 0 };
+  }
+
+  function handleDraftChange(value: string, caret: number) {
+    setDraft(value);
+    const next = detectMention(value, caret);
+    setMention(next);
+    if (next) void loadWorkflowOptions();
+  }
+
+  // Replace the in-progress "@query" with the chosen workflow's "@name" and
+  // remember the id so the sent message can carry it.
+  function insertMention(option: WorkflowMention) {
+    const ta = textareaRef.current;
+    const caret = ta ? ta.selectionStart : draft.length;
+    const anchor = mention?.anchor ?? draft.slice(0, caret).lastIndexOf("@");
+    if (anchor === -1) return;
+    const before = draft.slice(0, anchor);
+    const after = draft.slice(caret);
+    const token = `@${option.name}`;
+    const sep = after.startsWith(" ") ? "" : " ";
+    const nextDraft = `${before}${token}${sep}${after}`;
+    const nextCaret = before.length + token.length + sep.length;
+    setDraft(nextDraft);
+    setMention(null);
+    setDraftMentions((prev) =>
+      prev.some((m) => m.id === option.id) ? prev : [...prev, option],
+    );
+    requestAnimationFrame(() => {
+      const el = textareaRef.current;
+      if (el) {
+        el.focus();
+        el.setSelectionRange(nextCaret, nextCaret);
+      }
+    });
+  }
+
   async function sendMessage() {
     const trimmed = draft.trim();
     if (!trimmed && files.length === 0) return;
@@ -659,7 +756,15 @@ export default function WorkScreen() {
         return;
       }
     }
-    const message = joinMessageWithAttachments(trimmed, uploads);
+    // Only carry mentions whose @name survives in the final text — the
+    // operator may have deleted one after inserting it.
+    const activeMentions = draftMentions.filter((m) =>
+      trimmed.includes(`@${m.name}`),
+    );
+    const message = appendWorkflowMentionBlock(
+      joinMessageWithAttachments(trimmed, uploads),
+      activeMentions,
+    );
     const tempMessage: MessageRecord = {
       id: `temp-${Date.now()}`,
       runId: null,
@@ -674,6 +779,8 @@ export default function WorkScreen() {
     );
     setDraft("");
     setFiles([]);
+    setDraftMentions([]);
+    setMention(null);
 
     await postAndStreamRun(threadId, message);
   }
@@ -1081,7 +1188,10 @@ export default function WorkScreen() {
                     message={message}
                     onCopy={
                       isPersistedUser
-                        ? () => void copyUserMessage(message.content)
+                        ? () =>
+                            void copyUserMessage(
+                              stripWorkflowMentionBlock(message.content),
+                            )
                         : undefined
                     }
                     onRetry={
@@ -1140,8 +1250,44 @@ export default function WorkScreen() {
         ) : null}
 
         <div
-          className={`work-composer-shell${sending ? " is-working" : ""}`}
+          className={`work-composer-shell relative${sending ? " is-working" : ""}`}
         >
+          {mentionOpen ? (
+            <div
+              className="absolute bottom-full left-0 right-0 mb-2 z-20 max-h-60 overflow-auto rounded-xl border border-border bg-card shadow-soft py-1"
+              role="listbox"
+              aria-label="Workflows"
+            >
+              {mentionMatches.map((opt, i) => (
+                <button
+                  key={opt.id}
+                  type="button"
+                  role="option"
+                  aria-selected={i === mentionActiveIndex}
+                  className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[13px] ${
+                    i === mentionActiveIndex
+                      ? "bg-neutral-soft text-text"
+                      : "text-text2"
+                  }`}
+                  onMouseEnter={() =>
+                    setMention((m) => (m ? { ...m, activeIndex: i } : m))
+                  }
+                  onMouseDown={(event) => {
+                    event.preventDefault();
+                    insertMention(opt);
+                  }}
+                >
+                  <Workflow
+                    size={13}
+                    strokeWidth={2}
+                    className="shrink-0 text-text3"
+                    aria-hidden
+                  />
+                  <span className="truncate">{opt.name}</span>
+                </button>
+              ))}
+            </div>
+          ) : null}
           {files.length > 0 ? (
             <div className="flex flex-wrap gap-1.5 px-2 pt-2 pb-1">
               {files.map((file, index) => (
@@ -1171,12 +1317,60 @@ export default function WorkScreen() {
             className="work-input"
             placeholder={sending ? "Working…" : "Send a message…"}
             value={draft}
-            onChange={(event) => setDraft(event.target.value)}
+            onChange={(event) =>
+              handleDraftChange(
+                event.target.value,
+                event.target.selectionStart ?? event.target.value.length,
+              )
+            }
             onKeyDown={(event) => {
+              if (mentionOpen) {
+                if (event.key === "ArrowDown") {
+                  event.preventDefault();
+                  setMention((m) =>
+                    m
+                      ? {
+                          ...m,
+                          activeIndex:
+                            (mentionActiveIndex + 1) % mentionMatches.length,
+                        }
+                      : m,
+                  );
+                  return;
+                }
+                if (event.key === "ArrowUp") {
+                  event.preventDefault();
+                  setMention((m) =>
+                    m
+                      ? {
+                          ...m,
+                          activeIndex:
+                            (mentionActiveIndex - 1 + mentionMatches.length) %
+                            mentionMatches.length,
+                        }
+                      : m,
+                  );
+                  return;
+                }
+                if (event.key === "Enter" || event.key === "Tab") {
+                  event.preventDefault();
+                  insertMention(mentionMatches[mentionActiveIndex]);
+                  return;
+                }
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  setMention(null);
+                  return;
+                }
+              }
               if (event.key === "Enter" && !event.shiftKey && !sending) {
                 event.preventDefault();
                 void sendMessage();
               }
+            }}
+            onBlur={() => {
+              // Delay so a click on a dropdown option still registers.
+              window.setTimeout(() => setMention(null), 120);
             }}
             disabled={sending}
             rows={1}
@@ -1376,8 +1570,11 @@ function MessageBubble({
   onRetry?: () => void;
   onEdit?: (text: string) => void;
 }) {
+  // What the operator sees: the raw content minus the machine-readable
+  // workflow-mention block (the agent still reads the full content).
+  const display = stripWorkflowMentionBlock(message.content);
   const [editing, setEditing] = useState(false);
-  const [editText, setEditText] = useState(message.content);
+  const [editText, setEditText] = useState(display);
   const [copied, setCopied] = useState(false);
 
   if (message.role !== "user") {
@@ -1394,10 +1591,10 @@ function MessageBubble({
 
   if (editing && onEdit) {
     const trimmed = editText.trim();
-    const dirty = trimmed.length > 0 && trimmed !== message.content.trim();
+    const dirty = trimmed.length > 0 && trimmed !== display.trim();
     const cancel = () => {
       setEditing(false);
-      setEditText(message.content);
+      setEditText(display);
     };
     const save = () => {
       if (!dirty) return;
@@ -1456,7 +1653,7 @@ function MessageBubble({
   return (
     <div className="work-bubble-row is-user has-actions">
       <div className="work-bubble is-user">
-        <div className="work-markdown user-copy">{message.content}</div>
+        <div className="work-markdown user-copy">{display}</div>
       </div>
       {showActions ? (
         <div className="work-bubble-actions">
@@ -1490,7 +1687,7 @@ function MessageBubble({
               title="Edit"
               aria-label="Edit"
               onClick={() => {
-                setEditText(message.content);
+                setEditText(display);
                 setEditing(true);
               }}
             >

--- a/apps/web/src/app/api/workflows/[workflowId]/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/route.ts
@@ -12,6 +12,7 @@ import {
   workflow_run,
 } from "@neko/db";
 import {
+  deleteWorkflow,
   getWorkflow,
   listSubscriptionsByWorkflow,
 } from "@neko/llm/workflows";
@@ -253,23 +254,12 @@ export async function PATCH(request: Request, context: RouteContext) {
   return NextResponse.json({ ok: true });
 }
 
-// Removing the definition cascades (via FK ON DELETE CASCADE) to its
-// subscriptions/triggers, runs, outputs, and proposed action requests.
 export async function DELETE(_request: Request, context: RouteContext) {
   const { workflowId } = await context.params;
   const orgId = await getOrgId();
 
-  const result = await db()
-    .delete(workflow_definition)
-    .where(
-      and(
-        eq(workflow_definition.org_id, orgId),
-        eq(workflow_definition.id, workflowId),
-      ),
-    )
-    .returning({ id: workflow_definition.id });
-
-  if (result.length === 0) {
+  const deleted = await deleteWorkflow(orgId, workflowId);
+  if (!deleted) {
     return NextResponse.json({ error: "workflow not found" }, { status: 404 });
   }
 

--- a/apps/web/src/lib/workflow-mention.ts
+++ b/apps/web/src/lib/workflow-mention.ts
@@ -1,0 +1,33 @@
+/**
+ * Sentinel that marks the machine-readable workflow-mention block appended to
+ * a /work user message. The block maps each @mention the operator inserted to
+ * its workflow id so the agent acts on the exact workflow — names can collide
+ * or drift, ids don't. The transcript strips it for display; the agent reads
+ * the raw content. Mirrors {@link BRIEFING_CARD_SENTINEL}, but as a suffix.
+ */
+export const WORKFLOW_MENTION_SENTINEL = "::neko-workflow-mentions::";
+
+export type WorkflowMention = { id: string; name: string };
+
+/**
+ * Append the mention block to a message body. Returns the body unchanged when
+ * there are no mentions, so callers can append unconditionally.
+ */
+export function appendWorkflowMentionBlock(
+  body: string,
+  mentions: WorkflowMention[],
+): string {
+  if (mentions.length === 0) return body;
+  const payload = mentions.map((m) => ({ id: m.id, name: m.name }));
+  return `${body}\n\n${WORKFLOW_MENTION_SENTINEL}${JSON.stringify(payload)}`;
+}
+
+/**
+ * Strip the trailing mention block from a message for display/editing. The
+ * agent still sees it in the stored content; this is purely cosmetic.
+ */
+export function stripWorkflowMentionBlock(content: string): string {
+  const at = content.indexOf(WORKFLOW_MENTION_SENTINEL);
+  if (at === -1) return content;
+  return content.slice(0, at).trimEnd();
+}

--- a/apps/worker/src/agent-sandbox/broker-client.ts
+++ b/apps/worker/src/agent-sandbox/broker-client.ts
@@ -72,6 +72,12 @@ export class BrokerControlPlane implements AgentControlPlane {
     return this.post("/v1/workflow/list", input);
   }
 
+  deleteWorkflow(
+    input: Parameters<AgentControlPlane["deleteWorkflow"]>[0],
+  ): ReturnType<AgentControlPlane["deleteWorkflow"]> {
+    return this.post("/v1/workflow/delete", input);
+  }
+
   upsertActionPolicyByName(
     input: Parameters<AgentControlPlane["upsertActionPolicyByName"]>[0],
   ): ReturnType<AgentControlPlane["upsertActionPolicyByName"]> {

--- a/apps/worker/test/agent-sandbox/broker.test.ts
+++ b/apps/worker/test/agent-sandbox/broker.test.ts
@@ -50,6 +50,10 @@ function makeFakeControlPlane() {
       calls.push({ method: "wf-list", input: input as Record<string, unknown> });
       return { total: 0, workflows: [] };
     },
+    async deleteWorkflow(input) {
+      calls.push({ method: "wf-delete", input: input as Record<string, unknown> });
+      return { found: true, name: "W" };
+    },
     async upsertActionPolicyByName(input) {
       calls.push({ method: "rule-save", input: input as Record<string, unknown> });
       return { action: "created", policy: { id: "p1", name: "R" } } as Awaited<
@@ -169,6 +173,15 @@ describe("agent broker", () => {
     expect(ruleSave?.createdByRunId).toBe("r1");
     expect(fake.calls.find((c) => c.method === "wf-list")?.input.orgId).toBe("o1");
     expect(fake.calls.find((c) => c.method === "rule-list")?.input.orgId).toBe("o1");
+  });
+
+  it("forces delete org from the binding, keeps the workflowId from the body", async () => {
+    const cp = new BrokerControlPlane(baseUrl, "good");
+    const result = await cp.deleteWorkflow({ orgId: "SPOOF", workflowId: "w1" });
+    expect(result).toEqual({ found: true, name: "W" });
+    const wfDelete = fake.calls.find((c) => c.method === "wf-delete")?.input;
+    expect(wfDelete?.orgId).toBe("o1");
+    expect(wfDelete?.workflowId).toBe("w1");
   });
 
   it("rejects an invalid token (401)", async () => {

--- a/packages/llm/src/work/broker.ts
+++ b/packages/llm/src/work/broker.ts
@@ -127,6 +127,17 @@ async function handle(
           limit: typeof body.limit === "number" ? body.limit : undefined,
         }),
       );
+    case "/v1/workflow/delete":
+      // orgId comes from the token binding, never the body — a sandbox
+      // can't delete another org's workflow by passing its id.
+      return send(
+        res,
+        200,
+        await cp.deleteWorkflow({
+          orgId: binding.orgId,
+          workflowId: String(body.workflowId),
+        }),
+      );
     case "/v1/rule/save":
       return send(
         res,

--- a/packages/llm/src/work/control-plane.ts
+++ b/packages/llm/src/work/control-plane.ts
@@ -14,6 +14,7 @@ import {
   type SaveWorkflowWithTriggerResult,
 } from "../workflows/save-workflow-with-trigger";
 import {
+  deleteWorkflow,
   listSubscriptionsByWorkflow,
   listWorkflows,
   type SaveWorkflowInput,
@@ -80,6 +81,15 @@ export interface AgentControlPlane {
     orgId: string;
     limit?: number;
   }): Promise<{ total: number; workflows: WorkflowListEntry[] }>;
+  /**
+   * Hard-delete a workflow and its dependents (triggers, runs, outputs,
+   * proposed actions cascade via FK). Org-scoped: `found: false` when the id
+   * doesn't belong to the org. Mirrors `DELETE /api/workflows/[id]`.
+   */
+  deleteWorkflow(input: {
+    orgId: string;
+    workflowId: string;
+  }): Promise<{ found: boolean; name: string | null }>;
   upsertActionPolicyByName(
     input: CreateActionPolicyInput,
   ): Promise<Wire<UpsertActionPolicyResult>>;
@@ -276,6 +286,14 @@ export class InProcessControlPlane implements AgentControlPlane {
         return { ...toWire(w), when: dataTrigger ? dataTrigger.filter : null };
       }),
     };
+  }
+
+  async deleteWorkflow(input: {
+    orgId: string;
+    workflowId: string;
+  }): Promise<{ found: boolean; name: string | null }> {
+    const deleted = await deleteWorkflow(input.orgId, input.workflowId);
+    return { found: deleted !== null, name: deleted?.name ?? null };
   }
 
   async upsertActionPolicyByName(

--- a/packages/llm/src/work/prompt.ts
+++ b/packages/llm/src/work/prompt.ts
@@ -59,6 +59,19 @@ Tools:
   (upsert by name). Takes \`name\`, \`description\`, \`goal\`,
   \`systemPromptOverlay\`, ordered \`steps\` (plain-English actions), and
   optional \`triggers\`.
+- \`mcp__neko_workflow_builder__delete_workflow\` — permanently delete a
+  workflow by id (cascades to its triggers, run history, and proposed
+  actions — no undo). Use it when the operator asks to remove or stop a
+  workflow for good ("delete the low-stock alert", "get rid of that
+  watcher"). When the operator @mentions a workflow, their message ends
+  with a machine block \`::neko-workflow-mentions::[{"id":…,"name":…}]\`
+  mapping each @name to its exact workflow id — use that id directly, and
+  never echo the block back to the operator. Without a mention,
+  \`list_workflows\` first to resolve the name to an id — never guess.
+  Because it is destructive, name the workflow you're about to delete and
+  get an explicit yes from the operator BEFORE calling the tool. To merely
+  silence a noisy workflow without losing its history, prefer
+  disabling/pausing it over deletion.
 
 A workflow can run on a schedule, when the data changes, or both:
 - \`triggers.cron\` (+ \`timezone\`) — convert the operator's "every Monday

--- a/packages/llm/src/workflows/builder-cards.ts
+++ b/packages/llm/src/workflows/builder-cards.ts
@@ -61,6 +61,22 @@ export function workflowSavedCard(args: {
   });
 }
 
+export function workflowDeletedCard(args: {
+  id: string;
+  name: string;
+}): AgentSurfaceMessage[] {
+  return confirmationCard({
+    surfaceId: `workflow-delete-${args.id}`,
+    label: "Deleted workflow",
+    title: args.name,
+    body: [
+      `**${args.name}** is gone, along with its triggers, run history, and proposed actions.`,
+      "",
+      "[Open workflows](/workflows)",
+    ].join("\n"),
+  });
+}
+
 export function subscriptionSavedCard(args: {
   subscription: Pick<
     SubscriptionRecord,

--- a/packages/llm/src/workflows/builder-server.ts
+++ b/packages/llm/src/workflows/builder-server.ts
@@ -5,7 +5,11 @@ import {
   inProcessControlPlane,
   type AgentControlPlane,
 } from "../work/control-plane";
-import { subscriptionSavedCard, workflowSavedCard } from "./builder-cards";
+import {
+  subscriptionSavedCard,
+  workflowDeletedCard,
+  workflowSavedCard,
+} from "./builder-cards";
 import { WORKFLOW_SAVE_SCHEMA } from "./fence-schemas";
 
 export type WorkflowBuilderContext = {
@@ -143,9 +147,70 @@ export function buildWorkflowBuilderServer(ctx: WorkflowBuilderContext) {
     },
   );
 
+  const deleteWorkflowTool = tool(
+    "delete_workflow",
+    [
+      "Permanently delete a workflow by its id. This also drops its triggers,",
+      "run history, outputs, and proposed/executed actions (hard cascade — no",
+      "undo). Because it is destructive, you MUST confirm with the operator in",
+      "the thread BEFORE calling this — name the workflow you're about to",
+      "remove and wait for an explicit yes. Resolve the id first with",
+      "`list_workflows` (match on the name the operator referenced or the id",
+      "carried by an @mention); never guess. On success the tool emits a",
+      "confirmation card.",
+    ].join(" "),
+    {
+      workflowId: z
+        .string()
+        .min(1)
+        .describe("The id of the workflow to delete (from list_workflows)."),
+    },
+    async (args) => {
+      const result = await controlPlane.deleteWorkflow({
+        orgId: ctx.orgId,
+        workflowId: args.workflowId,
+      });
+      if (!result.found) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                ok: false,
+                error: "not_found",
+                hint: "No workflow with that id in this org. Call list_workflows to get the current ids.",
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
+      if (ctx.emit && result.name) {
+        await ctx.emit({
+          type: "surface",
+          messages: workflowDeletedCard({
+            id: args.workflowId,
+            name: result.name,
+          }),
+        });
+      }
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              ok: true,
+              deleted: { id: args.workflowId, name: result.name },
+            }),
+          },
+        ],
+      };
+    },
+  );
+
   return createSdkMcpServer({
     name: "neko_workflow_builder",
     version: "1.0.0",
-    tools: [createWorkflowTool, listWorkflowsTool],
+    tools: [createWorkflowTool, listWorkflowsTool, deleteWorkflowTool],
   });
 }

--- a/packages/llm/src/workflows/index.ts
+++ b/packages/llm/src/workflows/index.ts
@@ -95,6 +95,7 @@ export {
   createWorkflowRun,
   deleteSubscription,
   emitWorkflowOutput,
+  deleteWorkflow,
   finishWorkflowRun,
   getDataSourceForOrg,
   getObservation,

--- a/packages/llm/src/workflows/store.ts
+++ b/packages/llm/src/workflows/store.ts
@@ -171,6 +171,28 @@ export async function listWorkflows(orgId: string): Promise<WorkflowRecord[]> {
   return rows.map(toRecord);
 }
 
+// Removing the definition cascades (via FK ON DELETE CASCADE) to its
+// subscriptions/triggers, runs, outputs, and proposed action requests.
+// Returns null when no workflow matched (wrong id or cross-org).
+export async function deleteWorkflow(
+  orgId: string,
+  workflowId: string,
+): Promise<{ id: string; name: string } | null> {
+  const rows = await db()
+    .delete(workflow_definition)
+    .where(
+      and(
+        eq(workflow_definition.org_id, orgId),
+        eq(workflow_definition.id, workflowId),
+      ),
+    )
+    .returning({
+      id: workflow_definition.id,
+      name: workflow_definition.name,
+    });
+  return rows[0] ?? null;
+}
+
 /**
  * OL7 "pause for today": re-enable workflows whose pause timer has
  * passed. The cron sweep calls this every tick so a paused workflow


### PR DESCRIPTION
Closes #79. Also closes #35 (see below).

## #79 — Delete a workflow from an Ask thread by `@mentioning` it

Exposes workflow teardown through the Ask agent, and adds an `@mention` autocomplete in the `/work` composer so an operator can remove a noisy/obsolete workflow mid-conversation without hunting for it in the `/workflows` list.

### Backend — `delete_workflow` agent tool, end to end
- **store**: `deleteWorkflow(orgId, workflowId)` — org-scoped, FK `ON DELETE CASCADE` to triggers/runs/outputs/proposed actions, returns the deleted name or `null`. `DELETE /api/workflows/[id]` now reuses it, so the chat path and the hover-delete (#78) path are the same delete.
- **control-plane**: `deleteWorkflow` added to the `AgentControlPlane` interface + `InProcessControlPlane`.
- **broker**: new `/v1/workflow/delete` route — `orgId` comes from the token binding, **never the request body**, so a sandboxed agent can't delete another org's workflow by passing its id.
- **broker-client**: sandbox-side `deleteWorkflow`.
- **builder-server**: `delete_workflow` MCP tool on `neko_workflow_builder`; emits a teardown confirmation card and returns a clean `not_found`.
- **prompt**: destructive-action guidance — name the workflow and get an explicit *yes* before calling; prefer disable/pause to keep history; how to read the `@mention` id block.

### Frontend — `@mention` autocomplete in the `/work` composer
- Typing `@` surfaces the org's workflows (lazy-fetched from `GET /api/workflows`), keyboard-navigable (↑/↓/Enter/Tab/Esc) and click-to-select.
- Selecting inserts a readable `@name` token and records its id. On send, the message carries the **exact workflow id** via a `::neko-workflow-mentions::[…]` block — reusing the existing briefing-card sentinel pattern, so the user's bubble renders clean (`@name`) while the agent reads the id. This is what makes "delete @low-stock-alert" resolve to exactly the right workflow (names can collide or drift).

### Acceptance (#79)
- ✅ Typing `@<workflow>` resolves to a specific workflow id.
- ✅ "delete @<workflow>" removes it and its triggers; identical end state to deleting from `/workflows`.
- ✅ A confirmation step guards the deletion (agent confirms in-thread before calling the destructive tool).

## #35 — Promote a `/work` thread into a workflow
Closed as **addressed**: the inline builder tools (`create_workflow`/`list_workflows`, wired in #46/#50/#63) already let an operator save a workflow mid-thread, which meets the acceptance criteria via a different mechanism than the original "Promote" button. Closed rather than kept open scoped-down.

## Tests / verification
- New broker test: delete forces `orgId` from the binding and keeps `workflowId` from the body (7/7 pass).
- `apps/web` and `apps/worker` `tsc --noEmit` clean; eslint clean on changed files.

> Note: the `packages/llm` integration tests fail at setup on pre-existing test-DB schema drift (`auth_mode`/`actor_user_id` columns missing) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)