### PR TITLE
fix(setup): reconnect the agent gateway after password rotation

### DIFF
--- a/apps/openneko/internal/cli/openshell_test.go
+++ b/apps/openneko/internal/cli/openshell_test.go
@@ -1,9 +1,13 @@
 package cli
 
 import (
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/open-neko/neko/apps/openneko/internal/config"
 )
 
 func TestAgentImageRef(t *testing.T) {
@@ -32,34 +36,58 @@ func TestOpenShellStateDirOverride(t *testing.T) {
 
 func TestConfigureOpenShellDBURL(t *testing.T) {
 	// Operator-set URL always wins.
-	t.Setenv("OPENSHELL_DB_URL", "postgres://op:set@elsewhere:5432/db")
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("OPENSHELL_DB_URL", "postgres://op:set@elsewhere:5432/db")
 	configureOpenShellDBURL()
 	if got := os.Getenv("OPENSHELL_DB_URL"); got != "postgres://op:set@elsewhere:5432/db" {
 		t.Fatalf("operator value must win: got %q", got)
 	}
 
-	// No local config -> leave unset so the compose default applies.
-	t.Setenv("OPENSHELL_DB_URL", "")
-	configureOpenShellDBURL()
-	if got := os.Getenv("OPENSHELL_DB_URL"); got != "" {
-		t.Fatalf("fresh install should not set the URL: got %q", got)
-	}
-
-	// Rotated password in config.json -> URL derived from it, host pinned to
-	// the compose network, special characters escaped.
+	// No operator override -> URL derived for the dedicated `openshell` role
+	// with the per-install secret-key password (NOT the neko password), host
+	// pinned to the compose network, database defaulting to neko.
 	dir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", dir)
-	if err := os.MkdirAll(filepath.Join(dir, "openneko"), 0o755); err != nil {
+	t.Setenv("OPENSHELL_DB_URL", "")
+	configureOpenShellDBURL()
+	got := os.Getenv("OPENSHELL_DB_URL")
+	u, err := url.Parse(got)
+	if err != nil {
+		t.Fatalf("derived URL not parseable: %q (%v)", got, err)
+	}
+	if u.User.Username() != "openshell" {
+		t.Fatalf("role should be openshell, got %q (url %q)", u.User.Username(), got)
+	}
+	if u.Host != "neko-db:5432" || u.Path != "/neko" {
+		t.Fatalf("host/db wrong: %q", got)
+	}
+	pw, _ := u.User.Password()
+	want, _ := config.OpenShellDBPassword("")
+	if pw != want || len(pw) != 64 { // sha256 hex
+		t.Fatalf("password should be the derived secret-key value (64 hex): got %d chars", len(pw))
+	}
+
+	// A rotated neko password in config.json must NOT leak into the gateway URL
+	// (the role is decoupled), and a custom database name is honored.
+	dir2 := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir2)
+	if err := os.MkdirAll(filepath.Join(dir2, "openneko"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	cfg := `{"pg":{"user":"neko","password":"p@ss:w/rd","database":"neko"}}`
-	if err := os.WriteFile(filepath.Join(dir, "openneko", "config.json"), []byte(cfg), 0o600); err != nil {
+	cfg := `{"pg":{"user":"neko","password":"p@ss:w/rd","database":"customdb"}}`
+	if err := os.WriteFile(filepath.Join(dir2, "openneko", "config.json"), []byte(cfg), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("OPENSHELL_DB_URL", "")
 	configureOpenShellDBURL()
-	if got := os.Getenv("OPENSHELL_DB_URL"); got != "postgres://neko:p%40ss%3Aw%2Frd@neko-db:5432/neko" {
-		t.Fatalf("derived URL wrong: got %q", got)
+	got = os.Getenv("OPENSHELL_DB_URL")
+	if !strings.Contains(got, "@neko-db:5432/customdb") {
+		t.Fatalf("custom database not honored: %q", got)
+	}
+	if strings.Contains(got, "p%40ss") || strings.Contains(got, "neko:") {
+		t.Fatalf("neko password leaked into the gateway URL: %q", got)
+	}
+	if u2, _ := url.Parse(got); u2.User.Username() != "openshell" {
+		t.Fatalf("role should be openshell, got url %q", got)
 	}
 }

--- a/apps/openneko/internal/cli/setup.go
+++ b/apps/openneko/internal/cli/setup.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-neko/neko/apps/openneko/internal/compose"
+	"github.com/open-neko/neko/apps/openneko/internal/config"
 	"github.com/open-neko/neko/apps/openneko/internal/plugin/marketplace"
 	"github.com/open-neko/neko/apps/openneko/internal/preflight"
 	"github.com/open-neko/neko/apps/openneko/internal/prompt"
@@ -131,6 +132,27 @@ at the prompt) to finish at the web UI. Credential flags
 			if err != nil {
 				return err
 			}
+
+			// Rotating the DB password mid-setup strands the already-running
+			// openshell-gateway: it baked the old password into OPENSHELL_DB_URL
+			// at bring-up, so it can no longer reach neko-db and every agent
+			// sandbox (chat/Ask) fails to provision. Persist the new password to
+			// the host config (the source `openneko start` reads) and recreate
+			// the gateway so it reconnects. The web self-restarts and the worker
+			// reconnects via the change-password route; the gateway is the gap.
+			if outcome.PasswordSet != "" {
+				if err := config.WriteLocalPgPassword("", outcome.PasswordSet); err != nil {
+					ui.Info(out, "warning: couldn't persist the DB password to the host config: %v", err)
+				}
+				if err := ui.Spin("Reconnecting the agent gateway", func() error {
+					return recreateOpenShellGateway(ctx, m)
+				}); err != nil {
+					ui.Info(out, "warning: agent gateway reconnect failed (%v) — run `openneko start` to retry", err)
+				} else {
+					ui.Success(out, "agent gateway reconnected")
+				}
+			}
+
 			if outcome.Configured {
 				if !skipPlugins {
 					if err := offerPluginInstall(ctx, out, pluginsCSV, interactive && !cfg.Headless); err != nil {

--- a/apps/openneko/internal/cli/setup.go
+++ b/apps/openneko/internal/cli/setup.go
@@ -133,23 +133,17 @@ at the prompt) to finish at the web UI. Credential flags
 				return err
 			}
 
-			// Rotating the DB password mid-setup strands the already-running
-			// openshell-gateway: it baked the old password into OPENSHELL_DB_URL
-			// at bring-up, so it can no longer reach neko-db and every agent
-			// sandbox (chat/Ask) fails to provision. Persist the new password to
-			// the host config (the source `openneko start` reads) and recreate
-			// the gateway so it reconnects. The web self-restarts and the worker
-			// reconnects via the change-password route; the gateway is the gap.
+			// Persist the rotated password to the host config (the source the
+			// CLI's own `neko` connection reads on later `start`/`migrate`
+			// runs). The web wizard writes it only to the in-container config
+			// volume, so without this the next host-side `neko` connection would
+			// fall back to the stale bootstrap default. The gateway itself is
+			// unaffected by the rotation — it runs on its dedicated `openshell`
+			// role (see ensureOpenShellGatewayRole), so no gateway restart is
+			// needed.
 			if outcome.PasswordSet != "" {
 				if err := config.WriteLocalPgPassword("", outcome.PasswordSet); err != nil {
 					ui.Info(out, "warning: couldn't persist the DB password to the host config: %v", err)
-				}
-				if err := ui.Spin("Reconnecting the agent gateway", func() error {
-					return recreateOpenShellGateway(ctx, m)
-				}); err != nil {
-					ui.Info(out, "warning: agent gateway reconnect failed (%v) — run `openneko start` to retry", err)
-				} else {
-					ui.Success(out, "agent gateway reconnected")
 				}
 			}
 

--- a/apps/openneko/internal/cli/start.go
+++ b/apps/openneko/internal/cli/start.go
@@ -204,9 +204,19 @@ func configureOpenShellDBURL() {
 	if os.Getenv("OPENSHELL_DB_URL") != "" {
 		return
 	}
+	if u, ok := deriveOpenShellDBURL(); ok {
+		_ = os.Setenv("OPENSHELL_DB_URL", u)
+	}
+}
+
+// deriveOpenShellDBURL builds the gateway's neko-db URL from the rotated
+// password in the host config. ok is false on a fresh install (no rotated
+// password yet — the compose default still matches the initial DB), so the
+// caller leaves OPENSHELL_DB_URL at the compose default.
+func deriveOpenShellDBURL() (string, bool) {
 	lc, _ := config.ReadLocal("")
 	if lc.Pg == nil || lc.Pg.Password == "" {
-		return // fresh install — the compose default matches the initial DB
+		return "", false
 	}
 	user := lc.Pg.User
 	if user == "" {
@@ -225,7 +235,49 @@ func configureOpenShellDBURL() {
 		Host:   "neko-db:5432",
 		Path:   "/" + database,
 	}
-	_ = os.Setenv("OPENSHELL_DB_URL", u.String())
+	return u.String(), true
+}
+
+// recreateOpenShellGateway force-recreates just the gateway container so it
+// reconnects to neko-db with the freshly rotated password. The web wizard
+// rotates the `neko` role mid-setup, but the gateway baked the old password
+// into OPENSHELL_DB_URL at bring-up — leaving it stranded ("password
+// authentication failed"), which kills every agent sandbox (chat/Ask). The web
+// self-restarts and the worker reconnects via the change-password route; the
+// gateway is the only piece whose creds come from an env var fixed at container
+// creation, so it must be replaced.
+//
+// --no-deps keeps web/worker and the one-shot certgen/reg untouched; the
+// gateway's PKI and registration live in persistent volumes, so its identity
+// survives the swap. No agent runs happen during setup, so the brief gateway
+// restart is safe.
+func recreateOpenShellGateway(ctx context.Context, mode compose.Mode) error {
+	if err := configureOpenShellStateDir(); err != nil {
+		return err
+	}
+	// Re-derive with the rotated password, bypassing configureOpenShellDBURL's
+	// "already set" guard — the bring-up earlier this run set the default.
+	if u, ok := deriveOpenShellDBURL(); ok {
+		_ = os.Setenv("OPENSHELL_DB_URL", u)
+	}
+	if os.Getenv("OPENNEKO_VERSION") == "" {
+		_ = os.Setenv("OPENNEKO_VERSION", "v"+version.Version)
+	}
+
+	sup := compose.New(assets.ComposeFS)
+	files, err := sup.Materialize(mode)
+	if err != nil {
+		return err
+	}
+	// "" reads the persisted project marker — the project that's actually
+	// running — rather than rewriting it.
+	project, err := sup.ProjectName("")
+	if err != nil {
+		return err
+	}
+	args := []string{"up", "-d", "--no-deps", "--force-recreate", "openshell-gateway"}
+	_, err = sup.Run(ctx, project, files, args, os.Stdout, os.Stderr)
+	return err
 }
 
 func waitDBHealthy(ctx context.Context, timeout time.Duration) error {

--- a/apps/openneko/internal/cli/start.go
+++ b/apps/openneko/internal/cli/start.go
@@ -82,7 +82,6 @@ func bringUpStack(ctx context.Context, cmd *cobra.Command, mode compose.Mode, op
 	if err := configureOpenShellStateDir(); err != nil {
 		return err
 	}
-	configureOpenShellDBURL()
 
 	sup := compose.New(assets.ComposeFS)
 	files, err := sup.Materialize(m)
@@ -108,21 +107,31 @@ func bringUpStack(ctx context.Context, cmd *cobra.Command, mode compose.Mode, op
 		quietPull = []string{"--quiet-pull"}
 	}
 
-	// Stage 1: bring up neko-db only, wait healthy, run migrations.
+	// Stage 1: bring up neko-db, wait healthy, migrate, then provision the
+	// gateway's dedicated DB role. neko-db comes up regardless of
+	// --skip-migrate because the role provisioning + OPENSHELL_DB_URL
+	// derivation below need a reachable DB before stage 2 starts the gateway.
+	up1 := append([]string{"up", "-d"}, pullFlag...)
+	up1 = append(up1, quietPull...)
+	up1 = append(up1, "neko-db")
+	if _, err := sup.Run(ctx, project, files, up1, os.Stdout, os.Stderr); err != nil {
+		return err
+	}
+	if err := waitDBHealthy(ctx, time.Minute); err != nil {
+		return err
+	}
 	if !opts.skipMigrate {
-		up1 := append([]string{"up", "-d"}, pullFlag...)
-		up1 = append(up1, quietPull...)
-		up1 = append(up1, "neko-db")
-		if _, err := sup.Run(ctx, project, files, up1, os.Stdout, os.Stderr); err != nil {
-			return err
-		}
-		if err := waitDBHealthy(ctx, time.Minute); err != nil {
-			return err
-		}
 		if err := runMigrations(ctx, cmd); err != nil {
 			return err
 		}
 	}
+	// The gateway dials neko-db with its OWN role, not the rotatable `neko`
+	// admin role — so a later password rotation never strands it. Ensure the
+	// role exists, then point OPENSHELL_DB_URL at it for stage 2.
+	if err := ensureOpenShellGatewayRole(ctx); err != nil {
+		return err
+	}
+	configureOpenShellDBURL()
 
 	// Pre-pull the agent sandbox image at install time so the gateway's first
 	// sandbox-create (the user's first chat) never blocks on a large pull.
@@ -200,6 +209,12 @@ func configureOpenShellStateDir() error {
 // config is the single source of the rotated password (ReadLocal decrypts
 // it), so build the URL from it on every start. An operator-set
 // OPENSHELL_DB_URL always wins.
+// openShellDBRole is the gateway's dedicated neko-db login role. It exists so
+// the gateway's DB credential is independent of the `neko` admin password the
+// operator rotates during setup — rotating that password never strands the
+// gateway, so it needs no restart.
+const openShellDBRole = "openshell"
+
 func configureOpenShellDBURL() {
 	if os.Getenv("OPENSHELL_DB_URL") != "" {
 		return
@@ -209,75 +224,67 @@ func configureOpenShellDBURL() {
 	}
 }
 
-// deriveOpenShellDBURL builds the gateway's neko-db URL from the rotated
-// password in the host config. ok is false on a fresh install (no rotated
-// password yet — the compose default still matches the initial DB), so the
-// caller leaves OPENSHELL_DB_URL at the compose default.
+// deriveOpenShellDBURL builds the gateway's neko-db URL for its dedicated role,
+// with the stable per-install password derived from the host secret-key. ok is
+// false only if that derivation fails (then the caller leaves the compose
+// default in place).
 func deriveOpenShellDBURL() (string, bool) {
-	lc, _ := config.ReadLocal("")
-	if lc.Pg == nil || lc.Pg.Password == "" {
+	pw, err := config.OpenShellDBPassword("")
+	if err != nil {
 		return "", false
 	}
-	user := lc.Pg.User
-	if user == "" {
-		user = "neko"
-	}
-	database := lc.Pg.Database
-	if database == "" {
-		database = "neko"
+	database := "neko"
+	if lc, _ := config.ReadLocal(""); lc.Pg != nil && lc.Pg.Database != "" {
+		database = lc.Pg.Database
 	}
 	// Host/port are the compose network's, not the local config's: the
 	// gateway dials neko-db inside the project network regardless of how
 	// host-side tools reach the DB.
 	u := url.URL{
 		Scheme: "postgres",
-		User:   url.UserPassword(user, lc.Pg.Password),
+		User:   url.UserPassword(openShellDBRole, pw),
 		Host:   "neko-db:5432",
 		Path:   "/" + database,
 	}
 	return u.String(), true
 }
 
-// recreateOpenShellGateway force-recreates just the gateway container so it
-// reconnects to neko-db with the freshly rotated password. The web wizard
-// rotates the `neko` role mid-setup, but the gateway baked the old password
-// into OPENSHELL_DB_URL at bring-up — leaving it stranded ("password
-// authentication failed"), which kills every agent sandbox (chat/Ask). The web
-// self-restarts and the worker reconnects via the change-password route; the
-// gateway is the only piece whose creds come from an env var fixed at container
-// creation, so it must be replaced.
-//
-// --no-deps keeps web/worker and the one-shot certgen/reg untouched; the
-// gateway's PKI and registration live in persistent volumes, so its identity
-// survives the swap. No agent runs happen during setup, so the brief gateway
-// restart is safe.
-func recreateOpenShellGateway(ctx context.Context, mode compose.Mode) error {
-	if err := configureOpenShellStateDir(); err != nil {
-		return err
+// ensureOpenShellGatewayRole provisions the gateway's dedicated DB login role
+// (idempotent — safe on every bring-up). The gateway shares the app's `public`
+// schema, so the role is a member of the app role and inherits its privileges
+// (it runs its own sqlx migrations and reads/writes without owning every
+// table); its password is the stable per-install value from the host
+// secret-key. Runs as the app superuser over the same connection migrations
+// use — which is reachable by the time this is called (stage 1 waited on it).
+func ensureOpenShellGatewayRole(ctx context.Context) error {
+	pw, err := config.OpenShellDBPassword("")
+	if err != nil {
+		return fmt.Errorf("derive gateway DB password: %w", err)
 	}
-	// Re-derive with the rotated password, bypassing configureOpenShellDBURL's
-	// "already set" guard — the bring-up earlier this run set the default.
-	if u, ok := deriveOpenShellDBURL(); ok {
-		_ = os.Setenv("OPENSHELL_DB_URL", u)
+	cc := defaultConn()
+	conn, err := pgx.Connect(ctx, cc.DSN())
+	if err != nil {
+		return fmt.Errorf("connect to provision gateway DB role: %w", err)
 	}
-	if os.Getenv("OPENNEKO_VERSION") == "" {
-		_ = os.Setenv("OPENNEKO_VERSION", "v"+version.Version)
-	}
+	defer conn.Close(ctx)
 
-	sup := compose.New(assets.ComposeFS)
-	files, err := sup.Materialize(mode)
-	if err != nil {
-		return err
+	appRole := cc.User
+	if appRole == "" {
+		appRole = "neko"
 	}
-	// "" reads the persisted project marker — the project that's actually
-	// running — rather than rewriting it.
-	project, err := sup.ProjectName("")
-	if err != nil {
-		return err
+	// pw is hex (no quotes/backslashes), so the literal is safe; the role names
+	// are fixed/operator-owned identifiers, not request input.
+	stmts := []string{
+		fmt.Sprintf(`DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '%s') THEN CREATE ROLE %s LOGIN; END IF; END $$`, openShellDBRole, openShellDBRole),
+		fmt.Sprintf(`ALTER ROLE %s WITH LOGIN PASSWORD '%s'`, openShellDBRole, pw),
+		fmt.Sprintf(`GRANT %s TO %s`, appRole, openShellDBRole),
 	}
-	args := []string{"up", "-d", "--no-deps", "--force-recreate", "openshell-gateway"}
-	_, err = sup.Run(ctx, project, files, args, os.Stdout, os.Stderr)
-	return err
+	for _, s := range stmts {
+		if _, err := conn.Exec(ctx, s); err != nil {
+			return fmt.Errorf("provision gateway DB role: %w", err)
+		}
+	}
+	return nil
 }
 
 func waitDBHealthy(ctx context.Context, timeout time.Duration) error {

--- a/apps/openneko/internal/config/crypt.go
+++ b/apps/openneko/internal/config/crypt.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -127,4 +128,20 @@ func MaybeDecryptValue(overrideDir, value string) (string, error) {
 // IsEncrypted reports whether a value is in the enc:v1 wire format.
 func IsEncrypted(value string) bool {
 	return strings.HasPrefix(value, encPrefix)
+}
+
+// OpenShellDBPassword derives the openshell-gateway's dedicated DB-role
+// password from the host secret-key. It is deterministic, per-install, and
+// stable — the same value on every run, derived independently of the `neko`
+// admin password the operator rotates. That decoupling is the point: rotating
+// the admin password never strands the gateway, so no gateway restart is
+// needed. Hex output (no quotes/backslashes/specials) is safe both in a SQL
+// password literal and in a connection URL.
+func OpenShellDBPassword(overrideDir string) (string, error) {
+	key, err := loadOrCreateKey(overrideDir)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(append(key, []byte("openneko:openshell-db:v1")...))
+	return hex.EncodeToString(sum[:]), nil
 }

--- a/apps/openneko/internal/config/crypt_test.go
+++ b/apps/openneko/internal/config/crypt_test.go
@@ -1,0 +1,67 @@
+package config
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+func TestOpenShellDBPasswordStableAndHex(t *testing.T) {
+	dir := t.TempDir()
+
+	a, err := OpenShellDBPassword(dir)
+	if err != nil {
+		t.Fatalf("derive: %v", err)
+	}
+	// Deterministic: same install (same secret-key) → same password, so every
+	// `start` derives the value the role was provisioned with.
+	b, err := OpenShellDBPassword(dir)
+	if err != nil {
+		t.Fatalf("derive again: %v", err)
+	}
+	if a != b {
+		t.Fatalf("not deterministic: %q vs %q", a, b)
+	}
+
+	// Hex (no quotes/specials) so it's safe in a SQL literal and a URL.
+	if len(a) != 64 {
+		t.Fatalf("want 64 hex chars, got %d", len(a))
+	}
+	if _, err := hex.DecodeString(a); err != nil {
+		t.Fatalf("not hex: %v", err)
+	}
+}
+
+func TestOpenShellDBPasswordPerInstall(t *testing.T) {
+	// Different secret-key (different install) → different password.
+	a, err := OpenShellDBPassword(t.TempDir())
+	if err != nil {
+		t.Fatalf("derive a: %v", err)
+	}
+	b, err := OpenShellDBPassword(t.TempDir())
+	if err != nil {
+		t.Fatalf("derive b: %v", err)
+	}
+	if a == b {
+		t.Fatal("two installs derived the same gateway password")
+	}
+}
+
+func TestOpenShellDBPasswordIndependentOfNekoPassword(t *testing.T) {
+	// Rotating the neko admin password must not change the derived gateway
+	// password (it's keyed only off the secret-key).
+	dir := t.TempDir()
+	before, err := OpenShellDBPassword(dir)
+	if err != nil {
+		t.Fatalf("derive before: %v", err)
+	}
+	if err := WriteLocalPgPassword(dir, "a-rotated-neko-password"); err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	after, err := OpenShellDBPassword(dir)
+	if err != nil {
+		t.Fatalf("derive after: %v", err)
+	}
+	if before != after {
+		t.Fatal("gateway password changed when the neko password rotated")
+	}
+}

--- a/apps/openneko/internal/config/local.go
+++ b/apps/openneko/internal/config/local.go
@@ -61,3 +61,40 @@ func ReadLocal(override string) (Local, string) {
 	}
 	return Local{}, ""
 }
+
+// WriteLocalPgPassword persists the rotated DB password into the host config
+// (~/.config/openneko/config.json), encrypted at rest (enc:v1) with the host
+// secret-key — the single source ReadLocal and configureOpenShellDBURL read.
+//
+// The web /setup wizard writes the same field, but it runs in a container and
+// can only reach the in-container config volume, never the host file. The CLI
+// is the one component that both holds the plaintext password and can write the
+// host path, so it bridges the gap here. Existing fields are preserved.
+func WriteLocalPgPassword(override, password string) error {
+	enc, err := EncryptValue(override, password)
+	if err != nil {
+		return err
+	}
+	dir := Dir(override)
+	path := filepath.Join(dir, "config.json")
+
+	// Merge over whatever is on disk so we only touch pg.password (read the
+	// raw bytes, not ReadLocal, to avoid round-tripping through decryption).
+	var lc Local
+	if data, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(data, &lc)
+	}
+	if lc.Pg == nil {
+		lc.Pg = &LocalPg{}
+	}
+	lc.Pg.Password = enc
+
+	out, err := json.MarshalIndent(lc, "", "  ")
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, out, 0o600)
+}

--- a/apps/openneko/internal/config/local_test.go
+++ b/apps/openneko/internal/config/local_test.go
@@ -1,0 +1,63 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWriteLocalPgPasswordRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := WriteLocalPgPassword(dir, "DemoPass2026!"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// On disk the password must be encrypted at rest (enc:v1), not plaintext.
+	raw, err := os.ReadFile(filepath.Join(dir, "config.json"))
+	if err != nil {
+		t.Fatalf("read file: %v", err)
+	}
+	var onDisk Local
+	if err := json.Unmarshal(raw, &onDisk); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if onDisk.Pg == nil || !IsEncrypted(onDisk.Pg.Password) {
+		t.Fatalf("password should be enc:v1 on disk, got %q", onDisk.Pg.Password)
+	}
+
+	// ReadLocal decrypts it back to the plaintext every host reader expects.
+	lc, path := ReadLocal(dir)
+	if path == "" {
+		t.Fatal("ReadLocal found no file")
+	}
+	if lc.Pg == nil || lc.Pg.Password != "DemoPass2026!" {
+		t.Fatalf("round-trip mismatch: %+v", lc.Pg)
+	}
+}
+
+func TestWriteLocalPgPasswordPreservesFields(t *testing.T) {
+	dir := t.TempDir()
+
+	// Seed an existing config with non-password pg fields.
+	seed, _ := json.Marshal(Local{Pg: &LocalPg{User: "neko", Database: "neko", Port: 5432}})
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), seed, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := WriteLocalPgPassword(dir, "rotated-pass"); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	lc, _ := ReadLocal(dir)
+	if lc.Pg == nil {
+		t.Fatal("pg block lost")
+	}
+	if lc.Pg.User != "neko" || lc.Pg.Database != "neko" || lc.Pg.Port != 5432 {
+		t.Fatalf("non-password fields not preserved: %+v", lc.Pg)
+	}
+	if lc.Pg.Password != "rotated-pass" {
+		t.Fatalf("password not written: %q", lc.Pg.Password)
+	}
+}

--- a/apps/openneko/internal/setup/wizard.go
+++ b/apps/openneko/internal/setup/wizard.go
@@ -36,6 +36,10 @@ type Config struct {
 type Outcome struct {
 	Configured bool // ran through Finish in the terminal
 	Skipped    bool // deferred to the browser (chosen, or no TTY + no flags)
+	// PasswordSet is the new DB password when this run rotated it (empty
+	// otherwise). The caller persists it to the host config and reconnects the
+	// agent gateway, which baked the old password at bring-up.
+	PasswordSet string
 }
 
 // errBrowser is returned by any step when the operator aborts to the browser.
@@ -79,20 +83,26 @@ func runInteractive(ctx context.Context, c *Client, out io.Writer, cfg Config) (
 		return browserHandoff(out, cfg), nil
 	}
 
-	err := stepsInteractive(ctx, c, out, cfg)
+	pw, err := stepsInteractive(ctx, c, out, cfg)
 	if errors.Is(err, errBrowser) {
-		return browserHandoff(out, cfg), nil
+		// A password set before bailing still needs the gateway reconnect, so
+		// carry it onto the browser-handoff outcome.
+		o := browserHandoff(out, cfg)
+		o.PasswordSet = pw
+		return o, nil
 	}
 	if err != nil {
 		return Outcome{}, err
 	}
-	return Outcome{Configured: true}, nil
+	return Outcome{Configured: true, PasswordSet: pw}, nil
 }
 
-func stepsInteractive(ctx context.Context, c *Client, out io.Writer, cfg Config) error {
+// stepsInteractive runs the terminal onboarding steps, returning the new DB
+// password when it rotated one this run (empty otherwise) alongside any error.
+func stepsInteractive(ctx context.Context, c *Client, out io.Writer, cfg Config) (passwordSet string, err error) {
 	changed, err := c.PasswordChanged(ctx)
 	if err != nil {
-		return err
+		return passwordSet, err
 	}
 
 	total := 3
@@ -120,18 +130,19 @@ func stepsInteractive(ctx context.Context, c *Client, out io.Writer, cfg Config)
 				}),
 		))
 		if err := runForm(form); err != nil {
-			return err
+			return passwordSet, err
 		}
 		if err := ui.Spin("Setting database password", func() error { return c.ChangePassword(ctx, pw) }); err != nil {
-			return err
+			return passwordSet, err
 		}
+		passwordSet = pw
 		ui.Success(out, "password set")
 	}
 
 	// 2. Data source (re-prompts until the connectivity test passes).
 	ds, err := c.GetDataSource(ctx)
 	if err != nil {
-		return err
+		return passwordSet, err
 	}
 	next("Connect your data", "GraphJin base URL — OpenNeko adds the GraphQL & MCP paths.")
 	root := defaultDataURL(cfg, ds)
@@ -140,7 +151,7 @@ func stepsInteractive(ctx context.Context, c *Client, out io.Writer, cfg Config)
 			huh.NewInput().Title("GraphJin URL").Value(&root).Validate(nonEmpty),
 		))
 		if err := runForm(form); err != nil {
-			return err
+			return passwordSet, err
 		}
 		gql, mcp := DeriveEndpoints(root)
 		var mcpOK bool
@@ -167,18 +178,18 @@ func stepsInteractive(ctx context.Context, c *Client, out io.Writer, cfg Config)
 	// 3. Agent backend + primary provider (re-prompts until the key validates).
 	agent, err := c.GetAgent(ctx)
 	if err != nil {
-		return err
+		return passwordSet, err
 	}
 	prov, err := c.GetProvider(ctx)
 	if err != nil {
-		return err
+		return passwordSet, err
 	}
 	next("Agent & model provider", "The model that runs your metric queries.")
 	backend := agent.Agent.Backend
 	if err := runForm(huh.NewForm(huh.NewGroup(
 		huh.NewSelect[string]().Title("Agent backend").Options(backendOptions(agent.Options)...).Value(&backend),
 	))); err != nil {
-		return err
+		return passwordSet, err
 	}
 	var provider string
 	if backend == "claude-agent" {
@@ -189,7 +200,7 @@ func stepsInteractive(ctx context.Context, c *Client, out io.Writer, cfg Config)
 		if err := runForm(huh.NewForm(huh.NewGroup(
 			huh.NewSelect[string]().Title("Model provider").Options(providerOptions(prov.Options.Primary)...).Value(&provider),
 		))); err != nil {
-			return err
+			return passwordSet, err
 		}
 	}
 	capJobs := agent.Agent.GlobalCap
@@ -199,7 +210,7 @@ func stepsInteractive(ctx context.Context, c *Client, out io.Writer, cfg Config)
 	for {
 		model, config, secrets, err := providerForm(modelDefault(prov.Defaults.Primary, provider, prov.Primary), prov.Fields.Primary[provider])
 		if err != nil {
-			return err
+			return passwordSet, err
 		}
 		draft := ProviderDraft{Scope: "primary", Provider: provider, Model: model, Enabled: true, Config: config, Secrets: secrets}
 		if err := ui.Spin("Validating provider key", func() error { return c.TestProvider(ctx, draft) }); err != nil {
@@ -212,7 +223,7 @@ func stepsInteractive(ctx context.Context, c *Client, out io.Writer, cfg Config)
 			}
 			return c.SaveProvider(ctx, draft)
 		}); err != nil {
-			return err
+			return passwordSet, err
 		}
 		ui.Success(out, "agent + provider saved")
 		break
@@ -224,7 +235,7 @@ func stepsInteractive(ctx context.Context, c *Client, out io.Writer, cfg Config)
 	if err := runForm(huh.NewForm(huh.NewGroup(
 		huh.NewConfirm().Title("Enable industry research?").Affirmative("Yes").Negative("No, skip").Value(&enable),
 	))); err != nil {
-		return err
+		return passwordSet, err
 	}
 	if enable {
 		for {
@@ -233,11 +244,11 @@ func stepsInteractive(ctx context.Context, c *Client, out io.Writer, cfg Config)
 				huh.NewSelect[string]().Title("Research provider").
 					Options(providerOptions(filterOut(prov.Options.Research, "disabled"))...).Value(&rprovider),
 			))); err != nil {
-				return err
+				return passwordSet, err
 			}
 			model, config, secrets, err := providerForm(prov.Defaults.Research[rprovider], prov.Fields.Research[rprovider])
 			if err != nil {
-				return err
+				return passwordSet, err
 			}
 			rdraft := ProviderDraft{Scope: "research", Provider: rprovider, Model: model, Enabled: true, Config: config, Secrets: secrets}
 			if err := ui.Spin("Validating research key", func() error { return c.TestProvider(ctx, rdraft) }); err != nil {
@@ -245,17 +256,17 @@ func stepsInteractive(ctx context.Context, c *Client, out io.Writer, cfg Config)
 				continue
 			}
 			if err := ui.Spin("Enabling research", func() error { return c.SaveProvider(ctx, rdraft) }); err != nil {
-				return err
+				return passwordSet, err
 			}
 			ui.Success(out, "research enabled")
 			break
 		}
 	} else if err := ui.Spin("Saving", func() error { return c.SaveProvider(ctx, disabledResearch()) }); err != nil {
-		return err
+		return passwordSet, err
 	}
 
 	// 5. Finish.
-	return ui.Spin("Finishing setup", func() error { return c.Finish(ctx) })
+	return passwordSet, ui.Spin("Finishing setup", func() error { return c.Finish(ctx) })
 }
 
 // runForm runs a huh form with the shared theme. A user abort (ctrl-c / esc) is
@@ -340,6 +351,7 @@ func nonEmpty(s string) error {
 // ----- headless -----
 
 func runHeadless(ctx context.Context, c *Client, cfg Config) (Outcome, error) {
+	passwordSet := ""
 	changed, err := c.PasswordChanged(ctx)
 	if err != nil {
 		return Outcome{}, err
@@ -354,6 +366,7 @@ func runHeadless(ctx context.Context, c *Client, cfg Config) (Outcome, error) {
 		if err := c.ChangePassword(ctx, cfg.AdminPassword); err != nil {
 			return Outcome{}, err
 		}
+		passwordSet = cfg.AdminPassword
 	}
 
 	ds, err := c.GetDataSource(ctx)
@@ -433,7 +446,7 @@ func runHeadless(ctx context.Context, c *Client, cfg Config) (Outcome, error) {
 	if err := c.Finish(ctx); err != nil {
 		return Outcome{}, err
 	}
-	return Outcome{Configured: true}, nil
+	return Outcome{Configured: true, PasswordSet: passwordSet}, nil
 }
 
 // ----- shared helpers -----

--- a/apps/openneko/internal/setup/wizard_test.go
+++ b/apps/openneko/internal/setup/wizard_test.go
@@ -86,6 +86,10 @@ func TestHeadlessConfigure(t *testing.T) {
 	if !outcome.Configured || outcome.Skipped {
 		t.Fatalf("want Configured, got %+v", outcome)
 	}
+	// The rotated password is surfaced so the CLI can reconnect the gateway.
+	if outcome.PasswordSet != "supersecret" {
+		t.Errorf("PasswordSet = %q, want supersecret", outcome.PasswordSet)
+	}
 
 	if _, ok := findWhere(recs, "POST", "/api/admin/change-password", func(b map[string]any) bool {
 		return b["password"] == "supersecret"
@@ -129,8 +133,14 @@ func TestHeadlessClaudeAgentLocksAnthropic(t *testing.T) {
 		Mode: "prod", BaseURL: srv.URL, Headless: true,
 		Backend: "claude-agent", Provider: "openai", ProviderKey: "sk", DataURL: "http://x:8080", NoResearch: true,
 	}
-	if _, err := Run(context.Background(), NewClient(srv.URL), &bytes.Buffer{}, cfg); err != nil {
+	outcome, err := Run(context.Background(), NewClient(srv.URL), &bytes.Buffer{}, cfg)
+	if err != nil {
 		t.Fatalf("Run: %v", err)
+	}
+	// Password was already changed → no rotation this run, so nothing to
+	// reconnect for.
+	if outcome.PasswordSet != "" {
+		t.Errorf("PasswordSet = %q, want empty (password already set)", outcome.PasswordSet)
 	}
 	// Even though Provider=openai was passed, claude-agent forces anthropic.
 	if _, ok := findWhere(recs, "PUT", "/api/settings/provider", func(b map[string]any) bool {


### PR DESCRIPTION
## The bug

On a fresh demo install, **Ask/chat silently fails** — the sandboxed agent can't reach the GraphJin data source (`ECONNREFUSED` at the egress proxy), and the operator only recovers with a manual `openneko stop && start`. Ask is the ~90% feature, so this is a launch blocker.

## Root cause

`openneko setup` rotates the `neko` Postgres role (web `ChangePassword` → `ALTER USER neko`). The **openshell-gateway** connects to `neko-db` as `neko` via `OPENSHELL_DB_URL`, **baked into its container env at bring-up** (`openshell.yml`, default `…:secret@…`). After the rotation it can no longer reconnect, so it fails to provision each sandbox's egress proxy and every agent run dies. Two gaps made it sticky: the web wizard writes the rotated password only to the in-container config volume (never the host `~/.config/openneko/config.json` the CLI reads), and nothing reconnected the gateway (web self-restarts, worker reconnects via `/admin/reconnect` — the gateway was the lone component with no reconnect path, since its creds are an env var fixed at container creation).

## The fix — decouple the gateway from the rotated role

Rather than recreate the gateway on every rotation (a bounce), the gateway gets its **own DB role** so rotation never touches it:

- **Dedicated `openshell` login role**, provisioned by the CLI right after migrations (`ensureOpenShellGatewayRole`): created if absent, `GRANT`ed membership in the app role (it shares the app's `public` schema and runs its own sqlx migrations via inherited privileges — **no superuser needed**), with a **stable per-install password derived from the host secret-key** (`config.OpenShellDBPassword`, deterministic hex — no new stored secret).
- Because that password is independent of the rotatable `neko` admin password, **rotating the admin password never disrupts the gateway** — no recreate, no bounce — and it covers a web-UI password change too, not just the setup-CLI path.
- `configureOpenShellDBURL` now points `OPENSHELL_DB_URL` at the `openshell` role; bring-up always starts `neko-db` and ensures the role *before* stage 2, so the gateway comes up on its own role from first boot. Upgrades flip over naturally on the next `start` (compose recreates the gateway when its env changes).
- `WriteLocalPgPassword` is kept: the CLI still needs the rotated `neko` password persisted to the host config for its own superuser connection (migrate + role provisioning) on later runs — this also fixes a latent bug where host-side `openneko start`/`migrate` couldn't connect as `neko` after a rotation.

## Verification

- **End-to-end on a live stack:** `openneko start` (new binary) provisions the `openshell` role (LOGIN, member of `neko`, not superuser) and boots the gateway on it; it creates sandboxes. Then `ALTER USER neko WITH PASSWORD …` makes `neko`'s **old network auth fail** (`password authentication failed for user "neko"` — the exact original Ask-killer), while the **untouched** gateway container keeps creating sandboxes. Decoupling proven.
- **Egress (direct):** with the per-run data-source egress rule applied, `graphjin cli execute_graphql` from inside a sandbox returns real GraphQL results through the proxy — the egress design itself was always sound.
- **Unit tests:** derived gateway password is stable, per-install, and independent of the neko password (`crypt_test.go`); `OPENSHELL_DB_URL` derives the `openshell`-role URL and the neko password never leaks into it (`openshell_test.go`); host-config password round-trip (`local_test.go`); wizard surfaces the rotated password (`wizard_test.go`).
- `go build` / `go vet` / `gofmt` and the full `apps/openneko` test suite pass.

## Commits
1. `fix(setup): reconnect the agent gateway after password rotation` — host-config persistence + initial reconnect approach.
2. `fix(setup): give the agent gateway its own DB role (rotation-proof)` — the robust decoupling; removes the per-rotation recreate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)