### PR TITLE
ci: deploy job GCs superseded images (ENOSPC twice)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -61,6 +61,17 @@ jobs:
             cd ~/openneko
             OPENNEKO_PORT=80 openneko start --mode demo --detach
             openneko status || true
+
+            # GC superseded OpenNeko images: every release pulls ~15GB and
+            # the disk fills after a few versions (two deploys have already
+            # died on ENOSPC). In-use tags survive (rmi refuses); non-fatal.
+            CUR=$(openneko version 2>/dev/null || true)
+            if [ -n "$CUR" ]; then
+              docker images --format '{{.Repository}}:{{.Tag}}' \
+                | grep '^ghcr.io/open-neko/' \
+                | grep -v ":v$CUR\$" \
+                | xargs -r docker rmi 2>/dev/null || true
+            fi
           EOF
 
       - name: Smoke test


### PR DESCRIPTION
Each release pulls ~15GB of OpenNeko images onto neko-vm's 58GB disk; superseded versions accumulate and the deploy dies on `no space left on device` — happened on the v2.2.1 cutover and again on v2.3.1. After a successful `openneko start`, the job now removes `ghcr.io/open-neko/*` tags other than the running version (in-use images survive; step is non-fatal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)