### PR TITLE
fix(web): restore answer list markers and tidy briefing rendering

### DIFF
--- a/apps/web/src/app/styles/_work.css
+++ b/apps/web/src/app/styles/_work.css
@@ -357,6 +357,20 @@
 .work-markdown ol {
   padding-left: 22px;
 }
+/* Tailwind's preflight resets ul/ol to list-style:none; restore real markers
+   so lists read as lists, with disc → circle → square cueing the nesting. */
+.work-markdown ul {
+  list-style: disc outside;
+}
+.work-markdown ol {
+  list-style: decimal outside;
+}
+.work-markdown ul ul {
+  list-style-type: circle;
+}
+.work-markdown ul ul ul {
+  list-style-type: square;
+}
 .work-markdown li + li {
   margin-top: 4px;
 }
@@ -650,11 +664,12 @@
   background: rgba(255,255,255,0.7);
   border-radius: 18px;
 }
-/* Synthetic Markdown surface (assistant prose wrapped in a fallback Markdown
-   surface) — when it sits inside a chat timeline, render it as the prominent
-   answer card. KPI cards / Briefing roots aren't styled here because they
-   bring their own card chrome. */
-.work-timeline .work-surface-frame:has(> .work-markdown) {
+/* The prominent answer card. Applies both to a synthetic Markdown surface
+   (assistant prose wrapped in a fallback Markdown surface) and to a Briefing
+   root — neither carries its own chrome, so the frame supplies it and the two
+   read as one cohesive answer instead of an unpadded translucent slab. */
+.work-timeline .work-surface-frame:has(> .work-markdown),
+.work-timeline .work-surface-frame:has(> .work-surface) {
   position: relative;
   background: linear-gradient(
     180deg,
@@ -760,4 +775,40 @@
 .work-surface-title + :not(.work-surface-sub),
 .work-surface-sub + * {
   margin-top: 14px;
+}
+/* Even rhythm between a briefing's prose and any inline KPI callouts. */
+.work-surface > .work-markdown + .work-markdown,
+.work-surface > .work-markdown + .icard,
+.work-surface > .icard + .work-markdown,
+.work-surface > .icard + .icard {
+  margin-top: 14px;
+}
+
+/* In-thread KPI card. The dashboard's .icard is a standalone grid tile —
+   heavy border, shadow, hover-lift, big "01" ordinal — which reads as a
+   box-in-a-box once it sits inside an answer card. Re-skin it as a flat
+   mood-tinted callout that belongs to the briefing around it. */
+.work-timeline .icard {
+  margin: 0;
+  cursor: default;
+  padding: 18px 20px 18px 24px;
+  background: color-mix(in srgb, var(--mood-tint, var(--card)) 45%, var(--card));
+  border: 1px solid color-mix(in srgb, var(--mood-color, var(--border)) 16%, transparent);
+  box-shadow: none;
+}
+.work-timeline .icard:hover {
+  transform: none;
+  box-shadow: none;
+  border-color: color-mix(in srgb, var(--mood-color, var(--border)) 16%, transparent);
+}
+.work-timeline .icard .inum {
+  display: none;
+}
+/* Headline/metric are flush-left once the ordinal is gone, so drop the
+   indent that kept the detail aligned under it. */
+.work-timeline .icard .dtext {
+  padding-left: 0;
+}
+.work-timeline .icard .dchart {
+  margin-left: 0;
 }


### PR DESCRIPTION
## What

Two rendering fixes for chat answers (`apps/web`, CSS only).

### Missing list markers (the main bug)
Bulleted/numbered lists in answers rendered as bare indented text — no `•`, no `1.` — so structure and nesting were invisible. Root cause: Tailwind's preflight resets `ul/ol` to `list-style: none` and `.work-markdown` only re-added the indent. Restored `disc → circle → square` (for nesting) and `decimal` markers, inheriting the body text color so they match the text rather than reading as a separate muted grey.

### Briefing surface cleanup
The in-thread Briefing never received answer-card chrome (an unpadded translucent slab), while its KPI cards reused the dashboard grid tile verbatim — heavy border/shadow/hover-lift plus a duplicated `01` ordinal (the ordinal index is never populated in `SurfaceBlock`). Gave the Briefing the same cohesive answer-card frame as a prose answer and re-skinned the KPI cards as flat mood-tinted callouts. Scoped to `.work-timeline`, so the dashboard insight deck is unchanged.

## Testing
Built the `web` image from this branch into a local `--mode demo` stack and verified: lists render with correct markers, the briefing reads as one cohesive card with flat callouts, and the dashboard deck is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)