### PR TITLE
fix: gateway DB URL tracks the rotated password — agent runs survive the setup wizard

### DIFF
--- a/apps/openneko/internal/cli/openshell_test.go
+++ b/apps/openneko/internal/cli/openshell_test.go
@@ -1,6 +1,10 @@
 package cli
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestAgentImageRef(t *testing.T) {
 	if got := agentImageRef("", "v1.2.3"); got != "ghcr.io/open-neko/agent:v1.2.3" {
@@ -23,5 +27,39 @@ func TestOpenShellStateDirOverride(t *testing.T) {
 	// An explicit existing value is always respected (no override).
 	if got := openShellStateDirOverride("darwin", "/Users/x", "/custom/state"); got != "" {
 		t.Fatalf("existing value must win: got %q", got)
+	}
+}
+
+func TestConfigureOpenShellDBURL(t *testing.T) {
+	// Operator-set URL always wins.
+	t.Setenv("OPENSHELL_DB_URL", "postgres://op:set@elsewhere:5432/db")
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	configureOpenShellDBURL()
+	if got := os.Getenv("OPENSHELL_DB_URL"); got != "postgres://op:set@elsewhere:5432/db" {
+		t.Fatalf("operator value must win: got %q", got)
+	}
+
+	// No local config -> leave unset so the compose default applies.
+	t.Setenv("OPENSHELL_DB_URL", "")
+	configureOpenShellDBURL()
+	if got := os.Getenv("OPENSHELL_DB_URL"); got != "" {
+		t.Fatalf("fresh install should not set the URL: got %q", got)
+	}
+
+	// Rotated password in config.json -> URL derived from it, host pinned to
+	// the compose network, special characters escaped.
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	if err := os.MkdirAll(filepath.Join(dir, "openneko"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := `{"pg":{"user":"neko","password":"p@ss:w/rd","database":"neko"}}`
+	if err := os.WriteFile(filepath.Join(dir, "openneko", "config.json"), []byte(cfg), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OPENSHELL_DB_URL", "")
+	configureOpenShellDBURL()
+	if got := os.Getenv("OPENSHELL_DB_URL"); got != "postgres://neko:p%40ss%3Aw%2Frd@neko-db:5432/neko" {
+		t.Fatalf("derived URL wrong: got %q", got)
 	}
 }

--- a/apps/openneko/internal/cli/start.go
+++ b/apps/openneko/internal/cli/start.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -52,6 +53,7 @@ Modes:
 			if err := configureOpenShellStateDir(); err != nil {
 				return err
 			}
+			configureOpenShellDBURL()
 
 			sup := compose.New(assets.ComposeFS)
 			files, err := sup.Materialize(m)
@@ -159,6 +161,42 @@ func configureOpenShellStateDir() error {
 		return err
 	}
 	return os.Setenv("OPENSHELL_STATE_DIR", dir)
+}
+
+// configureOpenShellDBURL derives the gateway's database URL from the local
+// config. The gateway keeps its state in neko-db, and the compose default URL
+// carries the initial password — after the setup wizard rotates the neko
+// role, a stale URL strands every sandbox create ("fetch settings failed:
+// password authentication failed"), which kills all agent runs. The local
+// config is the single source of the rotated password (ReadLocal decrypts
+// it), so build the URL from it on every start. An operator-set
+// OPENSHELL_DB_URL always wins.
+func configureOpenShellDBURL() {
+	if os.Getenv("OPENSHELL_DB_URL") != "" {
+		return
+	}
+	lc, _ := config.ReadLocal("")
+	if lc.Pg == nil || lc.Pg.Password == "" {
+		return // fresh install — the compose default matches the initial DB
+	}
+	user := lc.Pg.User
+	if user == "" {
+		user = "neko"
+	}
+	database := lc.Pg.Database
+	if database == "" {
+		database = "neko"
+	}
+	// Host/port are the compose network's, not the local config's: the
+	// gateway dials neko-db inside the project network regardless of how
+	// host-side tools reach the DB.
+	u := url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(user, lc.Pg.Password),
+		Host:   "neko-db:5432",
+		Path:   "/" + database,
+	}
+	_ = os.Setenv("OPENSHELL_DB_URL", u.String())
 }
 
 func waitDBHealthy(ctx context.Context, timeout time.Duration) error {


### PR DESCRIPTION
Found on production immediately after the wizard's password step: every chat run fails at `openshell sandbox create` with the gateway's own error — `fetch settings failed: database error: password authentication failed for user "neko"`.

The gateway stores its state in neko-db and gets its URL from compose: `OPENSHELL_DB_URL: ${OPENSHELL_DB_URL:-postgres://neko:secret@neko-db:5432/neko}`. The wizard rotates the `neko` role's password, web/worker pick the new one up from config.json — but the gateway's URL is frozen at `secret`, and from that moment **no agent run can start on the deployment**. The release smoke can't catch it because it never runs the wizard.

`openneko start` now derives `OPENSHELL_DB_URL` from the local config (the Go reader already decrypts the rotated password), pinning host to the compose network (`neko-db:5432`); a fresh install (no config) keeps the compose default, and an operator-set env var always wins. Unit test covers operator-override, fresh-install, and special-character escaping in the derived URL.

Note for the wizard flow: the gateway only picks the new URL up on the next `openneko start`. A follow-up could restart the gateway from the password-change path; with this fix, any restart self-heals, which is the floor we need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)