### PR TITLE
feat(cli): guided `openneko setup` — install, preflight, onboarding, plugins

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,6 +38,15 @@ jobs:
       - name: Verify embedded migrations are in sync
         run: ./scripts/sync-migrations.sh --check
 
+      - name: gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "These files are not gofmt-clean; run 'gofmt -w .':"
+            echo "$unformatted"
+            exit 1
+          fi
+
       - name: go vet
         run: go vet ./...
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,30 +10,28 @@ What you're installing, feature by feature, in plain language: **[FEATURES.md](F
 
 ## Install
 
-### macOS (Homebrew)
-
 ```bash
-brew install open-neko/tap/openneko
+curl -fsSL https://openneko.app/install.sh | sh
 mkdir -p ~/openneko && cd ~/openneko
-openneko start --mode demo --detach
+openneko setup --mode demo
 ```
 
-### Linux
-
-```bash
-TAG=$(curl -fsSL https://api.github.com/repos/open-neko/openneko/releases/latest | grep -oE '"tag_name": *"[^"]+"' | head -1 | cut -d'"' -f4)
-ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')
-curl -fsSL "https://github.com/open-neko/openneko/releases/download/$TAG/openneko_${TAG#v}_linux_$ARCH.tar.gz" | tar -xz openneko
-sudo install -m 0755 openneko /usr/local/bin/ && rm -f openneko
-mkdir -p ~/openneko && cd ~/openneko
-openneko start --mode demo --detach
-```
-
-Open [http://localhost:3000](http://localhost:3000) and finish the setup wizard.
+The installer picks the right path for your platform — Homebrew on macOS, a checksum-verified release binary on Linux — and checks for Docker. `openneko setup` then runs preflight (Docker daemon up, host supported, ports free), brings up the stack, and configures it (see [Setup](#setup)).
 
 `--mode demo` pulls pinned images and loads AdventureWorks sample data with three example watchers. For your own data, use `--mode prod` ([Use your own data](#use-your-own-data)).
 
-## Setup wizard
+### Manual install
+
+Prefer to manage the binary yourself:
+
+- **macOS (Homebrew):** `brew install open-neko/tap/openneko`
+- **Linux:** download `openneko_<version>_linux_<arch>.tar.gz` from the [latest release](https://github.com/open-neko/openneko/releases/latest), verify it against `checksums.txt`, and put `openneko` on your `PATH`.
+
+Then run `openneko setup` (guided), or `openneko start` to bring the stack up without the guided flow.
+
+## Setup
+
+`openneko setup` walks through the steps below **in the terminal**. Prefer a browser? Choose **browser** at the first prompt (or pass `--skip-onboarding`, or just run `openneko start`) and open [http://localhost:3000](http://localhost:3000) for the same wizard. Either way:
 
 1. Choose an admin database password.
 2. Confirm the pre-filled GraphJin URL (`--mode demo`) or enter your own (`--mode prod`).
@@ -41,16 +39,20 @@ Open [http://localhost:3000](http://localhost:3000) and finish the setup wizard.
 4. Add your provider API key.
 5. Add an industry research provider, or skip.
 
+Both paths drive the same web endpoints with the same validation (a live provider-key test, a data-source connectivity check), and each step persists independently — so you can start in the terminal and finish in the browser, or vice versa. For unattended installs (CI), pass `--admin-password`, `--provider`, `--provider-key`, etc. to run setup headless.
+
+As a final optional step, `openneko setup` offers to install **first-party plugins** from the [official marketplace](https://open-neko.github.io/plugins/) — Slack, Shopify, Telegram, Google Workspace, web search, SSO. Pick from the list and each plugin prompts for its own configuration (API keys, tokens), saved into the sandbox. Skip it with `--skip-plugins`, or pre-select non-interactively with `--plugins @open-neko/plugin-slack,@open-neko/plugin-shopify`.
+
 The AdventureWorks seed pre-fills business onboarding (`AdventureWorks Cycles`, fiscal year `July`, seats `CEO`/`CFO`/`COO`, priorities `Defend wholesale margins` / `Grow DTC in Europe`). Otherwise fill it in at `/onboarding`.
 
 ## Use your own data
 
 ```bash
 mkdir -p ~/openneko && cd ~/openneko
-openneko start --mode prod --detach
+openneko setup --mode prod
 ```
 
-Enter your GraphJin base URL in the setup wizard. If GraphJin runs on your host, use `http://host.docker.internal:8080` — OpenNeko appends the GraphQL and MCP paths automatically.
+Enter your GraphJin base URL when setup asks for it (terminal or browser). If GraphJin runs on your host, use `http://host.docker.internal:8080` — OpenNeko appends the GraphQL and MCP paths automatically.
 
 ## Plugins
 
@@ -67,6 +69,7 @@ Browse the marketplace at [open-neko.github.io/plugins](https://open-neko.github
 ## Command reference
 
 ```bash
+openneko setup [--mode prod|dev|demo]  # guided: preflight + bring-up + configure
 openneko start [--mode prod|dev|demo] [--detach]
 openneko status                    # docker compose ps proxy
 openneko logs [service…] [-f]
@@ -74,7 +77,7 @@ openneko stop [--volumes]          # --volumes wipes data
 openneko migrate                   # apply pending migrations against running neko-db
 openneko seed adventureworks       # one-shot demo data load (already done by --mode demo)
 openneko reset [--all]             # tear down + clear local config (--all also wipes secrets/marketplaces)
-openneko doctor                    # host check, docker version, manifest state
+openneko doctor                    # host check, docker daemon, manifest state
 openneko version
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,26 +16,15 @@
 
 You'll need **Docker** and **one LLM provider API key**.
 
-**macOS** — Homebrew:
-
 ```bash
-brew install open-neko/tap/openneko
+curl -fsSL https://openneko.app/install.sh | sh
 mkdir -p ~/openneko && cd ~/openneko
-openneko start --mode demo --detach
+openneko setup --mode demo
 ```
 
-**Linux** — latest release binary:
+The installer detects your OS/arch (Homebrew on macOS, a checksum-verified release binary on Linux) and checks for Docker. `openneko setup` then runs preflight checks, brings up the stack, and walks you through configuration **right in the terminal** — admin password, data source, model provider + key. Prefer a browser? Choose **browser** at the first prompt (or pass `--skip-onboarding`) to finish the wizard at [http://localhost:3000](http://localhost:3000).
 
-```bash
-TAG=$(curl -fsSL https://api.github.com/repos/open-neko/openneko/releases/latest | grep -oE '"tag_name": *"[^"]+"' | head -1 | cut -d'"' -f4)
-ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')
-curl -fsSL "https://github.com/open-neko/openneko/releases/download/$TAG/openneko_${TAG#v}_linux_$ARCH.tar.gz" | tar -xz openneko
-sudo install -m 0755 openneko /usr/local/bin/ && rm -f openneko
-mkdir -p ~/openneko && cd ~/openneko
-openneko start --mode demo --detach
-```
-
-Open [http://localhost:3000](http://localhost:3000) and finish the setup wizard. The demo seeds three watchers against sample data — kick off **Slow-Ship Operations** from `/workflows` and watch an *"orders stuck in pending > 5 days"* finding land on your Briefing.
+The demo seeds three watchers against sample data — kick off **Slow-Ship Operations** from `/workflows` and watch an *"orders stuck in pending > 5 days"* finding land on your Briefing.
 
 Full propose-and-approve walkthrough, the live trial (order simulator + scenario injector), and connecting your own data → **[INSTALL.md](INSTALL.md)**.
 

--- a/apps/openneko/README.md
+++ b/apps/openneko/README.md
@@ -6,15 +6,22 @@ laptop, on a self-hosted server, and inside the worker container.
 
 ## Install
 
-**macOS (Apple Silicon):**
+One line, any platform:
 
 ```bash
-brew install open-neko/tap/openneko
+curl -fsSL https://openneko.app/install.sh | sh
 ```
 
-**Linux (amd64 / arm64):** download the tarball for your platform from
-[github.com/open-neko/openneko/releases](https://github.com/open-neko/openneko/releases)
-and put `openneko` somewhere on your `PATH`.
+The installer detects your OS/arch and installs via Homebrew on macOS or a
+checksum-verified release tarball on Linux (amd64 / arm64). Then run the guided
+`openneko setup`.
+
+Manual:
+
+- **macOS (Homebrew):** `brew install open-neko/tap/openneko`
+- **Linux:** download the tarball from
+  [github.com/open-neko/openneko/releases](https://github.com/open-neko/openneko/releases),
+  verify it against `checksums.txt`, and put `openneko` on your `PATH`.
 
 You also need Docker (Docker Desktop on macOS, Docker Engine on Linux).
 
@@ -23,6 +30,7 @@ You also need Docker (Docker Desktop on macOS, Docker Engine on Linux).
 ### Stack supervision
 
 ```bash
+openneko setup [--mode prod|dev|demo]   # guided install: preflight + bring-up + configure
 openneko start [--mode prod|dev|demo] [--detach]
 openneko stop [--volumes]
 openneko status

--- a/apps/openneko/internal/cli/cli_test.go
+++ b/apps/openneko/internal/cli/cli_test.go
@@ -23,7 +23,7 @@ func TestExitCodeFor(t *testing.T) {
 
 func TestRootHasAllCommands(t *testing.T) {
 	root := NewRoot()
-	want := []string{"init", "install", "remove", "list", "doctor", "marketplace", "secrets", "version", "start", "stop", "status", "logs", "migrate", "seed", "reset"}
+	want := []string{"setup", "init", "install", "remove", "list", "doctor", "marketplace", "secrets", "version", "start", "stop", "status", "logs", "migrate", "seed", "reset"}
 	got := map[string]bool{}
 	for _, c := range root.Commands() {
 		got[c.Name()] = true

--- a/apps/openneko/internal/cli/doctor.go
+++ b/apps/openneko/internal/cli/doctor.go
@@ -3,13 +3,12 @@ package cli
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/open-neko/neko/apps/openneko/internal/host"
 	"github.com/open-neko/neko/apps/openneko/internal/plugin/manifest"
+	"github.com/open-neko/neko/apps/openneko/internal/preflight"
 )
 
 func newDoctorCmd() *cobra.Command {
@@ -45,11 +44,14 @@ func newDoctorCmd() *cobra.Command {
 			fmt.Fprintf(out, "manifest: %s at %s\n", label, file)
 			fmt.Fprintf(out, "plugins:  %d\n", pluginCount)
 
-			dockerVer := detectDocker()
-			fmt.Fprintf(out, "docker:   %s\n", dockerVer)
+			docker := preflight.Docker()
+			fmt.Fprintf(out, "docker:   %s\n", docker.Detail)
+			if docker.Level == preflight.Fail && docker.Remediation != "" {
+				fmt.Fprintf(out, "  fix: %s\n", docker.Remediation)
+			}
 
-			if other := otherOpennekoOnPath(); other != "" {
-				fmt.Fprintf(out, "warning:  duplicate `openneko` on PATH at %s — remove the older one\n", other)
+			if dup := preflight.DuplicateBinary(); dup.Level == preflight.Warn {
+				fmt.Fprintf(out, "warning:  %s — %s\n", dup.Detail, dup.Remediation)
 			}
 
 			if !h.Supported {
@@ -58,34 +60,4 @@ func newDoctorCmd() *cobra.Command {
 			return nil
 		},
 	}
-}
-
-func detectDocker() string {
-	bin, err := exec.LookPath("docker")
-	if err != nil {
-		return "not found"
-	}
-	out, err := exec.Command(bin, "--version").Output()
-	if err != nil {
-		return bin + " (version probe failed)"
-	}
-	return strings.TrimSpace(string(out))
-}
-
-// otherOpennekoOnPath returns a second openneko on PATH that isn't this one,
-// or "" if there's no duplicate. Useful while operators are transitioning off
-// the npm `@open-neko/cli`.
-func otherOpennekoOnPath() string {
-	self, err := os.Executable()
-	if err != nil {
-		return ""
-	}
-	bin, err := exec.LookPath("openneko")
-	if err != nil {
-		return ""
-	}
-	if bin == self {
-		return ""
-	}
-	return bin
 }

--- a/apps/openneko/internal/cli/init.go
+++ b/apps/openneko/internal/cli/init.go
@@ -15,7 +15,7 @@ func newInitCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "init",
 		Short: "Create an empty openneko.plugins.json in the current directory",
-		Args: cobra.NoArgs,
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if code, proxied := MaybeProxyToWorker(cmd); proxied {
 				return WithExit(code, nil)

--- a/apps/openneko/internal/cli/list.go
+++ b/apps/openneko/internal/cli/list.go
@@ -16,7 +16,7 @@ func newListCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Show plugins listed in the project's openneko.plugins.json",
-		Args: cobra.NoArgs,
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if code, proxied := MaybeProxyToWorker(cmd); proxied {
 				return WithExit(code, nil)

--- a/apps/openneko/internal/cli/marketplace.go
+++ b/apps/openneko/internal/cli/marketplace.go
@@ -25,7 +25,7 @@ func newMarketplaceListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list",
 		Short: "Show trusted marketplaces",
-		Args: cobra.NoArgs,
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if code, proxied := MaybeProxyToWorker(cmd); proxied {
 				return WithExit(code, nil)
@@ -55,7 +55,7 @@ func newMarketplaceAddCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "add <url>",
 		Short: "Trust a third-party marketplace URL",
-		Args: cobra.ExactArgs(1),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if code, proxied := MaybeProxyToWorker(cmd); proxied {
 				return WithExit(code, nil)
@@ -99,7 +99,7 @@ func newMarketplaceRemoveCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "remove <name-or-url>",
 		Short: "Stop trusting a marketplace",
-		Args: cobra.ExactArgs(1),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if code, proxied := MaybeProxyToWorker(cmd); proxied {
 				return WithExit(code, nil)

--- a/apps/openneko/internal/cli/remove.go
+++ b/apps/openneko/internal/cli/remove.go
@@ -14,7 +14,7 @@ func newRemoveCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "remove <name>",
 		Short: "Remove a plugin from openneko.plugins.json",
-		Args: cobra.ExactArgs(1),
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if code, proxied := MaybeProxyToWorker(cmd); proxied {
 				return WithExit(code, nil)

--- a/apps/openneko/internal/cli/root.go
+++ b/apps/openneko/internal/cli/root.go
@@ -67,9 +67,10 @@ func NewRoot() *cobra.Command {
 		Short: "OpenNeko operator CLI",
 		Long: `openneko — supervises the OpenNeko stack and manages plugins.
 
+Getting started: setup (guided install — preflight, bring-up, configure).
 Plugin ops: init, install, list, remove, marketplace, secrets, doctor.
 Stack ops:  start, stop, logs, status, migrate, seed, reset.`,
-		Version: version.Version,
+		Version:       version.Version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}
@@ -82,6 +83,7 @@ Stack ops:  start, stop, logs, status, migrate, seed, reset.`,
 	// happen to have a compose stack running alongside `pnpm dev`).
 	cmd.PersistentFlags().Bool("local", false, "Force local execution; don't auto-proxy plugin ops into a running worker container")
 	cmd.AddCommand(
+		newSetupCmd(),
 		newInitCmd(),
 		newInstallCmd(),
 		newRemoveCmd(),

--- a/apps/openneko/internal/cli/secrets.go
+++ b/apps/openneko/internal/cli/secrets.go
@@ -23,7 +23,7 @@ func newSecretsListCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "list [<plugin>]",
 		Short: "Show env keys stored for a plugin (or all plugins); values never echoed",
-		Args: cobra.MaximumNArgs(1),
+		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if code, proxied := MaybeProxyToWorker(cmd); proxied {
 				return WithExit(code, nil)
@@ -89,7 +89,7 @@ func newSecretsSetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "set <plugin> <key> [<value>]",
 		Short: "Set an env value for a plugin",
-		Args: cobra.RangeArgs(2, 3),
+		Args:  cobra.RangeArgs(2, 3),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if code, proxied := MaybeProxyToWorker(cmd); proxied {
 				return WithExit(code, nil)
@@ -144,7 +144,7 @@ func newSecretsUnsetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "unset <plugin> <key>",
 		Short: "Remove an env value",
-		Args: cobra.ExactArgs(2),
+		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if code, proxied := MaybeProxyToWorker(cmd); proxied {
 				return WithExit(code, nil)

--- a/apps/openneko/internal/cli/setup.go
+++ b/apps/openneko/internal/cli/setup.go
@@ -1,0 +1,309 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-neko/neko/apps/openneko/internal/compose"
+	"github.com/open-neko/neko/apps/openneko/internal/plugin/marketplace"
+	"github.com/open-neko/neko/apps/openneko/internal/preflight"
+	"github.com/open-neko/neko/apps/openneko/internal/prompt"
+	"github.com/open-neko/neko/apps/openneko/internal/setup"
+)
+
+func newSetupCmd() *cobra.Command {
+	var (
+		mode           string
+		verbose        bool
+		skipOnboarding bool
+
+		// Headless onboarding overrides. Setting any credential flag opts the
+		// run into headless mode (no prompts), so CI and the demo-install skill
+		// can configure without a browser.
+		adminPassword    string
+		backend          string
+		provider         string
+		providerKey      string
+		model            string
+		dataURL          string
+		researchProvider string
+		researchKey      string
+		noResearch       bool
+
+		skipPlugins bool
+		pluginsCSV  string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "setup",
+		Short: "Guided install: preflight, bring up the stack, then configure",
+		Long: `Guided first-run install.
+
+  1. Preflight — Docker daemon up, host supported, required ports free.
+  2. Bring up the stack (same staged flow as ` + "`openneko start`" + `).
+  3. Configure — admin password, data source, agent + provider, research.
+
+Step 3 runs in the terminal, or pass --skip-onboarding (or just choose "browser"
+at the prompt) to finish at the web UI. Credential flags
+(--admin-password/--provider/--provider-key/…) run step 3 headless for CI.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out := cmd.OutOrStdout()
+			ctx, cancel := context.WithCancel(cmd.Context())
+			defer cancel()
+
+			m := compose.Mode(mode)
+			if m == "" {
+				m = compose.ModeProd
+			}
+			baseURL := webBaseURL()
+			client := setup.NewClient(baseURL)
+			alreadyUp := client.Ready(ctx)
+
+			// 1 + 2. Preflight then bring-up — skipped if the stack already
+			// answers (re-running setup against a live install jumps straight
+			// to configuration). Port checks only run for a fresh bring-up,
+			// since a live OpenNeko legitimately holds those ports.
+			if alreadyUp {
+				fmt.Fprintln(out, "Existing OpenNeko detected — skipping preflight and bring-up.")
+			} else {
+				if err := runPreflight(out); err != nil {
+					return err
+				}
+				fmt.Fprintln(out, "\nBringing up the stack…")
+				if err := bringUpStack(ctx, cmd, m, bringUpOptions{detach: true, quiet: !verbose}); err != nil {
+					return err
+				}
+				fmt.Fprintf(out, "Waiting for the web app at %s…\n", baseURL)
+				if err := client.WaitReady(ctx, 120*time.Second); err != nil {
+					return err
+				}
+			}
+			fmt.Fprintln(out, "✓ web app ready")
+
+			// 3. Onboarding.
+			interactive := prompt.IsInteractive()
+			headless := adminPassword != "" || provider != "" || providerKey != "" ||
+				backend != "" || model != "" || researchProvider != "" || researchKey != ""
+
+			if skipOnboarding {
+				fmt.Fprintf(out, "\nFinish setup in your browser: %s\n", baseURL)
+				return nil
+			}
+			if !interactive && !headless {
+				fmt.Fprintf(out, "\nNo TTY and no setup flags — finish setup in your browser: %s\n", baseURL)
+				return nil
+			}
+
+			cfg := setup.Config{
+				Mode:             string(m),
+				BaseURL:          baseURL,
+				Headless:         headless || !interactive,
+				AdminPassword:    adminPassword,
+				Backend:          backend,
+				Provider:         provider,
+				ProviderKey:      providerKey,
+				Model:            model,
+				DataURL:          dataURL,
+				ResearchProvider: researchProvider,
+				ResearchKey:      researchKey,
+				NoResearch:       noResearch,
+			}
+			outcome, err := setup.Run(ctx, client, out, cfg)
+			if err != nil {
+				return err
+			}
+			if outcome.Configured {
+				if !skipPlugins {
+					if err := offerPluginInstall(ctx, out, pluginsCSV, interactive && !cfg.Headless); err != nil {
+						return err
+					}
+				}
+				fmt.Fprintf(out, "\n✓ Setup complete. Open %s/onboarding to describe your business.\n", baseURL)
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&mode, "mode", "prod", "Stack mode: prod|dev|demo")
+	cmd.Flags().BoolVar(&verbose, "verbose", false, "Stream full image-pull output during bring-up")
+	cmd.Flags().BoolVar(&skipOnboarding, "skip-onboarding", false, "Bring up the stack only; finish configuration in the browser")
+	cmd.Flags().StringVar(&adminPassword, "admin-password", "", "Headless: admin database password")
+	cmd.Flags().StringVar(&backend, "backend", "", "Headless: agent backend (hermes|claude-agent)")
+	cmd.Flags().StringVar(&provider, "provider", "", "Headless: primary model provider")
+	cmd.Flags().StringVar(&providerKey, "provider-key", "", "Headless: primary provider API key")
+	cmd.Flags().StringVar(&model, "model", "", "Headless: primary model (default: provider default)")
+	cmd.Flags().StringVar(&dataURL, "data-url", "", "GraphJin base URL (default: per-mode)")
+	cmd.Flags().StringVar(&researchProvider, "research-provider", "", "Headless: research provider")
+	cmd.Flags().StringVar(&researchKey, "research-key", "", "Headless: research provider API key")
+	cmd.Flags().BoolVar(&noResearch, "no-research", false, "Headless: leave industry research disabled")
+	cmd.Flags().BoolVar(&skipPlugins, "skip-plugins", false, "Skip the optional first-party plugin step")
+	cmd.Flags().StringVar(&pluginsCSV, "plugins", "", "Install these first-party plugins non-interactively (comma-separated)")
+	return cmd
+}
+
+// offerPluginInstall lets the operator install (and configure) first-party
+// plugins from the official marketplace as a final, optional setup step. Each
+// install reuses `openneko install` via the binary itself, so it runs through
+// the worker proxy AND its env-prompt — selecting a plugin prompts for and
+// persists that plugin's API keys/tokens. csv (from --plugins) drives a
+// non-interactive selection; otherwise the operator picks from a list.
+func offerPluginInstall(ctx context.Context, out io.Writer, csv string, interactive bool) error {
+	preselected := splitCSV(csv)
+	if len(preselected) == 0 && !interactive {
+		return nil
+	}
+	mp, err := marketplace.NewClient().Fetch(ctx, marketplace.OfficialURL)
+	if err != nil {
+		fmt.Fprintf(out, "\n(Skipping plugins — couldn't reach the marketplace: %v)\n", err)
+		return nil
+	}
+	if len(mp.Plugins) == 0 {
+		return nil
+	}
+
+	var chosen []string
+	if len(preselected) > 0 {
+		chosen = matchPlugins(preselected, mp.Plugins)
+	} else {
+		fmt.Fprintf(out, "\nOptional: install first-party plugins from %s.\n", mp.Name)
+		fmt.Fprintln(out, "Selecting a plugin also prompts for its configuration (API keys, tokens).")
+		for i, p := range mp.Plugins {
+			fmt.Fprintf(out, "  [%d] %s — %s\n", i+1, p.Name, p.Description)
+		}
+		sel, err := prompt.Visible("Install which? (comma-separated numbers, 'all', or Enter to skip): ")
+		if err != nil {
+			return err
+		}
+		chosen = resolvePluginSelection(sel, mp.Plugins)
+	}
+	if len(chosen) == 0 {
+		return nil
+	}
+
+	self, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	for _, name := range chosen {
+		fmt.Fprintf(out, "\nInstalling %s …\n", name)
+		ic := exec.CommandContext(ctx, self, "install", name)
+		ic.Stdin = os.Stdin
+		ic.Stdout = os.Stdout
+		ic.Stderr = os.Stderr
+		if err := ic.Run(); err != nil {
+			fmt.Fprintf(out, "  ✗ %s install failed: %v (continuing)\n", name, err)
+		}
+	}
+	return nil
+}
+
+func splitCSV(s string) []string {
+	var out []string
+	for t := range strings.SplitSeq(s, ",") {
+		if t = strings.TrimSpace(t); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// resolvePluginSelection turns a user reply ("all", "1,3", or names) into a
+// list of plugin names.
+func resolvePluginSelection(sel string, plugins []marketplace.Plugin) []string {
+	sel = strings.TrimSpace(sel)
+	if sel == "" {
+		return nil
+	}
+	if strings.EqualFold(sel, "all") {
+		names := make([]string, len(plugins))
+		for i, p := range plugins {
+			names[i] = p.Name
+		}
+		return names
+	}
+	return matchPlugins(splitCSV(sel), plugins)
+}
+
+// matchPlugins resolves tokens (1-based indices or exact names) against the
+// catalog, de-duplicating and preserving order.
+func matchPlugins(tokens []string, plugins []marketplace.Plugin) []string {
+	var out []string
+	seen := map[string]bool{}
+	add := func(name string) {
+		if name != "" && !seen[name] {
+			seen[name] = true
+			out = append(out, name)
+		}
+	}
+	for _, tok := range tokens {
+		if n, err := strconv.Atoi(tok); err == nil {
+			if n >= 1 && n <= len(plugins) {
+				add(plugins[n-1].Name)
+			}
+			continue
+		}
+		for _, p := range plugins {
+			if p.Name == tok {
+				add(p.Name)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// webBaseURL resolves the local web app URL from the published port (matching
+// status.go's probeWeb).
+func webBaseURL() string {
+	port := strings.TrimSpace(os.Getenv("OPENNEKO_PORT"))
+	if port == "" {
+		port = "3000"
+	}
+	return "http://localhost:" + port
+}
+
+// runPreflight runs the host readiness checks and prints them, returning a
+// non-nil (exit-coded) error if any hard check fails. Host failure exits 3 to
+// match root.go's code map; other failures exit 1.
+func runPreflight(out io.Writer) error {
+	fmt.Fprintln(out, "Preflight:")
+	checks := []preflight.Result{preflight.Host(), preflight.Docker()}
+	checks = append(checks, preflight.Ports(preflight.DefaultPorts)...)
+	checks = append(checks, preflight.DuplicateBinary())
+
+	code := 0
+	for _, c := range checks {
+		switch c.Level {
+		case preflight.Pass:
+			fmt.Fprintf(out, "  ✓ %s: %s\n", c.Name, c.Detail)
+		case preflight.Warn:
+			fmt.Fprintf(out, "  ! %s: %s\n", c.Name, c.Detail)
+			if c.Remediation != "" {
+				fmt.Fprintf(out, "      %s\n", c.Remediation)
+			}
+		case preflight.Fail:
+			fmt.Fprintf(out, "  ✗ %s: %s\n", c.Name, c.Detail)
+			if c.Remediation != "" {
+				fmt.Fprintf(out, "      %s\n", c.Remediation)
+			}
+			if c.Name == "host" {
+				code = 3
+			} else if code == 0 {
+				code = 1
+			}
+		}
+	}
+	if code != 0 {
+		return WithExit(code, fmt.Errorf("preflight failed — fix the above and re-run `openneko setup`"))
+	}
+	return nil
+}

--- a/apps/openneko/internal/cli/setup_test.go
+++ b/apps/openneko/internal/cli/setup_test.go
@@ -1,0 +1,45 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/open-neko/neko/apps/openneko/internal/plugin/marketplace"
+)
+
+func TestSplitCSV(t *testing.T) {
+	got := splitCSV("a, b ,,c ")
+	want := []string{"a", "b", "c"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("splitCSV = %v, want %v", got, want)
+	}
+	if got := splitCSV("  "); got != nil {
+		t.Fatalf("splitCSV(blank) = %v, want nil", got)
+	}
+}
+
+func TestResolvePluginSelection(t *testing.T) {
+	plugins := []marketplace.Plugin{
+		{Name: "@x/a"}, {Name: "@x/b"}, {Name: "@x/c"},
+	}
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"all", []string{"@x/a", "@x/b", "@x/c"}},
+		{"ALL", []string{"@x/a", "@x/b", "@x/c"}},
+		{"1,3", []string{"@x/a", "@x/c"}},
+		{"@x/b", []string{"@x/b"}},
+		{"2, @x/a", []string{"@x/b", "@x/a"}},
+		{"9", nil},                     // out of range
+		{"nope", nil},                  // unknown name
+		{"1,@x/a,1", []string{"@x/a"}}, // de-duped
+	}
+	for _, c := range cases {
+		got := resolvePluginSelection(c.in, plugins)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("resolvePluginSelection(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}

--- a/apps/openneko/internal/cli/start.go
+++ b/apps/openneko/internal/cli/start.go
@@ -36,84 +36,13 @@ Modes:
   demo  Core + AdventureWorks trial bundle`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			m := compose.Mode(mode)
-			if m == "" {
-				m = compose.ModeProd
-			}
-			// Pin compose's image tags to this binary's version unless the
-			// caller has already set OPENNEKO_VERSION — that lets the smoke
-			// workflow (which builds openneko fresh from source, so its
-			// embedded version is "0.0.0-dev") test against a real release
-			// tag.
-			if os.Getenv("OPENNEKO_VERSION") == "" {
-				_ = os.Setenv("OPENNEKO_VERSION", "v"+version.Version)
-			}
-
-			// SEC9: OpenShell is the only agent runtime.
-			if err := configureOpenShellStateDir(); err != nil {
-				return err
-			}
-			configureOpenShellDBURL()
-
-			sup := compose.New(assets.ComposeFS)
-			files, err := sup.Materialize(m)
-			if err != nil {
-				return err
-			}
-			project, err := sup.ProjectName(m)
-			if err != nil {
-				return err
-			}
-
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
-
-			pullFlag := []string{}
-			if pullPolicy != "" {
-				switch pullPolicy {
-				case "always", "missing", "never":
-					pullFlag = []string{"--pull", pullPolicy}
-				default:
-					return fmt.Errorf("--pull must be one of: always, missing, never (got %q)", pullPolicy)
-				}
-			}
-
-			// Stage 1: bring up neko-db only, wait healthy, run migrations.
-			if !skipMigrate {
-				if _, err := sup.Run(ctx, project, files, append([]string{"up", "-d"}, append(pullFlag, "neko-db")...), os.Stdout, os.Stderr); err != nil {
-					return err
-				}
-				if err := waitDBHealthy(ctx, time.Minute); err != nil {
-					return err
-				}
-				if err := runMigrations(ctx, cmd); err != nil {
-					return err
-				}
-			}
-
-			// Pre-pull the agent sandbox image at install time so the gateway's
-			// first sandbox-create (the user's first chat) never blocks on a
-			// large pull. Best-effort: a failure just falls back to a lazy pull.
-			agentImg := agentImageRef(os.Getenv("OPENNEKO_AGENT_IMAGE"), os.Getenv("OPENNEKO_VERSION"))
-			fmt.Fprintf(os.Stderr, "Pre-pulling agent sandbox image %s ...\n", agentImg)
-			if err := sup.EnsureImage(ctx, agentImg, os.Stdout, os.Stderr); err != nil {
-				fmt.Fprintf(os.Stderr, "warning: agent image pre-pull failed (%v); it will pull on first use\n", err)
-			}
-
-			// Stage 2: bring up the rest.
-			upArgs := []string{"up"}
-			if detach {
-				upArgs = append(upArgs, "-d")
-			}
-			upArgs = append(upArgs, pullFlag...)
-			code, err := sup.Run(ctx, project, files, upArgs, os.Stdout, os.Stderr)
-			if err != nil {
-				return err
-			}
-			if code != 0 {
-				return WithExit(code, nil)
-			}
-			return nil
+			return bringUpStack(ctx, cmd, compose.Mode(mode), bringUpOptions{
+				detach:      detach,
+				skipMigrate: skipMigrate,
+				pullPolicy:  pullPolicy,
+			})
 		},
 	}
 	cmd.Flags().StringVar(&mode, "mode", "prod", "Stack mode: prod|dev|demo")
@@ -121,6 +50,106 @@ Modes:
 	cmd.Flags().BoolVar(&skipMigrate, "skip-migrate", false, "Skip running migrations on start (advanced)")
 	cmd.Flags().StringVar(&pullPolicy, "pull", "", "Override compose pull policy: always|missing|never (default: compose decides)")
 	return cmd
+}
+
+// bringUpOptions controls a stack bring-up. `start` and `setup` share the same
+// staged flow; setup sets quiet to trim the install chatter into clean step
+// lines (it adds --quiet-pull and skips the verbose pre-pull banner).
+type bringUpOptions struct {
+	detach      bool
+	skipMigrate bool
+	pullPolicy  string
+	quiet       bool
+}
+
+// bringUpStack runs the staged bring-up shared by `start` and `setup`:
+// neko-db → wait healthy → migrate → pre-pull the agent image → compose up the
+// rest. Extracted from newStartCmd so setup reuses the exact same path.
+func bringUpStack(ctx context.Context, cmd *cobra.Command, mode compose.Mode, opts bringUpOptions) error {
+	m := mode
+	if m == "" {
+		m = compose.ModeProd
+	}
+	// Pin compose's image tags to this binary's version unless the caller has
+	// already set OPENNEKO_VERSION — that lets the smoke workflow (which builds
+	// openneko fresh from source, so its embedded version is "0.0.0-dev") test
+	// against a real release tag.
+	if os.Getenv("OPENNEKO_VERSION") == "" {
+		_ = os.Setenv("OPENNEKO_VERSION", "v"+version.Version)
+	}
+
+	// SEC9: OpenShell is the only agent runtime.
+	if err := configureOpenShellStateDir(); err != nil {
+		return err
+	}
+	configureOpenShellDBURL()
+
+	sup := compose.New(assets.ComposeFS)
+	files, err := sup.Materialize(m)
+	if err != nil {
+		return err
+	}
+	project, err := sup.ProjectName(m)
+	if err != nil {
+		return err
+	}
+
+	pullFlag := []string{}
+	if opts.pullPolicy != "" {
+		switch opts.pullPolicy {
+		case "always", "missing", "never":
+			pullFlag = []string{"--pull", opts.pullPolicy}
+		default:
+			return fmt.Errorf("--pull must be one of: always, missing, never (got %q)", opts.pullPolicy)
+		}
+	}
+	quietPull := []string{}
+	if opts.quiet {
+		quietPull = []string{"--quiet-pull"}
+	}
+
+	// Stage 1: bring up neko-db only, wait healthy, run migrations.
+	if !opts.skipMigrate {
+		up1 := append([]string{"up", "-d"}, pullFlag...)
+		up1 = append(up1, quietPull...)
+		up1 = append(up1, "neko-db")
+		if _, err := sup.Run(ctx, project, files, up1, os.Stdout, os.Stderr); err != nil {
+			return err
+		}
+		if err := waitDBHealthy(ctx, time.Minute); err != nil {
+			return err
+		}
+		if err := runMigrations(ctx, cmd); err != nil {
+			return err
+		}
+	}
+
+	// Pre-pull the agent sandbox image at install time so the gateway's first
+	// sandbox-create (the user's first chat) never blocks on a large pull.
+	// Best-effort: a failure just falls back to a lazy pull.
+	agentImg := agentImageRef(os.Getenv("OPENNEKO_AGENT_IMAGE"), os.Getenv("OPENNEKO_VERSION"))
+	if !opts.quiet {
+		fmt.Fprintf(os.Stderr, "Pre-pulling agent sandbox image %s ...\n", agentImg)
+	}
+	if err := sup.EnsureImage(ctx, agentImg, os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: agent image pre-pull failed (%v); it will pull on first use\n", err)
+	}
+
+	// Stage 2: bring up the rest.
+	upArgs := []string{"up"}
+	if opts.detach {
+		upArgs = append(upArgs, "-d")
+	}
+	upArgs = append(upArgs, pullFlag...)
+	upArgs = append(upArgs, quietPull...)
+	code, err := sup.Run(ctx, project, files, upArgs, os.Stdout, os.Stderr)
+	if err != nil {
+		return err
+	}
+	if code != 0 {
+		return WithExit(code, nil)
+	}
+	return nil
 }
 
 // agentImageRef resolves the agent sandbox image: an explicit override wins,

--- a/apps/openneko/internal/config/crypt.go
+++ b/apps/openneko/internal/config/crypt.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-
 )
 
 // Mirrors packages/llm/src/secrets.ts exactly: AES-256-GCM, key =

--- a/apps/openneko/internal/db/migrate_test.go
+++ b/apps/openneko/internal/db/migrate_test.go
@@ -78,13 +78,13 @@ type fakeRows struct {
 	idx   int
 }
 
-func (r *fakeRows) Close()                                              {}
-func (r *fakeRows) Err() error                                          { return nil }
-func (r *fakeRows) CommandTag() pgconn.CommandTag                       { return pgconn.CommandTag{} }
-func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription        { return nil }
-func (r *fakeRows) RawValues() [][]byte                                 { return nil }
-func (r *fakeRows) Values() ([]any, error)                              { return nil, nil }
-func (r *fakeRows) Conn() *pgx.Conn                                     { return nil }
+func (r *fakeRows) Close()                                       {}
+func (r *fakeRows) Err() error                                   { return nil }
+func (r *fakeRows) CommandTag() pgconn.CommandTag                { return pgconn.CommandTag{} }
+func (r *fakeRows) FieldDescriptions() []pgconn.FieldDescription { return nil }
+func (r *fakeRows) RawValues() [][]byte                          { return nil }
+func (r *fakeRows) Values() ([]any, error)                       { return nil, nil }
+func (r *fakeRows) Conn() *pgx.Conn                              { return nil }
 func (r *fakeRows) Next() bool {
 	if r.idx >= len(r.names) {
 		return false
@@ -228,12 +228,12 @@ func TestApplyAcquiresAndReleasesAdvisoryLock(t *testing.T) {
 
 func TestShouldRunInTransaction(t *testing.T) {
 	cases := map[string]bool{
-		"0001_init.sql":                              true,
+		"0001_init.sql": true,
 		"0016_reindex_after_pgvector_swap_no_tx.sql": false,
-		"weird_no_tx.sql":                            false,
-		"_no_tx.sql":                                 false,
-		"":                                           true,
-		"plain.sql":                                  true,
+		"weird_no_tx.sql": false,
+		"_no_tx.sql":      false,
+		"":                true,
+		"plain.sql":       true,
 	}
 	for name, want := range cases {
 		if got := shouldRunInTransaction(name); got != want {

--- a/apps/openneko/internal/host/host.go
+++ b/apps/openneko/internal/host/host.go
@@ -19,6 +19,13 @@ func Check() Result {
 	return checkWith(runtime.GOOS, runtime.GOARCH, hasDocker)
 }
 
+// Platform reports OS/arch support independent of whether docker is present.
+// preflight checks docker separately so it can give a sharper "daemon not
+// running" remediation, so it wants the OS/arch verdict on its own.
+func Platform() Result {
+	return checkWith(runtime.GOOS, runtime.GOARCH, func() bool { return true })
+}
+
 func checkWith(goos, goarch string, docker func() bool) Result {
 	triple := goos + "-" + goarch
 	switch goos {

--- a/apps/openneko/internal/plugin/store/store_test.go
+++ b/apps/openneko/internal/plugin/store/store_test.go
@@ -85,11 +85,11 @@ func TestRemoveMiss(t *testing.T) {
 
 func TestSlugify(t *testing.T) {
 	cases := map[string]string{
-		"My Marketplace":           "my-marketplace",
-		"  weird!!! Stuff   ":      "weird-stuff",
-		"123":                      "123",
+		"My Marketplace":      "my-marketplace",
+		"  weird!!! Stuff   ": "weird-stuff",
+		"123":                 "123",
 		"this-is-a-very-long-name-that-exceeds-the-forty-char-cap": "this-is-a-very-long-name-that-exceeds-th",
-		"---":                      "",
+		"---": "",
 	}
 	for in, want := range cases {
 		if got := Slugify(in); got != want {

--- a/apps/openneko/internal/preflight/preflight.go
+++ b/apps/openneko/internal/preflight/preflight.go
@@ -1,0 +1,152 @@
+// Package preflight runs the host readiness checks shared by `openneko doctor`
+// and `openneko setup`: is this OS/arch supported, is the Docker daemon up, are
+// the host ports free, and is there a single openneko on PATH. Each check
+// returns a Result so callers can either print it (doctor) or gate on it
+// (setup).
+package preflight
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/open-neko/neko/apps/openneko/internal/host"
+)
+
+type Level int
+
+const (
+	Pass Level = iota
+	Warn
+	Fail
+)
+
+type Result struct {
+	Name        string // short label, e.g. "host", "docker", "port 3000 (web)"
+	Level       Level
+	Detail      string // version, triple, or what's wrong
+	Remediation string // how to fix; set when Warn/Fail
+}
+
+// OK is false only for a hard failure — a Warn is still OK to proceed past.
+func (r Result) OK() bool { return r.Level != Fail }
+
+// Host reports whether this OS/arch can run the OpenShell sandbox runtime,
+// independent of docker (Docker covers that with a sharper message).
+func Host() Result {
+	h := host.Platform()
+	if h.Supported {
+		return Result{Name: "host", Level: Pass, Detail: h.Triple + " (supported)"}
+	}
+	return Result{Name: "host", Level: Fail, Detail: h.Triple, Remediation: h.Reason}
+}
+
+// Docker reports whether the docker CLI is installed and its daemon answering.
+// `docker info --format {{.ServerVersion}}` does both: it only succeeds when the
+// daemon is reachable, and returns the server version for the detail line.
+func Docker() Result {
+	bin, err := exec.LookPath("docker")
+	if err != nil {
+		return Result{
+			Name:        "docker",
+			Level:       Fail,
+			Detail:      "not found on PATH",
+			Remediation: "Install Docker Desktop (macOS) or Docker Engine (Linux): https://docs.docker.com/get-docker/",
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, bin, "info", "--format", "{{.ServerVersion}}").Output()
+	if err != nil {
+		return Result{
+			Name:        "docker",
+			Level:       Fail,
+			Detail:      "installed, but the daemon isn't responding",
+			Remediation: "Start Docker Desktop (macOS) or `sudo systemctl start docker` (Linux), then re-run.",
+		}
+	}
+	ver := strings.TrimSpace(string(out))
+	detail := "daemon running"
+	if ver != "" {
+		detail = "daemon running (server " + ver + ")"
+	}
+	return Result{Name: "docker", Level: Pass, Detail: detail}
+}
+
+// PortSpec is a host port the stack publishes, with the env var that overrides
+// it (matching start.go's envInt lookups).
+type PortSpec struct {
+	Label  string
+	EnvVar string
+	Def    int
+}
+
+// DefaultPorts are the host ports a fresh bring-up needs free. The demo's
+// AdventureWorks Postgres is internal-only, so it adds no host port.
+var DefaultPorts = []PortSpec{
+	{"web", "OPENNEKO_PORT", 3000},
+	{"metadata Postgres", "OPENNEKO_DB_PORT", 5432},
+	{"metadata GraphJin", "OPENNEKO_GRAPHJIN_PORT", 8089},
+}
+
+// Port resolves a spec's effective port from its env override.
+func (s PortSpec) Port() int {
+	if v := strings.TrimSpace(os.Getenv(s.EnvVar)); v != "" {
+		if p, err := strconv.Atoi(v); err == nil {
+			return p
+		}
+	}
+	return s.Def
+}
+
+// Ports checks each spec's port is bindable on the loopback. A bound port means
+// something already holds it — including a previous OpenNeko, so callers that
+// might be re-running against a live stack should skip this (see setup).
+func Ports(specs []PortSpec) []Result {
+	out := make([]Result, 0, len(specs))
+	for _, s := range specs {
+		port := s.Port()
+		name := fmt.Sprintf("port %d (%s)", port, s.Label)
+		ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		if err != nil {
+			out = append(out, Result{
+				Name:        name,
+				Level:       Fail,
+				Detail:      "in use",
+				Remediation: fmt.Sprintf("Free it, or pick another port with %s=<port>.", s.EnvVar),
+			})
+			continue
+		}
+		_ = ln.Close()
+		out = append(out, Result{Name: name, Level: Pass, Detail: "free"})
+	}
+	return out
+}
+
+// DuplicateBinary warns when a second openneko shadows or competes with the
+// running one on PATH — common while operators migrate off the old npm CLI.
+func DuplicateBinary() Result {
+	self, err := os.Executable()
+	if err != nil {
+		return Result{Name: "path", Level: Pass, Detail: "single openneko on PATH"}
+	}
+	bin, lookErr := exec.LookPath("openneko")
+	return duplicateBinaryWith(self, bin, lookErr)
+}
+
+func duplicateBinaryWith(self, found string, lookErr error) Result {
+	if lookErr != nil || found == self {
+		return Result{Name: "path", Level: Pass, Detail: "single openneko on PATH"}
+	}
+	return Result{
+		Name:        "path",
+		Level:       Warn,
+		Detail:      "duplicate openneko at " + found,
+		Remediation: "Remove the older one to avoid version confusion.",
+	}
+}

--- a/apps/openneko/internal/preflight/preflight_test.go
+++ b/apps/openneko/internal/preflight/preflight_test.go
@@ -1,0 +1,95 @@
+package preflight
+
+import (
+	"net"
+	"strconv"
+	"testing"
+)
+
+func TestPortsFreeWhenUnbound(t *testing.T) {
+	// Grab a free port from the OS, then release it so the spec sees it free.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+
+	specs := []PortSpec{{Label: "test", EnvVar: "NOPE_UNSET", Def: port}}
+	res := Ports(specs)
+	if len(res) != 1 {
+		t.Fatalf("want 1 result, got %d", len(res))
+	}
+	if res[0].Level != Pass {
+		t.Fatalf("want Pass for free port %d, got %+v", port, res[0])
+	}
+}
+
+func TestPortsFailWhenBound(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer ln.Close()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	specs := []PortSpec{{Label: "test", EnvVar: "OPENNEKO_TEST_PORT", Def: port}}
+	res := Ports(specs)
+	if res[0].Level != Fail {
+		t.Fatalf("want Fail for bound port %d, got %+v", port, res[0])
+	}
+	if res[0].Remediation == "" {
+		t.Fatal("expected a remediation naming the override env var")
+	}
+}
+
+func TestPortSpecEnvOverride(t *testing.T) {
+	t.Setenv("OPENNEKO_TEST_PORT_OVERRIDE", "55999")
+	s := PortSpec{Label: "test", EnvVar: "OPENNEKO_TEST_PORT_OVERRIDE", Def: 3000}
+	if got := s.Port(); got != 55999 {
+		t.Fatalf("want override 55999, got %d", got)
+	}
+	// Junk override falls back to the default.
+	t.Setenv("OPENNEKO_TEST_PORT_OVERRIDE", "not-a-number")
+	if got := s.Port(); got != 3000 {
+		t.Fatalf("want fallback 3000, got %d", got)
+	}
+}
+
+func TestDuplicateBinary(t *testing.T) {
+	// PATH openneko is this same binary → no false-positive nag.
+	if r := duplicateBinaryWith("/usr/local/bin/openneko", "/usr/local/bin/openneko", nil); r.Level != Pass {
+		t.Fatalf("same path should be Pass, got %+v", r)
+	}
+	// No openneko on PATH → nothing to warn about.
+	if r := duplicateBinaryWith("/usr/local/bin/openneko", "", errNotFound); r.Level != Pass {
+		t.Fatalf("lookup error should be Pass, got %+v", r)
+	}
+	// A different openneko shadows us → warn with remediation.
+	r := duplicateBinaryWith("/opt/me/openneko", "/usr/bin/openneko", nil)
+	if r.Level != Warn || r.Remediation == "" {
+		t.Fatalf("different path should Warn with remediation, got %+v", r)
+	}
+}
+
+var errNotFound = &lookErr{}
+
+type lookErr struct{}
+
+func (*lookErr) Error() string { return "not found" }
+
+func TestResultOK(t *testing.T) {
+	if !(Result{Level: Pass}).OK() || !(Result{Level: Warn}).OK() {
+		t.Fatal("Pass and Warn should be OK")
+	}
+	if (Result{Level: Fail}).OK() {
+		t.Fatal("Fail should not be OK")
+	}
+}
+
+// Guard the loopback-join helper shape Ports relies on.
+func TestJoinHostPortShape(t *testing.T) {
+	if got := net.JoinHostPort("127.0.0.1", strconv.Itoa(8089)); got != "127.0.0.1:8089" {
+		t.Fatalf("unexpected join: %s", got)
+	}
+}

--- a/apps/openneko/internal/setup/client.go
+++ b/apps/openneko/internal/setup/client.go
@@ -1,0 +1,296 @@
+// Package setup drives OpenNeko's first-run admin onboarding from the terminal
+// by calling the same web endpoints the browser wizard uses
+// (apps/web/src/app/settings/SetupWizard.tsx). The web app is the single source
+// of truth — this package adds no config-writing logic of its own, so the CLI
+// and browser paths can never drift. Choosing "finish in the browser" simply
+// skips the calls and prints the URL.
+package setup
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Client is a thin typed wrapper over the web setup API at BaseURL.
+type Client struct {
+	BaseURL string
+	HTTP    *http.Client
+}
+
+// NewClient targets the local web app. The timeout is generous because the
+// provider/data-source test endpoints make live upstream calls.
+func NewClient(baseURL string) *Client {
+	return &Client{
+		BaseURL: strings.TrimRight(baseURL, "/"),
+		HTTP:    &http.Client{Timeout: 120 * time.Second},
+	}
+}
+
+// ----- payload shapes (mirror SetupWizard.tsx) -----
+
+type Field struct {
+	Key         string `json:"key"`
+	Label       string `json:"label"`
+	Kind        string `json:"kind"` // text | secret | url
+	Required    bool   `json:"required,omitempty"`
+	Placeholder string `json:"placeholder,omitempty"`
+	Help        string `json:"help,omitempty"`
+}
+
+type ProviderOption struct {
+	Value       string `json:"value"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+type ProviderConfig struct {
+	Scope    string         `json:"scope"`
+	Source   string         `json:"source"` // org | env | default
+	Provider string         `json:"provider"`
+	Model    string         `json:"model"`
+	Enabled  bool           `json:"enabled"`
+	Config   map[string]any `json:"config"`
+}
+
+type ProviderSettings struct {
+	Primary  ProviderConfig `json:"primary"`
+	Research ProviderConfig `json:"research"`
+	Options  struct {
+		Primary  []ProviderOption `json:"primary"`
+		Research []ProviderOption `json:"research"`
+	} `json:"options"`
+	Defaults struct {
+		Primary  map[string]string `json:"primary"`
+		Research map[string]string `json:"research"`
+	} `json:"defaults"`
+	Fields struct {
+		Primary  map[string][]Field `json:"primary"`
+		Research map[string][]Field `json:"research"`
+	} `json:"fields"`
+}
+
+type AgentBackendOption struct {
+	Value       string `json:"value"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+type AgentSettings struct {
+	Agent struct {
+		Source    string `json:"source"`
+		Backend   string `json:"backend"`
+		GlobalCap int    `json:"globalCap"`
+	} `json:"agent"`
+	Options  []AgentBackendOption `json:"options"`
+	Defaults struct {
+		GlobalCap int `json:"globalCap"`
+	} `json:"defaults"`
+}
+
+type DataSource struct {
+	Source     string `json:"source"` // org | unset
+	Kind       string `json:"kind"`
+	GraphqlURL string `json:"graphqlUrl"`
+	McpURL     string `json:"mcpUrl"`
+	Label      string `json:"label"`
+}
+
+// ProviderDraft is the body for provider test + save (primary or research).
+type ProviderDraft struct {
+	Scope    string            `json:"scope"` // primary | research
+	Provider string            `json:"provider"`
+	Model    string            `json:"model"`
+	Enabled  bool              `json:"enabled"`
+	Config   map[string]string `json:"config"`
+	Secrets  map[string]string `json:"secrets"`
+}
+
+// ----- readiness -----
+
+// Ready does one short-timeout probe (GET change-password is config-file
+// backed, so it answers as soon as the web process is serving).
+func (c *Client) Ready(ctx context.Context) bool {
+	probe := &http.Client{Timeout: 2 * time.Second}
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/api/admin/change-password", nil)
+	resp, err := probe.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.StatusCode == http.StatusOK
+}
+
+// WaitReady polls Ready until the web app answers. Bring-up has already waited
+// for neko-db + migrations, so once web answers the DB-backed endpoints work
+// too.
+func (c *Client) WaitReady(ctx context.Context, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		if c.Ready(ctx) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("web app at %s did not become ready within %s", c.BaseURL, timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Second):
+		}
+	}
+}
+
+// ----- state reads -----
+
+func (c *Client) PasswordChanged(ctx context.Context) (bool, error) {
+	var out struct {
+		Changed bool `json:"changed"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/api/admin/change-password", nil, &out); err != nil {
+		return false, err
+	}
+	return out.Changed, nil
+}
+
+func (c *Client) GetProvider(ctx context.Context) (*ProviderSettings, error) {
+	var out ProviderSettings
+	if err := c.do(ctx, http.MethodGet, "/api/settings/provider", nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) GetAgent(ctx context.Context) (*AgentSettings, error) {
+	var out AgentSettings
+	if err := c.do(ctx, http.MethodGet, "/api/settings/agent", nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (c *Client) GetDataSource(ctx context.Context) (*DataSource, error) {
+	var out DataSource
+	if err := c.do(ctx, http.MethodGet, "/api/settings/data-source", nil, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// ----- mutations + gates -----
+
+func (c *Client) ChangePassword(ctx context.Context, password string) error {
+	return c.do(ctx, http.MethodPost, "/api/admin/change-password",
+		map[string]string{"password": password}, nil)
+}
+
+// TestDataSource runs the same connectivity gate the wizard does. It returns
+// mcpOk so callers can note an unreachable MCP (fine for the agent path)
+// without treating it as failure.
+func (c *Client) TestDataSource(ctx context.Context, graphqlURL, mcpURL string) (mcpOK bool, err error) {
+	var out struct {
+		MCPOk *bool `json:"mcpOk"`
+	}
+	if err := c.do(ctx, http.MethodPost, "/api/settings/data-source/test",
+		map[string]string{"graphqlUrl": graphqlURL, "mcpUrl": mcpURL}, &out); err != nil {
+		return false, err
+	}
+	return out.MCPOk == nil || *out.MCPOk, nil
+}
+
+func (c *Client) SaveDataSource(ctx context.Context, graphqlURL, mcpURL, label string) error {
+	return c.do(ctx, http.MethodPut, "/api/settings/data-source",
+		map[string]string{"graphqlUrl": graphqlURL, "mcpUrl": mcpURL, "label": label}, nil)
+}
+
+// TestProvider validates a provider key with a real one-shot call — the same
+// gate the wizard runs before saving.
+func (c *Client) TestProvider(ctx context.Context, draft ProviderDraft) error {
+	return c.do(ctx, http.MethodPost, "/api/settings/provider/test", draft, nil)
+}
+
+func (c *Client) SaveAgent(ctx context.Context, backend string, globalCap int) error {
+	return c.do(ctx, http.MethodPut, "/api/settings/agent",
+		map[string]any{"backend": backend, "globalCap": globalCap}, nil)
+}
+
+func (c *Client) SaveProvider(ctx context.Context, draft ProviderDraft) error {
+	return c.do(ctx, http.MethodPut, "/api/settings/provider", draft, nil)
+}
+
+func (c *Client) Finish(ctx context.Context) error {
+	return c.do(ctx, http.MethodPost, "/settings/finish", nil, nil)
+}
+
+// do issues a JSON request and decodes a JSON response. Non-2xx responses
+// carry a {"error": "..."} body which is surfaced verbatim.
+func (c *Client) do(ctx context.Context, method, path string, body, out any) error {
+	var rdr io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return err
+		}
+		rdr = bytes.NewReader(b)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, rdr)
+	if err != nil {
+		return err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var e struct {
+			Error string `json:"error"`
+		}
+		_ = json.Unmarshal(data, &e)
+		if e.Error != "" {
+			return errors.New(e.Error)
+		}
+		return fmt.Errorf("%s %s: HTTP %d", method, path, resp.StatusCode)
+	}
+	if out != nil && len(data) > 0 {
+		return json.Unmarshal(data, out)
+	}
+	return nil
+}
+
+// ----- endpoint derivation (ported from SetupWizard.tsx deriveRoot/Endpoints) -----
+
+const (
+	graphqlSuffix = "/api/v1/graphql"
+	mcpSuffix     = "/api/v1/mcp"
+)
+
+// DeriveEndpoints accepts a bare root, a trailing-slash root, or a full
+// GraphQL/MCP URL and returns the canonical graphql + mcp endpoints.
+func DeriveEndpoints(rootURL string) (graphqlURL, mcpURL string) {
+	root := deriveRoot(rootURL)
+	return root + graphqlSuffix, root + mcpSuffix
+}
+
+func deriveRoot(input string) string {
+	s := strings.TrimRight(strings.TrimSpace(input), "/")
+	lower := strings.ToLower(s)
+	switch {
+	case strings.HasSuffix(lower, graphqlSuffix):
+		s = s[:len(s)-len(graphqlSuffix)]
+	case strings.HasSuffix(lower, mcpSuffix):
+		s = s[:len(s)-len(mcpSuffix)]
+	}
+	return strings.TrimRight(s, "/")
+}

--- a/apps/openneko/internal/setup/client_test.go
+++ b/apps/openneko/internal/setup/client_test.go
@@ -1,0 +1,82 @@
+package setup
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDeriveEndpoints(t *testing.T) {
+	cases := map[string]string{
+		"http://graphjin:8080":                "http://graphjin:8080",
+		"http://graphjin:8080/":               "http://graphjin:8080",
+		"http://graphjin:8080/api/v1/graphql": "http://graphjin:8080",
+		"http://graphjin:8080/api/v1/mcp":     "http://graphjin:8080",
+		"http://host.docker.internal:8080//":  "http://host.docker.internal:8080",
+		"HTTP://Up.Example/API/V1/GRAPHQL":    "HTTP://Up.Example", // case-insensitive suffix strip
+	}
+	for in, wantRoot := range cases {
+		gql, mcp := DeriveEndpoints(in)
+		if gql != wantRoot+graphqlSuffix {
+			t.Errorf("%q: graphql = %q, want %q", in, gql, wantRoot+graphqlSuffix)
+		}
+		if mcp != wantRoot+mcpSuffix {
+			t.Errorf("%q: mcp = %q, want %q", in, mcp, wantRoot+mcpSuffix)
+		}
+	}
+}
+
+func TestClientErrorSurfacing(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "that password is too common"})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	err := c.ChangePassword(context.Background(), "secret")
+	if err == nil || err.Error() != "that password is too common" {
+		t.Fatalf("want surfaced server error, got %v", err)
+	}
+}
+
+func TestClientTestDataSourceMcpOk(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mcpOk := false
+		_ = json.NewEncoder(w).Encode(map[string]any{"ok": true, "mcpOk": &mcpOk})
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL)
+	ok, err := c.TestDataSource(context.Background(), "http://x/api/v1/graphql", "http://x/api/v1/mcp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected mcpOk=false to propagate")
+	}
+}
+
+func TestClientReady(t *testing.T) {
+	up := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/admin/change-password" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]bool{"changed": false})
+	}))
+	defer up.Close()
+
+	if !NewClient(up.URL).Ready(context.Background()) {
+		t.Fatal("expected Ready=true for a serving app")
+	}
+	// A closed server isn't reachable.
+	down := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	addr := down.URL
+	down.Close()
+	if NewClient(addr).Ready(context.Background()) {
+		t.Fatal("expected Ready=false for a down app")
+	}
+}

--- a/apps/openneko/internal/setup/wizard.go
+++ b/apps/openneko/internal/setup/wizard.go
@@ -1,0 +1,504 @@
+package setup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/open-neko/neko/apps/openneko/internal/prompt"
+)
+
+// Config carries everything the onboarding flow needs. Headless callers set the
+// override fields and Headless=true; interactive callers leave them empty.
+type Config struct {
+	Mode    string // demo | prod | dev — picks the data-source default
+	BaseURL string // web app URL, for the browser handoff message
+
+	Headless bool // run from flags without prompting
+
+	AdminPassword    string
+	Backend          string
+	Provider         string
+	ProviderKey      string
+	Model            string
+	DataURL          string
+	ResearchProvider string
+	ResearchKey      string
+	NoResearch       bool
+}
+
+// Outcome reports how onboarding ended so the caller can print the right
+// next-step message.
+type Outcome struct {
+	Configured bool // ran through Finish in the terminal
+	Skipped    bool // deferred to the browser (chosen, or no TTY + no flags)
+}
+
+// errBrowser is returned by any step when the operator opts out to the browser.
+var errBrowser = errors.New("browser handoff")
+
+var forbiddenPasswords = map[string]bool{"secret": true, "password": true, "postgres": true}
+
+const minPasswordLen = 8
+
+// Run executes onboarding against the web app. Headless runs from Config
+// fields; interactive prompts step by step and can bail to the browser at any
+// point (partial progress persists server-side, so resuming in the browser just
+// continues).
+func Run(ctx context.Context, c *Client, out io.Writer, cfg Config) (Outcome, error) {
+	if cfg.Headless {
+		return runHeadless(ctx, c, cfg)
+	}
+	return runInteractive(ctx, c, out, cfg)
+}
+
+// ----- interactive -----
+
+func runInteractive(ctx context.Context, c *Client, out io.Writer, cfg Config) (Outcome, error) {
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "OpenNeko is up. Configure it now in the terminal, or finish in your browser?")
+	choice, err := prompt.Visible("  [t] terminal  ·  [b] browser  (t): ")
+	if err != nil {
+		return Outcome{}, err
+	}
+	if strings.EqualFold(strings.TrimSpace(choice), "b") {
+		return browserHandoff(out, cfg), nil
+	}
+	fmt.Fprintln(out, "  (type b at any prompt to switch to the browser)")
+
+	err = stepsInteractive(ctx, c, out, cfg)
+	if errors.Is(err, errBrowser) {
+		return browserHandoff(out, cfg), nil
+	}
+	if err != nil {
+		return Outcome{}, err
+	}
+	return Outcome{Configured: true}, nil
+}
+
+func stepsInteractive(ctx context.Context, c *Client, out io.Writer, cfg Config) error {
+	// 1. Admin DB password (only when still the bootstrap default).
+	changed, err := c.PasswordChanged(ctx)
+	if err != nil {
+		return err
+	}
+	if !changed {
+		fmt.Fprintln(out, "\n1. Choose a database password (min 8 chars; you won't enter it again).")
+		pw, err := promptNewPassword(out)
+		if err != nil {
+			return err
+		}
+		if err := c.ChangePassword(ctx, pw); err != nil {
+			return err
+		}
+		fmt.Fprintln(out, "   ✓ password set")
+	}
+
+	// 2. Data source.
+	ds, err := c.GetDataSource(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(out, "\n2. Connect your data (GraphJin base URL).")
+	for {
+		root, err := askLine("   GraphJin URL", defaultDataURL(cfg, ds))
+		if err != nil {
+			return err
+		}
+		gql, mcp := DeriveEndpoints(root)
+		mcpOK, err := c.TestDataSource(ctx, gql, mcp)
+		if err != nil {
+			fmt.Fprintf(out, "   ✗ %s — try again.\n", err)
+			continue
+		}
+		if err := c.SaveDataSource(ctx, gql, mcp, "primary"); err != nil {
+			fmt.Fprintf(out, "   ✗ %s — try again.\n", err)
+			continue
+		}
+		if mcpOK {
+			fmt.Fprintln(out, "   ✓ data source saved")
+		} else {
+			fmt.Fprintln(out, "   ✓ data source saved (MCP unreachable — fine for the agent path)")
+		}
+		break
+	}
+
+	// 3. Agent backend + primary provider.
+	agent, err := c.GetAgent(ctx)
+	if err != nil {
+		return err
+	}
+	prov, err := c.GetProvider(ctx)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(out, "\n3. Choose the agent + model provider.")
+	backend, err := chooseOption(out, "   Agent backend", toOptions(agent.Options), agent.Agent.Backend)
+	if err != nil {
+		return err
+	}
+	var provider string
+	if backend == "claude-agent" {
+		provider = "anthropic"
+		fmt.Fprintln(out, "   Provider: anthropic (locked by Claude Agent backend)")
+	} else {
+		provider, err = chooseOption(out, "   Provider", prov.Options.Primary, prov.Primary.Provider)
+		if err != nil {
+			return err
+		}
+	}
+	model, err := askLine("   Model", modelDefault(prov.Defaults.Primary, provider, prov.Primary))
+	if err != nil {
+		return err
+	}
+	config, secrets, err := collectFields(prov.Fields.Primary[provider])
+	if err != nil {
+		return err
+	}
+	cap := agent.Agent.GlobalCap
+	if cap == 0 {
+		cap = agent.Defaults.GlobalCap
+	}
+	draft := ProviderDraft{Scope: "primary", Provider: provider, Model: model, Enabled: true, Config: config, Secrets: secrets}
+	fmt.Fprintln(out, "   validating key…")
+	if err := c.TestProvider(ctx, draft); err != nil {
+		return fmt.Errorf("provider key test failed: %w", err)
+	}
+	if err := c.SaveAgent(ctx, backend, cap); err != nil {
+		return err
+	}
+	if err := c.SaveProvider(ctx, draft); err != nil {
+		return err
+	}
+	fmt.Fprintln(out, "   ✓ agent + provider saved")
+
+	// 4. Research (optional).
+	fmt.Fprintln(out, "\n4. Industry research (optional).")
+	enable, err := askYesNo("   Enable industry research?", false)
+	if err != nil {
+		return err
+	}
+	if enable {
+		rprovider, err := chooseOption(out, "   Research provider", filterOut(prov.Options.Research, "disabled"), researchDefault(prov.Options.Research))
+		if err != nil {
+			return err
+		}
+		rmodel, err := askLine("   Model", prov.Defaults.Research[rprovider])
+		if err != nil {
+			return err
+		}
+		rconfig, rsecrets, err := collectFields(prov.Fields.Research[rprovider])
+		if err != nil {
+			return err
+		}
+		rdraft := ProviderDraft{Scope: "research", Provider: rprovider, Model: rmodel, Enabled: true, Config: rconfig, Secrets: rsecrets}
+		fmt.Fprintln(out, "   validating key…")
+		if err := c.TestProvider(ctx, rdraft); err != nil {
+			return fmt.Errorf("research key test failed: %w", err)
+		}
+		if err := c.SaveProvider(ctx, rdraft); err != nil {
+			return err
+		}
+		fmt.Fprintln(out, "   ✓ research enabled")
+	} else if err := c.SaveProvider(ctx, disabledResearch()); err != nil {
+		return err
+	}
+
+	// 5. Finish.
+	return c.Finish(ctx)
+}
+
+// ----- headless -----
+
+func runHeadless(ctx context.Context, c *Client, cfg Config) (Outcome, error) {
+	changed, err := c.PasswordChanged(ctx)
+	if err != nil {
+		return Outcome{}, err
+	}
+	if !changed {
+		if cfg.AdminPassword == "" {
+			return Outcome{}, errors.New("setup: --admin-password is required (database still has the bootstrap default)")
+		}
+		if err := validatePassword(cfg.AdminPassword); err != nil {
+			return Outcome{}, err
+		}
+		if err := c.ChangePassword(ctx, cfg.AdminPassword); err != nil {
+			return Outcome{}, err
+		}
+	}
+
+	ds, err := c.GetDataSource(ctx)
+	if err != nil {
+		return Outcome{}, err
+	}
+	gql, mcp := DeriveEndpoints(defaultDataURL(cfg, ds))
+	if _, err := c.TestDataSource(ctx, gql, mcp); err != nil {
+		return Outcome{}, fmt.Errorf("data source test failed: %w", err)
+	}
+	if err := c.SaveDataSource(ctx, gql, mcp, "primary"); err != nil {
+		return Outcome{}, err
+	}
+
+	agent, err := c.GetAgent(ctx)
+	if err != nil {
+		return Outcome{}, err
+	}
+	prov, err := c.GetProvider(ctx)
+	if err != nil {
+		return Outcome{}, err
+	}
+	backend := cfg.Backend
+	if backend == "" {
+		backend = agent.Agent.Backend
+	}
+	provider := cfg.Provider
+	if backend == "claude-agent" {
+		provider = "anthropic"
+	}
+	if provider == "" {
+		return Outcome{}, errors.New("setup: --provider is required")
+	}
+	if cfg.ProviderKey == "" {
+		return Outcome{}, errors.New("setup: --provider-key is required")
+	}
+	model := cfg.Model
+	if model == "" {
+		model = modelDefault(prov.Defaults.Primary, provider, prov.Primary)
+	}
+	secretKey := secretFieldKey(prov.Fields.Primary[provider])
+	cap := agent.Agent.GlobalCap
+	if cap == 0 {
+		cap = agent.Defaults.GlobalCap
+	}
+	draft := ProviderDraft{
+		Scope: "primary", Provider: provider, Model: model, Enabled: true,
+		Config: map[string]string{}, Secrets: map[string]string{secretKey: cfg.ProviderKey},
+	}
+	if err := c.TestProvider(ctx, draft); err != nil {
+		return Outcome{}, fmt.Errorf("provider key test failed: %w", err)
+	}
+	if err := c.SaveAgent(ctx, backend, cap); err != nil {
+		return Outcome{}, err
+	}
+	if err := c.SaveProvider(ctx, draft); err != nil {
+		return Outcome{}, err
+	}
+
+	if !cfg.NoResearch && cfg.ResearchProvider != "" && cfg.ResearchKey != "" {
+		rmodel := prov.Defaults.Research[cfg.ResearchProvider]
+		rkey := secretFieldKey(prov.Fields.Research[cfg.ResearchProvider])
+		rdraft := ProviderDraft{
+			Scope: "research", Provider: cfg.ResearchProvider, Model: rmodel, Enabled: true,
+			Config: map[string]string{}, Secrets: map[string]string{rkey: cfg.ResearchKey},
+		}
+		if err := c.TestProvider(ctx, rdraft); err != nil {
+			return Outcome{}, fmt.Errorf("research key test failed: %w", err)
+		}
+		if err := c.SaveProvider(ctx, rdraft); err != nil {
+			return Outcome{}, err
+		}
+	} else if err := c.SaveProvider(ctx, disabledResearch()); err != nil {
+		return Outcome{}, err
+	}
+
+	if err := c.Finish(ctx); err != nil {
+		return Outcome{}, err
+	}
+	return Outcome{Configured: true}, nil
+}
+
+// ----- shared helpers -----
+
+func browserHandoff(out io.Writer, cfg Config) Outcome {
+	fmt.Fprintf(out, "\nFinish setup in your browser: %s\n", cfg.BaseURL)
+	return Outcome{Skipped: true}
+}
+
+func defaultDataURL(cfg Config, ds *DataSource) string {
+	if ds != nil && ds.Source == "org" && ds.GraphqlURL != "" {
+		return deriveRoot(ds.GraphqlURL)
+	}
+	if cfg.DataURL != "" {
+		return cfg.DataURL
+	}
+	if cfg.Mode == "demo" {
+		return "http://graphjin:8080"
+	}
+	return "http://host.docker.internal:8080"
+}
+
+func modelDefault(defaults map[string]string, provider string, current ProviderConfig) string {
+	if d := defaults[provider]; d != "" {
+		return d
+	}
+	if current.Provider == provider && current.Model != "" {
+		return current.Model
+	}
+	return ""
+}
+
+func researchDefault(opts []ProviderOption) string {
+	for _, o := range opts {
+		if o.Value != "disabled" {
+			return o.Value
+		}
+	}
+	return ""
+}
+
+func disabledResearch() ProviderDraft {
+	return ProviderDraft{Scope: "research", Provider: "disabled", Model: "", Enabled: false, Config: map[string]string{}, Secrets: map[string]string{}}
+}
+
+func filterOut(opts []ProviderOption, drop string) []ProviderOption {
+	out := make([]ProviderOption, 0, len(opts))
+	for _, o := range opts {
+		if o.Value != drop {
+			out = append(out, o)
+		}
+	}
+	return out
+}
+
+func toOptions(in []AgentBackendOption) []ProviderOption {
+	out := make([]ProviderOption, len(in))
+	for i, o := range in {
+		out[i] = ProviderOption{Value: o.Value, Label: o.Label, Description: o.Description}
+	}
+	return out
+}
+
+// secretFieldKey returns the key of the first secret-kind field, defaulting to
+// "apiKey" when the provider declares none explicitly.
+func secretFieldKey(fields []Field) string {
+	for _, f := range fields {
+		if f.Kind == "secret" {
+			return f.Key
+		}
+	}
+	return "apiKey"
+}
+
+func validatePassword(pw string) error {
+	if len(pw) < minPasswordLen {
+		return fmt.Errorf("password must be at least %d characters", minPasswordLen)
+	}
+	if forbiddenPasswords[strings.ToLower(pw)] {
+		return errors.New("that password is too common; pick something else")
+	}
+	return nil
+}
+
+// ----- prompt helpers -----
+
+// askLine reads a visible line with a default; "b" bails to the browser.
+func askLine(label, def string) (string, error) {
+	suffix := ""
+	if def != "" {
+		suffix = fmt.Sprintf(" [%s]", def)
+	}
+	v, err := prompt.Visible(fmt.Sprintf("%s%s: ", label, suffix))
+	if err != nil {
+		return "", err
+	}
+	v = strings.TrimSpace(v)
+	if strings.EqualFold(v, "b") {
+		return "", errBrowser
+	}
+	if v == "" {
+		return def, nil
+	}
+	return v, nil
+}
+
+func askYesNo(label string, def bool) (bool, error) {
+	hint := "y/N"
+	if def {
+		hint = "Y/n"
+	}
+	v, err := prompt.Visible(fmt.Sprintf("%s (%s): ", label, hint))
+	if err != nil {
+		return false, err
+	}
+	v = strings.TrimSpace(strings.ToLower(v))
+	if v == "b" {
+		return false, errBrowser
+	}
+	if v == "" {
+		return def, nil
+	}
+	return v == "y" || v == "yes", nil
+}
+
+// chooseOption prints the options and reads a value (accepts the value itself
+// or its 1-based index); empty keeps def.
+func chooseOption(out io.Writer, label string, opts []ProviderOption, def string) (string, error) {
+	for i, o := range opts {
+		marker := " "
+		if o.Value == def {
+			marker = "*"
+		}
+		fmt.Fprintf(out, "     %s [%d] %s — %s\n", marker, i+1, o.Value, o.Description)
+	}
+	v, err := askLine(label, def)
+	if err != nil {
+		return "", err
+	}
+	for i, o := range opts {
+		if v == o.Value || v == fmt.Sprintf("%d", i+1) {
+			return o.Value, nil
+		}
+	}
+	if v == def {
+		return def, nil
+	}
+	return "", fmt.Errorf("unknown option %q", v)
+}
+
+func promptNewPassword(out io.Writer) (string, error) {
+	for {
+		pw, err := prompt.Hidden("   New password: ")
+		if err != nil {
+			return "", err
+		}
+		if err := validatePassword(pw); err != nil {
+			fmt.Fprintf(out, "   ✗ %s\n", err)
+			continue
+		}
+		confirm, err := prompt.Hidden("   Confirm password: ")
+		if err != nil {
+			return "", err
+		}
+		if pw != confirm {
+			fmt.Fprintln(out, "   ✗ passwords don't match")
+			continue
+		}
+		return pw, nil
+	}
+}
+
+// collectFields prompts each provider field, routing secret-kind fields through
+// a hidden prompt and the rest into the config map.
+func collectFields(fields []Field) (config, secrets map[string]string, err error) {
+	config = map[string]string{}
+	secrets = map[string]string{}
+	for _, f := range fields {
+		label := "   " + f.Label
+		if f.Kind == "secret" {
+			v, err := prompt.Hidden(label + ": ")
+			if err != nil {
+				return nil, nil, err
+			}
+			secrets[f.Key] = v
+			continue
+		}
+		v, err := askLine(label, f.Placeholder)
+		if err != nil {
+			return nil, nil, err
+		}
+		config[f.Key] = v
+	}
+	return config, secrets, nil
+}

--- a/apps/openneko/internal/setup/wizard_test.go
+++ b/apps/openneko/internal/setup/wizard_test.go
@@ -1,0 +1,203 @@
+package setup
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type recorded struct {
+	method string
+	path   string
+	body   map[string]any
+}
+
+// mockSetupServer answers every endpoint the onboarding flow touches and
+// records each request so tests can assert the call sequence and bodies.
+func mockSetupServer(changed bool, recs *[]recorded) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		*recs = append(*recs, recorded{r.Method, r.URL.Path, body})
+		enc := json.NewEncoder(w)
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/admin/change-password":
+			_ = enc.Encode(map[string]bool{"changed": changed})
+		case "GET /api/settings/data-source":
+			_ = enc.Encode(map[string]any{"source": "unset"})
+		case "GET /api/settings/agent":
+			_ = enc.Encode(map[string]any{
+				"agent": map[string]any{"source": "default", "backend": "hermes", "globalCap": 5},
+				"options": []map[string]string{
+					{"value": "hermes", "label": "Hermes", "description": "any provider"},
+					{"value": "claude-agent", "label": "Claude Agent", "description": "anthropic"},
+				},
+				"defaults": map[string]any{"globalCap": 5},
+			})
+		case "GET /api/settings/provider":
+			_ = enc.Encode(map[string]any{
+				"primary":  map[string]any{"scope": "primary", "source": "default", "provider": "anthropic", "model": "", "enabled": false, "config": map[string]any{}},
+				"research": map[string]any{"scope": "research", "source": "default", "provider": "disabled", "model": "", "enabled": false, "config": map[string]any{}},
+				"options": map[string]any{
+					"primary":  []map[string]string{{"value": "anthropic", "label": "Anthropic", "description": "claude"}},
+					"research": []map[string]string{{"value": "disabled", "label": "Disabled", "description": "off"}, {"value": "perplexity", "label": "Perplexity", "description": "research"}},
+				},
+				"defaults": map[string]any{
+					"primary":  map[string]string{"anthropic": "claude-opus-4-7"},
+					"research": map[string]string{"perplexity": "sonar"},
+				},
+				"fields": map[string]any{
+					"primary":  map[string]any{"anthropic": []map[string]any{{"key": "apiKey", "label": "API key", "kind": "secret", "required": true}}},
+					"research": map[string]any{"perplexity": []map[string]any{{"key": "apiKey", "label": "API key", "kind": "secret"}}},
+				},
+			})
+		default:
+			_ = enc.Encode(map[string]any{"ok": true})
+		}
+	}))
+}
+
+func findWhere(recs []recorded, method, path string, pred func(map[string]any) bool) (recorded, bool) {
+	for _, rec := range recs {
+		if rec.method == method && rec.path == path && (pred == nil || pred(rec.body)) {
+			return rec, true
+		}
+	}
+	return recorded{}, false
+}
+
+func TestHeadlessConfigure(t *testing.T) {
+	var recs []recorded
+	srv := mockSetupServer(false, &recs)
+	defer srv.Close()
+
+	out := &bytes.Buffer{}
+	cfg := Config{
+		Mode: "demo", BaseURL: srv.URL, Headless: true,
+		AdminPassword: "supersecret", Provider: "anthropic", ProviderKey: "sk-test", NoResearch: true,
+	}
+	outcome, err := Run(context.Background(), NewClient(srv.URL), out, cfg)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !outcome.Configured || outcome.Skipped {
+		t.Fatalf("want Configured, got %+v", outcome)
+	}
+
+	if _, ok := findWhere(recs, "POST", "/api/admin/change-password", func(b map[string]any) bool {
+		return b["password"] == "supersecret"
+	}); !ok {
+		t.Error("missing password change with the supplied password")
+	}
+	// Data source saved with demo's internal GraphJin root, canonical suffix.
+	if _, ok := findWhere(recs, "PUT", "/api/settings/data-source", func(b map[string]any) bool {
+		return b["graphqlUrl"] == "http://graphjin:8080/api/v1/graphql"
+	}); !ok {
+		t.Error("data source not saved with derived demo endpoint")
+	}
+	// Provider key tested before save, keyed by the provider's secret field.
+	if _, ok := findWhere(recs, "POST", "/api/settings/provider/test", func(b map[string]any) bool {
+		s, _ := b["secrets"].(map[string]any)
+		return s != nil && s["apiKey"] == "sk-test"
+	}); !ok {
+		t.Error("provider key not tested with apiKey secret")
+	}
+	if _, ok := findWhere(recs, "PUT", "/api/settings/agent", func(b map[string]any) bool {
+		return b["backend"] == "hermes"
+	}); !ok {
+		t.Error("agent backend not saved")
+	}
+	if _, ok := findWhere(recs, "PUT", "/api/settings/provider", func(b map[string]any) bool {
+		return b["scope"] == "research" && b["provider"] == "disabled"
+	}); !ok {
+		t.Error("research not explicitly disabled")
+	}
+	if _, ok := findWhere(recs, "POST", "/settings/finish", nil); !ok {
+		t.Error("setup not finished")
+	}
+}
+
+func TestHeadlessClaudeAgentLocksAnthropic(t *testing.T) {
+	var recs []recorded
+	srv := mockSetupServer(true, &recs) // password already changed
+	defer srv.Close()
+
+	cfg := Config{
+		Mode: "prod", BaseURL: srv.URL, Headless: true,
+		Backend: "claude-agent", Provider: "openai", ProviderKey: "sk", DataURL: "http://x:8080", NoResearch: true,
+	}
+	if _, err := Run(context.Background(), NewClient(srv.URL), &bytes.Buffer{}, cfg); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// Even though Provider=openai was passed, claude-agent forces anthropic.
+	if _, ok := findWhere(recs, "PUT", "/api/settings/provider", func(b map[string]any) bool {
+		return b["scope"] == "primary" && b["provider"] == "anthropic"
+	}); !ok {
+		t.Error("claude-agent should lock the primary provider to anthropic")
+	}
+}
+
+func TestHeadlessMissingFlags(t *testing.T) {
+	var recs []recorded
+	srv := mockSetupServer(true, &recs) // password already set, so not the blocker
+	defer srv.Close()
+
+	cfg := Config{Mode: "demo", BaseURL: srv.URL, Headless: true, Provider: "anthropic"} // no provider-key
+	_, err := Run(context.Background(), NewClient(srv.URL), &bytes.Buffer{}, cfg)
+	if err == nil {
+		t.Fatal("expected error for missing --provider-key")
+	}
+}
+
+func TestHeadlessMissingPassword(t *testing.T) {
+	var recs []recorded
+	srv := mockSetupServer(false, &recs) // password NOT set and none provided
+	defer srv.Close()
+
+	cfg := Config{Mode: "demo", BaseURL: srv.URL, Headless: true, Provider: "anthropic", ProviderKey: "k"}
+	_, err := Run(context.Background(), NewClient(srv.URL), &bytes.Buffer{}, cfg)
+	if err == nil {
+		t.Fatal("expected error for missing --admin-password on a bootstrap-default DB")
+	}
+}
+
+func TestPureHelpers(t *testing.T) {
+	if err := validatePassword("short"); err == nil {
+		t.Error("short password should fail")
+	}
+	if err := validatePassword("secret"); err == nil {
+		t.Error("forbidden password should fail")
+	}
+	if err := validatePassword("longenough"); err != nil {
+		t.Errorf("valid password rejected: %v", err)
+	}
+
+	if k := secretFieldKey([]Field{{Key: "X", Kind: "text"}, {Key: "tok", Kind: "secret"}}); k != "tok" {
+		t.Errorf("secretFieldKey = %q, want tok", k)
+	}
+	if k := secretFieldKey(nil); k != "apiKey" {
+		t.Errorf("secretFieldKey default = %q, want apiKey", k)
+	}
+
+	demo := defaultDataURL(Config{Mode: "demo"}, &DataSource{Source: "unset"})
+	if demo != "http://graphjin:8080" {
+		t.Errorf("demo default = %q", demo)
+	}
+	saved := defaultDataURL(Config{Mode: "demo"}, &DataSource{Source: "org", GraphqlURL: "http://h:9/api/v1/graphql"})
+	if saved != "http://h:9" {
+		t.Errorf("saved-source default = %q, want root", saved)
+	}
+
+	if m := modelDefault(map[string]string{"anthropic": "claude-x"}, "anthropic", ProviderConfig{}); m != "claude-x" {
+		t.Errorf("modelDefault = %q", m)
+	}
+	if r := disabledResearch(); r.Provider != "disabled" || r.Enabled {
+		t.Errorf("disabledResearch = %+v", r)
+	}
+	if got := filterOut([]ProviderOption{{Value: "disabled"}, {Value: "perplexity"}}, "disabled"); len(got) != 1 || got[0].Value != "perplexity" {
+		t.Errorf("filterOut = %+v", got)
+	}
+}


### PR DESCRIPTION
## What & why

Getting to a running OpenNeko had three rough stretches before `openneko start`: acquiring the binary (brittle on Linux, no checksum verify, no hosted installer), bringing the stack up (no preflight, raw Docker errors, no handoff), and configuring (browser-only). This makes the whole path first-class from the CLI.

Companion PR in the website repo hosts the `curl | sh` installer at `openneko.app/install.sh`.

## What's here

- **`openneko setup`** — one guided command:
  1. **Preflight** (new `internal/preflight`, shared with `doctor`): host support, **Docker daemon up** (not just installed), required host ports free (names the override env var), duplicate-on-PATH.
  2. **Bring-up** — extracted from `start` into `bringUpStack` and reused, so `start` behaviour is unchanged; then waits for web readiness.
  3. **Terminal onboarding** (new `internal/setup`): a thin HTTP client that drives the **same web endpoints as the browser wizard**, with the same live provider-key and data-source test gates — **no new web code, no drift**. Skippable to the browser at any step; headless flags (`--admin-password`, `--provider`, `--provider-key`, …) for CI.
  4. **Optional plugins** — install + configure first-party plugins from the official marketplace. Reuses `openneko install` via the binary, so each selected plugin also prompts for and persists its own keys/tokens. `--skip-plugins` / `--plugins a,b`.
- **`doctor`** now reports Docker daemon status with a remediation (via the shared preflight package).
- **gofmt enforcement** — added a gofmt gate to the go workflow and formatted the tree (separate `chore` commit).
- Docs updated to the one-line installer + `openneko setup`.

## Commits

- `chore(openneko): enforce gofmt in CI and format the tree`
- `feat(cli): guided openneko setup — install, preflight, onboarding, plugins`

## Test plan

- `gofmt -l .` clean · `go vet ./...` clean · `go test ./...` (15 pkgs pass; new unit tests for preflight, the setup client, the headless wizard flow, and plugin selection) · `go build ./...`.
- Manual: `openneko setup --mode demo` → preflight ✓ → bring-up → terminal onboarding to a real Briefing; re-run choosing **browser** for a clean handoff to `localhost:3000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)