### PR TITLE
ci: deploy follows smoked releases, not merges

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,14 @@
 name: Deploy to VM
 
+# The VM runs the RELEASED stack, so the deployable artifact is a smoked
+# release — not a merge to main. Chaining off the smoke means the VM only
+# ever receives releases that booted and served in CI, and never restarts
+# pointlessly on ordinary merges (the old push-to-main trigger predates the
+# compose cutover, when every merge produced a source deploy).
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: ["post-release smoke"]
+    types: [completed]
   workflow_dispatch:
 
 concurrency:
@@ -11,6 +17,8 @@ concurrency:
 
 jobs:
   deploy:
+    # A failed smoke means the release was demoted — never deploy it.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Configure SSH


### PR DESCRIPTION
User-spotted sequencing flaw: "why does the vm deploy action fire before the release?"

The trigger was a leftover from the source-deploy era (every merge = deployable code). Post-cutover the deployable artifact is a **smoked release**, which doesn't exist at merge time — so deploys either churned the stack with no change or shipped the *previous* release right before a new one landed.

Now: release-please → binaries → **post-release smoke (gate)** → deploy. A failed smoke (release demoted off Latest) never deploys. Manual `workflow_dispatch` unchanged.

The full pipeline reads: merge → release → build → verify serving in CI → deploy that exact verified artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)