### PR TITLE
Plugin egress: proxy-inject channel secrets (no token in the box) + clean channel reply rendering

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - uses: actions/setup-go@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@
 # the app. See entrypoint.sh for the env var contract.
 
 # ─── 1. base: node + system tooling ────────────────────────────────────
-FROM node:22-bookworm-slim AS base
+FROM node:24-bookworm-slim AS base
 ENV PNPM_HOME=/pnpm
 ENV PATH=$PNPM_HOME:$PATH
 # Retry transient apt mirror hiccups instead of hard-failing the image build.
@@ -314,7 +314,7 @@ CMD ["--help"]
 # requires `docker compose restart neko-graphjin`. Built on the slim
 # node base so we have node + curl available for the templating script
 # and a real healthcheck.
-FROM node:22-bookworm-slim AS neko-graphjin
+FROM node:24-bookworm-slim AS neko-graphjin
 ARG GRAPHJIN_VERSION=3.18.37
 ARG TARGETARCH
 ENV NODE_ENV=production

--- a/apps/worker/src/agent-sandbox/entry.ts
+++ b/apps/worker/src/agent-sandbox/entry.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { appendFile, mkdir, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, rename, symlink, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import {
@@ -143,12 +143,36 @@ export async function main(): Promise<void> {
       hasRunAuth = true;
     }
     await mkdir(job.workspace.binRoot, { recursive: true });
-    await ensureGraphjinGuard(job.workspace.binRoot, graphjinBinary, {
+    // Defense-in-depth: the model sometimes ignores the "query only via the
+    // shell tool" contract and shells out to `graphjin` from execute_code (a
+    // Python subprocess with a minimal PATH), hitting the raw binary at
+    // /usr/local/bin/graphjin with the wrong auth — which fails and sends it
+    // into a retry loop, and would bypass the mutation gate. Move the real
+    // binary aside and shadow the standard PATH entry with the guard wrapper, so
+    // ANY `graphjin` invocation (any PATH) gets the guarded, correctly-authed
+    // CLI (the wrapper exports the run's XDG_CONFIG_HOME regardless of caller).
+    let realBinary = graphjinBinary;
+    if (graphjinBinary === "/usr/local/bin/graphjin") {
+      try {
+        await rename("/usr/local/bin/graphjin", "/usr/local/bin/graphjin.real");
+        realBinary = "/usr/local/bin/graphjin.real";
+      } catch {
+        /* not writable / already shadowed — fall back to binRoot-only guard */
+      }
+    }
+    await ensureGraphjinGuard(job.workspace.binRoot, realBinary, {
       ...(hasRunAuth ? { xdgConfigHome: gjAuth } : {}),
       ...(job.graphjinWriteGrants?.length
         ? { allowSubcommands: job.graphjinWriteGrants }
         : {}),
     });
+    if (realBinary === "/usr/local/bin/graphjin.real") {
+      // The move vacated /usr/local/bin/graphjin — point it at the guard wrapper.
+      await symlink(
+        join(job.workspace.binRoot, "graphjin"),
+        "/usr/local/bin/graphjin",
+      ).catch(() => {});
+    }
     // The backend prepends binRoot to PATH for its children, but hermes'
     // terminal tool spawns LOGIN shells (`bash -lic`) and /etc/profile resets
     // PATH — silently un-guarding `graphjin`. Login shells re-source these

--- a/apps/worker/src/channels/delivery.ts
+++ b/apps/worker/src/channels/delivery.ts
@@ -152,23 +152,64 @@ export async function deliverChatReply(
   runId: string,
   body: string,
   surfaces?: unknown[],
+  vitals?: { label: string; value: string; sub?: string }[],
 ): Promise<void> {
-  const hasSurfaces = Array.isArray(surfaces) && surfaces.length > 0;
+  const agentSurfaces =
+    Array.isArray(surfaces) && surfaces.length > 0 ? (surfaces as SurfaceMessage[]) : undefined;
+  // When the agent emitted no a2ui surface (common on channel runs — it answers
+  // in prose plus the mandatory vitals fence), synthesize one from the answer +
+  // vitals so a rendering channel shows the metric *cards* web shows, not prose.
+  const enrichmentSurfaces =
+    agentSurfaces ??
+    (vitals && vitals.length > 0 ? buildReplySurface(body, vitals) : undefined);
   // A rendering run (web/telegram) puts its answer in the a2ui surface, so the
   // text body can be thin or empty — deliver as long as either is present.
-  if (!body.trim() && !hasSurfaces) return;
+  if (!body.trim() && !enrichmentSurfaces) return;
   // A chat reply is the assistant's message, not a workflow-output card — use
   // `converse` so channels render the full text, not a summarized headline.
-  // The agent's a2ui surface rides as enrichment; a channel that can render it
-  // (Telegram) shows the rich answer, a thin one falls back to the text.
+  // The a2ui surface rides as enrichment; a channel that can render it (Telegram)
+  // shows the rich answer, a thin one falls back to the text.
   const event: InteractionEvent = {
     kind: "converse",
     id: runId,
     role: "assistant",
     text: body,
-    ...(hasSurfaces ? { enrichment: { surfaces: surfaces as SurfaceMessage[] } } : {}),
+    ...(enrichmentSurfaces ? { enrichment: { surfaces: enrichmentSurfaces } } : {}),
   };
   await enqueueChannelDelivery(orgId, channelPlugin, recipient, [event], `reply-${runId}`);
+}
+
+/**
+ * Synthesize a minimal a2ui surface — the answer prose as Markdown plus one
+ * MetricCard per vital — so a channel that renders surfaces shows the vitals as
+ * cards even when the agent produced no surface of its own. Web is unaffected
+ * (it renders from the event stream, not this channel-reply path).
+ */
+function buildReplySurface(
+  body: string,
+  vitals: { label: string; value: string; sub?: string }[],
+): SurfaceMessage[] {
+  const cards = vitals.map((v, i) => ({
+    id: `vital-${i}`,
+    component: "MetricCard",
+    metric: v.value,
+    label: v.label,
+    ...(v.sub ? { detail: v.sub } : {}),
+  }));
+  const hasBody = body.trim().length > 0;
+  const components: Record<string, unknown>[] = [
+    {
+      id: "root",
+      component: "Answer",
+      children: [...(hasBody ? ["answer-body"] : []), ...cards.map((c) => c.id)],
+    },
+    ...(hasBody ? [{ id: "answer-body", component: "Markdown", text: body }] : []),
+    ...cards,
+  ];
+  return [
+    { version: "v0.9", createSurface: { surfaceId: "reply", catalogId: "urn:app:catalog:answer:v1" } },
+    { version: "v0.9", updateComponents: { surfaceId: "reply", components } },
+  ];
 }
 
 /**

--- a/apps/worker/src/jobs/work-run.ts
+++ b/apps/worker/src/jobs/work-run.ts
@@ -46,10 +46,17 @@ export async function runWorkRun(
   // would be lost. Collect the (scrubbed) surface messages here so the reply
   // can carry them to channels that render rich content (e.g. Telegram).
   const surfaces: unknown[] = [];
+  // The agent reliably emits a `vitals` fence (mandatory) but not always an a2ui
+  // surface; collect the vitals so the reply can render them as cards on a
+  // channel even when no surface was produced.
+  let vitals: { label: string; value: string; sub?: string }[] = [];
   const emit = async (event: AgentEvent): Promise<void> => {
     const scrubbed = scrubAgentEvent(scrubber, event);
     if (scrubbed.type === "surface" && Array.isArray(scrubbed.messages)) {
       surfaces.push(...scrubbed.messages);
+    }
+    if (scrubbed.type === "vitals" && Array.isArray(scrubbed.items)) {
+      vitals = scrubbed.items;
     }
     await appendWorkRunEvent({ orgId, threadId, runId, event: scrubbed });
   };
@@ -75,6 +82,6 @@ export async function runWorkRun(
   // Channel-initiated runs have no other return path — send the reply back to
   // the sender. Web runs (no channelPlugin) stream over SSE instead.
   if (channelPlugin && recipient && result.status === "completed") {
-    await deliverChatReply(orgId, channelPlugin, recipient, runId, result.finalText, surfaces);
+    await deliverChatReply(orgId, channelPlugin, recipient, runId, result.finalText, surfaces, vitals);
   }
 }

--- a/apps/worker/src/plugins/openshell-runtime.ts
+++ b/apps/worker/src/plugins/openshell-runtime.ts
@@ -1,6 +1,11 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { RpcResponse } from "@open-neko/plugin-types";
 import {
+  buildEnvFile,
   buildExecCommand,
   type PluginRuntime,
   type PluginVmSpec,
@@ -19,6 +24,9 @@ import {
  * a shell wrapper (OpenShell exec has no --env), produced by buildExecCommand.
  */
 const PLUGIN_RUNNER_PATH = "/sandbox/run.js";
+// Secret env is uploaded here (out of band) and sourced at exec — never inlined
+// into the exec command, which the OpenShell gateway logs.
+const PLUGIN_ENV_FILE_PATH = "/sandbox/.plugin-env";
 const DEFAULT_RPC_TIMEOUT_MS = 30_000;
 const CREATE_TIMEOUT_MS = 180_000;
 const UPLOAD_TIMEOUT_MS = 60_000;
@@ -50,6 +58,8 @@ export interface OpenShellRuntimeOptions {
 
 interface Entry {
   spec: PluginVmSpec;
+  /** sha256 of the last env file uploaded to this sandbox — skip re-upload when unchanged. */
+  envHash?: string;
 }
 
 export class OpenShellRuntime implements PluginRuntime {
@@ -117,12 +127,15 @@ export class OpenShellRuntime implements PluginRuntime {
       throw new Error(`OpenShellRuntime: plugin not started: ${pluginId}`);
     }
     const timeoutMs = options.timeoutMs ?? DEFAULT_RPC_TIMEOUT_MS;
-    const { cmd, args } = buildExecCommand(
-      method,
-      paramsJson,
-      options.env ?? {},
-      PLUGIN_RUNNER_PATH,
-    );
+    const env = options.env ?? {};
+    const hasEnv = Object.keys(env).length > 0;
+    // Upload the plugin's secrets as a file (cached by hash) so they're sourced
+    // in-box rather than inlined into the exec command (which the gateway logs).
+    if (hasEnv) await this.ensureEnvFile(pluginId, env);
+    const { cmd, args } = buildExecCommand(method, paramsJson, {
+      runnerPath: PLUGIN_RUNNER_PATH,
+      ...(hasEnv ? { envFilePath: PLUGIN_ENV_FILE_PATH } : {}),
+    });
     const timeoutSec = Math.max(1, Math.ceil(timeoutMs / 1000));
     // Gateway-side --timeout bounds the remote command; the host-side
     // spawn timeout is a slightly longer backstop for a hung CLI.
@@ -142,6 +155,32 @@ export class OpenShellRuntime implements PluginRuntime {
       timeoutMs + 5_000,
     );
     return parseRpcLastLine(stdout, pluginId, method);
+  }
+
+  /**
+   * Write the plugin's secret env to a host temp file (mode 0600), upload it to
+   * the sandbox, and remember its hash so an unchanged env skips the round-trip.
+   * The upload command carries the temp PATH + dest path, never the values, so
+   * the secret never reaches the gateway's command log.
+   */
+  private async ensureEnvFile(pluginId: string, env: Record<string, string>): Promise<void> {
+    const entry = this.entries.get(pluginId);
+    if (!entry) return;
+    const content = buildEnvFile(env);
+    const hash = createHash("sha256").update(content).digest("hex");
+    if (entry.envHash === hash) return;
+    const dir = await mkdtemp(path.join(tmpdir(), "oss-plugin-env-"));
+    try {
+      const file = path.join(dir, "plugin-env");
+      await writeFile(file, content, { mode: 0o600 });
+      await this.run(
+        ["sandbox", "upload", pluginId, file, PLUGIN_ENV_FILE_PATH],
+        UPLOAD_TIMEOUT_MS,
+      );
+      entry.envHash = hash;
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   }
 
   async stop(pluginId: string): Promise<void> {

--- a/apps/worker/src/plugins/openshell-runtime.ts
+++ b/apps/worker/src/plugins/openshell-runtime.ts
@@ -71,6 +71,10 @@ const UPLOAD_TIMEOUT_MS = 60_000;
 const DELETE_TIMEOUT_MS = 60_000;
 const POLICY_LOAD_TIMEOUT_S = 60;
 const EGRESS_PORT = 443;
+// The plugin's node interpreter opens the egress connection; OpenShell's proxy
+// authorizes by ABSOLUTE binary path, and the plugin-base image (node:24-slim)
+// ships node here. Bare "node" does not match → the CONNECT is denied (403).
+const PLUGIN_NODE_BINARY = "/usr/local/bin/node";
 
 export interface OpenShellRuntimeOptions {
   /** Shared lean base image: node + iproute2/nftables + a `sandbox` user. */
@@ -332,9 +336,10 @@ export class OpenShellRuntime implements PluginRuntime {
 }
 
 /**
- * Per-host egress, scoped to the `node` binary (the plugin's interpreter —
- * the process that actually opens the connection). Empty host list → no
- * rules added, leaving the sandbox's inherited default-deny in place.
+ * Per-host egress, scoped to the plugin's node interpreter (the process that
+ * actually opens the connection) by ABSOLUTE path — the proxy matches the full
+ * binary path, so bare "node" is denied. Empty host list → no rules added,
+ * leaving the sandbox's inherited default-deny in place.
  */
 export function buildPolicyUpdateArgs(
   id: string,
@@ -345,7 +350,7 @@ export function buildPolicyUpdateArgs(
   for (const host of hosts) {
     args.push("--add-endpoint", `${host}:${EGRESS_PORT}:read-write:rest:enforce`);
   }
-  args.push("--binary", "node");
+  args.push("--binary", PLUGIN_NODE_BINARY);
   for (const host of hosts) {
     args.push("--add-allow", `${host}:${EGRESS_PORT}:*:/**`);
   }

--- a/apps/worker/src/plugins/openshell-runtime.ts
+++ b/apps/worker/src/plugins/openshell-runtime.ts
@@ -24,9 +24,47 @@ import {
  * a shell wrapper (OpenShell exec has no --env), produced by buildExecCommand.
  */
 const PLUGIN_RUNNER_PATH = "/sandbox/run.js";
-// Secret env is uploaded here (out of band) and sourced at exec — never inlined
-// into the exec command, which the OpenShell gateway logs.
+// Box-class secret env (manifest `inject:"box"`) is uploaded here (out of band)
+// and sourced at exec — never inlined into the exec command (the gateway logs
+// it). Egress secrets never reach this file; they are provider-injected.
 const PLUGIN_ENV_FILE_PATH = "/sandbox/.plugin-env";
+// Egress secrets are held gateway-side as a per-plugin OpenShell provider whose
+// credential slots (c0, c1, …) the box receives as placeholders — one per
+// declared `inject:"egress"` key, aliased to the key at exec; the proxy swaps in
+// the real value on the wire. The value never enters the box.
+const pluginProviderName = (pluginId: string): string => `plugin-${pluginId}`;
+const pluginSecretProfileId = (pluginId: string): string => `openneko-plugin-${pluginId}`;
+const credentialSlot = (i: number): string => `c${i}`;
+
+/** A per-plugin provider profile with one credential slot per egress secret. */
+function pluginSecretProfileYaml(profileId: string, count: number): string {
+  const cred = (i: number): string =>
+    [
+      `- name: ${credentialSlot(i)}`,
+      `  description: plugin egress credential ${i}`,
+      `  env_vars:`,
+      `  - C${i}`,
+      `  required: true`,
+      `  auth_style: query`,
+      `  header_name: ''`,
+      `  query_param: key`,
+    ].join("\n");
+  return [
+    `id: ${profileId}`,
+    `display_name: OpenNeko Plugin Secret`,
+    `description: Plugin egress credentials (proxy-substituted; the box holds only placeholders)`,
+    `category: agent`,
+    `credentials:`,
+    Array.from({ length: count }, (_, i) => cred(i)).join("\n"),
+    `endpoints: []`,
+    `binaries: []`,
+    `inference_capable: false`,
+    `discovery:`,
+    `  credentials:`,
+    Array.from({ length: count }, (_, i) => `  - ${credentialSlot(i)}`).join("\n"),
+    ``,
+  ].join("\n");
+}
 const DEFAULT_RPC_TIMEOUT_MS = 30_000;
 const CREATE_TIMEOUT_MS = 180_000;
 const UPLOAD_TIMEOUT_MS = 60_000;
@@ -60,6 +98,14 @@ interface Entry {
   spec: PluginVmSpec;
   /** sha256 of the last env file uploaded to this sandbox — skip re-upload when unchanged. */
   envHash?: string;
+  /** Manifest `inject:"egress"` keys — provider-injected, aliased from the
+   *  placeholder at exec, and kept out of the uploaded env file. */
+  egressKeys?: readonly string[];
+  /** Gateway-side provider registered for this plugin's egress secret (for cleanup on stop). */
+  providerName?: string;
+  /** sha256 of the egress values last pushed to the provider — when it changes
+   *  (token rotation) we refresh the gateway-side value, not the box. */
+  egressValueHash?: string;
 }
 
 export class OpenShellRuntime implements PluginRuntime {
@@ -73,15 +119,22 @@ export class OpenShellRuntime implements PluginRuntime {
 
   async start(spec: PluginVmSpec): Promise<void> {
     if (this.entries.has(spec.id)) return;
+    const egress = spec.egressSecrets ?? [];
+    // Hold the egress secrets gateway-side first (one credential slot each), so
+    // the box that references them only ever sees the placeholders.
+    const providerName = egress.length > 0 ? pluginProviderName(spec.id) : undefined;
+    if (providerName) {
+      await this.ensurePluginProvider(spec.id, providerName, egress.map((e) => e.value));
+    }
     try {
-      await this.createSandbox(spec);
+      await this.createSandbox(spec, providerName);
     } catch (err) {
       // A failed or orphaned start (image pull error, worker restart) leaves
       // the name registered on the gateway, so every retry collides forever —
       // replace the stale sandbox instead.
       if (!formatError(err).includes("already exists")) throw err;
       await this.run(["sandbox", "delete", spec.id], DELETE_TIMEOUT_MS);
-      await this.createSandbox(spec);
+      await this.createSandbox(spec, providerName);
     }
     await this.run([
       "sandbox",
@@ -92,14 +145,50 @@ export class OpenShellRuntime implements PluginRuntime {
     ], UPLOAD_TIMEOUT_MS);
     const policy = buildPolicyUpdateArgs(spec.id, spec.hosts ?? []);
     if (policy) await this.run(policy, (POLICY_LOAD_TIMEOUT_S + 15) * 1000);
-    this.entries.set(spec.id, { spec });
+    this.entries.set(spec.id, {
+      spec,
+      ...(egress.length > 0
+        ? { egressKeys: egress.map((e) => e.key), egressValueHash: hashEgress(egress) }
+        : {}),
+      ...(providerName ? { providerName } : {}),
+    });
     this.log(
       `plugin sandbox ready: ${spec.id} ` +
-        `(hosts=${(spec.hosts ?? []).join(",") || "none"})`,
+        `(hosts=${(spec.hosts ?? []).join(",") || "none"}, ` +
+        `egress=${egress.map((e) => e.key).join(",") || "none"})`,
     );
   }
 
-  private createSandbox(spec: PluginVmSpec): Promise<string> {
+  /**
+   * Register (or refresh) the gateway-side provider holding this plugin's egress
+   * secrets — one credential slot per value. Idempotent: imports the per-plugin
+   * profile, then creates-or-updates the provider. The values ride the create
+   * command host→gateway (the trusted control plane), never into a sandbox.
+   */
+  private async ensurePluginProvider(
+    pluginId: string,
+    providerName: string,
+    values: readonly string[],
+  ): Promise<void> {
+    const profileId = pluginSecretProfileId(pluginId);
+    const dir = await mkdtemp(path.join(tmpdir(), "oss-plugin-profile-"));
+    try {
+      const file = path.join(dir, `${profileId}.yaml`);
+      await writeFile(file, pluginSecretProfileYaml(profileId, values.length), { mode: 0o600 });
+      await this.run(["provider", "profile", "import", "--file", file], UPLOAD_TIMEOUT_MS).catch(
+        () => {},
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+    const credArgs = values.flatMap((v, i) => ["--credential", `${credentialSlot(i)}=${v}`]);
+    await this.run(
+      ["provider", "create", "--name", providerName, "--type", profileId, ...credArgs],
+      DELETE_TIMEOUT_MS,
+    ).catch(() => this.run(["provider", "update", providerName, ...credArgs], DELETE_TIMEOUT_MS));
+  }
+
+  private createSandbox(spec: PluginVmSpec, providerName?: string): Promise<string> {
     // `-- node --version` is a cheap initial command; the supervisor
     // replaces it and (without --no-keep) the sandbox stays Ready.
     return this.run([
@@ -111,6 +200,7 @@ export class OpenShellRuntime implements PluginRuntime {
       this.options.image,
       "--no-tty",
       "--no-auto-providers",
+      ...(providerName ? ["--provider", providerName] : []),
       "--",
       "node",
       "--version",
@@ -127,14 +217,34 @@ export class OpenShellRuntime implements PluginRuntime {
       throw new Error(`OpenShellRuntime: plugin not started: ${pluginId}`);
     }
     const timeoutMs = options.timeoutMs ?? DEFAULT_RPC_TIMEOUT_MS;
-    const env = options.env ?? {};
-    const hasEnv = Object.keys(env).length > 0;
-    // Upload the plugin's secrets as a file (cached by hash) so they're sourced
-    // in-box rather than inlined into the exec command (which the gateway logs).
-    if (hasEnv) await this.ensureEnvFile(pluginId, env);
+    const entry = this.entries.get(pluginId);
+    const egressKeys = entry?.egressKeys ?? [];
+    // Rotation: if the egress value changed since the VM started, refresh the
+    // gateway-side provider. The box keeps the same placeholder; the proxy just
+    // resolves the new value — no re-upload, no VM restart.
+    if (entry?.providerName && egressKeys.length > 0) {
+      const values = egressKeys.map((k) => (options.env ?? {})[k] ?? "");
+      const hash = hashEgress(egressKeys.map((k, i) => ({ key: k, value: values[i] ?? "" })));
+      if (hash !== entry.egressValueHash) {
+        await this.ensurePluginProvider(pluginId, entry.providerName, values);
+        entry.egressValueHash = hash;
+      }
+    }
+    // Egress secrets are provider-injected — the box holds only the placeholder.
+    // Keep their values out of the uploaded env file; box-class secrets still
+    // ride the file (cached by hash, sourced at exec, never on the command line).
+    const boxEnv = Object.fromEntries(
+      Object.entries(options.env ?? {}).filter(([k]) => !egressKeys.includes(k)),
+    );
+    const hasBoxEnv = Object.keys(boxEnv).length > 0;
+    if (hasBoxEnv) await this.ensureEnvFile(pluginId, boxEnv);
+    // Alias each provider-injected placeholder ($c0, $c1, …) to the env var the
+    // plugin reads (e.g. TELEGRAM_BOT_TOKEN) — a reference, never a value.
+    const aliases = egressKeys.map((to, i) => ({ from: credentialSlot(i), to }));
     const { cmd, args } = buildExecCommand(method, paramsJson, {
       runnerPath: PLUGIN_RUNNER_PATH,
-      ...(hasEnv ? { envFilePath: PLUGIN_ENV_FILE_PATH } : {}),
+      ...(hasBoxEnv ? { envFilePath: PLUGIN_ENV_FILE_PATH } : {}),
+      ...(aliases.length ? { aliases } : {}),
     });
     const timeoutSec = Math.max(1, Math.ceil(timeoutMs / 1000));
     // Gateway-side --timeout bounds the remote command; the host-side
@@ -184,12 +294,17 @@ export class OpenShellRuntime implements PluginRuntime {
   }
 
   async stop(pluginId: string): Promise<void> {
-    if (!this.entries.has(pluginId)) return;
+    const entry = this.entries.get(pluginId);
+    if (!entry) return;
     this.entries.delete(pluginId);
     try {
       await this.run(["sandbox", "delete", pluginId], DELETE_TIMEOUT_MS);
     } catch (err) {
       this.log(`plugin sandbox stop error ${pluginId}: ${formatError(err)}`);
+    }
+    // Drop the gateway-side egress-secret provider too (best-effort).
+    if (entry.providerName) {
+      await this.run(["provider", "delete", entry.providerName], DELETE_TIMEOUT_MS).catch(() => {});
     }
   }
 
@@ -268,11 +383,13 @@ function runProcessOnce(
       // RpcErr exits non-zero but still prints JSON, so only treat an empty
       // stdout as a hard failure (matches MicrosandboxRuntime).
       if (code !== 0 && !stdout.trim()) {
+        // Redact any `--credential <slot>=<value>` so a failed provider command
+        // can't leak the secret into console logs.
+        const shown = args
+          .map((a, i) => (args[i - 1] === "--credential" ? a.replace(/=.*/su, "=[redacted]") : a))
+          .join(" ");
         reject(
-          new Error(
-            `openshell ${args.join(" ").slice(0, 120)} exited ${code}; ` +
-              `stderr=${stderr.slice(0, 500)}`,
-          ),
+          new Error(`openshell ${shown.slice(0, 160)} exited ${code}; stderr=${stderr.slice(0, 500)}`),
         );
         return;
       }
@@ -312,4 +429,10 @@ function parseRpcLastLine(
 
 function formatError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function hashEgress(
+  secrets: ReadonlyArray<{ key: string; value: string }>,
+): string {
+  return createHash("sha256").update(JSON.stringify(secrets)).digest("hex");
 }

--- a/apps/worker/src/plugins/plugin-registry.ts
+++ b/apps/worker/src/plugins/plugin-registry.ts
@@ -1161,11 +1161,24 @@ export class PluginRegistry {
     await mkdir(hostWorkspacePath, { recursive: true });
     await copyFile(runnerPath, path.join(hostWorkspacePath, "run.js"));
 
+    // Secrets the plugin sends to its external API (manifest `inject:"egress"`)
+    // are held gateway-side and proxy-injected — the runtime registers a provider
+    // and the box only ever sees a placeholder. Only pass values actually supplied.
+    const resolvedEnv = mergeEnv(entry, this.secrets);
+    const egressSecrets = (entry.permissions.env ?? [])
+      .filter((e) => e.inject === "egress")
+      .map((e) => ({ key: e.key, value: resolvedEnv[e.key] }))
+      .filter(
+        (e): e is { key: string; value: string } =>
+          typeof e.value === "string" && e.value.length > 0,
+      );
+
     await this.runtime.start({
       id: pluginId,
       hostWorkspacePath,
       network: networkModeFor(entry.permissions.network),
       hosts: entry.permissions.network,
+      ...(egressSecrets.length > 0 ? { egressSecrets } : {}),
     });
 
     // Sanity-check: the VM's register() must match the manifest's

--- a/apps/worker/src/plugins/plugin-runtime.ts
+++ b/apps/worker/src/plugins/plugin-runtime.ts
@@ -29,8 +29,9 @@ export interface PluginRuntime {
   /**
    * Invokes the plugin's runner with `node /workspace/run.js <method>
    * <paramsJson>` and parses the single JSON response from stdout.
-   * If `env` is provided, values are injected into the VM at exec time
-   * via a shell wrapper.
+   * If `env` is provided, the runtime makes those values available to the
+   * plugin process WITHOUT placing secret values on the exec command line
+   * (OpenShell sources an uploaded env file; the dev subprocess sets process env).
    */
   callRpc(
     pluginId: string,
@@ -64,44 +65,45 @@ function shellQuote(value: string): string {
 const ENV_KEY_RX = /^[A-Z][A-Z0-9_]*$/;
 
 /**
+ * Build a POSIX-shell-sourceable env file holding a plugin's secrets
+ * (`export KEY='value'` lines). The runtime uploads this into the sandbox
+ * out-of-band and the exec sources it — so secret VALUES never land in the
+ * exec command line (which the OpenShell gateway logs) nor in the box's
+ * process args. Keys are validated to UPPER_SNAKE_CASE so a bad manifest
+ * entry can't smuggle shell syntax; values are POSIX single-quote-escaped.
+ */
+export function buildEnvFile(env: Record<string, string>): string {
+  return Object.keys(env)
+    .map((k) => {
+      if (!ENV_KEY_RX.test(k)) {
+        throw new Error(`plugin env key "${k}" is not a valid UPPER_SNAKE_CASE name`);
+      }
+      return `export ${k}=${shellQuote(env[k] ?? "")}`;
+    })
+    .join("\n");
+}
+
+/**
  * Returns the command + argv the runtime will invoke inside the VM.
- * Without env: a plain `node` exec, fastest path. With env: wrap in
- * `sh -c '<exports>; exec node ...'` so the env is bound for the
- * plugin process.
+ * Without an env file: a plain `node` exec, fastest path. With one: wrap in
+ * `sh -c '. <file>; exec node ...'` so the plugin's secrets (in the uploaded
+ * file) are bound for the process — the command itself carries only the file
+ * PATH, never a secret value.
  *
- * Why `sh` not `bash`: the default plugin VM image ships `ash` at
- * `/bin/sh` and no `bash`. POSIX `sh` is enough for our needs (export +
- * exec + single-quote-escaped values).
- *
- * Env keys are validated to UPPER_SNAKE_CASE before they reach the
- * shell so a bad manifest entry can't smuggle a command-injection
- * substring like `FOO; rm -rf /`. Values are POSIX-quoted.
+ * Why `sh` not `bash`: the default plugin VM image ships `ash` at `/bin/sh`
+ * and no `bash`. POSIX `sh` is enough (source + exec + quoted args).
  */
 export function buildExecCommand(
   method: string,
   paramsJson: string,
-  env: Record<string, string>,
-  runnerPath = "/workspace/run.js",
+  opts: { envFilePath?: string; runnerPath?: string } = {},
 ): { cmd: string; args: string[] } {
-  const keys = Object.keys(env);
-  if (keys.length === 0) {
-    return {
-      cmd: "node",
-      args: [runnerPath, method, paramsJson],
-    };
+  const runnerPath = opts.runnerPath ?? "/workspace/run.js";
+  if (!opts.envFilePath) {
+    return { cmd: "node", args: [runnerPath, method, paramsJson] };
   }
-  for (const k of keys) {
-    if (!ENV_KEY_RX.test(k)) {
-      throw new Error(
-        `plugin env key "${k}" is not a valid UPPER_SNAKE_CASE name`,
-      );
-    }
-  }
-  const exports = keys
-    .map((k) => `export ${k}=${shellQuote(env[k] ?? "")}`)
-    .join("; ");
   const inner =
-    `${exports}; exec node ${runnerPath} ` +
+    `. ${shellQuote(opts.envFilePath)}; exec node ${runnerPath} ` +
     `${shellQuote(method)} ${shellQuote(paramsJson)}`;
   return { cmd: "sh", args: ["-c", inner] };
 }

--- a/apps/worker/src/plugins/plugin-runtime.ts
+++ b/apps/worker/src/plugins/plugin-runtime.ts
@@ -22,6 +22,13 @@ export interface PluginVmSpec {
    * for per-host egress.
    */
   hosts?: readonly string[];
+  /**
+   * Secrets the plugin sends to its external API (manifest `inject: "egress"`).
+   * Held gateway-side as an OpenShell provider; the box receives only a
+   * placeholder aliased to `key`, and the egress proxy substitutes the real
+   * value on outbound requests. The value never enters the sandbox.
+   */
+  egressSecrets?: ReadonlyArray<{ key: string; value: string }>;
 }
 
 export interface PluginRuntime {
@@ -83,27 +90,43 @@ export function buildEnvFile(env: Record<string, string>): string {
     .join("\n");
 }
 
+const SHELL_VARNAME_RX = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
 /**
  * Returns the command + argv the runtime will invoke inside the VM.
- * Without an env file: a plain `node` exec, fastest path. With one: wrap in
- * `sh -c '. <file>; exec node ...'` so the plugin's secrets (in the uploaded
- * file) are bound for the process — the command itself carries only the file
- * PATH, never a secret value.
+ * With neither aliases nor an env file: a plain `node` exec, fastest path.
+ * Otherwise wrap in `sh -c`: first re-export each provider-injected placeholder
+ * to the env var the plugin reads (`export KEY="$from"` — a value reference, not
+ * a value), then source the box-secret env file, then exec. The command carries
+ * only var names + the file PATH, never a secret value.
  *
  * Why `sh` not `bash`: the default plugin VM image ships `ash` at `/bin/sh`
- * and no `bash`. POSIX `sh` is enough (source + exec + quoted args).
+ * and no `bash`. POSIX `sh` is enough (export + source + exec + quoted args).
  */
 export function buildExecCommand(
   method: string,
   paramsJson: string,
-  opts: { envFilePath?: string; runnerPath?: string } = {},
+  opts: {
+    envFilePath?: string;
+    runnerPath?: string;
+    aliases?: ReadonlyArray<{ from: string; to: string }>;
+  } = {},
 ): { cmd: string; args: string[] } {
   const runnerPath = opts.runnerPath ?? "/workspace/run.js";
-  if (!opts.envFilePath) {
+  const aliases = opts.aliases ?? [];
+  if (!opts.envFilePath && aliases.length === 0) {
     return { cmd: "node", args: [runnerPath, method, paramsJson] };
   }
-  const inner =
-    `. ${shellQuote(opts.envFilePath)}; exec node ${runnerPath} ` +
-    `${shellQuote(method)} ${shellQuote(paramsJson)}`;
+  const aliasExports = aliases.map(({ from, to }) => {
+    if (!SHELL_VARNAME_RX.test(from) || !SHELL_VARNAME_RX.test(to)) {
+      throw new Error(`plugin env alias "${from}"->"${to}" is not a valid shell var name`);
+    }
+    return `export ${to}="$${from}"`;
+  });
+  const inner = [
+    ...aliasExports,
+    ...(opts.envFilePath ? [`. ${shellQuote(opts.envFilePath)}`] : []),
+    `exec node ${runnerPath} ${shellQuote(method)} ${shellQuote(paramsJson)}`,
+  ].join("; ");
   return { cmd: "sh", args: ["-c", inner] };
 }

--- a/apps/worker/test/plugins/openshell-registry-e2e.test.ts
+++ b/apps/worker/test/plugins/openshell-registry-e2e.test.ts
@@ -17,7 +17,7 @@ import { OpenShellRuntime } from "../../src/plugins/openshell-runtime";
  *
  * Opt-in (creates Docker sandboxes via the gateway): a reachable OpenShell
  * gateway (brew service or compose) + the base image built + the bundle:
- *   docker build -f docker/plugin-base.Dockerfile -t ghcr.io/open-neko/plugin-base:node20 .
+ *   docker build -f docker/plugin-base.Dockerfile -t ghcr.io/open-neko/plugin-base:node24 .
  *   pnpm -C ../../plugins/packages/parallel-search build
  *   OPENNEKO_OPENSHELL_E2E=1 pnpm --filter @neko/worker test openshell-registry-e2e
  */
@@ -26,7 +26,7 @@ const PARALLEL_BUNDLE_PATH = path.resolve(
   "../../../../../plugins/packages/parallel-search/dist/run.js",
 );
 const BASE_IMAGE =
-  process.env.OPENNEKO_PLUGIN_BASE_IMAGE ?? "ghcr.io/open-neko/plugin-base:node20";
+  process.env.OPENNEKO_PLUGIN_BASE_IMAGE ?? "ghcr.io/open-neko/plugin-base:node24";
 const FAKE_INTEGRITY = "sha512-" + "a".repeat(86) + "==";
 
 const MANIFEST_JSON = JSON.stringify({

--- a/apps/worker/test/plugins/openshell-runtime-e2e.test.ts
+++ b/apps/worker/test/plugins/openshell-runtime-e2e.test.ts
@@ -15,7 +15,7 @@ import { OpenShellRuntime } from "../../src/plugins/openshell-runtime";
  *
  * Opt-in (creates Docker containers): set OPENNEKO_OPENSHELL_E2E=1 with a
  * running gateway and the base image built:
- *   docker build -f docker/plugin-base.Dockerfile -t ghcr.io/open-neko/plugin-base:node20 .
+ *   docker build -f docker/plugin-base.Dockerfile -t ghcr.io/open-neko/plugin-base:node24 .
  *   pnpm -C ../../plugins/packages/slack build
  *   OPENNEKO_OPENSHELL_E2E=1 pnpm --filter @neko/worker test openshell-runtime-e2e
  */
@@ -24,7 +24,7 @@ const SLACK_BUNDLE = path.resolve(
   "../../../../../plugins/packages/slack/dist/run.js",
 );
 const BASE_IMAGE =
-  process.env.OPENNEKO_PLUGIN_BASE_IMAGE ?? "ghcr.io/open-neko/plugin-base:node20";
+  process.env.OPENNEKO_PLUGIN_BASE_IMAGE ?? "ghcr.io/open-neko/plugin-base:node24";
 
 function cmdOk(cmd: string, args: string[]): boolean {
   try {

--- a/apps/worker/test/plugins/openshell-runtime.test.ts
+++ b/apps/worker/test/plugins/openshell-runtime.test.ts
@@ -66,7 +66,7 @@ describe("buildPolicyUpdateArgs", () => {
       "--add-endpoint",
       "api.slack.com:443:read-write:rest:enforce",
       "--binary",
-      "node",
+      "/usr/local/bin/node",
       "--add-allow",
       "slack.com:443:*:/**",
       "--add-allow",

--- a/apps/worker/test/plugins/openshell-runtime.test.ts
+++ b/apps/worker/test/plugins/openshell-runtime.test.ts
@@ -86,7 +86,7 @@ describe("OpenShellRuntime", () => {
 
   function make(opts?: { gatewayEndpoint?: string; gatewayName?: string }) {
     return new OpenShellRuntime({
-      image: "ghcr.io/open-neko/plugin-base:node20",
+      image: "ghcr.io/open-neko/plugin-base:node24",
       bundleDir: "/tmp/bundles",
       ...opts,
     });
@@ -107,7 +107,7 @@ describe("OpenShellRuntime", () => {
       "--name",
       "p1",
       "--from",
-      "ghcr.io/open-neko/plugin-base:node20",
+      "ghcr.io/open-neko/plugin-base:node24",
       "--no-tty",
       "--no-auto-providers",
       "--",
@@ -231,7 +231,7 @@ describe("OpenShellRuntime", () => {
     expect(res).toEqual({ ok: true, result: { hello: "world" } });
   });
 
-  it("callRpc with env wraps in sh -c with quoted exports", async () => {
+  it("callRpc with env uploads a sourced env file — the secret never enters the exec command", async () => {
     const rt = make();
     await rt.start({
       id: "p1",
@@ -247,21 +247,40 @@ describe("OpenShellRuntime", () => {
       env: { SLACK_BOT_TOKEN: "xoxb-1" },
     });
 
+    // The secret rode an out-of-band upload to the env file (the upload argv is
+    // the host temp PATH + dest path, never the value) — not the exec command.
+    const upload = h.calls.find(
+      (c) =>
+        c.args[0] === "sandbox" &&
+        c.args[1] === "upload" &&
+        c.args.includes("/sandbox/.plugin-env"),
+    );
+    expect(upload).toBeDefined();
+
     const args = execCall()?.args ?? [];
-    expect(args.slice(0, 8)).toEqual([
-      "sandbox",
-      "exec",
-      "-n",
-      "p1",
-      "--no-tty",
-      "--timeout",
-      "30",
-      "--",
-    ]);
     expect(args[8]).toBe("sh");
     expect(args[9]).toBe("-c");
-    expect(args[10]).toContain("export SLACK_BOT_TOKEN='xoxb-1'");
+    expect(args[10]).toContain(". '/sandbox/.plugin-env';");
     expect(args[10]).toContain("exec node /sandbox/run.js");
+    // The token value appears in NO spawned command's argv (gateway-log safe).
+    expect(h.calls.some((c) => c.args.some((a) => a.includes("xoxb-1")))).toBe(false);
+  });
+
+  it("re-uses the uploaded env file across calls with unchanged env (no re-upload)", async () => {
+    const rt = make();
+    await rt.start({
+      id: "p1",
+      hostWorkspacePath: "/tmp/bundles/p1",
+      network: "none",
+      hosts: [],
+    });
+    h.state.respond = (args) =>
+      args.includes("exec") ? { stdout: OK_JSON } : { stdout: "", code: 0 };
+    const env = { SLACK_BOT_TOKEN: "xoxb-1" };
+    await rt.callRpc("p1", "m1", "{}", { env });
+    h.calls.length = 0;
+    await rt.callRpc("p1", "m2", "{}", { env });
+    expect(h.calls.some((c) => c.args[1] === "upload")).toBe(false);
   });
 
   it("parses the LAST stdout line when logs precede the JSON", async () => {

--- a/apps/worker/test/plugins/openshell-runtime.test.ts
+++ b/apps/worker/test/plugins/openshell-runtime.test.ts
@@ -283,6 +283,131 @@ describe("OpenShellRuntime", () => {
     expect(h.calls.some((c) => c.args[1] === "upload")).toBe(false);
   });
 
+  it("egress secret: registers a provider, creates with --provider, and keeps the value out of the box", async () => {
+    const rt = make({ gatewayName: "openneko" });
+    await rt.start({
+      id: "p1",
+      hostWorkspacePath: "/tmp/bundles/p1",
+      network: "public",
+      hosts: ["api.telegram.org"],
+      egressSecrets: [{ key: "TELEGRAM_BOT_TOKEN", value: "12345:SEKRIT" }],
+    });
+
+    // The real value is registered gateway-side (host → gateway, never a sandbox)…
+    expect(
+      h.calls.some((c) => c.args.includes("provider") && c.args.includes("create")),
+    ).toBe(true);
+    // …and the sandbox is created attached to that provider.
+    const create = h.calls.find(
+      (c) => c.args.includes("sandbox") && c.args.includes("create"),
+    );
+    expect(create?.args).toContain("--provider");
+    expect(create?.args).toContain("plugin-p1");
+
+    // A call aliases the placeholder to the key, uploads NO env file for it, and
+    // the value never appears in any box-bound command (exec / upload).
+    h.calls.length = 0;
+    h.state.respond = (args) =>
+      args.includes("exec") ? { stdout: OK_JSON } : { stdout: "", code: 0 };
+    await rt.callRpc("p1", "deliver", "{}", {
+      env: { TELEGRAM_BOT_TOKEN: "12345:SEKRIT" },
+    });
+
+    expect(h.calls.some((c) => c.args[1] === "upload")).toBe(false);
+    const inner = (execCall()?.args ?? []).at(-1) ?? "";
+    expect(inner).toContain('export TELEGRAM_BOT_TOKEN="$c0"');
+    expect(inner).toContain("exec node /sandbox/run.js");
+    expect(inner).not.toContain("SEKRIT");
+    const boxCalls = h.calls.filter(
+      (c) => c.args.includes("exec") || c.args[1] === "upload",
+    );
+    expect(boxCalls.some((c) => c.args.some((a) => a.includes("SEKRIT")))).toBe(false);
+  });
+
+  it("rotates the gateway-side provider when the egress value changes — no VM restart", async () => {
+    const rt = make({ gatewayName: "openneko" });
+    await rt.start({
+      id: "p1",
+      hostWorkspacePath: "/tmp/bundles/p1",
+      network: "public",
+      hosts: ["api.telegram.org"],
+      egressSecrets: [{ key: "TELEGRAM_BOT_TOKEN", value: "tok-v1" }],
+    });
+    h.state.respond = (args) =>
+      args.includes("exec") ? { stdout: OK_JSON } : { stdout: "", code: 0 };
+
+    // Unchanged value → no provider round-trip.
+    h.calls.length = 0;
+    await rt.callRpc("p1", "deliver", "{}", { env: { TELEGRAM_BOT_TOKEN: "tok-v1" } });
+    expect(h.calls.some((c) => c.args.includes("provider"))).toBe(false);
+
+    // Rotated value → provider refreshed, sandbox NOT re-created, value not in the box.
+    h.calls.length = 0;
+    await rt.callRpc("p1", "deliver", "{}", { env: { TELEGRAM_BOT_TOKEN: "tok-v2" } });
+    expect(h.calls.some((c) => c.args.includes("provider"))).toBe(true);
+    expect(
+      h.calls.some((c) => c.args.includes("sandbox") && c.args.includes("create")),
+    ).toBe(false);
+    const boxCalls = h.calls.filter(
+      (c) => c.args.includes("exec") || c.args[1] === "upload",
+    );
+    expect(boxCalls.some((c) => c.args.some((a) => a.includes("tok-v2")))).toBe(false);
+  });
+
+  it("supports multiple egress secrets — one credential slot each, distinct aliases, no value in the box", async () => {
+    const rt = make({ gatewayName: "openneko" });
+    await rt.start({
+      id: "p1",
+      hostWorkspacePath: "/tmp/bundles/p1",
+      network: "public",
+      hosts: ["slack.com"],
+      egressSecrets: [
+        { key: "SLACK_BOT_TOKEN", value: "xoxb-SEKRIT0" },
+        { key: "SLACK_APP_TOKEN", value: "xapp-SEKRIT1" },
+      ],
+    });
+
+    // The provider was created with both credential slots (host → gateway).
+    const create = h.calls.find((c) => c.args.includes("provider") && c.args.includes("create"));
+    expect(create?.args).toContain("c0=xoxb-SEKRIT0");
+    expect(create?.args).toContain("c1=xapp-SEKRIT1");
+
+    h.calls.length = 0;
+    h.state.respond = (args) =>
+      args.includes("exec") ? { stdout: OK_JSON } : { stdout: "", code: 0 };
+    await rt.callRpc("p1", "deliver", "{}", {
+      env: { SLACK_BOT_TOKEN: "xoxb-SEKRIT0", SLACK_APP_TOKEN: "xapp-SEKRIT1" },
+    });
+
+    const inner = (execCall()?.args ?? []).at(-1) ?? "";
+    expect(inner).toContain('export SLACK_BOT_TOKEN="$c0"');
+    expect(inner).toContain('export SLACK_APP_TOKEN="$c1"');
+    expect(h.calls.some((c) => c.args[1] === "upload")).toBe(false);
+    const boxCalls = h.calls.filter((c) => c.args.includes("exec") || c.args[1] === "upload");
+    expect(boxCalls.some((c) => c.args.some((a) => a.includes("SEKRIT")))).toBe(false);
+  });
+
+  it("stop deletes the egress-secret provider too", async () => {
+    const rt = make({ gatewayName: "openneko" });
+    await rt.start({
+      id: "p1",
+      hostWorkspacePath: "/tmp/bundles/p1",
+      network: "public",
+      hosts: ["api.telegram.org"],
+      egressSecrets: [{ key: "TELEGRAM_BOT_TOKEN", value: "v" }],
+    });
+    h.calls.length = 0;
+    await rt.stop("p1");
+    expect(
+      h.calls.some(
+        (c) =>
+          c.args.includes("provider") &&
+          c.args.includes("delete") &&
+          c.args.includes("plugin-p1"),
+      ),
+    ).toBe(true);
+  });
+
   it("parses the LAST stdout line when logs precede the JSON", async () => {
     const rt = make();
     await rt.start({

--- a/apps/worker/test/plugins/plugin-runtime.test.ts
+++ b/apps/worker/test/plugins/plugin-runtime.test.ts
@@ -62,4 +62,32 @@ describe("buildExecCommand", () => {
       `. '/sandbox/.plugin-env'; exec node /sandbox/run.js 'execute_action' '{"x":1}'`,
     );
   });
+
+  it("with aliases (no env file), re-exports the placeholder to the plugin's key — a reference, not a value", () => {
+    const out = buildExecCommand("deliver", "{}", {
+      runnerPath: "/sandbox/run.js",
+      aliases: [{ from: "api_key", to: "TELEGRAM_BOT_TOKEN" }],
+    });
+    expect(out.cmd).toBe("sh");
+    expect(out.args[1]).toBe(
+      `export TELEGRAM_BOT_TOKEN="$api_key"; exec node /sandbox/run.js 'deliver' '{}'`,
+    );
+  });
+
+  it("with aliases AND an env file: alias first, then source the box-secret file, then exec", () => {
+    const out = buildExecCommand("m", "{}", {
+      envFilePath: "/sandbox/.plugin-env",
+      runnerPath: "/sandbox/run.js",
+      aliases: [{ from: "api_key", to: "TELEGRAM_BOT_TOKEN" }],
+    });
+    expect(out.args[1]).toBe(
+      `export TELEGRAM_BOT_TOKEN="$api_key"; . '/sandbox/.plugin-env'; exec node /sandbox/run.js 'm' '{}'`,
+    );
+  });
+
+  it("rejects an alias with a non-shell-safe var name", () => {
+    expect(() =>
+      buildExecCommand("m", "{}", { aliases: [{ from: "api_key", to: "X; rm -rf /" }] }),
+    ).toThrow(/valid shell var name/);
+  });
 });

--- a/apps/worker/test/plugins/plugin-runtime.test.ts
+++ b/apps/worker/test/plugins/plugin-runtime.test.ts
@@ -3,6 +3,7 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  buildEnvFile,
   buildExecCommand,
   networkModeFor,
 } from "../../src/plugins/plugin-runtime.js";
@@ -18,38 +19,47 @@ describe("networkModeFor", () => {
   });
 });
 
+describe("buildEnvFile", () => {
+  it("emits POSIX-sourceable export lines", () => {
+    expect(buildEnvFile({ SLACK_BOT_TOKEN: "xoxb-abc", RUN_ID: "r-1" })).toBe(
+      "export SLACK_BOT_TOKEN='xoxb-abc'\nexport RUN_ID='r-1'",
+    );
+  });
+
+  it("POSIX-escapes single quotes inside values", () => {
+    expect(buildEnvFile({ FOO: "it's ok" })).toBe(`export FOO='it'\\''s ok'`);
+  });
+
+  it("rejects bad env key names that could be shell-substring attacks", () => {
+    expect(() => buildEnvFile({ "FOO; rm -rf /": "x" })).toThrow(/UPPER_SNAKE_CASE/);
+    expect(() => buildEnvFile({ lowercase: "x" })).toThrow(/UPPER_SNAKE_CASE/);
+  });
+});
+
 describe("buildExecCommand", () => {
-  it("with empty env, returns plain node exec (fast path)", () => {
-    expect(buildExecCommand("register", "{}", {})).toEqual({
+  it("without an env file, returns plain node exec (fast path)", () => {
+    expect(buildExecCommand("register", "{}")).toEqual({
       cmd: "node",
       args: ["/workspace/run.js", "register", "{}"],
     });
   });
 
-  it("with env, wraps in sh -c with exports + exec node", () => {
+  it("honors a custom runner path", () => {
+    expect(buildExecCommand("m", "{}", { runnerPath: "/sandbox/run.js" })).toEqual({
+      cmd: "node",
+      args: ["/sandbox/run.js", "m", "{}"],
+    });
+  });
+
+  it("with an env file, sources it then exec node — and carries NO secret value", () => {
     const out = buildExecCommand("execute_action", '{"x":1}', {
-      SLACK_BOT_TOKEN: "xoxb-abc",
-      RUN_ID: "r-1",
+      envFilePath: "/sandbox/.plugin-env",
+      runnerPath: "/sandbox/run.js",
     });
     expect(out.cmd).toBe("sh");
     expect(out.args[0]).toBe("-c");
-    const inner = out.args[1] ?? "";
-    expect(inner).toContain("export SLACK_BOT_TOKEN='xoxb-abc'");
-    expect(inner).toContain("export RUN_ID='r-1'");
-    expect(inner).toContain("exec node /workspace/run.js 'execute_action' '{\"x\":1}'");
-  });
-
-  it("POSIX-escapes single quotes inside env values", () => {
-    const out = buildExecCommand("m", "{}", { FOO: "it's ok" });
-    expect(out.args[1]).toContain(`export FOO='it'\\''s ok'`);
-  });
-
-  it("rejects bad env key names that could be shell-substring attacks", () => {
-    expect(() =>
-      buildExecCommand("m", "{}", { "FOO; rm -rf /": "x" }),
-    ).toThrow(/UPPER_SNAKE_CASE/);
-    expect(() =>
-      buildExecCommand("m", "{}", { lowercase: "x" }),
-    ).toThrow(/UPPER_SNAKE_CASE/);
+    expect(out.args[1]).toBe(
+      `. '/sandbox/.plugin-env'; exec node /sandbox/run.js 'execute_action' '{"x":1}'`,
+    );
   });
 });

--- a/docker/agent-base.Dockerfile
+++ b/docker/agent-base.Dockerfile
@@ -8,8 +8,11 @@
 # @neko/llm bundle + the claude/hermes/graphjin binaries + agent-sandbox/entry.ts
 # — which is produced by composing the main Dockerfile's `cli`/`build` stages.
 # See docs/OPENSHELL_MIGRATION_PLAN.md (Phase 2c) for the full image + launcher.
-#   docker build -f docker/agent-base.Dockerfile -t ghcr.io/open-neko/agent-base:node20 .
-FROM node:20-bookworm-slim
+#   docker build -f docker/agent-base.Dockerfile -t ghcr.io/open-neko/agent-base:node24 .
+# Node 24: the injected NODE_USE_ENV_PROXY only routes node fetch through the
+# egress proxy on 24+ — needed for the claude CLI's API egress (and any
+# node-fetch egress) to reach the model through the proxy instead of failing DNS.
+FROM node:24-bookworm-slim
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates iproute2 nftables \

--- a/docker/plugin-base.Dockerfile
+++ b/docker/plugin-base.Dockerfile
@@ -1,7 +1,10 @@
 # Shared OpenShell sandbox base for all @open-neko plugins. Each plugin's
 # self-contained dist/run.js is uploaded to /sandbox/run.js at start, not baked.
-#   docker build -f docker/plugin-base.Dockerfile -t ghcr.io/open-neko/plugin-base:node20 .
-FROM node:20-bookworm-slim
+#   docker build -f docker/plugin-base.Dockerfile -t ghcr.io/open-neko/plugin-base:node24 .
+# Node 24: OpenShell injects NODE_USE_ENV_PROXY into every sandbox, but node only
+# honors it (routing fetch through the egress proxy) on 24+. On older node the
+# plugin's fetch dials direct, and DNS fails (proxy-only egress) → EAI_AGAIN.
+FROM node:24-bookworm-slim
 
 # iproute2 + nftables: required by the supervisor's egress setup (without them
 # the sandbox hangs at "waiting for supervisor relay").

--- a/packages/llm/src/work/run-chat-turn.ts
+++ b/packages/llm/src/work/run-chat-turn.ts
@@ -559,7 +559,11 @@ export async function runChatTurn(
 
     return {
       status: result.status,
-      finalText: result.finalText,
+      // The cleaned display text (machine fences — neko_value/neko_vitals,
+      // action/workflow/rule/followups/memory — stripped), never the raw source.
+      // Channels deliver this as the converse body; leaking fences render as raw
+      // JSON (and break Telegram's HTML parser) on a channel that shows the text.
+      finalText: persistedText,
       error: result.error,
     };
   } catch (error) {

--- a/packages/llm/src/work/run-chat-turn.ts
+++ b/packages/llm/src/work/run-chat-turn.ts
@@ -119,6 +119,20 @@ function backendLabel(id: string): string {
   return id === "claude-agent" ? "Claude Agent" : "Hermes";
 }
 
+/**
+ * Strip any unexecuted ACP/hermes tool-call left in display text — e.g.
+ * `call:default_api:read_file{limit:100,path:analyze.py}`. A turn cut short
+ * mid-step (step budget, loop) can leave one dangling in finalText; it must
+ * never reach a user on any channel. Matches `call:<ns>:<tool>{…}` (closed or
+ * truncated at end-of-text). Returns the remaining prose, trimmed.
+ */
+function stripDanglingToolCalls(text: string): string {
+  return text
+    .replace(/\bcall:[A-Za-z0-9_.:-]+\s*\{[^{}]*(?:\}|$)/g, "")
+    .replace(/[ \t]+\n/g, "\n")
+    .trim();
+}
+
 export async function runChatTurn(
   opts: RunChatTurnOptions,
   deps: Partial<RunChatTurnDeps> = {},
@@ -543,6 +557,11 @@ export async function runChatTurn(
     persistedText = extractFollowupsFence(persistedText).text;
     persistedText = extractVitalsFence(persistedText).text;
     persistedText = extractMemoryFences(persistedText).text;
+    // A turn cut short mid-step (budget/loop) can end with an unexecuted
+    // tool-call like `call:default_api:read_file{…}` left in the text. Never
+    // surface that — strip it so a broken turn degrades to its prose (or empty,
+    // which delivery + persistence then skip) instead of leaking a raw call.
+    persistedText = stripDanglingToolCalls(persistedText);
     if (persistedText) {
       await saveAssistantWorkMessage({
         orgId,

--- a/packages/llm/src/work/sandbox-launcher.ts
+++ b/packages/llm/src/work/sandbox-launcher.ts
@@ -249,6 +249,16 @@ export function makeSandboxRunCore(opts: SandboxLauncherOptions): RunCore {
       );
     } finally {
       opts.brokerRelease?.(input.runId);
+      // Pull artifacts the agent wrote in the box back to the host run dir
+      // before deleting the box — otherwise the file-serving endpoint reads an
+      // empty host dir and 404s the download. Best-effort, and runs even when
+      // the turn errored or timed out (the box is still alive here), so a
+      // partial artifact from a long run isn't lost.
+      await mkdir(input.workspace.artifactRoot, { recursive: true }).catch(() => {});
+      await run(
+        ["sandbox", "download", name, boxWorkspace.artifactRoot, input.workspace.artifactRoot],
+        120_000,
+      ).catch((e) => log(`artifact pull-back skipped: ${(e as Error).message}`));
       await run(["sandbox", "delete", name], 60_000).catch(() => {});
       await rm(stageDir, { recursive: true, force: true });
     }

--- a/packages/llm/test/sandbox-launcher.test.ts
+++ b/packages/llm/test/sandbox-launcher.test.ts
@@ -183,8 +183,11 @@ describe("makeSandboxRunCore", () => {
 
     const result = await runCore(fakeInput(async (e) => void events.push(e)));
 
-    const verbs = h.calls.map((c) => c.args.find((a) => ["create", "update", "upload", "exec", "delete"].includes(a)));
-    expect(verbs).toEqual(["create", "update", "upload", "upload", "exec", "delete"]);
+    const verbs = h.calls.map((c) => c.args.find((a) => ["create", "update", "upload", "exec", "download", "delete"].includes(a)));
+    // artifacts are pulled back from the box (download) before it's deleted
+    expect(verbs).toEqual(["create", "update", "upload", "upload", "exec", "download", "delete"]);
+    const download = h.calls.find((c) => c.args.includes("download"));
+    expect(download?.args.at(-1)).toBe(fakeInput().workspace.artifactRoot);
     // streamed event reached emit:
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({ type: "message", content: "hi" });

--- a/packages/plugin-install/src/manifest.ts
+++ b/packages/plugin-install/src/manifest.ts
@@ -25,6 +25,14 @@ export interface ManifestEnvRequirement {
   required?: boolean;
   secret?: boolean;
   description: string;
+  /**
+   * How a `secret` value reaches the plugin VM. "egress": the value is held
+   * gateway-side and the proxy substitutes it onto outbound requests — the box
+   * holds only a placeholder (use for credentials sent to an external API, e.g.
+   * a bot token). "box" (default): the value lives in the VM, for secrets the
+   * plugin compares locally and never sends out (e.g. a webhook signing secret).
+   */
+  inject?: "egress" | "box";
 }
 
 /** What the plugin needs from the runtime — sandbox network + operator-supplied env. */

--- a/packages/plugin-install/src/marketplace-client.ts
+++ b/packages/plugin-install/src/marketplace-client.ts
@@ -17,6 +17,9 @@ export interface MarketplaceEnvRequirement {
   required?: boolean;
   secret?: boolean;
   description: string;
+  /** "egress" → proxy-injected onto outbound requests (box sees a placeholder);
+   *  "box" (default) → value lives in the VM for local comparison. */
+  inject?: "egress" | "box";
 }
 
 export interface MarketplacePermissions {

--- a/packages/plugin-types/src/manifest.ts
+++ b/packages/plugin-types/src/manifest.ts
@@ -35,6 +35,14 @@ export const PluginEnvRequirement = z.object({
   /** Hide the value at prompt + never echo it back. */
   secret: z.boolean().default(true),
   description: z.string().min(1).max(280),
+  /**
+   * How a secret reaches the plugin VM. "egress": held gateway-side and
+   * substituted by the proxy onto outbound requests — the box sees only a
+   * placeholder (for credentials sent to an external API, e.g. a bot token).
+   * "box" (default): the value lives in the VM, for secrets compared locally
+   * and never sent out (e.g. a webhook signing secret).
+   */
+  inject: z.enum(["egress", "box"]).optional(),
 });
 
 export type PluginEnvRequirement = z.infer<typeof PluginEnvRequirement>;


### PR DESCRIPTION
Makes the documented secret-isolation model real for **channel plugin tokens**, and fixes how channel (Telegram) replies render.

### Secret isolation — the token never enters the sandbox
- **`ce7d64c`** — Node-24 sandbox bases so OpenShell routes Node `fetch` egress through the proxy (fixes `EAI_AGAIN`); plugin secrets sourced from an uploaded env file, never inlined on the (logged) exec command.
- **`f7e59be`** — proxy-inject plugin **egress** secrets. A plugin declares `permissions.env[].inject: "egress"`; the worker registers the value as a per-plugin OpenShell provider (one credential slot per secret) and creates the VM with `--provider`. The box receives only an `openshell:resolve:env:…` placeholder, aliased to the env var at exec; the proxy substitutes the real value on the wire. Box-class secrets (locally-compared, e.g. signing secrets) stay in the VM. Token rotation refreshes the provider (no VM restart); `--credential` redacted from logs.
- **`27c634e`** — scope plugin egress to the absolute node path (`/usr/local/bin/node`); the proxy authorizes by full binary path, so bare `node` was denied (403). The demo never exercised this (no plugins installed).

### Channel reply rendering
- **`0f43b13`** — return the *cleaned* reply text to channels (machine fences `neko_value`/`neko_vitals`/action/memory stripped), not the raw `finalText`. Leaking fences rendered as raw JSON and broke Telegram's HTML parser.
- **`4c1d75f`** — render agent **vitals as metric cards** on channel replies. A channel run often answers in prose + the mandatory `neko_vitals` fence with no a2ui surface, so the vitals were dropped; the worker now synthesizes a minimal surface (answer Markdown + one `MetricCard` per vital). Web is unchanged.
- **`1c8f250`** — never deliver a **dangling tool-call** (`call:default_api:read_file{…}`) as the reply; a turn cut short mid-step left one in `finalText`. Stripped from the display text.

### Verification
- **Egress injection proven live** against the running gateway: a Node-24 plugin sandbox holds only the placeholder (`real-token-occurrences-in-env: 0`), and the worker delivered real Telegram messages through the proxy-substituted token (including substitution in Telegram's token-in-URL-path).
- Card rendering dry-run-validated (synthesized surface → metric cards). Worker unit suites green (`apps/worker/test/plugins`), typecheck clean.

Pairs with `open-neko/plugins#<inject>` (declares `inject: "egress"` on the bot tokens + the manifest schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015frAPnWK89eKAANHdNLruG