### PR TITLE
Fix OpenShell sandbox egress (Node 24) + keep plugin secrets off the exec command

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - uses: actions/setup-go@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # the app. See entrypoint.sh for the env var contract.
 
 # ─── 1. base: node + system tooling ────────────────────────────────────
-FROM node:22-bookworm-slim AS base
+FROM node:24-bookworm-slim AS base
 ENV PNPM_HOME=/pnpm
 ENV PATH=$PNPM_HOME:$PATH
 # Retry transient apt mirror hiccups instead of hard-failing the image build.
@@ -314,7 +314,7 @@ CMD ["--help"]
 # requires `docker compose restart neko-graphjin`. Built on the slim
 # node base so we have node + curl available for the templating script
 # and a real healthcheck.
-FROM node:22-bookworm-slim AS neko-graphjin
+FROM node:24-bookworm-slim AS neko-graphjin
 ARG GRAPHJIN_VERSION=3.18.37
 ARG TARGETARCH
 ENV NODE_ENV=production

--- a/apps/worker/src/plugins/openshell-runtime.ts
+++ b/apps/worker/src/plugins/openshell-runtime.ts
@@ -1,6 +1,11 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { RpcResponse } from "@open-neko/plugin-types";
 import {
+  buildEnvFile,
   buildExecCommand,
   type PluginRuntime,
   type PluginVmSpec,
@@ -19,6 +24,9 @@ import {
  * a shell wrapper (OpenShell exec has no --env), produced by buildExecCommand.
  */
 const PLUGIN_RUNNER_PATH = "/sandbox/run.js";
+// Secret env is uploaded here (out of band) and sourced at exec — never inlined
+// into the exec command, which the OpenShell gateway logs.
+const PLUGIN_ENV_FILE_PATH = "/sandbox/.plugin-env";
 const DEFAULT_RPC_TIMEOUT_MS = 30_000;
 const CREATE_TIMEOUT_MS = 180_000;
 const UPLOAD_TIMEOUT_MS = 60_000;
@@ -50,6 +58,8 @@ export interface OpenShellRuntimeOptions {
 
 interface Entry {
   spec: PluginVmSpec;
+  /** sha256 of the last env file uploaded to this sandbox — skip re-upload when unchanged. */
+  envHash?: string;
 }
 
 export class OpenShellRuntime implements PluginRuntime {
@@ -117,12 +127,15 @@ export class OpenShellRuntime implements PluginRuntime {
       throw new Error(`OpenShellRuntime: plugin not started: ${pluginId}`);
     }
     const timeoutMs = options.timeoutMs ?? DEFAULT_RPC_TIMEOUT_MS;
-    const { cmd, args } = buildExecCommand(
-      method,
-      paramsJson,
-      options.env ?? {},
-      PLUGIN_RUNNER_PATH,
-    );
+    const env = options.env ?? {};
+    const hasEnv = Object.keys(env).length > 0;
+    // Upload the plugin's secrets as a file (cached by hash) so they're sourced
+    // in-box rather than inlined into the exec command (which the gateway logs).
+    if (hasEnv) await this.ensureEnvFile(pluginId, env);
+    const { cmd, args } = buildExecCommand(method, paramsJson, {
+      runnerPath: PLUGIN_RUNNER_PATH,
+      ...(hasEnv ? { envFilePath: PLUGIN_ENV_FILE_PATH } : {}),
+    });
     const timeoutSec = Math.max(1, Math.ceil(timeoutMs / 1000));
     // Gateway-side --timeout bounds the remote command; the host-side
     // spawn timeout is a slightly longer backstop for a hung CLI.
@@ -142,6 +155,32 @@ export class OpenShellRuntime implements PluginRuntime {
       timeoutMs + 5_000,
     );
     return parseRpcLastLine(stdout, pluginId, method);
+  }
+
+  /**
+   * Write the plugin's secret env to a host temp file (mode 0600), upload it to
+   * the sandbox, and remember its hash so an unchanged env skips the round-trip.
+   * The upload command carries the temp PATH + dest path, never the values, so
+   * the secret never reaches the gateway's command log.
+   */
+  private async ensureEnvFile(pluginId: string, env: Record<string, string>): Promise<void> {
+    const entry = this.entries.get(pluginId);
+    if (!entry) return;
+    const content = buildEnvFile(env);
+    const hash = createHash("sha256").update(content).digest("hex");
+    if (entry.envHash === hash) return;
+    const dir = await mkdtemp(path.join(tmpdir(), "oss-plugin-env-"));
+    try {
+      const file = path.join(dir, "plugin-env");
+      await writeFile(file, content, { mode: 0o600 });
+      await this.run(
+        ["sandbox", "upload", pluginId, file, PLUGIN_ENV_FILE_PATH],
+        UPLOAD_TIMEOUT_MS,
+      );
+      entry.envHash = hash;
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   }
 
   async stop(pluginId: string): Promise<void> {

--- a/apps/worker/src/plugins/plugin-runtime.ts
+++ b/apps/worker/src/plugins/plugin-runtime.ts
@@ -29,8 +29,9 @@ export interface PluginRuntime {
   /**
    * Invokes the plugin's runner with `node /workspace/run.js <method>
    * <paramsJson>` and parses the single JSON response from stdout.
-   * If `env` is provided, values are injected into the VM at exec time
-   * via a shell wrapper.
+   * If `env` is provided, the runtime makes those values available to the
+   * plugin process WITHOUT placing secret values on the exec command line
+   * (OpenShell sources an uploaded env file; the dev subprocess sets process env).
    */
   callRpc(
     pluginId: string,
@@ -64,44 +65,45 @@ function shellQuote(value: string): string {
 const ENV_KEY_RX = /^[A-Z][A-Z0-9_]*$/;
 
 /**
+ * Build a POSIX-shell-sourceable env file holding a plugin's secrets
+ * (`export KEY='value'` lines). The runtime uploads this into the sandbox
+ * out-of-band and the exec sources it — so secret VALUES never land in the
+ * exec command line (which the OpenShell gateway logs) nor in the box's
+ * process args. Keys are validated to UPPER_SNAKE_CASE so a bad manifest
+ * entry can't smuggle shell syntax; values are POSIX single-quote-escaped.
+ */
+export function buildEnvFile(env: Record<string, string>): string {
+  return Object.keys(env)
+    .map((k) => {
+      if (!ENV_KEY_RX.test(k)) {
+        throw new Error(`plugin env key "${k}" is not a valid UPPER_SNAKE_CASE name`);
+      }
+      return `export ${k}=${shellQuote(env[k] ?? "")}`;
+    })
+    .join("\n");
+}
+
+/**
  * Returns the command + argv the runtime will invoke inside the VM.
- * Without env: a plain `node` exec, fastest path. With env: wrap in
- * `sh -c '<exports>; exec node ...'` so the env is bound for the
- * plugin process.
+ * Without an env file: a plain `node` exec, fastest path. With one: wrap in
+ * `sh -c '. <file>; exec node ...'` so the plugin's secrets (in the uploaded
+ * file) are bound for the process — the command itself carries only the file
+ * PATH, never a secret value.
  *
- * Why `sh` not `bash`: the default plugin VM image ships `ash` at
- * `/bin/sh` and no `bash`. POSIX `sh` is enough for our needs (export +
- * exec + single-quote-escaped values).
- *
- * Env keys are validated to UPPER_SNAKE_CASE before they reach the
- * shell so a bad manifest entry can't smuggle a command-injection
- * substring like `FOO; rm -rf /`. Values are POSIX-quoted.
+ * Why `sh` not `bash`: the default plugin VM image ships `ash` at `/bin/sh`
+ * and no `bash`. POSIX `sh` is enough (source + exec + quoted args).
  */
 export function buildExecCommand(
   method: string,
   paramsJson: string,
-  env: Record<string, string>,
-  runnerPath = "/workspace/run.js",
+  opts: { envFilePath?: string; runnerPath?: string } = {},
 ): { cmd: string; args: string[] } {
-  const keys = Object.keys(env);
-  if (keys.length === 0) {
-    return {
-      cmd: "node",
-      args: [runnerPath, method, paramsJson],
-    };
+  const runnerPath = opts.runnerPath ?? "/workspace/run.js";
+  if (!opts.envFilePath) {
+    return { cmd: "node", args: [runnerPath, method, paramsJson] };
   }
-  for (const k of keys) {
-    if (!ENV_KEY_RX.test(k)) {
-      throw new Error(
-        `plugin env key "${k}" is not a valid UPPER_SNAKE_CASE name`,
-      );
-    }
-  }
-  const exports = keys
-    .map((k) => `export ${k}=${shellQuote(env[k] ?? "")}`)
-    .join("; ");
   const inner =
-    `${exports}; exec node ${runnerPath} ` +
+    `. ${shellQuote(opts.envFilePath)}; exec node ${runnerPath} ` +
     `${shellQuote(method)} ${shellQuote(paramsJson)}`;
   return { cmd: "sh", args: ["-c", inner] };
 }

--- a/apps/worker/test/plugins/openshell-registry-e2e.test.ts
+++ b/apps/worker/test/plugins/openshell-registry-e2e.test.ts
@@ -17,7 +17,7 @@ import { OpenShellRuntime } from "../../src/plugins/openshell-runtime";
  *
  * Opt-in (creates Docker sandboxes via the gateway): a reachable OpenShell
  * gateway (brew service or compose) + the base image built + the bundle:
- *   docker build -f docker/plugin-base.Dockerfile -t ghcr.io/open-neko/plugin-base:node20 .
+ *   docker build -f docker/plugin-base.Dockerfile -t ghcr.io/open-neko/plugin-base:node24 .
  *   pnpm -C ../../plugins/packages/parallel-search build
  *   OPENNEKO_OPENSHELL_E2E=1 pnpm --filter @neko/worker test openshell-registry-e2e
  */
@@ -26,7 +26,7 @@ const PARALLEL_BUNDLE_PATH = path.resolve(
   "../../../../../plugins/packages/parallel-search/dist/run.js",
 );
 const BASE_IMAGE =
-  process.env.OPENNEKO_PLUGIN_BASE_IMAGE ?? "ghcr.io/open-neko/plugin-base:node20";
+  process.env.OPENNEKO_PLUGIN_BASE_IMAGE ?? "ghcr.io/open-neko/plugin-base:node24";
 const FAKE_INTEGRITY = "sha512-" + "a".repeat(86) + "==";
 
 const MANIFEST_JSON = JSON.stringify({

--- a/apps/worker/test/plugins/openshell-runtime-e2e.test.ts
+++ b/apps/worker/test/plugins/openshell-runtime-e2e.test.ts
@@ -15,7 +15,7 @@ import { OpenShellRuntime } from "../../src/plugins/openshell-runtime";
  *
  * Opt-in (creates Docker containers): set OPENNEKO_OPENSHELL_E2E=1 with a
  * running gateway and the base image built:
- *   docker build -f docker/plugin-base.Dockerfile -t ghcr.io/open-neko/plugin-base:node20 .
+ *   docker build -f docker/plugin-base.Dockerfile -t ghcr.io/open-neko/plugin-base:node24 .
  *   pnpm -C ../../plugins/packages/slack build
  *   OPENNEKO_OPENSHELL_E2E=1 pnpm --filter @neko/worker test openshell-runtime-e2e
  */
@@ -24,7 +24,7 @@ const SLACK_BUNDLE = path.resolve(
   "../../../../../plugins/packages/slack/dist/run.js",
 );
 const BASE_IMAGE =
-  process.env.OPENNEKO_PLUGIN_BASE_IMAGE ?? "ghcr.io/open-neko/plugin-base:node20";
+  process.env.OPENNEKO_PLUGIN_BASE_IMAGE ?? "ghcr.io/open-neko/plugin-base:node24";
 
 function cmdOk(cmd: string, args: string[]): boolean {
   try {

--- a/apps/worker/test/plugins/openshell-runtime.test.ts
+++ b/apps/worker/test/plugins/openshell-runtime.test.ts
@@ -86,7 +86,7 @@ describe("OpenShellRuntime", () => {
 
   function make(opts?: { gatewayEndpoint?: string; gatewayName?: string }) {
     return new OpenShellRuntime({
-      image: "ghcr.io/open-neko/plugin-base:node20",
+      image: "ghcr.io/open-neko/plugin-base:node24",
       bundleDir: "/tmp/bundles",
       ...opts,
     });
@@ -107,7 +107,7 @@ describe("OpenShellRuntime", () => {
       "--name",
       "p1",
       "--from",
-      "ghcr.io/open-neko/plugin-base:node20",
+      "ghcr.io/open-neko/plugin-base:node24",
       "--no-tty",
       "--no-auto-providers",
       "--",
@@ -231,7 +231,7 @@ describe("OpenShellRuntime", () => {
     expect(res).toEqual({ ok: true, result: { hello: "world" } });
   });
 
-  it("callRpc with env wraps in sh -c with quoted exports", async () => {
+  it("callRpc with env uploads a sourced env file — the secret never enters the exec command", async () => {
     const rt = make();
     await rt.start({
       id: "p1",
@@ -247,21 +247,40 @@ describe("OpenShellRuntime", () => {
       env: { SLACK_BOT_TOKEN: "xoxb-1" },
     });
 
+    // The secret rode an out-of-band upload to the env file (the upload argv is
+    // the host temp PATH + dest path, never the value) — not the exec command.
+    const upload = h.calls.find(
+      (c) =>
+        c.args[0] === "sandbox" &&
+        c.args[1] === "upload" &&
+        c.args.includes("/sandbox/.plugin-env"),
+    );
+    expect(upload).toBeDefined();
+
     const args = execCall()?.args ?? [];
-    expect(args.slice(0, 8)).toEqual([
-      "sandbox",
-      "exec",
-      "-n",
-      "p1",
-      "--no-tty",
-      "--timeout",
-      "30",
-      "--",
-    ]);
     expect(args[8]).toBe("sh");
     expect(args[9]).toBe("-c");
-    expect(args[10]).toContain("export SLACK_BOT_TOKEN='xoxb-1'");
+    expect(args[10]).toContain(". '/sandbox/.plugin-env';");
     expect(args[10]).toContain("exec node /sandbox/run.js");
+    // The token value appears in NO spawned command's argv (gateway-log safe).
+    expect(h.calls.some((c) => c.args.some((a) => a.includes("xoxb-1")))).toBe(false);
+  });
+
+  it("re-uses the uploaded env file across calls with unchanged env (no re-upload)", async () => {
+    const rt = make();
+    await rt.start({
+      id: "p1",
+      hostWorkspacePath: "/tmp/bundles/p1",
+      network: "none",
+      hosts: [],
+    });
+    h.state.respond = (args) =>
+      args.includes("exec") ? { stdout: OK_JSON } : { stdout: "", code: 0 };
+    const env = { SLACK_BOT_TOKEN: "xoxb-1" };
+    await rt.callRpc("p1", "m1", "{}", { env });
+    h.calls.length = 0;
+    await rt.callRpc("p1", "m2", "{}", { env });
+    expect(h.calls.some((c) => c.args[1] === "upload")).toBe(false);
   });
 
   it("parses the LAST stdout line when logs precede the JSON", async () => {

--- a/apps/worker/test/plugins/plugin-runtime.test.ts
+++ b/apps/worker/test/plugins/plugin-runtime.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  buildEnvFile,
   buildExecCommand,
   networkModeFor,
 } from "../../src/plugins/plugin-runtime.js";
@@ -18,38 +19,47 @@ describe("networkModeFor", () => {
   });
 });
 
+describe("buildEnvFile", () => {
+  it("emits POSIX-sourceable export lines", () => {
+    expect(buildEnvFile({ SLACK_BOT_TOKEN: "xoxb-abc", RUN_ID: "r-1" })).toBe(
+      "export SLACK_BOT_TOKEN='xoxb-abc'\nexport RUN_ID='r-1'",
+    );
+  });
+
+  it("POSIX-escapes single quotes inside values", () => {
+    expect(buildEnvFile({ FOO: "it's ok" })).toBe(`export FOO='it'\\''s ok'`);
+  });
+
+  it("rejects bad env key names that could be shell-substring attacks", () => {
+    expect(() => buildEnvFile({ "FOO; rm -rf /": "x" })).toThrow(/UPPER_SNAKE_CASE/);
+    expect(() => buildEnvFile({ lowercase: "x" })).toThrow(/UPPER_SNAKE_CASE/);
+  });
+});
+
 describe("buildExecCommand", () => {
-  it("with empty env, returns plain node exec (fast path)", () => {
-    expect(buildExecCommand("register", "{}", {})).toEqual({
+  it("without an env file, returns plain node exec (fast path)", () => {
+    expect(buildExecCommand("register", "{}")).toEqual({
       cmd: "node",
       args: ["/workspace/run.js", "register", "{}"],
     });
   });
 
-  it("with env, wraps in sh -c with exports + exec node", () => {
+  it("honors a custom runner path", () => {
+    expect(buildExecCommand("m", "{}", { runnerPath: "/sandbox/run.js" })).toEqual({
+      cmd: "node",
+      args: ["/sandbox/run.js", "m", "{}"],
+    });
+  });
+
+  it("with an env file, sources it then exec node — and carries NO secret value", () => {
     const out = buildExecCommand("execute_action", '{"x":1}', {
-      SLACK_BOT_TOKEN: "xoxb-abc",
-      RUN_ID: "r-1",
+      envFilePath: "/sandbox/.plugin-env",
+      runnerPath: "/sandbox/run.js",
     });
     expect(out.cmd).toBe("sh");
     expect(out.args[0]).toBe("-c");
-    const inner = out.args[1] ?? "";
-    expect(inner).toContain("export SLACK_BOT_TOKEN='xoxb-abc'");
-    expect(inner).toContain("export RUN_ID='r-1'");
-    expect(inner).toContain("exec node /workspace/run.js 'execute_action' '{\"x\":1}'");
-  });
-
-  it("POSIX-escapes single quotes inside env values", () => {
-    const out = buildExecCommand("m", "{}", { FOO: "it's ok" });
-    expect(out.args[1]).toContain(`export FOO='it'\\''s ok'`);
-  });
-
-  it("rejects bad env key names that could be shell-substring attacks", () => {
-    expect(() =>
-      buildExecCommand("m", "{}", { "FOO; rm -rf /": "x" }),
-    ).toThrow(/UPPER_SNAKE_CASE/);
-    expect(() =>
-      buildExecCommand("m", "{}", { lowercase: "x" }),
-    ).toThrow(/UPPER_SNAKE_CASE/);
+    expect(out.args[1]).toBe(
+      `. '/sandbox/.plugin-env'; exec node /sandbox/run.js 'execute_action' '{"x":1}'`,
+    );
   });
 });

--- a/docker/agent-base.Dockerfile
+++ b/docker/agent-base.Dockerfile
@@ -8,8 +8,11 @@
 # @neko/llm bundle + the claude/hermes/graphjin binaries + agent-sandbox/entry.ts
 # — which is produced by composing the main Dockerfile's `cli`/`build` stages.
 # See docs/OPENSHELL_MIGRATION_PLAN.md (Phase 2c) for the full image + launcher.
-#   docker build -f docker/agent-base.Dockerfile -t ghcr.io/open-neko/agent-base:node20 .
-FROM node:20-bookworm-slim
+#   docker build -f docker/agent-base.Dockerfile -t ghcr.io/open-neko/agent-base:node24 .
+# Node 24: the injected NODE_USE_ENV_PROXY only routes node fetch through the
+# egress proxy on 24+ — needed for the claude CLI's API egress (and any
+# node-fetch egress) to reach the model through the proxy instead of failing DNS.
+FROM node:24-bookworm-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates iproute2 nftables \

--- a/docker/plugin-base.Dockerfile
+++ b/docker/plugin-base.Dockerfile
@@ -1,7 +1,10 @@
 # Shared OpenShell sandbox base for all @open-neko plugins. Each plugin's
 # self-contained dist/run.js is uploaded to /sandbox/run.js at start, not baked.
-#   docker build -f docker/plugin-base.Dockerfile -t ghcr.io/open-neko/plugin-base:node20 .
-FROM node:20-bookworm-slim
+#   docker build -f docker/plugin-base.Dockerfile -t ghcr.io/open-neko/plugin-base:node24 .
+# Node 24: OpenShell injects NODE_USE_ENV_PROXY into every sandbox, but node only
+# honors it (routing fetch through the egress proxy) on 24+. On older node the
+# plugin's fetch dials direct, and DNS fails (proxy-only egress) → EAI_AGAIN.
+FROM node:24-bookworm-slim
 
 # iproute2 + nftables: required by the supervisor's egress setup (without them
 # the sandbox hangs at "waiting for supervisor relay").


### PR DESCRIPTION
Two related OpenShell-sandbox fixes. Root cause of the Telegram `getUpdates … fetch failed (EAI_AGAIN)` on the demo **and** the bot-token-in-gateway-logs leak.

## 1. Egress proxy / DNS (Node 24)
OpenShell injects `NODE_USE_ENV_PROXY` (+ `HTTP_PROXY`) into every sandbox, but Node only honors it — routing `fetch` through the egress proxy, which resolves DNS **host-side** — on **Node 24+**. The sandbox bases were Node 20 (plugins) / 22 (agent), so any Node-`fetch` egress dialed direct and DNS failed (egress is proxy-only) → `EAI_AGAIN`.

- **Confirmed:** the Telegram plugin (Node 20 `fetch`) fails this way on the demo — host + worker reach `api.telegram.org` fine over IPv4; only the nested sandbox can't resolve.
- **Latent, same cause:** the **claude backend** runs the `claude` CLI (Node) whose Anthropic API calls go through Node `fetch` — it would hit the same wall. It isn't biting today only because the demo runs **hermes**, a Go binary that honors `HTTP_PROXY` natively (the one proxy-correct agent path).

Fix: bump all sandbox/build bases to Node 24 — `plugin-base`, `agent-base`, the main `Dockerfile` (`base` + `neko-graphjin`), and CI. The already-injected proxy env then works for *all* node-`fetch` egress (plugins, the claude CLI, MCP-bridge children), keeping the proxy-only egress model intact.

## 2. Plugin secrets off the exec command
The runtime inlined `export TELEGRAM_BOT_TOKEN='<value>'; exec node …` into the `openshell exec` command, which the gateway logs (`command_preview`) — leaking the token in cleartext and putting it in the box's process args, against the key-isolation model. Now `buildEnvFile` writes the secrets to a host temp file (mode 0600), the runtime uploads it into the sandbox (cached by sha256, re-uploaded only on change), and the exec sources it. The command carries only the file **path** — never a secret value.

> Note: for a token in a URL **path** (Telegram's `/bot<token>/`), OpenShell's query/header credential injection can't keep it fully out of the box, so the realistic fix is "not in the command/logs." Header/query-secret plugins could later move to full proxy-credential injection (the agent's `keyAliases` model).

## Tests
Updated `plugin-runtime` + `openshell-runtime` unit tests (incl. an assertion that the secret value appears in **no** spawned argv, and that the env file is uploaded + reused). 87 worker plugin tests pass; worker typecheck clean.

## ⚠️ Validation
Can't be validated against a live OpenShell gateway here. Before relying on it: the **images must be rebuilt at Node 24** (plugin-base, agent, web/worker/graphjin) and the egress verified on `neko-vm` — i.e. a Telegram round-trip succeeds and (ideally) a claude turn reaches Anthropic through the proxy. The Node-24 bump touches the whole stack build, so watch the image builds. Also **rotate the leaked Telegram bot token** (it's in the current gateway logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)