### PR TITLE
chore: relicense to Elastic License 2.0 + contributor CLA (open-core Phase 0)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,35 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened, closed]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA Assistant
+        if: >-
+          (github.event.comment.body == 'recheck' ||
+           github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') ||
+          github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
+        with:
+          path-to-signatures: signatures/version1/cla.json
+          path-to-document: https://github.com/open-neko/openneko/blob/main/CLA.md
+          branch: cla-signatures
+          allowlist: '*[bot]'
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
+          custom-notsigned-prcomment: 'Thanks for your pull request! Before we can merge it, please read our [Contributor License Agreement](https://github.com/open-neko/openneko/blob/main/CLA.md) and sign it by posting the comment below.'
+          custom-allsigned-prcomment: 'All contributors have signed the CLA. ✅'

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,89 @@
+# OpenNeko Contributor License Agreement
+
+Thank you for contributing to OpenNeko. This Contributor License Agreement
+("Agreement") sets out the terms under which intellectual property in your
+contributions is provided to the OpenNeko project, maintained by Amit Deshmukh
+(the "Project Maintainer"). It protects you, the Project Maintainer, and the
+users of OpenNeko. It does not change your right to use your own contributions
+for any other purpose.
+
+By signing this Agreement — for example, by commenting your acceptance on a pull
+request — you accept and agree to the following terms for your past, present, and
+future Contributions submitted to the project.
+
+## 1. Definitions
+
+"You" (or "Your") means the individual or legal entity that owns, or is legally
+entitled to grant the licenses described here for, and that submits, a
+Contribution.
+
+"Contribution" means any original work of authorship, including any modifications
+or additions to existing work, that You intentionally submit to the project for
+inclusion in, or documentation of, OpenNeko. "Submit" means any form of
+electronic, verbal, or written communication sent to the project or its
+maintainers, including but not limited to pull requests, commits, issues, and
+discussions, but excluding communication that is conspicuously marked in writing
+as "Not a Contribution."
+
+## 2. Copyright License
+
+You retain ownership of the copyright in Your Contribution. Subject to this
+Agreement, You grant to the Project Maintainer and to recipients of software
+distributed by the project a perpetual, worldwide, non-exclusive, royalty-free,
+irrevocable copyright license to reproduce, prepare derivative works of, publicly
+display, publicly perform, sublicense, distribute, and otherwise exploit Your
+Contribution and such derivative works.
+
+You expressly agree that the Project Maintainer may license and relicense Your
+Contribution under any license terms, including the Elastic License 2.0, other
+open-source or source-available licenses, and proprietary or commercial license
+terms, and may include Your Contribution in both the freely available and the
+commercially licensed editions of OpenNeko.
+
+## 3. Patent License
+
+Subject to this Agreement, You grant to the Project Maintainer and to recipients
+of software distributed by the project a perpetual, worldwide, non-exclusive,
+royalty-free, irrevocable (except as stated below) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer Your Contribution,
+where such license applies only to those patent claims licensable by You that are
+necessarily infringed by Your Contribution alone or by combination of Your
+Contribution with the project to which it was submitted. If any entity institutes
+patent litigation alleging that Your Contribution, or the project to which You
+contributed, constitutes direct or contributory patent infringement, then any
+patent licenses granted to that entity under this Agreement terminate as of the
+date such litigation is filed.
+
+## 4. Your Representations
+
+You represent that:
+
+- You are legally entitled to grant the above licenses. If Your employer has
+  rights to intellectual property You create, You represent that You have
+  received permission to make the Contribution on behalf of that employer, or
+  that Your employer has waived such rights for Your Contribution.
+- Each of Your Contributions is Your original creation, or You have identified
+  and provided complete details of any third-party license or other restriction
+  of which You are personally aware and which is associated with any part of Your
+  Contribution.
+- To the best of Your knowledge, Your Contribution does not violate any third
+  party's copyrights, trademarks, patents, or other intellectual property rights.
+
+## 5. No Obligation; No Warranty
+
+You are not expected to provide support for Your Contribution, except to the
+extent You desire to do so. Unless required by applicable law or agreed in
+writing, You provide Your Contribution on an "AS IS" basis, without warranties or
+conditions of any kind, either express or implied.
+
+## 6. Miscellaneous
+
+This Agreement is the entire agreement between You and the Project Maintainer
+regarding Your Contributions and supersedes any prior agreement on that subject.
+If any provision of this Agreement is held unenforceable, the remaining
+provisions remain in full force and effect.
+
+---
+
+If You are signing on behalf of a legal entity, You represent that You are
+authorized to bind that entity to this Agreement, and "You" includes that entity.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,8 @@ go test -tags=integration -count=1 -timeout 10m ./internal/db/...
 
 Keep PRs focused — one change per PR makes review tractable. Include a short description of the user-visible behavior change, and link the issue it closes if there is one.
 
-## License
+## Contributor License Agreement
 
-By contributing, you agree that your contributions will be licensed under the [Apache License 2.0](LICENSE).
+Before your first pull request can be merged, you'll need to sign the OpenNeko [Contributor License Agreement](CLA.md). A bot prompts you automatically on your first PR — it's a single comment to sign.
+
+The CLA lets you keep the copyright in your contribution while granting the project the rights it needs to license OpenNeko under the [Elastic License 2.0](LICENSE) and a separate commercial license, and to relicense if ever necessary. See [LICENSING.md](LICENSING.md) for how OpenNeko is licensed.

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,102 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Copyright (c) 2026 Amit Deshmukh (the "Licensor").
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+OpenNeko is made available under the Elastic License 2.0, reproduced below.
+Certain enterprise components are instead made available under a separate
+commercial license — see LICENSING.md and LICENSE-COMMERCIAL.md for the full
+model.
 
-   1. Definitions.
+----------------------------------------------------------------------
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+Elastic License 2.0
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
+URL: https://www.elastic.co/licensing/elastic-license
 
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
+## Acceptance
 
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
+By using the software, you agree to all of the terms and conditions below.
 
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
+## Copyright License
 
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
 
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
+## Limitations
 
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
 
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
 
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
 
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
+## Patents
 
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
 
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
+## Notices
 
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
 
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
 
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
+## No Other Rights
 
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
+These terms do not imply any licenses other than those expressly granted in
+these terms.
 
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
+## Termination
 
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
 
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for describing the origin of the Work and
-      reproducing the content of the NOTICE file.
+## No Liability
 
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
 
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
+## Definitions
 
-   9. Accepting Warranty or Support. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or support.
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
 
-   END OF TERMS AND CONDITIONS
+**you** refers to the individual or entity agreeing to these terms.
 
-   APPENDIX: How to apply the Apache License to your work.
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
 
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
+**your licenses** are all the licenses granted to you for the software under
+these terms.
 
-   Copyright 2026 Amit Deshmukh
+**use** means anything you do with the software requiring one of your licenses.
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+**trademark** means trademarks, service marks, and similar rights.

--- a/LICENSE-COMMERCIAL.md
+++ b/LICENSE-COMMERCIAL.md
@@ -1,0 +1,45 @@
+# OpenNeko Commercial License
+
+Copyright (c) 2026 Amit Deshmukh. All rights reserved.
+
+Most of OpenNeko is made available under the Elastic License 2.0 (see
+[LICENSE](LICENSE)). This Commercial License instead governs the **enterprise
+components** of OpenNeko — the files and modules identified by the SPDX header
+`LicenseRef-OpenNeko-Commercial`, together with any components designated as
+enterprise features in [LICENSING.md](LICENSING.md) (collectively, the
+"Enterprise Software").
+
+## Grant
+
+No license to the Enterprise Software is granted by this document. The Enterprise
+Software is proprietary. You may use, copy, modify, or distribute the Enterprise
+Software only if you hold a valid, current commercial subscription or license
+agreement with the Project Maintainer (a "Commercial Agreement"), and then only
+in accordance with that Commercial Agreement.
+
+## Permitted reference use
+
+Absent a Commercial Agreement, you may view the source of the Enterprise Software
+where it is published, and you may build and run it solely for local development,
+testing, and evaluation. You may not use the Enterprise Software, or enable its
+functionality, in production or for any commercial purpose without a Commercial
+Agreement.
+
+## Restrictions
+
+Without a Commercial Agreement you may not: (a) run the Enterprise Software in
+production; (b) move, change, disable, or circumvent any license-key or
+entitlement mechanism that gates the Enterprise Software; or (c) remove or obscure
+any licensing, copyright, or proprietary notices.
+
+## No warranty; no liability
+
+As far as the law allows, the Enterprise Software comes "as is," without any
+warranty or condition, and the Project Maintainer will not be liable for any
+damages arising out of these terms or the use or nature of the Enterprise
+Software, under any kind of legal claim.
+
+## Obtaining a license
+
+To obtain a Commercial Agreement, contact the Project Maintainer via
+<https://openneko.app>.

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,69 @@
+# How OpenNeko is licensed
+
+OpenNeko uses an **open-core** model with two licenses:
+
+| Edition | License | What it covers |
+|---|---|---|
+| **Core** | [Elastic License 2.0](LICENSE) (source-available) | Everything except the enterprise components below. Free to self-host and use. |
+| **Enterprise** | [OpenNeko Commercial License](LICENSE-COMMERCIAL.md) | Governance, compliance, and org-scale administration features. Requires a paid Commercial Agreement to use in production. |
+
+> OpenNeko is **source-available**, not OSI "open source." You can read,
+> self-host, modify, and redistribute the Core, but the Elastic License 2.0
+> prohibits offering OpenNeko to third parties as a hosted or managed service and
+> prohibits circumventing the license-key / entitlement functionality.
+
+## What's free (Elastic License 2.0)
+
+Everything you need to run OpenNeko securely for yourself or your team:
+
+- The agent runtime, Ask workspace, briefings, workflows, and watchers
+- The plugin system and sandbox, with on-the-wire model-key injection
+- Secrets encryption at rest, multi-tenant isolation, the RBAC engine, and
+  local / solo authentication
+- Personal access passes, memory integrity, and manual approval gates
+- Multi-user collaboration over chat channels (Slack / Telegram)
+
+## What's enterprise (Commercial License)
+
+Features whose buyer is an organization's IT, security, or compliance function —
+they scale with org size, not individual use:
+
+- **Teams on the web** — enterprise SSO / SAML / OIDC, SCIM provisioning, and web
+  multi-user login
+- **Approval policy engine** — auto-approval rules and per-organization policies
+  (manual approval stays free)
+- **Compliance & audit** — the tamper-evident, hash-chained audit log with SIEM
+  export, and dual-identity audit trails
+- **Governance** — install / plugin policy, behavioral alarms, org / hardened
+  security profiles, and context-versioning governance
+- **External secrets** — the Infisical vault integration
+
+The authoritative per-feature mapping (with the feature keys that gate each one)
+lives alongside the code; enterprise files carry the SPDX header
+`LicenseRef-OpenNeko-Commercial`.
+
+## Plugins are not derivative works
+
+OpenNeko loads plugins as separate processes inside sandboxes, across a defined
+RPC boundary. A third-party plugin that communicates with OpenNeko only across
+that boundary is an independent work and is **not** a derivative work of
+OpenNeko. Plugin authors may license their plugins however they choose.
+
+## Trademarks
+
+"OpenNeko" and the OpenNeko logo are trademarks of the Project Maintainer.
+Neither the Elastic License 2.0 nor the Commercial License grants you rights to
+use these marks. You may make nominative reference to OpenNeko (for example,
+"works with OpenNeko"), but you may not use the name or logo in a way that implies
+endorsement, and a redistributed or modified version may not be called
+"OpenNeko."
+
+## Contributing
+
+Contributions are welcome under a [Contributor License Agreement](CLA.md), which
+lets the project license your contribution under both the Elastic License 2.0 and
+the Commercial License. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## Getting a commercial license
+
+Contact us via <https://openneko.app> to discuss an Enterprise subscription.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OpenNeko
 
-[![License](https://img.shields.io/badge/license-Apache_2.0-blue)](LICENSE)
+[![License](https://img.shields.io/badge/license-Elastic_2.0-0B64A0)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/open-neko/openneko)](https://github.com/open-neko/openneko/releases/latest)
 [![Self-hosted · Docker](https://img.shields.io/badge/self--hosted-Docker-2496ED?logo=docker&logoColor=white)](INSTALL.md)
 [![openneko.app](https://img.shields.io/badge/openneko.app-website-111111)](https://openneko.app)
@@ -58,7 +58,7 @@ The memory layer runs on your own Postgres, on your own infrastructure:
 - **Action policies** — your rules for what auto-fires, what queues, what's blocked.
 - **Decision history** — every approval, rejection, and execution receipt.
 
-Apache 2.0, self-hosted, single Postgres. Take a backup, take it with you.
+Source-available (Elastic License 2.0), self-hosted, single Postgres. Take a backup, take it with you.
 
 ## Plugins
 
@@ -79,7 +79,7 @@ openneko install @open-neko/plugin-parallel-search
 - **Bring your own LLM.** Hermes runs against Anthropic, OpenAI, Google, Ollama, and others; Claude Agent runs Anthropic in-process. Pick per task, swap any time.
 - **Plugins in OpenShell sandboxes.** Outbound network is allowlisted per manifest, not blanket-open.
 - **Agent in a sandbox by default.** The agent loop itself runs inside an OpenShell policy sandbox — default-deny egress, and the model API key never enters the box (the gateway proxy injects it on the wire). See [OPENSHELL.md](OPENSHELL.md).
-- **Apache 2.0.** Inspect everything. Fork it. Take your data with you.
+- **Source-available (Elastic License 2.0).** Read the source, self-host, take your data with you. Enterprise features are separately licensed — see [LICENSING.md](LICENSING.md).
 
 ## Docs
 
@@ -95,11 +95,11 @@ Please file bugs and feature requests at [github.com/open-neko/openneko/issues](
 
 ## Contributing
 
-Pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the developer setup, repository layout, and the checks to run before opening a PR.
+Pull requests are welcome — on your first PR a bot will ask you to sign a quick [Contributor License Agreement](CLA.md). See [CONTRIBUTING.md](CONTRIBUTING.md) for the developer setup, repository layout, and the checks to run before opening a PR.
 
 ## License
 
-OpenNeko is licensed under the [Apache License 2.0](LICENSE).
+OpenNeko's core is **source-available** under the [Elastic License 2.0](LICENSE): self-host and use it freely, but you may not offer it to third parties as a hosted or managed service. Some enterprise features are separately licensed under the [OpenNeko Commercial License](LICENSE-COMMERCIAL.md). See **[LICENSING.md](LICENSING.md)** for the full model.
 
 ## Author
 

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -1,6 +1,6 @@
 # Third-party software shipped with OpenNeko
 
-OpenNeko is distributed under the [Apache License 2.0](LICENSE). The Apache-2.0 grant covers OpenNeko's own source code. This file lists third-party software that is **shipped alongside** OpenNeko (bundled in npm dependencies, Docker images, or release artifacts) and the additional license obligations those carry.
+OpenNeko is distributed under the [Elastic License 2.0](LICENSE) — some enterprise components are instead under a separate commercial license (see [LICENSING.md](LICENSING.md)). That grant covers OpenNeko's own source code. This file lists third-party software that is **shipped alongside** OpenNeko (bundled in npm dependencies, Docker images, or release artifacts) and the additional license obligations those carry.
 
 This file is the canonical NOTICE. Operators who redistribute OpenNeko in any form must ship this file alongside.
 

--- a/apps/openneko/LICENSE
+++ b/apps/openneko/LICENSE
@@ -1,18 +1,102 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+Copyright (c) 2026 Amit Deshmukh (the "Licensor").
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+OpenNeko is made available under the Elastic License 2.0, reproduced below.
+Certain enterprise components are instead made available under a separate
+commercial license — see LICENSING.md and LICENSE-COMMERCIAL.md in the
+repository root for the full model.
 
-       http://www.apache.org/licenses/LICENSE-2.0
+----------------------------------------------------------------------
 
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Elastic License 2.0
 
-   See the full Apache License 2.0 text at the URL above, or in the top-level
-   LICENSE file of the OpenNeko repository.
+URL: https://www.elastic.co/licensing/elastic-license
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/apps/openneko/README.md
+++ b/apps/openneko/README.md
@@ -117,4 +117,4 @@ go test -tags=integration -count=1 -timeout 10m ./internal/db/...
 
 ## License
 
-Apache 2.0. See [LICENSE](./LICENSE).
+Elastic License 2.0 (source-available). See [LICENSE](./LICENSE), and [LICENSING.md](../../LICENSING.md) for the full open-core model.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "neko",
   "version": "2.8.0",
   "private": true,
-  "license": "Apache-2.0",
+  "license": "Elastic-2.0",
   "author": "Amit Deshmukh (https://github.com/amitdeshmukh)",
   "homepage": "https://openneko.app",
   "repository": {

--- a/packages/plugin-install/package.json
+++ b/packages/plugin-install/package.json
@@ -2,7 +2,7 @@
   "name": "@open-neko/plugin-install",
   "version": "2.8.0",
   "private": true,
-  "license": "Apache-2.0",
+  "license": "Elastic-2.0",
   "description": "Shared library for OpenNeko plugin install + secrets-store. Consumed by both the worker (reads the secrets store, will gain a server-side install path) and the openneko CLI (the operator-facing surface).",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/plugin-types/README.md
+++ b/packages/plugin-types/README.md
@@ -53,4 +53,4 @@ node run.js <method> <json-params>
 
 ## License
 
-Apache-2.0
+Elastic-2.0 — see [LICENSING.md](../../LICENSING.md).

--- a/packages/plugin-types/package.json
+++ b/packages/plugin-types/package.json
@@ -2,7 +2,7 @@
   "name": "@open-neko/plugin-types",
   "version": "2.8.0",
   "description": "Public types and RPC schema for OpenNeko plugins. Vendored from open-neko/plugins/packages/types — the canonical npm-published copy lives there for external plugin authors; this in-tree copy is what the worker consumes via workspace.",
-  "license": "Apache-2.0",
+  "license": "Elastic-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/open-neko/openneko.git",

--- a/packages/secret-crypt/package.json
+++ b/packages/secret-crypt/package.json
@@ -2,7 +2,7 @@
   "name": "@neko/secret-crypt",
   "version": "1.19.1",
   "private": true,
-  "license": "Apache-2.0",
+  "license": "Elastic-2.0",
   "description": "The enc:v1 at-rest cipher (AES-256-GCM keyed from ~/.config/openneko/secret-key). Canonical TS implementation; apps/openneko/internal/secrets/crypt.go is the Go mirror, pinned together by the cross-language fixture test.",
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
## What

Establishes OpenNeko's licensing boundary — Phase 0 of the open-core plan (tasks #1–#3). This is the change that stops free distribution of the enterprise features **going forward**; the runtime gating is incremental and lands in later PRs.

### Licensing model
- **Core → Elastic License 2.0** (source-available). Free to self-host, but **no** offering OpenNeko to third parties as a managed/hosted service, and **no** circumventing the license-key/entitlement functionality. This is what blocks AWS-style rehosting and protects the future feature gate.
- **Enterprise → OpenNeko Commercial License** (`LICENSE-COMMERCIAL.md`). Governs the enterprise components (to be marked with the SPDX header `LicenseRef-OpenNeko-Commercial` in a follow-up).
- **`LICENSING.md`** documents the free/enterprise split, the plugin-boundary carve-out (plugins across the sandbox/RPC boundary are not derivative works), and the **trademark** policy.

### CLA
- `CLA.md` — a license-grant Individual CLA: you keep copyright; the project gets the right to license under ELv2 **and** the commercial license, and to relicense. Preserves dual-licensing now that the repo is no longer Apache.
- `.github/workflows/cla.yml` — CLA Assistant; prompts signers on their first PR.

### Files
- `LICENSE` (Apache-2.0 → ELv2) and `apps/openneko/LICENSE` (Go binary, same)
- `package.json` + 3 manifests: `"license": "Elastic-2.0"`
- `README.md`, `CONTRIBUTING.md`, `THIRD_PARTY_LICENSES.md`, two sub-READMEs → "source-available" wording + CLA mention
- New: `CLA.md`, `LICENSING.md`, `LICENSE-COMMERCIAL.md`, `.github/workflows/cla.yml`

### Deliberately unchanged
- **Past Apache-2.0 releases** stay Apache-2.0 — this binds forward versions only.
- **Anthropic-derived built-in skills** (`packages/llm/assets/builtin-skills/*`) keep their Apache-2.0 license, attribution, and `LICENSE.txt`.

## ⚠️ Before merge — action required
1. **Legal review.** `CLA.md` and `LICENSE-COMMERCIAL.md` are solid drafts but should be reviewed by counsel. Confirm the **licensor entity** ("Amit Deshmukh" vs a company) across `LICENSE`, `LICENSE-COMMERCIAL.md`, and `CLA.md`.
2. **Add the `CLA_SIGNATURES_TOKEN` repo secret** (a PAT with `contents: write`) so the CLA workflow can record signatures on a `cla-signatures` branch. (The workflow runs from the base branch on `pull_request_target`, so it won't trigger on *this* PR — only after merge.)
3. **Positioning:** OpenNeko is now "source-available," not OSI "open source" — update external site/marketing copy that still says "open source."

## Not in this PR (next phases)
Feature map (#4), SPDX headers + consolidation (#5), `hasFeature()` runtime gate (#6), and per-bucket gating (#7–#9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)