### PR TITLE
ci(cla): don't lock PR conversations after merge

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -26,6 +26,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
         with:
+          # Don't lock PR conversations after merge — it blocks release-please
+          # from commenting on its (now-locked) release PR, failing the job.
+          lock-pullrequest-aftermerge: false
           path-to-signatures: signatures/version1/cla.json
           path-to-document: https://github.com/open-neko/openneko/blob/main/CLA.md
           branch: cla-signatures


### PR DESCRIPTION
## Problem

The **Release Please** job fails on every release (e.g. [v2.10.0 run](https://github.com/open-neko/openneko/actions/runs/28076995773), and the same on v2.9.0) with:

> `Unable to create comment because issue is locked.`

The release itself is created fine; the job dies only on release-please's follow-up "released" comment to the release PR — because that PR is **locked**.

## Cause

`.github/workflows/cla.yml` uses `contributor-assistant/github-action`, whose `lock-pullrequest-aftermerge` input **defaults to `true`**. The workflow runs on `pull_request_target: closed`, so it locks the conversation of *every* PR on merge — including the `chore(main): release X` release PRs. release-please then can't comment → red job. (Started failing right after the CLA workflow was added; pre-CLA releases were green.)

## Fix

Set `lock-pullrequest-aftermerge: false`. CLA enforcement is unchanged — this only stops the post-merge conversation lock, so release-please can finalize its release PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)