### PR TITLE
fix(docker,demo): un-break v2.7.1 — restore agent toolchain to web/worker + demo seed/setup fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,43 +21,32 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl tini \
     && rm -rf /var/lib/apt/lists/*
 
-# ─── 2. runtime-base: lean base for web/worker ─────────────────────────
-# web/worker share this; the heavy agent toolchain (graphjin/hermes/claude/
-# libreoffice) lives one layer up in `cli` so only the agent image carries it.
+# ─── 2. runtime-base: node + agent-orchestration toolchain ─────────────
+# web, worker AND agent all run agent turns in-process (runChatTurn /
+# runWorkflowTurn / profiler / metric-agent in @neko/llm), which shell out to
+# the `graphjin` CLI and the hermes/claude backend — so all three need this
+# layer. Only the doc-skill toolchain (LibreOffice/python) is agent-exclusive
+# and lives one layer up in `cli`.
 FROM base AS runtime-base
+ARG GRAPHJIN_VERSION=3.18.37
+ARG HERMES_AGENT_REF=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 ARG OPENSHELL_VERSION=0.0.54
 # TARGETARCH is auto-supplied by buildx (amd64 or arm64).
 ARG TARGETARCH
-# unzip + postgresql-client are needed by db/load-adventureworks-baked.sh
-# (demo seeder, runs inside the worker container with no apt-get available
-# at runtime since the container runs as the `neko` user, not root).
-# git: git-URL skill installs shallow-clone. openssh-client: `openshell sandbox
-# exec` relays over ssh (unix:/run/openshell/ssh.sock), so the worker — which
-# shells out to it for the agent sandbox — needs an ssh client.
+# unzip + postgresql-client: db/load-adventureworks-baked.sh (demo seed, runs in
+# the worker). git: git-URL skill installs. openssh-client: `openshell sandbox
+# exec` relays over ssh, so web/worker — which run agent turns and spawn
+# sandboxes — need an ssh client.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git unzip postgresql-client openssh-client \
     && rm -rf /var/lib/apt/lists/*
-# openshell: CLI driver the worker uses to spawn + relay to agent sandboxes.
-# Static musl binary, no runtime deps.
-RUN OS_ARCH="$(case "${TARGETARCH}" in amd64) echo x86_64 ;; arm64) echo aarch64 ;; *) echo "${TARGETARCH}" ;; esac)" \
-    && curl -fsSL -o /tmp/openshell.tgz \
-      "https://github.com/NVIDIA/OpenShell/releases/download/v${OPENSHELL_VERSION}/openshell-${OS_ARCH}-unknown-linux-musl.tar.gz" \
-    && tar -xzf /tmp/openshell.tgz -C /usr/local/bin openshell \
-    && rm /tmp/openshell.tgz \
-    && openshell --version
-
-# ─── 2b. cli: agent toolchain (only the `agent` image builds from this) ──
-# graphjin: metric agent uses `graphjin cli`. hermes: default Hermes backend.
-# claude: claude-agent backend (Anthropic SDK spawns it).
-FROM runtime-base AS cli
-ARG GRAPHJIN_VERSION=3.18.37
-ARG HERMES_AGENT_REF=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
-ARG TARGETARCH
+# graphjin: every in-process agent turn queries the data source via `graphjin cli`.
 RUN curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/graphjin.tgz \
       "https://github.com/dosco/graphjin/releases/download/v${GRAPHJIN_VERSION}/graphjin_${GRAPHJIN_VERSION}_linux_${TARGETARCH}.tar.gz" \
     && tar -xzf /tmp/graphjin.tgz -C /usr/local/bin graphjin \
     && rm /tmp/graphjin.tgz \
     && graphjin version
+# hermes: default agent backend (any provider). claude: claude-agent backend.
 RUN curl -LsSf --retry 5 --retry-delay 5 --retry-all-errors https://astral.sh/uv/install.sh \
       | env UV_INSTALL_DIR=/usr/local/bin sh -s -- --no-modify-path \
     && UV_TOOL_DIR=/usr/local/uv/tools \
@@ -72,10 +61,19 @@ RUN curl -LsSf --retry 5 --retry-delay 5 --retry-all-errors https://astral.sh/uv
     && /usr/local/uv/tools/hermes-agent/bin/python -c "import mcp, websockets" \
     && echo "hermes MCP SDK present"
 RUN npm install -g @anthropic-ai/claude-code
+# openshell: CLI to spawn + relay to agent sandboxes. Static musl, no deps.
+RUN OS_ARCH="$(case "${TARGETARCH}" in amd64) echo x86_64 ;; arm64) echo aarch64 ;; *) echo "${TARGETARCH}" ;; esac)" \
+    && curl -fsSL -o /tmp/openshell.tgz \
+      "https://github.com/NVIDIA/OpenShell/releases/download/v${OPENSHELL_VERSION}/openshell-${OS_ARCH}-unknown-linux-musl.tar.gz" \
+    && tar -xzf /tmp/openshell.tgz -C /usr/local/bin openshell \
+    && rm /tmp/openshell.tgz \
+    && openshell --version
 
-# Bundled skills (xlsx / pptx / docx / pdf / skill-creator) shell out to
-# Python + LibreOffice + Poppler / qpdf. Mirror packages/llm/src/work/skill-deps.ts
-# so a fresh image has what they need at runtime.
+# ─── 2b. cli: + doc-skill toolchain (agent image only) ─────────────────
+# Bundled skills (xlsx / pptx / docx / pdf) shell out to Python + LibreOffice +
+# Poppler / qpdf via the agent's Bash inside the OpenShell sandbox — web/worker
+# never run these, so the ~1GB toolchain stays out of their images.
+FROM runtime-base AS cli
 RUN apt-get update && apt-get install -y --no-install-recommends \
       python3 python3-pip libreoffice poppler-utils qpdf \
     && rm -rf /var/lib/apt/lists/* \
@@ -142,7 +140,9 @@ RUN mkdir -p /app/.transformers-cache && \
     cd /app/packages/llm && node scripts/prewarm-embedding.mjs
 
 # ─── 5a. web runtime ───────────────────────────────────────────────────
-FROM base AS web
+# FROM runtime-base (not base): web runs agent turns in-process (runChatTurn /
+# runWorkflowTurn) which shell out to graphjin + the hermes/claude backend.
+FROM runtime-base AS web
 WORKDIR /app
 # Writable HOME under /tmp so the entrypoint can materialize config on
 # read-only container filesystems. PORT=8080 matches the common PaaS

--- a/apps/openneko/assets/compose/demo.yml
+++ b/apps/openneko/assets/compose/demo.yml
@@ -108,7 +108,7 @@ services:
       NEKO_PG_DATABASE: neko
     volumes:
       - openneko-config:/config/openneko
-    command: ["node", "packages/db/src/seed-adventureworks.mjs"]
+    command: ["node", "node_modules/@neko/db/src/seed-adventureworks.mjs"]
     restart: "no"
 
   adventureworks-simulator:

--- a/apps/openneko/internal/setup/client.go
+++ b/apps/openneko/internal/setup/client.go
@@ -231,42 +231,76 @@ func (c *Client) Finish(ctx context.Context) error {
 
 // do issues a JSON request and decodes a JSON response. Non-2xx responses
 // carry a {"error": "..."} body which is surfaced verbatim.
+//
+// It retries transient transport errors (EOF / connection refused) and 502-504
+// for a short window: changing the admin password makes the web container
+// restart (OPENNEKO_RESTART_WEB_ON_PASSWORD_CHANGE), so a request issued right
+// after — e.g. the live provider-key test — can land mid-restart. Every endpoint
+// here is idempotent, so retrying is safe.
 func (c *Client) do(ctx context.Context, method, path string, body, out any) error {
-	var rdr io.Reader
+	var bodyBytes []byte
 	if body != nil {
 		b, err := json.Marshal(body)
 		if err != nil {
 			return err
 		}
-		rdr = bytes.NewReader(b)
+		bodyBytes = b
 	}
-	req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, rdr)
-	if err != nil {
-		return err
-	}
-	if body != nil {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	resp, err := c.HTTP.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	data, _ := io.ReadAll(resp.Body)
-	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		var e struct {
-			Error string `json:"error"`
+	deadline := time.Now().Add(45 * time.Second)
+	for attempt := 0; ; attempt++ {
+		var rdr io.Reader
+		if bodyBytes != nil {
+			rdr = bytes.NewReader(bodyBytes)
 		}
-		_ = json.Unmarshal(data, &e)
-		if e.Error != "" {
-			return errors.New(e.Error)
+		req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, rdr)
+		if err != nil {
+			return err
 		}
-		return fmt.Errorf("%s %s: HTTP %d", method, path, resp.StatusCode)
+		if bodyBytes != nil {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		resp, err := c.HTTP.Do(req)
+		if err != nil {
+			if time.Now().Before(deadline) && ctx.Err() == nil {
+				if waitErr := sleepCtx(ctx, time.Second); waitErr != nil {
+					return waitErr
+				}
+				continue // transport error (web likely restarting) — retry
+			}
+			return err
+		}
+		data, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode >= 502 && resp.StatusCode <= 504 && time.Now().Before(deadline) {
+			if waitErr := sleepCtx(ctx, time.Second); waitErr != nil {
+				return waitErr
+			}
+			continue // transient gateway error during restart — retry
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			var e struct {
+				Error string `json:"error"`
+			}
+			_ = json.Unmarshal(data, &e)
+			if e.Error != "" {
+				return errors.New(e.Error)
+			}
+			return fmt.Errorf("%s %s: HTTP %d", method, path, resp.StatusCode)
+		}
+		if out != nil && len(data) > 0 {
+			return json.Unmarshal(data, out)
+		}
+		return nil
 	}
-	if out != nil && len(data) > 0 {
-		return json.Unmarshal(data, out)
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
 	}
-	return nil
 }
 
 // ----- endpoint derivation (ported from SetupWizard.tsx deriveRoot/Endpoints) -----

--- a/compose.adventureworks.yml
+++ b/compose.adventureworks.yml
@@ -174,7 +174,7 @@ services:
       no_proxy: localhost,127.0.0.1,::1,neko-db,worker,web,graphjin,adventureworks-db,host.docker.internal,host.internal
     volumes:
       - openneko-config:/config/openneko
-    command: ["node", "packages/db/src/seed-adventureworks.mjs"]
+    command: ["node", "node_modules/@neko/db/src/seed-adventureworks.mjs"]
     restart: "no"
 
   web:

--- a/db/load-adventureworks-baked.sh
+++ b/db/load-adventureworks-baked.sh
@@ -18,6 +18,8 @@ set -eu
 export ADVENTUREWORKS_CACHE_DIR="${ADVENTUREWORKS_CACHE_DIR:-/cache}"
 export ADVENTUREWORKS_INSTALL_SQL="${ADVENTUREWORKS_INSTALL_SQL:-/app/db/seeds/dev/adventureworks-install.sql}"
 
-cd /app/apps/worker
+# The worker image is a `pnpm deploy --prod` closure rooted at /app, so the
+# loader is /app/scripts/load-adventureworks.ts (not /app/apps/worker/...).
+cd /app
 echo "[adventureworks] running TS loader from baked worker image"
 exec node --import tsx/esm scripts/load-adventureworks.ts


### PR DESCRIPTION
## Why (regression in released v2.7.1)
#139 over-pruned the images. **web and worker run agent turns in-process** — `runChatTurn` / `runWorkflowTurn` (web) and the profiler / `metric-agent` (worker), all in `@neko/llm` — and those shell out to the **`graphjin` CLI** and run the **hermes/claude** backend. The prune removed graphjin/hermes/claude from both, so on v2.7.1:
- **worker**: briefing generation fails → `graphjin CLI is not installed on PATH`
- **web**: `/work` chat + workflow runs fail the same way

The original needs-matrix grep only scanned `apps/*/src` and missed these spawns (they live in the `@neko/llm` dependency). Only the **LibreOffice + python doc-skill toolchain** is genuinely agent-exclusive — it runs via the agent's Bash *inside the OpenShell sandbox*, and neither web nor worker references `soffice`.

## What
- **Dockerfile**: move `graphjin + hermes + claude` into `runtime-base` (web, worker, agent all need them); keep only LibreOffice/python in `cli` (agent-only). `web` → `FROM runtime-base` (not `base`). Keeps the worker `node_modules` prune and the ~1 GB LibreOffice drop from web/worker.
- **`demo.yml` + `compose.adventureworks.yml`**: seed command → `node_modules/@neko/db/src/seed-adventureworks.mjs` (worker image is a `pnpm deploy --prod` closure rooted at `/app`, not the old `packages/db` source tree).
- **`db/load-adventureworks-baked.sh`**: `cd /app` (was `/app/apps/worker`).
- **`internal/setup/client.go`**: retry transient transport errors (EOF / 502–504) so the **headless** `openneko setup` survives the web restart triggered by the admin-password change (`OPENNEKO_RESTART_WEB_ON_PASSWORD_CHANGE`).

## Verified end-to-end
Fresh `openneko setup --mode demo` with the v2.7.1 CLI (installed via `openneko.app/install.sh`) → preflight ✓ → bring-up ✓ → headless onboarding (hermes + google-gemini/`gemini-3.5-flash`) ✓ → **demo seed succeeds** → **business profile + per-role metric cards generate, data-grounded** (e.g. 0.277% scrap rate, 33.5% DTC mix, $44.19M TTM territory revenue), via gemini-3.5-flash.

| image | before | after |
|---|---|---|
| neko-web | 2.08 GB | **1.45 GB** |
| neko-worker | 3.35 GB | **2.12 GB** |
| agent | 2.72 GB | unchanged |

Content checks: web & worker now have graphjin/hermes/claude and **no** soffice; agent has all incl. soffice.

> Note unrelated to this PR: the in-browser `/work` **chat** agent (sandboxed via OpenShell) was flaky on the test host — one run hit the 540s hermes turn budget (gemini-3.5-flash is slow), another hit an OpenShell sandbox policy-update error. The agent did run and produce grounded output; this is an OpenShell-sandbox/model-speed matter on macOS, separate from these fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)