### PR TITLE
feat: Slack conversational channel (worker) — Socket Mode, thread continuity, compaction

### DIFF
--- a/apps/worker/src/channels/delivery.ts
+++ b/apps/worker/src/channels/delivery.ts
@@ -16,8 +16,10 @@ import {
   type WorkflowOutputDeliveryHook,
 } from "@neko/llm/workflows";
 import {
+  createWorkMessage,
   createWorkRun,
   createWorkThread,
+  getOrCreateChannelThread,
   type RunChannel,
 } from "@neko/llm/work";
 import { getPluginRegistryInstance } from "../plugins/registry-instance.js";
@@ -35,6 +37,21 @@ function channelFromPlugin(pluginName: string): RunChannel {
   // action plugin (@open-neko/plugin-slack), so plugin- maps too.
   const m = pluginName.match(/(?:channel|plugin)-([a-z0-9-]+)$/i);
   return (m ? m[1].toLowerCase() : pluginName) as RunChannel;
+}
+
+// Stable per-conversation key from the channel-native recipient (+ thread),
+// so the same DM / channel thread maps to one work_thread across turns.
+function conversationKeyFor(
+  recipient: Record<string, unknown>,
+  threadRef?: string,
+): string {
+  const base =
+    (typeof recipient.channel === "string" && recipient.channel) ||
+    (recipient.chatId != null && String(recipient.chatId)) ||
+    (typeof recipient.to === "string" && recipient.to) ||
+    "";
+  if (!base) return "";
+  return threadRef ? `${base}:${threadRef}` : base;
 }
 
 type IntentEvent =
@@ -288,8 +305,17 @@ export async function dispatchInboundIntent(
     );
     return;
   }
-  console.log(
-    `[channel-inbound] select ${intent.ref}=${intent.optionId} (no handler wired)`,
+  // Other channels may still emit a raw select; continue the conversation with
+  // the chosen option instead of dropping it (Slack sends the label as text).
+  await startChatRun(
+    orgId,
+    intent.optionId,
+    channelFromPlugin(channelPlugin),
+    channelPlugin,
+    recipient,
+    undefined,
+    sender,
+    actor,
   );
 }
 
