### PR TITLE
feat: free-text personas in onboarding (solo + multi-user) and a 2-card briefing grid

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -63,7 +63,8 @@
 :root,
 html[data-density="compact"] {
   --d-dash-width: 1200px;
-  --d-brief-cols: repeat(auto-fill, minmax(300px, 1fr));
+  /* Cap at TWO cards side by side — charts need the width to stay legible. */
+  --d-brief-cols: repeat(2, minmax(0, 1fr));
   --d-brief-gap: 12px;
   --d-greet: 30px;
   --d-section-gap: 22px;
@@ -106,6 +107,9 @@ html[data-density="comfortable"] {
 
 .brief-grid {
   display: grid; grid-template-columns: var(--d-brief-cols); gap: var(--d-brief-gap); align-items: start;
+}
+@media (max-width: 700px) {
+  .brief-grid { grid-template-columns: 1fr; }
 }
 .brief-grid .icard { margin-bottom: 0; }
 .dash-root .icard { padding: var(--d-icard-pad); cursor: default; }

--- a/apps/web/src/app/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/app/onboarding/OnboardingWizard.tsx
@@ -11,7 +11,11 @@ const INPUT_CLS =
   "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-[15px] font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
 const LABEL_CLS = "text-[14px] font-semibold text-text";
 
-const ALL_SEATS = ["CEO", "CFO", "CRO", "COO", "CIO", "CPO"] as const;
+// Quick-pick suggestions only — seats are free text (CV3 personas). A
+// custom role flows through metrics, briefing tabs, and the persona
+// prompt the same as these.
+const SUGGESTED_SEATS = ["CEO", "CFO", "CRO", "COO", "CIO", "CPO"];
+const MAX_SEAT_LENGTH = 40;
 const MONTHS = [
   "January", "February", "March", "April", "May", "June",
   "July", "August", "September", "October", "November", "December",
@@ -43,6 +47,7 @@ export default function OnboardingWizard({ initial = EMPTY_INITIAL }: { initial?
   const [seats, setSeats] = useState<string[]>(
     initial.activeSeats.length > 0 ? initial.activeSeats : ["CEO"],
   );
+  const [customSeat, setCustomSeat] = useState("");
   const [prioritiesText, setPrioritiesText] = useState(initial.priorities.join("\n"));
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -77,6 +82,15 @@ export default function OnboardingWizard({ initial = EMPTY_INITIAL }: { initial?
     setSeats((prev) =>
       prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s],
     );
+  };
+
+  const addCustomSeat = () => {
+    const s = customSeat.trim().slice(0, MAX_SEAT_LENGTH);
+    if (!s) return;
+    setSeats((prev) =>
+      prev.some((x) => x.toLowerCase() === s.toLowerCase()) ? prev : [...prev, s],
+    );
+    setCustomSeat("");
   };
 
   const submit = async () => {
@@ -151,9 +165,9 @@ export default function OnboardingWizard({ initial = EMPTY_INITIAL }: { initial?
           />
         </Field>
 
-        <Field label="Which CXO seats are active?">
+        <Field label="Which seats are active? Pick or add your own.">
           <div className="flex gap-[7px] flex-wrap">
-            {ALL_SEATS.map((s) => {
+            {[...SUGGESTED_SEATS, ...seats.filter((s) => !SUGGESTED_SEATS.includes(s))].map((s) => {
               const isOn = seats.includes(s);
               return (
                 <button
@@ -172,6 +186,29 @@ export default function OnboardingWizard({ initial = EMPTY_INITIAL }: { initial?
                 </button>
               );
             })}
+          </div>
+          <div className="flex gap-[7px] mt-2">
+            <input
+              className={INPUT_CLS + " flex-1"}
+              value={customSeat}
+              maxLength={MAX_SEAT_LENGTH}
+              placeholder="Add your own — e.g. Head of Ops, VP Sales"
+              onChange={(e) => setCustomSeat(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key !== "Enter") return;
+                e.preventDefault();
+                addCustomSeat();
+              }}
+              aria-label="Add a custom seat"
+            />
+            <button
+              type="button"
+              onClick={addCustomSeat}
+              disabled={!customSeat.trim()}
+              className="px-4.5 rounded-xl border-[1.5px] border-border font-body text-[14.5px] font-medium cursor-pointer text-text2 hover:border-accent hover:text-accent disabled:opacity-40 disabled:cursor-default"
+            >
+              Add
+            </button>
           </div>
         </Field>
 

--- a/apps/web/src/app/onboarding/PersonaStep.tsx
+++ b/apps/web/src/app/onboarding/PersonaStep.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+const INPUT_CLS =
+  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-[15px] font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)] w-full";
+
+/**
+ * Per-user onboarding (CV3): members joining an already-onboarded org
+ * describe their role in their own words. Writes their operator_profile
+ * row; the agent's <operator-profile> block picks it up on their next run.
+ */
+export default function PersonaStep({ initialRoleTemplate }: { initialRoleTemplate: string }) {
+  const router = useRouter();
+  const [roleTemplate, setRoleTemplate] = useState(initialRoleTemplate);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async () => {
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/settings/persona", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ roleTemplate }),
+      });
+      if (!res.ok) throw new Error(`save failed (${res.status})`);
+      router.push("/");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="max-w-[560px] mx-auto px-5 py-12">
+      <h1 className="font-display text-[26px] font-extrabold tracking-[-0.02em] text-text">
+        What do you do here?
+      </h1>
+      <p className="text-[14.5px] text-text2 mt-2 leading-[1.55]">
+        Your workspace is already set up. Describe your role in your own words —
+        briefings, answers, and priorities get tailored to it. You can change
+        this anytime in Settings.
+      </p>
+      <textarea
+        className={INPUT_CLS + " mt-5"}
+        rows={4}
+        value={roleTemplate}
+        onChange={(e) => setRoleTemplate(e.target.value)}
+        placeholder={
+          "e.g. I run EU wholesale operations — I care about stock-outs, reorder lead times, and margin on the top 50 SKUs."
+        }
+        aria-label="Describe your role"
+      />
+      {error && <div className="text-[13px] text-red-600 mt-2">{error}</div>}
+      <div className="flex gap-3 mt-5">
+        <button
+          type="button"
+          onClick={submit}
+          disabled={submitting || !roleTemplate.trim()}
+          className="px-5 py-2.5 rounded-full bg-text text-bg font-body text-[14.5px] font-semibold cursor-pointer disabled:opacity-40 disabled:cursor-default"
+        >
+          {submitting ? "Saving…" : "Save and continue"}
+        </button>
+        <button
+          type="button"
+          onClick={() => router.push("/")}
+          className="px-5 py-2.5 rounded-full border-[1.5px] border-border text-text2 font-body text-[14.5px] font-medium cursor-pointer hover:border-accent hover:text-accent"
+        >
+          Skip for now
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -2,9 +2,12 @@ import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { connection } from "next/server";
 import { db, eq, onboarding_wizard, organization } from "@neko/db";
+import { getOperatorProfile } from "@neko/llm/work";
 import { getOrgId } from "@/lib/db";
+import { getCurrentActor } from "@/lib/actor";
 import { getSetupCompleteAt } from "@/lib/org-state";
 import OnboardingWizard, { type WizardInitial } from "./OnboardingWizard";
+import PersonaStep from "./PersonaStep";
 
 const ORG_NAME_STUB = "My Workspace";
 
@@ -14,6 +17,20 @@ export default async function OnboardingPage() {
   const setupCompleteAt = await getSetupCompleteAt(orgId);
   if (!setupCompleteAt) {
     redirect("/settings");
+  }
+
+  // CV3: onboarding is mode-aware. The ORG wizard below is the admin's
+  // one-time setup; a MEMBER landing here after the org is set up gets the
+  // per-user persona step instead (their operator_profile row drives the
+  // agent's <operator-profile> block for their runs).
+  const actor = await getCurrentActor();
+  if (actor.role === "member" && actor.userId) {
+    const profile = await getOperatorProfile(orgId, actor.userId);
+    return (
+      <Suspense fallback={null}>
+        <PersonaStep initialRoleTemplate={profile?.roleTemplate ?? ""} />
+      </Suspense>
+    );
   }
 
   const [wizardRows, orgRows] = await Promise.all([


### PR DESCRIPTION
Three UX gaps called out while testing production:

1. **Onboarding seats were a hardcoded enum** (`CEO/CFO/CRO/COO/CIO/CPO`) even though CV3's persona backend takes free text everywhere. They're now quick-pick suggestions plus an "add your own" input ("Head of Ops", "VP Sales"…). `MetricAgentInput.role` widened to `string` is unnecessary — downstream (`ROLE_FOCUS` fallback, `discovery-pathways`, submit route) already accepts arbitrary strings.

2. **Onboarding now works in multi-user mode**: `/onboarding` is mode-aware. Admin + un-onboarded org → the org wizard (unchanged). A **member** on an onboarded org → a lightweight persona step ("What do you do here?") that writes their `operator_profile` row via `/api/settings/persona` — the agent's `<operator-profile>` block picks it up on their next run. Skippable; editable later in Settings.

3. **Briefing grid caps at 2 metric cards side-by-side** (1 below 700px) — `auto-fill minmax(300px,1fr)` packed 3–4 on wide screens and crushed the charts.

No seed/schema changes needed: `active_seats` stays a string array; seeded values render as selected chips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)