### PR TITLE
feat: hermes gets the full neko MCP tool set (ACP stdio bridges) + the orphaned sandbox fixes from #108

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,9 +54,12 @@ RUN curl -LsSf --retry 5 --retry-delay 5 --retry-all-errors https://astral.sh/uv
        UV_PYTHON_INSTALL_DIR=/usr/local/uv/python \
        UV_CACHE_DIR=/tmp/uv-cache \
        uv tool install --python 3.11 \
+         --with mcp --with websockets \
          "hermes-agent[acp] @ git+https://github.com/NousResearch/hermes-agent.git@${HERMES_AGENT_REF}" \
     && rm -rf /tmp/uv-cache /root/.cache/uv \
-    && hermes --version
+    && hermes --version \
+    && /usr/local/uv/tools/hermes-agent/bin/python -c "import mcp, websockets" \
+    && echo "hermes MCP SDK present"
 RUN npm install -g @anthropic-ai/claude-code
 # openshell: CLI driver for the OpenShell plugin runtime
 # (OPENNEKO_PLUGIN_RUNTIME=openshell). Static musl binary, no runtime deps.

--- a/apps/web/src/app/actions/page.tsx
+++ b/apps/web/src/app/actions/page.tsx
@@ -17,8 +17,8 @@ type Filter = "awaiting" | "fired" | "rejected" | "all";
 
 type ActionRow = {
   id: string;
-  workflowRunId: string;
-  workflow: { id: string; name: string };
+  workflowRunId: string | null;
+  workflow: { id: string; name: string } | null;
   triggeredByObservation: { title: string } | null;
   kind: string;
   target: string | null;
@@ -85,7 +85,7 @@ function isFilter(value: string | null): value is Filter {
 
 type Group = {
   key: string;
-  runId: string;
+  runId: string | null;
   runAt: string;
   trigger: string | null;
   workflowName: string;
@@ -99,7 +99,8 @@ function groupActions(actions: ActionRow[]): Group[] {
   const map = new Map<string, Group>();
   for (const row of actions) {
     const state = stateFor(row);
-    const key = `${row.workflowRunId}:${state}`;
+    // Chat-proposed admin actions have no workflow run — group each alone.
+    const key = `${row.workflowRunId ?? row.id}:${state}`;
     const existing = map.get(key);
     if (existing) {
       existing.rows.push(row);
@@ -109,7 +110,7 @@ function groupActions(actions: ActionRow[]): Group[] {
         runId: row.workflowRunId,
         runAt: row.runAt,
         trigger: row.triggeredByObservation?.title ?? null,
-        workflowName: row.workflow.name,
+        workflowName: row.workflow?.name ?? "the assistant",
         state,
         rows: [row],
       });
@@ -372,7 +373,7 @@ function ActionReadingPane({
           {action.summary || action.kind}
         </h2>
         <div className="text-[12.5px] text-text2 mt-2 leading-[1.5]">
-          Proposed by <span className="text-text font-semibold">{action.workflow.name}</span>
+          Proposed by <span className="text-text font-semibold">{action.workflow?.name ?? "the assistant"}</span>
           {action.triggeredByObservation ? <> · triggered by “{action.triggeredByObservation.title}”</> : null}
         </div>
 

--- a/apps/web/src/app/api/approvals/route.ts
+++ b/apps/web/src/app/api/approvals/route.ts
@@ -94,8 +94,11 @@ export async function GET(request: NextRequest) {
       policyName: action_policy.name,
     })
     .from(action_request)
-    .innerJoin(workflow_run, eq(action_request.workflow_run_id, workflow_run.id))
-    .innerJoin(
+    // LEFT joins: chat-proposed admin actions (plugin/user/channel/data-source/
+    // source-config) carry no workflow_run_id — inner joins dropped them here
+    // while the badge counted them, leaving them unapprovable in the UI.
+    .leftJoin(workflow_run, eq(action_request.workflow_run_id, workflow_run.id))
+    .leftJoin(
       workflow_definition,
       eq(workflow_run.workflow_id, workflow_definition.id),
     )
@@ -131,7 +134,7 @@ export async function GET(request: NextRequest) {
     actions: sorted.map((r) => ({
       id: r.id,
       workflowRunId: r.workflowRunId,
-      workflow: { id: r.workflowId, name: r.workflowName },
+      workflow: r.workflowId ? { id: r.workflowId, name: r.workflowName } : null,
       triggeredByObservation: r.observationTitle
         ? { title: r.observationTitle }
         : null,
@@ -153,7 +156,7 @@ export async function GET(request: NextRequest) {
             : null,
       approverLabel: r.approvedByUserId ?? r.policyName ?? null,
       rejectionReason: r.rejectionReason,
-      runAt: (r.runStartedAt ?? r.runCreatedAt).toISOString(),
+      runAt: (r.runStartedAt ?? r.runCreatedAt ?? r.createdAt).toISOString(),
       createdAt: r.createdAt.toISOString(),
     })),
     count: sorted.length,

--- a/apps/web/src/app/api/work/threads/[threadId]/runs/route.ts
+++ b/apps/web/src/app/api/work/threads/[threadId]/runs/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { resolveAgentBackend, AgentBackendConfigError } from "@neko/llm";
+import {
+  resolveAgentBackend,
+  AgentBackendConfigError,
+  ensureHostConfigProvisioned,
+} from "@neko/llm";
 import {
   agentRuntimeDepsFromEnv,
   createWorkRun,
@@ -94,6 +98,11 @@ export async function POST(request: NextRequest, context: RouteContext) {
   // The web server stays the control plane, launches the box, and relays
   // events over the existing SSE.
   const broker = await ensureAgentBroker();
+
+  // Derive the agent-sandbox env (model egress, gateway provider, key alias)
+  // before the first launch — a fresh web process otherwise launches boxes
+  // that can't reach the model until a settings save re-provisions.
+  await ensureHostConfigProvisioned(orgId);
 
   void runChatTurn(
     {

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -14,6 +14,7 @@
     "test:e2e": "vitest run --config vitest.e2e.config.ts"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
     "@neko/channels": "workspace:*",
     "@neko/db": "workspace:*",
     "@neko/interaction": "workspace:*",
@@ -25,7 +26,6 @@
     "pg-boss": "^10.1.5",
     "tsx": "^4.19.2"
   },
-  "optionalDependencies": {},
   "devDependencies": {
     "@types/node": "^20",
     "@types/pg": "^8.20.0",

--- a/apps/worker/src/agent-sandbox/entry.ts
+++ b/apps/worker/src/agent-sandbox/entry.ts
@@ -77,12 +77,19 @@ export async function main(): Promise<void> {
     apiKey: process.env.ANTHROPIC_API_KEY ?? process.env.CLAUDE_API_KEY,
   });
 
-  // Only claude-agent's MCP tools touch the control plane mid-turn; hermes
-  // emits fences the host parses after the turn, so it needs no broker.
+  // MCP tools reach the control plane mid-turn through the broker — claude
+  // via in-process SDK servers, hermes via stdio bridge children that ACP
+  // launches from this path.
   const controlPlane =
     brokerUrl && brokerToken
       ? new BrokerControlPlane(brokerUrl, brokerToken)
       : undefined;
+  if (brokerUrl && brokerToken) {
+    process.env.OPENNEKO_MCP_BRIDGE = new URL(
+      "./mcp-bridge.ts",
+      import.meta.url,
+    ).pathname;
+  }
 
   const emit = (event: AgentEvent): Promise<void> => {
     emitLine(EVENT_MARKER, event);

--- a/apps/worker/src/agent-sandbox/entry.ts
+++ b/apps/worker/src/agent-sandbox/entry.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import {
   makeAgentBackend,
@@ -11,6 +11,7 @@ import {
   ensureGraphjinGuard,
   resolveBinaryOnPath,
   runAgentBackend,
+  sandboxReachableUrl,
   type RunAgentBackendInput,
 } from "@neko/llm/work";
 import { BrokerControlPlane } from "./broker-client";
@@ -44,6 +45,9 @@ interface SandboxJob {
   workspace: AgentWorkspace;
   /** GJ5: policy write grants resolved host-side (the box has no DB). */
   graphjinWriteGrants?: string[];
+  /** GJ6: the org's GraphJin MCP URL, resolved host-side. Lets the box
+   *  build a client.json even in legacy (token-less) mode. */
+  graphjinServerUrl?: string;
 }
 
 function requireEnv(name: string): string {
@@ -103,7 +107,34 @@ export async function main(): Promise<void> {
   const graphjinBinary = await resolveBinaryOnPath("graphjin");
   if (graphjinBinary) {
     const gjAuth = join(job.workspace.runRoot, "gj-auth");
-    const hasRunAuth = existsSync(join(gjAuth, "graphjin", "client.json"));
+    const clientJsonPath = join(gjAuth, "graphjin", "client.json");
+    let hasRunAuth = existsSync(clientJsonPath);
+    if (hasRunAuth) {
+      // The uploaded client.json holds the HOST's view of the server — a
+      // loopback URL points at the box itself here. Rewrite to the gateway's
+      // host alias.
+      const cfg = JSON.parse(readFileSync(clientJsonPath, "utf8")) as {
+        server?: string;
+      };
+      if (cfg.server) {
+        const reachable = sandboxReachableUrl(cfg.server);
+        if (reachable !== cfg.server) {
+          await writeFile(
+            clientJsonPath,
+            JSON.stringify({ ...cfg, server: reachable }),
+          );
+        }
+      }
+    } else if (job.graphjinServerUrl) {
+      // Legacy/anonymous data source: no token, but the CLI still needs a
+      // server URL (it has no default in the box).
+      await mkdir(join(gjAuth, "graphjin"), { recursive: true });
+      await writeFile(
+        clientJsonPath,
+        JSON.stringify({ server: sandboxReachableUrl(job.graphjinServerUrl) }),
+      );
+      hasRunAuth = true;
+    }
     await mkdir(job.workspace.binRoot, { recursive: true });
     await ensureGraphjinGuard(job.workspace.binRoot, graphjinBinary, {
       ...(hasRunAuth ? { xdgConfigHome: gjAuth } : {}),

--- a/apps/worker/src/agent-sandbox/mcp-bridge.ts
+++ b/apps/worker/src/agent-sandbox/mcp-bridge.ts
@@ -1,0 +1,135 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import {
+  buildAuditViewerServer,
+  buildChannelManagerServer,
+  buildDataSourceManagerServer,
+  buildPluginActionServer,
+  buildPluginManagerServer,
+  buildSkillBuilderServer,
+  buildSourceConfigManagerServer,
+  buildUserManagerServer,
+  buildWorkMemoryServer,
+  type PluginActionDescriptor,
+} from "@neko/llm/work";
+import { buildRuleBuilderServer, buildWorkflowBuilderServer } from "@neko/llm/workflows";
+import { BrokerControlPlane } from "./broker-client";
+
+/**
+ * Stdio MCP server for ACP backends (hermes). The agent process can't hand
+ * its in-process SDK server instances across a process boundary, so hermes'
+ * `session/new` mcpServers entries launch THIS script — one child per named
+ * server — and it rebuilds that server bound to the broker control plane
+ * (the same path claude's in-box tools use). Spawned by hermes inside the
+ * sandbox; never runs on the host.
+ *
+ * argv[2] = server name (agent-core's mcpServers map key). Per-run context
+ * arrives via env (agent-core's mcpBridgeEnv); broker coords inherit through
+ * the process env (entry.ts → hermes → here).
+ */
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`mcp-bridge: missing required env ${name}`);
+  return value;
+}
+
+export function buildBridgeServer(
+  name: string,
+  ctx: {
+    orgId: string;
+    threadId: string;
+    runId: string;
+    skillsRoot: string;
+    pluginActions: PluginActionDescriptor[];
+    controlPlane: BrokerControlPlane;
+  },
+): { instance: { connect: (t: Transport) => Promise<void> } } {
+  const { orgId, threadId, runId, skillsRoot, pluginActions, controlPlane } = ctx;
+  // Tool emits stream into the run on the in-process path; from a bridge
+  // child they have no channel back, and the durable effects (action
+  // requests, memory rows) persist via the control plane regardless.
+  const emit = () => {};
+  const common = { orgId, runId, emit, controlPlane };
+  switch (name) {
+    case "neko_skills":
+      return buildSkillBuilderServer(skillsRoot);
+    case "neko_memory":
+      return buildWorkMemoryServer({ orgId, threadId, runId }, { controlPlane });
+    case "neko_workflow_builder":
+      return buildWorkflowBuilderServer({
+        orgId,
+        createdByThreadId: threadId,
+        createdByRunId: runId,
+        emit,
+        controlPlane,
+      });
+    case "neko_rule_builder":
+      return buildRuleBuilderServer({
+        orgId,
+        createdByThreadId: threadId,
+        createdByRunId: runId,
+        emit,
+        controlPlane,
+      });
+    case "neko_plugin_manager":
+      return buildPluginManagerServer(common);
+    case "neko_user_manager":
+      return buildUserManagerServer(common);
+    case "neko_channel_manager":
+      return buildChannelManagerServer(common);
+    case "neko_data_source_manager":
+      return buildDataSourceManagerServer(common);
+    case "neko_source_config_manager":
+      return buildSourceConfigManagerServer(common);
+    case "neko_audit":
+      return buildAuditViewerServer({ orgId, runId, controlPlane });
+    case "neko_plugin_actions": {
+      const server = buildPluginActionServer({
+        orgId,
+        threadId,
+        runId,
+        descriptors: pluginActions,
+        emit,
+        controlPlane,
+      });
+      if (!server) throw new Error("mcp-bridge: no plugin actions in this run");
+      return server;
+    }
+    default:
+      throw new Error(`mcp-bridge: unknown server ${name}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const name = process.argv[2];
+  if (!name) throw new Error("mcp-bridge: missing server-name argument");
+  const controlPlane = new BrokerControlPlane(
+    requireEnv("OPENNEKO_BROKER_URL"),
+    requireEnv("OPENNEKO_BROKER_TOKEN"),
+  );
+  const server = buildBridgeServer(name, {
+    orgId: requireEnv("OPENNEKO_MCP_ORG_ID"),
+    threadId: requireEnv("OPENNEKO_MCP_THREAD_ID"),
+    runId: requireEnv("OPENNEKO_MCP_RUN_ID"),
+    skillsRoot: requireEnv("OPENNEKO_MCP_SKILLS_ROOT"),
+    pluginActions: JSON.parse(
+      process.env.OPENNEKO_MCP_PLUGIN_ACTIONS ?? "[]",
+    ) as PluginActionDescriptor[],
+    controlPlane,
+  });
+  await server.instance.connect(new StdioServerTransport());
+}
+
+const invokedDirectly =
+  process.argv[1]?.endsWith("mcp-bridge.ts") ||
+  process.argv[1]?.endsWith("mcp-bridge.js");
+if (invokedDirectly) {
+  main().catch((err: unknown) => {
+    console.error(
+      "[mcp-bridge] fatal:",
+      err instanceof Error ? err.message : String(err),
+    );
+    process.exit(1);
+  });
+}

--- a/apps/worker/test/agent-sandbox/mcp-bridge.test.ts
+++ b/apps/worker/test/agent-sandbox/mcp-bridge.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { buildBridgeServer } from "../../src/agent-sandbox/mcp-bridge.js";
+import { BrokerControlPlane } from "../../src/agent-sandbox/broker-client.js";
+
+const SERVERS = [
+  "neko_skills",
+  "neko_memory",
+  "neko_workflow_builder",
+  "neko_rule_builder",
+  "neko_plugin_manager",
+  "neko_user_manager",
+  "neko_channel_manager",
+  "neko_data_source_manager",
+  "neko_source_config_manager",
+  "neko_audit",
+  "neko_plugin_actions",
+];
+
+function ctx() {
+  return {
+    orgId: "org-1",
+    threadId: "11111111-1111-4111-8111-111111111111",
+    runId: "22222222-2222-4222-8222-222222222222",
+    skillsRoot: "/tmp/skills",
+    pluginActions: [
+      {
+        kind: "send_slack_message",
+        pluginId: "@open-neko/plugin-slack",
+        description: "send",
+        scope: "external" as const,
+      },
+    ],
+    controlPlane: new BrokerControlPlane("http://127.0.0.1:9", "tok"),
+  };
+}
+
+describe("mcp-bridge buildBridgeServer", () => {
+  it("constructs a connectable server for every name hermes mounts", () => {
+    for (const name of SERVERS) {
+      const server = buildBridgeServer(name, ctx());
+      expect(server.instance, name).toBeTruthy();
+      expect(typeof server.instance.connect, name).toBe("function");
+    }
+  });
+
+  it("throws on unknown server names", () => {
+    expect(() => buildBridgeServer("neko_nope", ctx())).toThrow(/unknown server/);
+  });
+});

--- a/packages/llm/src/agent-backend.ts
+++ b/packages/llm/src/agent-backend.ts
@@ -139,6 +139,11 @@ export type AgentRunOptions = {
   onEvent?: (event: AgentEvent) => Promise<void> | void;
   backendState?: Record<string, unknown>;
   mcpServers?: Record<string, unknown>;
+  /** Per-run context for backends that mount MCP servers as stdio child
+   *  processes (hermes/ACP) instead of in-process SDK instances. The bridge
+   *  entry (OPENNEKO_MCP_BRIDGE) rebuilds each named server from this env;
+   *  broker coords ride the process env. */
+  mcpBridgeEnv?: Record<string, string>;
   /** Web turn ⇒ the agent renders a2ui cards. Backends that can't take the
    *  in-process SDK card server (hermes) wire their own render tool when set.
    *  See docs/PER_CHANNEL_RENDERING.md. */

--- a/packages/llm/src/agent-backends/hermes-acp-client.ts
+++ b/packages/llm/src/agent-backends/hermes-acp-client.ts
@@ -57,7 +57,15 @@ export type AcpJsonRpcError = {
 export class AcpProtocolError extends Error {
   readonly code: number;
   constructor(err: AcpJsonRpcError) {
-    super(err.message);
+    // hermes puts the actionable cause in data.details ("No LLM provider
+    // configured…"); the message alone is often just "Internal error".
+    super(
+      err.data &&
+        typeof err.data === "object" &&
+        typeof (err.data as { details?: unknown }).details === "string"
+        ? `${err.message}: ${(err.data as { details: string }).details}`
+        : err.message,
+    );
     this.name = "AcpProtocolError";
     this.code = err.code;
   }

--- a/packages/llm/src/agent-backends/hermes-acp-client.ts
+++ b/packages/llm/src/agent-backends/hermes-acp-client.ts
@@ -101,6 +101,20 @@ export function createAcpClient(child: ChildProcess): AcpClient {
     closedResolve();
   };
 
+  const respond = (id: number, result?: unknown, error?: AcpJsonRpcError) => {
+    const frame =
+      JSON.stringify(
+        error
+          ? { jsonrpc: "2.0", id, error }
+          : { jsonrpc: "2.0", id, result: result ?? null },
+      ) + "\n";
+    try {
+      stdin.write(frame);
+    } catch {
+      // Child already gone; the close handler disposes.
+    }
+  };
+
   rl.on("line", (line) => {
     const trimmed = line.trim();
     if (!trimmed) return;
@@ -108,6 +122,36 @@ export function createAcpClient(child: ChildProcess): AcpClient {
     try {
       frame = JSON.parse(trimmed) as Record<string, unknown>;
     } catch {
+      return;
+    }
+    if (typeof frame.method === "string" && typeof frame.id === "number") {
+      // Inbound REQUEST from hermes (a response carries no method). Hermes
+      // ≥0.14 asks terminal/tool permission over ACP — unanswered, the tool
+      // fails as "User denied", which cuts off the CLI data path. The
+      // sandbox + graphjin guard are the enforcement boundary here, so
+      // approve; everything else gets a definitive method-not-found.
+      if (frame.method === "session/request_permission") {
+        const params = (frame.params ?? {}) as {
+          options?: Array<{ optionId?: unknown; kind?: unknown }>;
+        };
+        const options = Array.isArray(params.options) ? params.options : [];
+        const allow =
+          options.find((o) => o.kind === "allow_once") ??
+          options.find((o) => o.kind === "allow_always") ??
+          options[0];
+        if (allow && typeof allow.optionId === "string") {
+          respond(frame.id, {
+            outcome: { outcome: "selected", optionId: allow.optionId },
+          });
+        } else {
+          respond(frame.id, { outcome: { outcome: "cancelled" } });
+        }
+        return;
+      }
+      respond(frame.id, undefined, {
+        code: -32601,
+        message: `method not supported: ${frame.method}`,
+      });
       return;
     }
     if (typeof frame.id === "number") {

--- a/packages/llm/src/agent-backends/hermes.ts
+++ b/packages/llm/src/agent-backends/hermes.ts
@@ -405,11 +405,15 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
     const bridgeServers =
       bridgePath && mcpBridgeEnv
         ? mcpServerNames
-            .filter((n) => n !== "neko_ui")
+            // neko_ui has its own stub; names are our map keys — the regex
+            // guards the shell interpolation below.
+            .filter((n) => n !== "neko_ui" && /^[a-z0-9_]+$/.test(n))
             .map((name) => ({
               name,
-              command: process.execPath,
-              args: ["--import", "tsx/esm", bridgePath, name],
+              // cd /app first: hermes spawns MCP children with the session
+              // cwd (/sandbox/…), where `--import tsx/esm` cannot resolve.
+              command: "/bin/sh",
+              args: ["-c", `cd /app && exec node --import tsx/esm ${bridgePath} ${name}`],
               env: bridgeEnv,
             }))
         : [];

--- a/packages/llm/src/agent-backends/hermes.ts
+++ b/packages/llm/src/agent-backends/hermes.ts
@@ -176,9 +176,11 @@ const DEFAULT_TIMEOUT_MS = 5 * 60_000;
 export class HermesBackend implements AgentBackend {
   readonly id = "hermes" as const;
   readonly capabilities = {
-    // ACP doesn't expose any of these to the runtime. Surfaces come via fence
-    // (see surface.ts); skills/memory only via prompt-mediated shell calls.
-    mcpTools: false,
+    // ACP mounts MCP servers as stdio children (session/new mcpServers) — the
+    // neko servers ride a bridge process (OPENNEKO_MCP_BRIDGE) that rebuilds
+    // each one over the broker control plane. Surfaces still come via fence
+    // (see surface.ts).
+    mcpTools: true,
     sdkStopHook: false,
     sessionResume: false,
     canUseToolGate: false,
@@ -224,6 +226,8 @@ export class HermesBackend implements AgentBackend {
           signal,
           onEvent,
           wantsCards,
+          mcpServerNames: Object.keys(opts.mcpServers ?? {}),
+          mcpBridgeEnv: opts.mcpBridgeEnv,
         });
         if (out.error) {
           lastErr = new Error(out.error);
@@ -271,6 +275,8 @@ type RunOnceArgs = {
   signal: AbortSignal | undefined;
   onEvent: AgentRunOptions["onEvent"];
   wantsCards: boolean;
+  mcpServerNames: string[];
+  mcpBridgeEnv: Record<string, string> | undefined;
 };
 
 type RunOnceOutcome = {
@@ -290,6 +296,8 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
     signal,
     onEvent,
     wantsCards,
+    mcpServerNames,
+    mcpBridgeEnv,
   } = args;
 
   let cwd: string;
@@ -383,12 +391,34 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
     });
 
     // session/new per turn — see file header for the session/load double-count rationale.
-    // TODO: verify whether Hermes ACP honors user-supplied mcpServers.
-    // session/new per turn — see file header for the session/load double-count rationale.
     // Web turns get the render_cards MCP server so the model renders cards.
-    const mcpServers = wantsCards
-      ? [{ name: RENDER_MCP_SERVER_NAME, command: process.execPath, args: [ensureRenderStub()], env: [] }]
-      : [];
+    // The neko tool servers mount as stdio bridge children when a bridge entry
+    // is available (in-box: entry.ts sets OPENNEKO_MCP_BRIDGE; broker coords
+    // ride the process env down to each child).
+    const bridgePath = process.env.OPENNEKO_MCP_BRIDGE;
+    const bridgeEnv = [
+      ...Object.entries(mcpBridgeEnv ?? {}),
+      ...["OPENNEKO_BROKER_URL", "OPENNEKO_BROKER_TOKEN"]
+        .map((k) => [k, process.env[k] ?? ""])
+        .filter(([, v]) => v),
+    ].map(([name, value]) => ({ name, value }));
+    const bridgeServers =
+      bridgePath && mcpBridgeEnv
+        ? mcpServerNames
+            .filter((n) => n !== "neko_ui")
+            .map((name) => ({
+              name,
+              command: process.execPath,
+              args: ["--import", "tsx/esm", bridgePath, name],
+              env: bridgeEnv,
+            }))
+        : [];
+    const mcpServers = [
+      ...(wantsCards
+        ? [{ name: RENDER_MCP_SERVER_NAME, command: process.execPath, args: [ensureRenderStub()], env: [] }]
+        : []),
+      ...bridgeServers,
+    ];
     const fresh = await client.request<{ sessionId: string }>("session/new", {
       cwd,
       mcpServers,

--- a/packages/llm/src/host-provision.ts
+++ b/packages/llm/src/host-provision.ts
@@ -378,6 +378,27 @@ async function provisionOpenShellRuntime(orgId: string, backend: string): Promis
   );
 }
 
+const provisionedOrgs = new Map<string, Promise<void>>();
+
+/**
+ * provisionHostConfig, once per org per process. The worker provisions at
+ * boot, but the web process used to derive the agent-sandbox env (model
+ * egress, gateway provider, key alias) only on a settings save — so every
+ * web restart silently launched sandboxes that couldn't reach the model
+ * until someone re-saved settings. Run paths call this instead.
+ */
+export function ensureHostConfigProvisioned(orgId: string): Promise<void> {
+  let p = provisionedOrgs.get(orgId);
+  if (!p) {
+    p = provisionHostConfig(orgId).catch((err) => {
+      provisionedOrgs.delete(orgId);
+      throw err;
+    });
+    provisionedOrgs.set(orgId, p);
+  }
+  return p;
+}
+
 export async function provisionHostConfig(orgId: string): Promise<void> {
   try {
     await provisionGraphJin(orgId);

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -30,7 +30,10 @@ export {
   UpstreamProviderError,
   detectUpstreamError,
 } from "./agent-error";
-export { provisionHostConfig } from "./host-provision";
+export {
+  ensureHostConfigProvisioned,
+  provisionHostConfig,
+} from "./host-provision";
 export {
   prefetchKnowledgePack,
   prefetchKnowledgeForOrg,

--- a/packages/llm/src/work/agent-core.ts
+++ b/packages/llm/src/work/agent-core.ts
@@ -145,6 +145,18 @@ export async function runAgentBackend(
     backendState,
     onEvent: emit,
     mcpServers,
+    // ACP backends mount the same servers as stdio bridge children — ship the
+    // per-run context the bridge needs to rebuild them (broker coords ride the
+    // process env; see apps/worker/src/agent-sandbox/mcp-bridge.ts).
+    mcpBridgeEnv: mcp
+      ? {
+          OPENNEKO_MCP_ORG_ID: orgId,
+          OPENNEKO_MCP_THREAD_ID: threadId,
+          OPENNEKO_MCP_RUN_ID: runId,
+          OPENNEKO_MCP_SKILLS_ROOT: workspace.skillsRoot,
+          OPENNEKO_MCP_PLUGIN_ACTIONS: JSON.stringify(pluginActions ?? []),
+        }
+      : undefined,
     wantsCards,
     tag: `work ${runId}`,
     signal,

--- a/packages/llm/src/work/index.ts
+++ b/packages/llm/src/work/index.ts
@@ -5,9 +5,17 @@ export * from "./behavior-monitor";
 export * from "./deployment-profile";
 export { buildWorkPrompt } from "./prompt";
 export {
+  buildAuditViewerServer,
+  buildChannelManagerServer,
+  buildDataSourceManagerServer,
+  buildPluginActionServer,
+  buildPluginManagerServer,
   buildRenderCardsServer,
   buildSkillBuilderServer,
+  buildSourceConfigManagerServer,
+  buildUserManagerServer,
   buildWorkMemoryServer,
+  type PluginActionDescriptor,
 } from "./tools";
 export {
   InProcessControlPlane,

--- a/packages/llm/src/work/index.ts
+++ b/packages/llm/src/work/index.ts
@@ -1,4 +1,5 @@
 export * from "./workspace";
+export * from "./sandbox-net";
 export * from "./graphjin-guard";
 export * from "./graphjin-actor-guard";
 export * from "./behavior-monitor";

--- a/packages/llm/src/work/sandbox-launcher.ts
+++ b/packages/llm/src/work/sandbox-launcher.ts
@@ -6,6 +6,7 @@ import { createInterface } from "node:readline";
 import type { AgentEvent, AgentRunResult } from "../agent-backend";
 import type { RunAgentBackendInput } from "./agent-core";
 import type { RunChatTurnDeps } from "./run-chat-turn";
+import { isLoopbackHost, SANDBOX_HOST_ALIAS } from "./sandbox-net";
 
 // Wire protocol shared with the in-image entrypoint. The agent runs in a
 // separate container, so these can't share a module at runtime — they MUST
@@ -127,6 +128,14 @@ export function makeSandboxRunCore(opts: SandboxLauncherOptions): RunCore {
       input.runId,
     );
 
+    // GJ6: the box must reach the org's GraphJin server — resolved here
+    // (host-side, where the DB lives) both for the egress rule and for the
+    // in-box client.json (entry.ts rewrites loopback to the host alias).
+    const dataEgress = await resolveDataSourceEgress(
+      input.orgId,
+      opts.graphjinBinaryInBox ?? "/usr/local/bin/graphjin",
+    );
+
     const job = {
       orgId: input.orgId,
       threadId: input.threadId,
@@ -144,6 +153,7 @@ export function makeSandboxRunCore(opts: SandboxLauncherOptions): RunCore {
       wantsCards: input.wantsCards ?? true,
       workspace: boxWorkspace,
       ...(graphjinWriteGrants.length > 0 ? { graphjinWriteGrants } : {}),
+      ...(dataEgress.serverUrl ? { graphjinServerUrl: dataEgress.serverUrl } : {}),
     };
 
     const stageDir = await mkdtemp(path.join(tmpdir(), "oss-agent-"));
@@ -187,17 +197,10 @@ export function makeSandboxRunCore(opts: SandboxLauncherOptions): RunCore {
             ];
           })()
         : [];
-      // GJ6: the box must reach the org's GraphJin server — allow its
-      // host:port for the in-box graphjin CLI (and node, for claude's
-      // MCP fetch path).
-      const dataEgress = await resolveDataSourceEgress(
-        input.orgId,
-        opts.graphjinBinaryInBox ?? "/usr/local/bin/graphjin",
-      );
       const policyArgs = buildModelEgressArgs(name, [
         ...(opts.modelEgress ?? []),
         ...brokerEgress,
-        ...dataEgress,
+        ...dataEgress.rules,
       ]);
       if (policyArgs) await run(policyArgs, 75_000);
 
@@ -250,7 +253,10 @@ export function makeSandboxRunCore(opts: SandboxLauncherOptions): RunCore {
 async function resolveDataSourceEgress(
   orgId: string,
   graphjinBinary: string,
-): Promise<Array<{ host: string; binary: string; port?: number }>> {
+): Promise<{
+  rules: Array<{ host: string; binary: string; port?: number }>;
+  serverUrl?: string;
+}> {
   try {
     const { data_source, db, desc, eq } = await import("@neko/db");
     const [src] = await db()
@@ -259,15 +265,22 @@ async function resolveDataSourceEgress(
       .where(eq(data_source.org_id, orgId))
       .orderBy(desc(data_source.is_default), data_source.created_at)
       .limit(1);
-    if (!src?.mcpUrl) return [];
+    if (!src?.mcpUrl) return { rules: [] };
     const u = new URL(src.mcpUrl);
     const port = Number(u.port) || (u.protocol === "https:" ? 443 : 80);
-    return [{ host: u.hostname, port, binary: graphjinBinary }];
+    // A host-local server (localhost data source) is only reachable from
+    // the box via the gateway's host alias — and the proxy refuses loopback
+    // endpoint rules outright, which would kill the whole policy update.
+    const host = isLoopbackHost(u.hostname) ? SANDBOX_HOST_ALIAS : u.hostname;
+    return {
+      rules: [{ host, port, binary: graphjinBinary }],
+      serverUrl: src.mcpUrl,
+    };
   } catch (err) {
     console.warn(
       `[agent-sandbox] data-source egress lookup failed: ${err instanceof Error ? err.message : err}`,
     );
-    return [];
+    return { rules: [] };
   }
 }
 

--- a/packages/llm/src/work/sandbox-net.ts
+++ b/packages/llm/src/work/sandbox-net.ts
@@ -1,0 +1,27 @@
+/**
+ * Host networking as seen from inside an OpenShell sandbox. Loopback on the
+ * host is unreachable from a box (it resolves to the box itself, and the
+ * gateway's egress proxy refuses loopback endpoint rules outright) — the
+ * gateway exposes the host as `host.openshell.internal` instead.
+ */
+export const SANDBOX_HOST_ALIAS = "host.openshell.internal";
+
+const LOOPBACK_HOST =
+  /^(localhost|127(?:\.\d{1,3}){3}|0\.0\.0\.0|\[?::1?\]?)$/iu;
+
+export function isLoopbackHost(hostname: string): boolean {
+  return LOOPBACK_HOST.test(hostname);
+}
+
+/** Rewrite a host-loopback URL to its sandbox-reachable form; other URLs
+ *  (and unparseable strings) pass through unchanged. */
+export function sandboxReachableUrl(raw: string): string {
+  try {
+    const u = new URL(raw);
+    if (!isLoopbackHost(u.hostname)) return raw;
+    u.hostname = SANDBOX_HOST_ALIAS;
+    return u.toString();
+  } catch {
+    return raw;
+  }
+}

--- a/packages/llm/test/agent-backends/hermes-acp-client.test.ts
+++ b/packages/llm/test/agent-backends/hermes-acp-client.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { PassThrough } from "node:stream";
+import type { ChildProcess } from "node:child_process";
+import { createAcpClient } from "../../src/agent-backends/hermes-acp-client";
+
+function makeFakeChild() {
+  const stdout = new PassThrough();
+  const stdin = new PassThrough();
+  const written: string[] = [];
+  stdin.on("data", (d: Buffer) => written.push(d.toString("utf8")));
+  const child = {
+    stdout,
+    stdin,
+    on: () => child,
+  } as unknown as ChildProcess;
+  return { child, stdout, written };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 10));
+
+describe("createAcpClient inbound requests", () => {
+  it("approves session/request_permission with the allow_once option", async () => {
+    const { child, stdout, written } = makeFakeChild();
+    createAcpClient(child);
+    stdout.write(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 7,
+        method: "session/request_permission",
+        params: {
+          sessionId: "s1",
+          options: [
+            { optionId: "reject", kind: "reject_once" },
+            { optionId: "yes-once", kind: "allow_once" },
+            { optionId: "yes-always", kind: "allow_always" },
+          ],
+        },
+      }) + "\n",
+    );
+    await flush();
+    const res = JSON.parse(written.join("").trim());
+    expect(res).toEqual({
+      jsonrpc: "2.0",
+      id: 7,
+      result: { outcome: { outcome: "selected", optionId: "yes-once" } },
+    });
+  });
+
+  it("answers unknown inbound requests with method-not-found instead of silence", async () => {
+    const { child, stdout, written } = makeFakeChild();
+    createAcpClient(child);
+    stdout.write(
+      JSON.stringify({ jsonrpc: "2.0", id: 9, method: "fs/read_text_file", params: {} }) + "\n",
+    );
+    await flush();
+    const res = JSON.parse(written.join("").trim());
+    expect(res.id).toBe(9);
+    expect(res.error.code).toBe(-32601);
+  });
+
+  it("still resolves our own outbound requests from response frames", async () => {
+    const { child, stdout, written } = makeFakeChild();
+    const client = createAcpClient(child);
+    const p = client.request("session/new", {});
+    await flush();
+    const sent = JSON.parse(written.join("").trim());
+    stdout.write(
+      JSON.stringify({ jsonrpc: "2.0", id: sent.id, result: { sessionId: "s2" } }) + "\n",
+    );
+    await expect(p).resolves.toEqual({ sessionId: "s2" });
+  });
+});

--- a/packages/llm/test/work/sandbox-net.test.ts
+++ b/packages/llm/test/work/sandbox-net.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  isLoopbackHost,
+  SANDBOX_HOST_ALIAS,
+  sandboxReachableUrl,
+} from "../../src/work/sandbox-net";
+
+describe("sandbox-net", () => {
+  it("classifies loopback hosts", () => {
+    for (const h of ["localhost", "LOCALHOST", "127.0.0.1", "127.1.2.3", "0.0.0.0", "::1", "[::1]"]) {
+      expect(isLoopbackHost(h), h).toBe(true);
+    }
+    for (const h of ["host.openshell.internal", "db.example.com", "10.0.0.5", "127a"]) {
+      expect(isLoopbackHost(h), h).toBe(false);
+    }
+  });
+
+  it("rewrites loopback URLs to the gateway host alias, keeping port and path", () => {
+    expect(sandboxReachableUrl("http://localhost:8080/api/v1/mcp")).toBe(
+      `http://${SANDBOX_HOST_ALIAS}:8080/api/v1/mcp`,
+    );
+    expect(sandboxReachableUrl("https://127.0.0.1/x")).toBe(
+      `https://${SANDBOX_HOST_ALIAS}/x`,
+    );
+  });
+
+  it("passes non-loopback and unparseable values through", () => {
+    expect(sandboxReachableUrl("https://gj.prod.example:443/api")).toBe(
+      "https://gj.prod.example:443/api",
+    );
+    expect(sandboxReachableUrl("not a url")).toBe("not a url");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
 
   apps/worker:
     dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: 1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@neko/channels':
         specifier: workspace:*
         version: link:../../packages/channels


### PR DESCRIPTION
## Hermes full MCP tool support
ACP's `session/new` accepts stdio `mcpServers` — hermes now mounts every neko server (skills, memory, workflow/rule builders, plugin/user/channel/data-source/source-config managers, audit, plugin actions), closing the chat-first-admin gap on the hermes backend. The in-process SDK instances can't cross a process boundary, so a bridge entry in the agent image (`mcp-bridge.ts`) rebuilds the named server over the broker control plane — the same path claude's in-box tools use.

**Proven live end-to-end:** hermes called `mcp_neko_plugin_manager_list_plugins` / `mcp_neko_channel_manager_list_channels`, proposed `plugin_uninstall @open-neko/plugin-slack` (HIGH risk, policy-gated), the approval cards rendered in /actions, all three proposals were human-rejected with reasons, and the audit chain recorded it.

Getting there surfaced and fixed three layers of silent failure:
1. **The agent image's hermes venv lacked the `mcp` python package** — hermes's `register_mcp_servers` no-ops at DEBUG when `import mcp` fails. Dockerfile now installs `--with mcp --with websockets` and *asserts the import at build time*.
2. **Hermes spawns MCP children with the session cwd** (`/sandbox`), where `--import tsx/esm` can't resolve — bridge commands `cd /app` first.
3. **ACP errors dropped `data.details`** — runs failed with bare "Internal error" while the actionable cause ("No LLM provider configured…") was discarded. Now surfaced.

## Also in this PR
- **Approvals UI: chat-proposed admin actions were unapprovable** — the list inner-joined `workflow_run`, so run-less requests were badge-counted but invisible in every tab, pending forever. Left-joined + null-safe ("Proposed by the assistant"), each run-less request groups alone.
- **Cherry-picked from the half-merged #108** (its branch auto-deleted before the last two commits were pushed): host-local data-source reachability from sandboxes (loopback → `host.openshell.internal` + in-box client.json), web run-path provisioning (`ensureHostConfigProvisioned` — chat no longer breaks after a web restart until a settings save), and the hermes permission-request handler.

## Tests
- New: `mcp-bridge.test.ts` (server construction for all 11 names), `hermes-acp-client.test.ts` (permission approve / method-not-found / response routing), `sandbox-net.test.ts` (loopback aliasing).
- Full suites green with verified exit codes: llm 520, worker 270, web 232. Worker + web typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)