@@ -307,16 +333,29 @@ async function startChatRun(
   },
 ): Promise<void> {
   const channelLabel = channel.charAt(0).toUpperCase() + channel.slice(1);
-  const thread = await createWorkThread(
-    orgId,
-    threadRef ? `${channelLabel} ${threadRef}` : channelLabel,
-    channel,
-    actor.userId ?? undefined,
-  );
+  const title = threadRef ? `${channelLabel} ${threadRef}` : channelLabel;
+  const conversationKey = recipient ? conversationKeyFor(recipient, threadRef) : "";
+  const thread = conversationKey
+    ? await getOrCreateChannelThread({
+        orgId,
+        channel,
+        conversationKey,
+        title,
+        createdByUserId: actor.userId ?? undefined,
+      })
+    : await createWorkThread(orgId, title, channel, actor.userId ?? undefined);
   const backend = await resolveAgentBackend(orgId);
   // K1: the CH3-resolved actor is the run's acting principal — a linked
   // sender gets their personal layer and role, unlinked stays anonymous.
   const run = await createWorkRun(orgId, thread.id, backend.id, actor);
+  // Record the user turn so reused threads build real conversation history.
+  await createWorkMessage({
+    orgId,
+    threadId: thread.id,
+    runId: run.id,
+    role: "user",
+    content: message,
+  });
   const inserted = await db()
     .insert(processing_job)
     .values({

--- a/apps/worker/src/channels/delivery.ts
+++ b/apps/worker/src/channels/delivery.ts
@@ -16,10 +16,12 @@ import {
   type WorkflowOutputDeliveryHook,
 } from "@neko/llm/workflows";
 import {
+  channelThreadId,
   createWorkMessage,
   createWorkRun,
   createWorkThread,
   getOrCreateChannelThread,
+  getWorkThread,
   type RunChannel,
 } from "@neko/llm/work";
 import { getPluginRegistryInstance } from "../plugins/registry-instance.js";
@@ -335,6 +337,15 @@ async function startChatRun(
   const channelLabel = channel.charAt(0).toUpperCase() + channel.slice(1);
   const title = threadRef ? `${channelLabel} ${threadRef}` : channelLabel;
   const conversationKey = recipient ? conversationKeyFor(recipient, threadRef) : "";
+  // W3.2: a bare in-thread channel reply only continues a thread the bot already
+  // owns — drop it when no matching work_thread exists (DMs and @-mentions still
+  // create one).
+  if (recipient?.requireThread) {
+    const existing = conversationKey
+      ? await getWorkThread(orgId, channelThreadId(orgId, channel, conversationKey))
+      : null;
+    if (!existing) return;
+  }
   const thread = conversationKey
     ? await getOrCreateChannelThread({
         orgId,

--- a/apps/worker/src/channels/delivery.ts
+++ b/apps/worker/src/channels/delivery.ts
@@ -41,7 +41,7 @@ function channelFromPlugin(pluginName: string): RunChannel {
 
 // Stable per-conversation key from the channel-native recipient (+ thread),
 // so the same DM / channel thread maps to one work_thread across turns.
-function conversationKeyFor(
+export function conversationKeyFor(
   recipient: Record<string, unknown>,
   threadRef?: string,
 ): string {

--- a/apps/worker/src/channels/inbound-poll.ts
+++ b/apps/worker/src/channels/inbound-poll.ts
@@ -21,6 +21,7 @@ import {
   savePollCursor,
 } from "./inbound-store.js";
 import { pollBackoffMs, shouldLogPollFailure } from "./poll-backoff.js";
+import { runSlackSocketLoop } from "./socket-loop.js";
 
 const DEDUP_PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 
@@ -84,6 +85,14 @@ export function startChannelInbound(orgId: string): { stop: () => void } {
       console.log(
         `[channel-inbound] ${provider.pluginName}: webhook ingress at ${process.env.OPENNEKO_PUBLIC_URL}/channels/${encodeURIComponent(provider.pluginName)}/inbound`,
       );
+      continue;
+    }
+    if (provider.ingress === "socket") {
+      void runSlackSocketLoop({
+        orgId,
+        pluginName: provider.pluginName,
+        isStopped: () => stopped,
+      });
       continue;
     }
     void pollLoop(provider.pluginName);

--- a/apps/worker/src/channels/socket-loop.ts
+++ b/apps/worker/src/channels/socket-loop.ts
@@ -36,7 +36,7 @@ async function openConnection(appToken: string): Promise<string> {
   return body.url;
 }
 
-async function handleFrame(
+export async function handleFrame(
   ws: MinimalWs,
   data: unknown,
   orgId: string,

--- a/apps/worker/src/channels/socket-loop.ts
+++ b/apps/worker/src/channels/socket-loop.ts
@@ -1,0 +1,143 @@
+// Slack Socket Mode transport, worker-side. The single-shot plugin runner can't
+// hold a persistent socket, so the worker owns the connection and hands each
+// inbound payload to processInboundUpdate (which parses it in the plugin VM).
+// Dependency-free on purpose: Node's global WebSocket + fetch.
+import { getPluginRegistryInstance } from "../plugins/registry-instance.js";
+import { processInboundUpdate } from "./delivery.js";
+import { pollBackoffMs } from "./poll-backoff.js";
+
+const SLACK_API_BASE = "https://slack.com/api";
+const msg = (e: unknown): string => (e instanceof Error ? e.message : String(e));
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+type MinimalWs = {
+  send(data: string): void;
+  close(): void;
+  addEventListener(type: "message", cb: (ev: { data: unknown }) => void): void;
+  addEventListener(type: "close" | "error", cb: () => void): void;
+};
+const WebSocketCtor = (globalThis as { WebSocket?: new (url: string) => MinimalWs })
+  .WebSocket;
+
+type SocketFrame = { type?: string; envelope_id?: string; payload?: unknown };
+
+async function openConnection(appToken: string): Promise<string> {
+  const res = await fetch(`${SLACK_API_BASE}/apps.connections.open`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${appToken}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+  });
+  const body = (await res.json()) as { ok?: boolean; url?: string; error?: string };
+  if (!body.ok || !body.url) {
+    throw new Error(`apps.connections.open failed: ${body.error ?? "no url returned"}`);
+  }
+  return body.url;
+}
+
+async function handleFrame(
+  ws: MinimalWs,
+  data: unknown,
+  orgId: string,
+  pluginName: string,
+): Promise<void> {
+  let frame: SocketFrame;
+  try {
+    frame = JSON.parse(typeof data === "string" ? data : String(data)) as SocketFrame;
+  } catch {
+    return;
+  }
+  if (frame.type === "hello") return;
+  if (frame.type === "disconnect") {
+    ws.close();
+    return;
+  }
+  // Ack before processing — Slack requires it within 3s and parsing spins up the VM.
+  if (frame.envelope_id) ws.send(JSON.stringify({ envelope_id: frame.envelope_id }));
+  if (
+    frame.payload &&
+    (frame.type === "events_api" ||
+      frame.type === "slash_commands" ||
+      frame.type === "interactive")
+  ) {
+    await processInboundUpdate(orgId, pluginName, frame.payload);
+  }
+}
+
+function pumpConnection(
+  wssUrl: string,
+  orgId: string,
+  pluginName: string,
+  isStopped: () => boolean,
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const ws = new WebSocketCtor!(wssUrl);
+    let settled = false;
+    const finish = (): void => {
+      if (settled) return;
+      settled = true;
+      clearInterval(stopTimer);
+      ws.close();
+      resolve();
+    };
+    const stopTimer = setInterval(() => {
+      if (isStopped()) finish();
+    }, 1000);
+    stopTimer.unref?.();
+    ws.addEventListener("message", (ev) => {
+      void handleFrame(ws, ev.data, orgId, pluginName).catch((e) =>
+        console.warn(`[channel-inbound] ${pluginName} socket frame error: ${msg(e)}`),
+      );
+    });
+    ws.addEventListener("close", finish);
+    ws.addEventListener("error", finish);
+  });
+}
+
+/**
+ * Slack Socket Mode loop for a channel plugin: connect, pump, reconnect with
+ * backoff. No-op (warns once) when the plugin has no SLACK_APP_TOKEN.
+ */
+export async function runSlackSocketLoop(opts: {
+  orgId: string;
+  pluginName: string;
+  isStopped: () => boolean;
+}): Promise<void> {
+  const { orgId, pluginName, isStopped } = opts;
+  if (!WebSocketCtor) {
+    console.warn(
+      `[channel-inbound] ${pluginName}: global WebSocket unavailable — Slack inbound disabled.`,
+    );
+    return;
+  }
+  let warnedNoToken = false;
+  let failureStreak = 0;
+  while (!isStopped()) {
+    try {
+      const reg = getPluginRegistryInstance();
+      if (!reg) return;
+      const appToken = (reg.getPluginEnv(pluginName) ?? {}).SLACK_APP_TOKEN;
+      if (!appToken) {
+        if (!warnedNoToken) {
+          console.warn(
+            `[channel-inbound] ${pluginName}: no SLACK_APP_TOKEN — Slack inbound disabled. Enable Socket Mode and set an xapp- app-level token (connections:write).`,
+          );
+          warnedNoToken = true;
+        }
+        return;
+      }
+      warnedNoToken = false;
+      const wssUrl = await openConnection(appToken);
+      console.log(`[channel-inbound] ${pluginName}: Socket Mode connected`);
+      await pumpConnection(wssUrl, orgId, pluginName, isStopped);
+      failureStreak = 0;
+    } catch (err) {
+      failureStreak++;
+      console.warn(
+        `[channel-inbound] ${pluginName} socket error (attempt ${failureStreak}): ${msg(err)}`,
+      );
+    }
+    if (!isStopped()) await sleep(pollBackoffMs(failureStreak));
+  }
+}

--- a/apps/worker/test/channels/delivery.test.ts
+++ b/apps/worker/test/channels/delivery.test.ts
@@ -48,7 +48,9 @@ vi.mock("@neko/db", () => ({
 vi.mock("@neko/llm", () => ({ resolveAgentBackend: vi.fn(async () => ({ id: "hermes" })) }));
 vi.mock("@neko/llm/work", () => ({
   createWorkThread: vi.fn(async () => ({ id: "thread-1" })),
+  getOrCreateChannelThread: vi.fn(async () => ({ id: "thread-1" })),
   createWorkRun: vi.fn(async () => ({ id: "run-1" })),
+  createWorkMessage: vi.fn(async () => ({ id: "msg-1" })),
 }));
 vi.mock("@neko/llm/interaction", () => ({
   outputRowToInteractionEvent: (r: unknown) => ({ kind: "inform", ...(r as object) }),
@@ -70,7 +72,7 @@ import {
   rejectActionRequest,
   setWorkflowOutputDeliveryHook,
 } from "@neko/llm/workflows";
-import { createWorkThread } from "@neko/llm/work";
+import { getOrCreateChannelThread } from "@neko/llm/work";
 import {
   deliverChatReply,
   dispatchInboundIntent,
@@ -142,7 +144,7 @@ describe("dispatchInboundIntent — utterance", () => {
       "@open-neko/channel-telegram",
       { chatId: 7 },
     );
-    expect(createWorkThread).toHaveBeenCalled();
+    expect(getOrCreateChannelThread).toHaveBeenCalled();
     expect(enqueue).toHaveBeenCalledWith(
       "work_run",
       expect.objectContaining({
@@ -153,6 +155,25 @@ describe("dispatchInboundIntent — utterance", () => {
         channel: "telegram",
         channelPlugin: "@open-neko/channel-telegram",
         recipient: { chatId: 7 },
+      }),
+    );
+  });
+});
+
+describe("dispatchInboundIntent — select (continuation fallback)", () => {
+  it("continues the conversation with the chosen option", async () => {
+    await dispatchInboundIntent(
+      "org-1",
+      { kind: "select", ref: "ar-9", optionId: "Option B" },
+      "@open-neko/channel-telegram",
+      { chatId: 7 },
+    );
+    expect(getOrCreateChannelThread).toHaveBeenCalled();
+    expect(enqueue).toHaveBeenCalledWith(
+      "work_run",
+      expect.objectContaining({
+        message: "Option B",
+        channelPlugin: "@open-neko/channel-telegram",
       }),
     );
   });

--- a/apps/worker/test/channels/delivery.test.ts
+++ b/apps/worker/test/channels/delivery.test.ts
@@ -74,6 +74,7 @@ import {
 } from "@neko/llm/workflows";
 import { getOrCreateChannelThread } from "@neko/llm/work";
 import {
+  conversationKeyFor,
   deliverChatReply,
   dispatchInboundIntent,
   ensureInboundBinding,
@@ -176,6 +177,23 @@ describe("dispatchInboundIntent — select (continuation fallback)", () => {
         channelPlugin: "@open-neko/channel-telegram",
       }),
     );
+  });
+});
+
+describe("conversationKeyFor", () => {
+  it("keys a Slack DM by channel and a thread by channel:threadRef", () => {
+    expect(conversationKeyFor({ kind: "slack", channel: "D9" })).toBe("D9");
+    expect(conversationKeyFor({ kind: "slack", channel: "C9" }, "171.5")).toBe("C9:171.5");
+  });
+
+  it("keys Telegram by chatId and WhatsApp by recipient address", () => {
+    expect(conversationKeyFor({ chatId: 7 }, "42")).toBe("7:42");
+    expect(conversationKeyFor({ to: "+15550001111" })).toBe("+15550001111");
+  });
+
+  it("returns empty when the recipient has no stable address", () => {
+    expect(conversationKeyFor({})).toBe("");
+    expect(conversationKeyFor({ foo: "bar" }, "42")).toBe("");
   });
 });
 

--- a/apps/worker/test/channels/delivery.test.ts
+++ b/apps/worker/test/channels/delivery.test.ts
@@ -51,6 +51,8 @@ vi.mock("@neko/llm/work", () => ({
   getOrCreateChannelThread: vi.fn(async () => ({ id: "thread-1" })),
   createWorkRun: vi.fn(async () => ({ id: "run-1" })),
   createWorkMessage: vi.fn(async () => ({ id: "msg-1" })),
+  channelThreadId: vi.fn(() => "tid-1"),
+  getWorkThread: vi.fn(async () => null),
 }));
 vi.mock("@neko/llm/interaction", () => ({
   outputRowToInteractionEvent: (r: unknown) => ({ kind: "inform", ...(r as object) }),
@@ -72,7 +74,7 @@ import {
   rejectActionRequest,
   setWorkflowOutputDeliveryHook,
 } from "@neko/llm/workflows";
-import { getOrCreateChannelThread } from "@neko/llm/work";
+import { getOrCreateChannelThread, getWorkThread } from "@neko/llm/work";
 import {
   conversationKeyFor,
   deliverChatReply,
@@ -176,6 +178,35 @@ describe("dispatchInboundIntent — select (continuation fallback)", () => {
         message: "Option B",
         channelPlugin: "@open-neko/channel-telegram",
       }),
+    );
+  });
+});
+
+describe("dispatchInboundIntent — channel thread-reply gate (W3.2)", () => {
+  it("drops a requireThread reply when no matching thread exists", async () => {
+    vi.mocked(getWorkThread).mockResolvedValueOnce(null);
+    await dispatchInboundIntent(
+      "org-1",
+      { kind: "utterance", text: "and last quarter?", threadRef: "171.5" },
+      "@open-neko/plugin-slack",
+      { kind: "slack", channel: "C9", thread_ts: "171.5", requireThread: true },
+    );
+    expect(getOrCreateChannelThread).not.toHaveBeenCalled();
+    expect(enqueue).not.toHaveBeenCalled();
+  });
+
+  it("continues a requireThread reply when the thread already exists", async () => {
+    vi.mocked(getWorkThread).mockResolvedValueOnce({ id: "thread-1" } as never);
+    await dispatchInboundIntent(
+      "org-1",
+      { kind: "utterance", text: "and last quarter?", threadRef: "171.5" },
+      "@open-neko/plugin-slack",
+      { kind: "slack", channel: "C9", thread_ts: "171.5", requireThread: true },
+    );
+    expect(getOrCreateChannelThread).toHaveBeenCalled();
+    expect(enqueue).toHaveBeenCalledWith(
+      "work_run",
+      expect.objectContaining({ message: "and last quarter?" }),
     );
   });
 });

--- a/apps/worker/test/channels/socket-loop.integration.test.ts
+++ b/apps/worker/test/channels/socket-loop.integration.test.ts
@@ -1,0 +1,178 @@
+import { createHash } from "node:crypto";
+import { createServer, type IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Integration test: drive runSlackSocketLoop against a REAL local WebSocket
+// server (real global WebSocket client, real apps.connections.open via a stubbed
+// fetch returning the local ws URL). Only processInboundUpdate — the seam into
+// the rest of the worker — is mocked. Exercises connect → ack → dispatch →
+// disconnect → backoff → reconnect, which handleFrame's unit test can't.
+vi.mock("../../src/channels/delivery.js", () => ({
+  processInboundUpdate: vi.fn(async () => true),
+}));
+vi.mock("../../src/plugins/registry-instance.js", () => ({
+  getPluginRegistryInstance: vi.fn(() => ({
+    getPluginEnv: () => ({ SLACK_APP_TOKEN: "xapp-test" }),
+  })),
+}));
+
+import { runSlackSocketLoop } from "../../src/channels/socket-loop";
+import { processInboundUpdate } from "../../src/channels/delivery.js";
+import { getPluginRegistryInstance } from "../../src/plugins/registry-instance.js";
+
+const WS_GUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11";
+const accept = (key: string) => createHash("sha1").update(key + WS_GUID).digest("base64");
+
+function encodeText(data: string): Buffer {
+  const body = Buffer.from(data, "utf8");
+  const n = body.length;
+  const head =
+    n < 126 ? Buffer.from([0x81, n]) : Buffer.from([0x81, 126, (n >> 8) & 0xff, n & 0xff]);
+  return Buffer.concat([head, body]);
+}
+
+// Decode a single masked client→server text frame (enough for the tiny acks).
+function decodeText(buf: Buffer): string | null {
+  if (buf.length < 2 || (buf[0] & 0x0f) !== 0x1) return null;
+  const masked = (buf[1] & 0x80) !== 0;
+  let len = buf[1] & 0x7f;
+  let off = 2;
+  if (len === 126) {
+    len = buf.readUInt16BE(2);
+    off = 4;
+  }
+  const mask = masked ? buf.subarray(off, (off += 4)) : null;
+  const body = buf.subarray(off, off + len);
+  const out = Buffer.alloc(len);
+  for (let i = 0; i < len; i++) out[i] = body[i] ^ (mask ? mask[i % 4] : 0);
+  return out.toString("utf8");
+}
+
+type WsConn = { received: string[]; send: (s: string) => void; close: () => void };
+
+function startWsServer(onConn: (c: WsConn, index: number) => void) {
+  const conns: WsConn[] = [];
+  const sockets: Duplex[] = [];
+  const server = createServer();
+  server.on("upgrade", (req: IncomingMessage, socket: Duplex) => {
+    sockets.push(socket);
+    socket.write(
+      "HTTP/1.1 101 Switching Protocols\r\n" +
+        "Upgrade: websocket\r\n" +
+        "Connection: Upgrade\r\n" +
+        `Sec-WebSocket-Accept: ${accept((req.headers["sec-websocket-key"] as string) ?? "")}\r\n\r\n`,
+    );
+    const conn: WsConn = {
+      received: [],
+      send: (s) => socket.write(encodeText(s)),
+      close: () => socket.destroy(),
+    };
+    const index = conns.push(conn) - 1;
+    socket.on("data", (chunk: Buffer) => {
+      const text = decodeText(chunk);
+      if (text !== null) conn.received.push(text);
+    });
+    socket.on("error", () => {});
+    onConn(conn, index);
+  });
+  return new Promise<{ port: number; conns: WsConn[]; close: () => Promise<void> }>((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      resolve({
+        port: typeof addr === "object" && addr ? addr.port : 0,
+        conns,
+        close: () =>
+          new Promise<void>((r) => {
+            for (const s of sockets) s.destroy();
+            server.close(() => r());
+          }),
+      });
+    });
+  });
+}
+
+const waitFor = async (pred: () => boolean, ms = 8000): Promise<void> => {
+  const start = Date.now();
+  while (!pred()) {
+    if (Date.now() - start > ms) throw new Error("waitFor timed out");
+    await new Promise((r) => setTimeout(r, 25));
+  }
+};
+
+describe("runSlackSocketLoop (integration: real WebSocket transport)", () => {
+  let stopped = true;
+  let realFetch: typeof globalThis.fetch;
+  let srv: Awaited<ReturnType<typeof startWsServer>> | undefined;
+  let loop: Promise<void> | undefined;
+
+  afterEach(async () => {
+    stopped = true;
+    if (loop) await loop.catch(() => {});
+    loop = undefined;
+    if (realFetch) globalThis.fetch = realFetch;
+    if (srv) await srv.close();
+    srv = undefined;
+    vi.clearAllMocks();
+  });
+
+  it("connects, acks before dispatch, then reconnects after a disconnect", async () => {
+    const EVENT = { type: "event_callback", event: { type: "message", text: "hi" } };
+    srv = await startWsServer((conn, index) => {
+      if (index === 0) {
+        // Send after the handshake settles into its own segment — bundling
+        // frames with the 101 response trips the client's parser.
+        setTimeout(() => {
+          conn.send(JSON.stringify({ type: "hello" }));
+          conn.send(JSON.stringify({ type: "events_api", envelope_id: "e1", payload: EVENT }));
+          // Slack sends a disconnect frame then drops the socket; mirror that so
+          // the client's close fires and the loop backs off + reconnects.
+          setTimeout(() => {
+            conn.send(JSON.stringify({ type: "disconnect" }));
+            conn.close();
+          }, 100);
+        }, 30);
+      }
+    });
+    realFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ ok: true, url: `ws://127.0.0.1:${srv!.port}/link` }),
+    })) as never;
+
+    stopped = false;
+    loop = runSlackSocketLoop({
+      orgId: "org-1",
+      pluginName: "@open-neko/plugin-slack",
+      isStopped: () => stopped,
+    });
+
+    await waitFor(() => srv!.conns.length >= 1 && srv!.conns[0].received.length >= 1);
+    expect(srv.conns[0].received).toContain(JSON.stringify({ envelope_id: "e1" }));
+    expect(processInboundUpdate).toHaveBeenCalledWith("org-1", "@open-neko/plugin-slack", EVENT);
+
+    // disconnect frame → close → 3s backoff → reconnect
+    await waitFor(() => srv!.conns.length >= 2, 8000);
+    expect(srv.conns.length).toBeGreaterThanOrEqual(2);
+  }, 15000);
+
+  it("bails without connecting when SLACK_APP_TOKEN is absent", async () => {
+    vi.mocked(getPluginRegistryInstance).mockReturnValueOnce({
+      getPluginEnv: () => ({}),
+    } as never);
+    srv = await startWsServer(() => {});
+    realFetch = globalThis.fetch;
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy as never;
+
+    stopped = false;
+    await runSlackSocketLoop({
+      orgId: "o",
+      pluginName: "@open-neko/plugin-slack",
+      isStopped: () => stopped,
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(srv.conns.length).toBe(0);
+  });
+});

--- a/apps/worker/test/channels/socket-loop.test.ts
+++ b/apps/worker/test/channels/socket-loop.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// handleFrame is the pure-ish core of the Slack Socket Mode loop. Mock the
+// downstream dispatch + registry so we test framing/ack/routing in isolation.
+vi.mock("../../src/channels/delivery.js", () => ({
+  processInboundUpdate: vi.fn(async () => true),
+}));
+vi.mock("../../src/plugins/registry-instance.js", () => ({
+  getPluginRegistryInstance: vi.fn(),
+}));
+
+import { handleFrame } from "../../src/channels/socket-loop";
+import { processInboundUpdate } from "../../src/channels/delivery.js";
+
+const makeWs = () => ({ send: vi.fn(), close: vi.fn() });
+const frame = (o: Record<string, unknown>) => JSON.stringify(o);
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("socket-loop handleFrame", () => {
+  it("ignores a hello frame (no ack, no close, no dispatch)", async () => {
+    const ws = makeWs();
+    await handleFrame(ws as never, frame({ type: "hello" }), "org-1", "p");
+    expect(ws.send).not.toHaveBeenCalled();
+    expect(ws.close).not.toHaveBeenCalled();
+    expect(processInboundUpdate).not.toHaveBeenCalled();
+  });
+
+  it("closes on a disconnect frame so the outer loop reconnects", async () => {
+    const ws = makeWs();
+    await handleFrame(ws as never, frame({ type: "disconnect", reason: "refresh" }), "org-1", "p");
+    expect(ws.close).toHaveBeenCalled();
+    expect(processInboundUpdate).not.toHaveBeenCalled();
+  });
+
+  it("acks an events_api envelope BEFORE dispatching its payload", async () => {
+    const ws = makeWs();
+    const payload = { type: "event_callback", event: { type: "message" } };
+    await handleFrame(
+      ws as never,
+      frame({ type: "events_api", envelope_id: "e1", payload }),
+      "org-1",
+      "p",
+    );
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ envelope_id: "e1" }));
+    expect(processInboundUpdate).toHaveBeenCalledWith("org-1", "p", payload);
+    // Slack requires the ack within 3s; parsing spins up the VM, so ack first.
+    expect(ws.send.mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(processInboundUpdate).mock.invocationCallOrder[0],
+    );
+  });
+
+  it("dispatches slash_commands and interactive payloads too", async () => {
+    const ws = makeWs();
+    await handleFrame(
+      ws as never,
+      frame({ type: "slash_commands", envelope_id: "e2", payload: { command: "/openneko" } }),
+      "o",
+      "p",
+    );
+    await handleFrame(
+      ws as never,
+      frame({ type: "interactive", envelope_id: "e3", payload: { type: "block_actions" } }),
+      "o",
+      "p",
+    );
+    expect(processInboundUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it("acks but does not dispatch a frame with no payload", async () => {
+    const ws = makeWs();
+    await handleFrame(ws as never, frame({ type: "events_api", envelope_id: "e4" }), "o", "p");
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ envelope_id: "e4" }));
+    expect(processInboundUpdate).not.toHaveBeenCalled();
+  });
+
+  it("ignores malformed JSON without throwing", async () => {
+    const ws = makeWs();
+    await expect(handleFrame(ws as never, "not json{", "o", "p")).resolves.toBeUndefined();
+    expect(ws.send).not.toHaveBeenCalled();
+    expect(processInboundUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/llm/src/work/compact-transcript.ts
+++ b/packages/llm/src/work/compact-transcript.ts
@@ -1,0 +1,82 @@
+import { ax } from "@ax-llm/ax";
+import { buildLlm } from "../llm";
+
+// Inline-transcript backends (Hermes) carry the whole thread in the prompt, so a
+// long-running channel/DM thread grows unbounded. Past COMPACT_AFTER messages we
+// fold everything older than the last KEEP_LAST into a rolling summary and keep
+// the recent tail verbatim — Claude-Code-style auto-compaction, message-count
+// triggered. Persisted on work_thread.backend_state.compaction (no migration).
+export const COMPACT_AFTER = Number(process.env.OPENNEKO_COMPACT_AFTER_MESSAGES) || 40;
+export const KEEP_LAST = Number(process.env.OPENNEKO_COMPACT_KEEP_LAST) || 12;
+
+export type ThreadCompaction = {
+  summary: string;
+  /** id of the last work_message folded into `summary`. */
+  throughMessageId: string;
+  updatedAt: string;
+  version: 1;
+};
+
+type CompactableMessage = { id: string; role: "user" | "assistant"; content: string };
+
+export type SummarizeFn = (
+  priorSummary: string,
+  transcript: string,
+  orgId?: string,
+) => Promise<string>;
+
+const DESCRIPTION = `You compact an OpenNeko analyst conversation so it can continue without the full transcript. Fold the prior summary and the new turns into one dense, factual summary (max ~400 tokens) capturing only what later turns need: the operator's goals and standing asks; key findings, metrics, and figures surfaced; decisions and actions taken (including approved/rejected actions); data sources, entities, and time ranges examined; open/pending items; and the current focus. No greetings, no meta-commentary, no markdown headers — just the substance.`;
+
+const compactor = ax(
+  `priorSummary:string "summary so far, may be empty", transcript:string "older conversation turns to fold in" -> summary:string "dense factual summary, max ~400 tokens"`,
+  { description: DESCRIPTION },
+);
+
+const defaultSummarize: SummarizeFn = async (priorSummary, transcript, orgId) => {
+  const llm = await buildLlm(orgId);
+  const result = await compactor.forward(llm, { priorSummary, transcript });
+  return String(result.summary ?? "").trim();
+};
+
+const renderTurns = (messages: CompactableMessage[]): string =>
+  messages.map((m) => `${m.role === "user" ? "Operator" : "Agent"}: ${m.content}`).join("\n\n");
+
+/**
+ * Decide whether to compact the thread's inlined transcript. Returns the summary
+ * to render (prior or freshly folded), the messages to keep verbatim, and — only
+ * when a fold happened this turn — the new compaction state to persist.
+ */
+export async function compactIfNeeded<T extends CompactableMessage>(args: {
+  messages: T[];
+  prior?: ThreadCompaction;
+  orgId?: string;
+  now: string;
+  summarize?: SummarizeFn;
+}): Promise<{ summary?: string; kept: T[]; newCompaction?: ThreadCompaction }> {
+  const foundIdx = args.prior
+    ? args.messages.findIndex((m) => m.id === args.prior!.throughMessageId)
+    : -1;
+  // A prior watermark we can't locate (e.g. the thread was truncated) is stale —
+  // ignore it and re-fold from scratch rather than double-count.
+  const prior = args.prior && foundIdx >= 0 ? args.prior : undefined;
+  const pending = foundIdx >= 0 ? args.messages.slice(foundIdx + 1) : args.messages;
+
+  if (pending.length <= COMPACT_AFTER) {
+    return { summary: prior?.summary, kept: pending };
+  }
+
+  const fold = pending.slice(0, pending.length - KEEP_LAST);
+  const kept = pending.slice(pending.length - KEEP_LAST);
+  const summarize = args.summarize ?? defaultSummarize;
+  const summary = await summarize(prior?.summary ?? "", renderTurns(fold), args.orgId);
+  return {
+    summary,
+    kept,
+    newCompaction: {
+      summary,
+      throughMessageId: fold[fold.length - 1].id,
+      updatedAt: args.now,
+      version: 1,
+    },
+  };
+}

--- a/packages/llm/src/work/prompt.ts
+++ b/packages/llm/src/work/prompt.ts
@@ -425,6 +425,8 @@ export function buildWorkPrompt(args: {
   knowledge: KnowledgePackContents;
   messages: AgentChatMessage[];
   currentUserMessage: string;
+  /** Rolling summary of older turns folded out of `messages` (compaction). */
+  priorSummary?: string;
   memoryContext?: string;
   /** CV3: compiled <operator-profile> block (already wrapped). */
   operatorProfile?: string;
@@ -449,6 +451,7 @@ export function buildWorkPrompt(args: {
     knowledge,
     messages,
     currentUserMessage,
+    priorSummary,
     memoryContext,
     operatorProfile,
     installedSkills,
@@ -495,9 +498,12 @@ that flags churn risk every Monday."
   ].filter((s) => s.length > 0);
 
   if (inlineTranscript) {
+    const summaryBlock = priorSummary
+      ? `[Earlier conversation summary]\n${priorSummary}\n\n`
+      : "";
     sections.push(
       `<conversation_so_far>
-${formatTranscript(messages)}
+${summaryBlock}${formatTranscript(messages)}
 </conversation_so_far>
 
 <current_user_message>

--- a/packages/llm/src/work/run-chat-turn.ts
+++ b/packages/llm/src/work/run-chat-turn.ts
@@ -42,6 +42,7 @@ import {
   getWorkRunActor,
 } from "./personas";
 import { buildWorkPrompt } from "./prompt";
+import { compactIfNeeded, type ThreadCompaction } from "./compact-transcript";
 import {
   finishWorkRun,
   getWorkThreadBundle,
@@ -234,8 +235,29 @@ export async function runChatTurn(
     const supportsMemoryTool = backend.capabilities.mcpTools;
     const supportsWorkflowTool = backend.capabilities.mcpTools;
     const supportsPolicyTool = backend.capabilities.mcpTools;
+    const inlineTranscript = !backend.capabilities.sessionResume;
 
-    const messages: AgentChatMessage[] = bundle.messages.map((row) => ({
+    // Inline-transcript backends grow unbounded on long threads — fold older
+    // turns into a rolling summary, keeping the recent tail verbatim.
+    let priorSummary: string | undefined;
+    let transcriptRows: typeof bundle.messages = bundle.messages;
+    let newCompaction: ThreadCompaction | undefined;
+    if (inlineTranscript) {
+      const prior = (
+        bundle.thread.backendState as { compaction?: ThreadCompaction }
+      ).compaction;
+      const compacted = await compactIfNeeded({
+        messages: bundle.messages,
+        prior,
+        orgId,
+        now: new Date().toISOString(),
+      });
+      priorSummary = compacted.summary;
+      transcriptRows = compacted.kept;
+      newCompaction = compacted.newCompaction;
+    }
+
+    const messages: AgentChatMessage[] = transcriptRows.map((row) => ({
       id: row.id,
       role: row.role,
       content: row.content,
@@ -266,6 +288,7 @@ export async function runChatTurn(
       knowledge,
       messages,
       currentUserMessage: message,
+      priorSummary,
       memoryContext,
       operatorProfile,
       installedSkills,
@@ -275,7 +298,7 @@ export async function runChatTurn(
       supportsMemoryTool,
       supportsWorkflowTool,
       supportsPolicyTool,
-      inlineTranscript: !backend.capabilities.sessionResume,
+      inlineTranscript,
       pluginActions: opts.pluginActions ?? [],
     });
 
@@ -295,11 +318,16 @@ export async function runChatTurn(
       signal,
     });
 
-    if (
-      result.backendState &&
-      result.backendState !== bundle.thread.backendState
-    ) {
-      await setWorkThreadBackendState(threadId, result.backendState);
+    const backendStateChanged =
+      result.backendState && result.backendState !== bundle.thread.backendState;
+    if (backendStateChanged || newCompaction) {
+      const base = (
+        backendStateChanged ? result.backendState : bundle.thread.backendState
+      ) as Record<string, unknown>;
+      await setWorkThreadBackendState(
+        threadId,
+        newCompaction ? { ...base, compaction: newCompaction } : base,
+      );
     }
 
     await finishWorkRun(runId, result.status, result.error ?? null);

--- a/packages/llm/src/work/store.ts
+++ b/packages/llm/src/work/store.ts
@@ -12,6 +12,7 @@ import {
   work_thread,
   workflow_run,
 } from "@neko/db";
+import { createHash } from "node:crypto";
 import type { AgentBackendId } from "../agent-backend";
 import type { AgentEvent } from "../agent-backend";
 
@@ -104,6 +105,55 @@ export async function createWorkThread(
     })
     .returning();
   return rows[0];
+}
+
+// Deterministic thread id per channel conversation, so repeated inbound messages
+// reuse one work_thread (and its history) instead of spawning a new one each turn.
+const CHANNEL_THREAD_NS = "8b9d2e7a-1c34-4f56-9a78-b0c1d2e3f405";
+
+function uuidv5(name: string, namespaceUuid: string): string {
+  const ns = Buffer.from(namespaceUuid.replace(/-/g, ""), "hex");
+  const bytes = createHash("sha1").update(ns).update(name).digest().subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const h = bytes.toString("hex");
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+}
+
+export function channelThreadId(
+  orgId: string,
+  channel: string,
+  conversationKey: string,
+): string {
+  return uuidv5(`${orgId}:${channel}:${conversationKey}`, CHANNEL_THREAD_NS);
+}
+
+export async function getOrCreateChannelThread(args: {
+  orgId: string;
+  channel: string;
+  conversationKey: string;
+  title?: string;
+  createdByUserId?: string | null;
+}) {
+  const id = channelThreadId(args.orgId, args.channel, args.conversationKey);
+  const inserted = await db()
+    .insert(work_thread)
+    .values({
+      id,
+      org_id: args.orgId,
+      title: args.title ?? "",
+      channel: args.channel,
+      created_by_user_id: args.createdByUserId ?? null,
+    })
+    .onConflictDoNothing()
+    .returning();
+  if (inserted[0]) return inserted[0];
+  const [existing] = await db()
+    .select()
+    .from(work_thread)
+    .where(eq(work_thread.id, id))
+    .limit(1);
+  return existing;
 }
 
 export async function deleteWorkThread(orgId: string, threadId: string): Promise<boolean> {

--- a/packages/llm/test/channel-thread-id.test.ts
+++ b/packages/llm/test/channel-thread-id.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { channelThreadId } from "../src/work/store";
+
+const UUID_V5 = /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("channelThreadId", () => {
+  it("is deterministic for the same (org, channel, conversation)", () => {
+    expect(channelThreadId("org-1", "slack", "D9")).toBe(
+      channelThreadId("org-1", "slack", "D9"),
+    );
+  });
+
+  it("differs across org, channel, or conversation key", () => {
+    const base = channelThreadId("org-1", "slack", "D9");
+    expect(channelThreadId("org-2", "slack", "D9")).not.toBe(base);
+    expect(channelThreadId("org-1", "telegram", "D9")).not.toBe(base);
+    expect(channelThreadId("org-1", "slack", "C9:171.5")).not.toBe(base);
+  });
+
+  it("produces a valid v5 UUID (accepted by a Postgres uuid column)", () => {
+    expect(channelThreadId("org-1", "slack", "D9")).toMatch(UUID_V5);
+  });
+});

--- a/packages/llm/test/compact-transcript.test.ts
+++ b/packages/llm/test/compact-transcript.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  COMPACT_AFTER,
+  KEEP_LAST,
+  compactIfNeeded,
+} from "../src/work/compact-transcript";
+
+const mk = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({
+    id: `m${i}`,
+    role: (i % 2 === 0 ? "user" : "assistant") as "user" | "assistant",
+    content: `turn ${i}`,
+  }));
+
+const NOW = "2026-06-15T00:00:00.000Z";
+
+describe("compactIfNeeded", () => {
+  it("is a no-op at or under the threshold (no summarize call)", async () => {
+    const summarize = vi.fn(async () => "S");
+    const out = await compactIfNeeded({ messages: mk(COMPACT_AFTER), now: NOW, summarize });
+    expect(summarize).not.toHaveBeenCalled();
+    expect(out.summary).toBeUndefined();
+    expect(out.newCompaction).toBeUndefined();
+    expect(out.kept).toHaveLength(COMPACT_AFTER);
+  });
+
+  it("folds the oldest and keeps the last KEEP_LAST when over threshold", async () => {
+    const n = COMPACT_AFTER + 10;
+    const summarize = vi.fn(async () => "SUMMARY");
+    const out = await compactIfNeeded({ messages: mk(n), now: NOW, summarize });
+    expect(summarize).toHaveBeenCalledTimes(1);
+    expect(summarize.mock.calls[0][0]).toBe(""); // no prior summary folded in
+    expect(out.summary).toBe("SUMMARY");
+    expect(out.kept).toHaveLength(KEEP_LAST);
+    expect(out.kept[0].id).toBe(`m${n - KEEP_LAST}`);
+    expect(out.newCompaction).toMatchObject({
+      summary: "SUMMARY",
+      throughMessageId: `m${n - KEEP_LAST - 1}`,
+      version: 1,
+    });
+  });
+
+  it("only folds messages after a prior watermark", async () => {
+    const summarize = vi.fn(async () => "S2");
+    const prior = { summary: "PRIOR", throughMessageId: "m20", updatedAt: NOW, version: 1 as const };
+    const out = await compactIfNeeded({ messages: mk(50), prior, now: NOW, summarize });
+    expect(summarize).not.toHaveBeenCalled(); // 29 pending ≤ threshold
+    expect(out.summary).toBe("PRIOR");
+    expect(out.kept[0].id).toBe("m21");
+    expect(out.kept).toHaveLength(29);
+    expect(out.newCompaction).toBeUndefined();
+  });
+
+  it("re-compacts, folding the prior summary plus the new chunk", async () => {
+    const summarize = vi.fn(async () => "S3");
+    const prior = { summary: "PRIOR", throughMessageId: "m5", updatedAt: NOW, version: 1 as const };
+    const out = await compactIfNeeded({ messages: mk(60), prior, now: NOW, summarize });
+    expect(summarize).toHaveBeenCalledTimes(1);
+    expect(summarize.mock.calls[0][0]).toBe("PRIOR");
+    expect(out.kept).toHaveLength(KEEP_LAST);
+    expect(out.kept[0].id).toBe(`m${60 - KEEP_LAST}`);
+    expect(out.newCompaction?.throughMessageId).toBe(`m${60 - KEEP_LAST - 1}`);
+  });
+
+  it("ignores a stale prior watermark (id absent) and refolds from scratch", async () => {
+    const summarize = vi.fn(async () => "S4");
+    const prior = { summary: "PRIOR", throughMessageId: "gone", updatedAt: NOW, version: 1 as const };
+    const out = await compactIfNeeded({ messages: mk(50), prior, now: NOW, summarize });
+    expect(summarize).toHaveBeenCalledTimes(1);
+    expect(summarize.mock.calls[0][0]).toBe(""); // stale prior dropped
+    expect(out.kept).toHaveLength(KEEP_LAST);
+  });
+});

--- a/packages/llm/test/integration/channel-thread-store.test.ts
+++ b/packages/llm/test/integration/channel-thread-store.test.ts
@@ -1,0 +1,67 @@
+import { afterAll, describe, expect, it } from "vitest";
+import { db, eq, pool, work_thread } from "@neko/db";
+import { dbReachable, withTestOrg } from "@neko/db/test-helpers";
+import { channelThreadId, getOrCreateChannelThread } from "../../src/work/store";
+
+const reachable = await dbReachable();
+const describeIfDb = reachable ? describe : describe.skip;
+
+if (!reachable) {
+  console.warn("[channel-thread-store] skipping: metadata Postgres unreachable.");
+}
+
+describeIfDb("getOrCreateChannelThread (upsert round-trip)", () => {
+  afterAll(async () => {
+    await pool().end();
+  });
+
+  it("creates once, then reuses the same row across turns", async () => {
+    await withTestOrg(async (orgId) => {
+      const first = await getOrCreateChannelThread({
+        orgId,
+        channel: "slack",
+        conversationKey: "D9",
+        title: "Slack DM",
+      });
+      const second = await getOrCreateChannelThread({
+        orgId,
+        channel: "slack",
+        conversationKey: "D9",
+        title: "ignored on reuse",
+      });
+
+      expect(first.id).toBe(channelThreadId(orgId, "slack", "D9"));
+      expect(second.id).toBe(first.id);
+
+      const rows = await db()
+        .select()
+        .from(work_thread)
+        .where(eq(work_thread.id, first.id));
+      expect(rows).toHaveLength(1);
+      // Reuse must not clobber the thread created on first contact.
+      expect(rows[0].title).toBe("Slack DM");
+    });
+  });
+
+  it("keys distinct conversations (DM vs thread) to distinct rows", async () => {
+    await withTestOrg(async (orgId) => {
+      const dm = await getOrCreateChannelThread({
+        orgId,
+        channel: "slack",
+        conversationKey: "D9",
+      });
+      const thread = await getOrCreateChannelThread({
+        orgId,
+        channel: "slack",
+        conversationKey: "C9:171.5",
+      });
+
+      expect(thread.id).not.toBe(dm.id);
+      const all = await db()
+        .select({ id: work_thread.id })
+        .from(work_thread)
+        .where(eq(work_thread.org_id, orgId));
+      expect(all).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Worker/LLM side of making Slack a conversational channel: inbound over Slack **Socket Mode**, per-conversation **thread continuity**, in-thread channel **follow-ups**, and Claude-Code-style **transcript compaction** so long threads stay bounded. Pairs with open-neko/plugins#36.

## What's included
- **Socket Mode ingress** (`apps/worker/src/channels/socket-loop.ts`) — worker-owned Slack Socket Mode client (Node global `WebSocket`/`fetch`, no new deps), acks envelopes within Slack's 3s window, feeds payloads through the plugin's `parse_inbound`. Activated via the reserved `ingress: "socket"` branch.
- **Thread continuity** — channel runs reuse one `work_thread` per conversation via a deterministic id (UUIDv5, **no migration**) and persist the inbound user turn, so DMs and channel threads keep history across turns (Telegram/WhatsApp benefit too).
- **W3.2 in-thread follow-up** — a bare channel thread reply continues a thread the bot already owns (gated on an existing `work_thread`).
- **Transcript compaction** (`packages/llm/src/work/compact-transcript.ts`) — folds turns older than the last 12 into a rolling summary once a thread passes 40 messages (inline-transcript backends; message-count trigger, env-overridable), persisted on `backend_state.compaction` (**no migration**). `buildWorkPrompt` renders an `[Earlier conversation summary]` block. Claude Agent untouched (its SDK manages context).
- `select` intent now continues the conversation instead of being silently dropped.

## Tests
- **Unit**: socket framing (ack-before-dispatch, routing), `conversationKeyFor`, `channelThreadId`, the W3.2 gate, compaction (fold/keep/watermark).
- **Integration**: socket loop against a real local WebSocket server (connect → ack → dispatch → reconnect); `getOrCreateChannelThread` against real Postgres.
- Worker typecheck clean; channels **69**, compaction **5**, llm thread-id **3** (+ Postgres integration).

## Activation
Reinstall the Slack plugin (picks up `ingress: socket` + env) and set `SLACK_APP_TOKEN`; configure the Slack app (Socket Mode, app-level token, `message.im` + `app_mention` subscriptions, `/openneko` command). See open-neko/plugins#36.

## Deferred
Token-based compaction trigger, manual `/compact`, ambient channel reading (W3.3), per-conversation proactive delivery binding, webhook ingress for the conversational flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)