### PR TITLE
fix: demo seed uses the decrypted rotated DB password

### DIFF
--- a/packages/db/src/seed-adventureworks.mjs
+++ b/packages/db/src/seed-adventureworks.mjs
@@ -42,6 +42,13 @@ const localConfig = await readLocalConfig();
 const localPg = localConfig.pg && typeof localConfig.pg === "object"
   ? localConfig.pg
   : {};
+// config.json stores the rotated password ENCRYPTED (enc:v1, see
+// writeLocalConfig) — using it raw fails auth on any deployment where the
+// wizard's password step ran. Decrypt like every other reader.
+if (typeof localPg.password === "string" && localPg.password.startsWith("enc:")) {
+  const { maybeDecryptSecret } = await import("@neko/secret-crypt");
+  localPg.password = maybeDecryptSecret(localPg.password);
+}
 const sslmode = localPg.sslmode ?? process.env.NEKO_PG_SSLMODE;
 const client = new pg.Client({
   host: localPg.host ?? process.env.NEKO_PG_HOST ?? "localhost",


### PR DESCRIPTION
Third and final seed bug from the production cutover: `writeLocalConfig` stores `pg.password` encrypted (`enc:v1…`) in config.json and every reader decrypts via `@neko/secret-crypt` — except `seed-adventureworks.mjs`, which used the ciphertext literally. Net effect: once the wizard's password step has run, every demo-stack restart fails its seed with `password authentication failed for user "neko"`.

Verified the mechanism on neko-vm: a credential probe with the raw config value fails identically; web/worker connect fine because they decrypt.

(Sequence for the record: seed bug #1 was the CV1 `ON CONFLICT` target — fixed in #116; #2 was the sources-mode `GJ_DATABASE_*` env crash-loop — fixed in #118; this is #3.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)