### PR TITLE
Fix OpenShell provisioning retry memoization

### DIFF
--- a/apps/web/src/app/api/work/threads/[threadId]/runs/route.ts
+++ b/apps/web/src/app/api/work/threads/[threadId]/runs/route.ts
@@ -63,6 +63,11 @@ export async function POST(request: NextRequest, context: RouteContext) {
     throw e;
   }
 
+  // Derive the agent-sandbox env (model egress, gateway provider, key alias)
+  // before creating the run. If gateway sync is temporarily unavailable, the
+  // memoized provision attempt is cleared and the caller can retry cleanly.
+  await ensureHostConfigProvisioned(orgId);
+
   const actor = await getCurrentActor();
   const run = await createWorkRun(orgId, threadId, backend.id, actor);
 
@@ -98,11 +103,6 @@ export async function POST(request: NextRequest, context: RouteContext) {
   // The web server stays the control plane, launches the box, and relays
   // events over the existing SSE.
   const broker = await ensureAgentBroker();
-
-  // Derive the agent-sandbox env (model egress, gateway provider, key alias)
-  // before the first launch — a fresh web process otherwise launches boxes
-  // that can't reach the model until a settings save re-provisions.
-  await ensureHostConfigProvisioned(orgId);
 
   void runChatTurn(
     {

--- a/packages/llm/src/host-provision.ts
+++ b/packages/llm/src/host-provision.ts
@@ -399,6 +399,10 @@ async function provisionOpenShellRuntime(orgId: string, backend: string): Promis
 
 const provisionedOrgs = new Map<string, Promise<void>>();
 
+type ProvisionHostConfigOptions = {
+  requireOpenShellSync?: boolean;
+};
+
 /**
  * provisionHostConfig, once per org per process. The worker provisions at
  * boot, but the web process used to derive the agent-sandbox env (model
@@ -409,7 +413,7 @@ const provisionedOrgs = new Map<string, Promise<void>>();
 export function ensureHostConfigProvisioned(orgId: string): Promise<void> {
   let p = provisionedOrgs.get(orgId);
   if (!p) {
-    p = provisionHostConfig(orgId).catch((err) => {
+    p = provisionHostConfig(orgId, { requireOpenShellSync: true }).catch((err) => {
       provisionedOrgs.delete(orgId);
       throw err;
     });
@@ -418,7 +422,10 @@ export function ensureHostConfigProvisioned(orgId: string): Promise<void> {
   return p;
 }
 
-export async function provisionHostConfig(orgId: string): Promise<void> {
+export async function provisionHostConfig(
+  orgId: string,
+  options: ProvisionHostConfigOptions = {},
+): Promise<void> {
   try {
     await provisionGraphJin(orgId);
   } catch (e) {
@@ -442,9 +449,11 @@ export async function provisionHostConfig(orgId: string): Promise<void> {
       ? backendCfg.backend
       : "hermes";
 
+  let openShellError: unknown;
   try {
     await provisionOpenShellRuntime(orgId, backend);
   } catch (e) {
+    openShellError = e;
     console.warn(
       `[host-provision] OpenShell runtime provision failed: ${e instanceof Error ? e.message : e}`,
     );
@@ -458,5 +467,9 @@ export async function provisionHostConfig(orgId: string): Promise<void> {
         `[host-provision] hermes write failed: ${e instanceof Error ? e.message : e}`,
       );
     }
+  }
+
+  if (openShellError && options.requireOpenShellSync) {
+    throw openShellError;
   }
 }

--- a/packages/llm/test/host-provision.test.ts
+++ b/packages/llm/test/host-provision.test.ts
@@ -9,6 +9,7 @@ import {
   describe,
   expect,
   it,
+  vi,
 } from "vitest";
 import {
   clearProvider,
@@ -21,10 +22,20 @@ import {
 } from "@neko/db/test-helpers";
 import { db, eq, data_source, pool } from "@neko/db";
 import {
+  ensureHostConfigProvisioned,
   hermesHomeForOrg,
   patchGraphjinSourcesJwtSecret,
   provisionHostConfig,
 } from "../src/host-provision";
+import { ensureOpenShellProvider } from "../src/work/sandbox-launcher";
+
+vi.mock("../src/work/sandbox-launcher", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../src/work/sandbox-launcher")>();
+  return {
+    ...actual,
+    ensureOpenShellProvider: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 const reachable = await dbReachable();
 const describeIfDb = reachable ? describe : describe.skip;
@@ -49,6 +60,7 @@ function graphjinPath(home: string): string {
 const ORIGINAL_HOME = process.env.HOME;
 const ORIGINAL_HERMES_HOME = process.env.HERMES_HOME;
 const ORIGINAL_XDG_CONFIG_HOME = process.env.XDG_CONFIG_HOME;
+const ensureOpenShellProviderMock = vi.mocked(ensureOpenShellProvider);
 
 describe("patchGraphjinSourcesJwtSecret", () => {
   it("replaces a source-mode placeholder", () => {
@@ -118,6 +130,8 @@ describeIfDb("provisionHostConfig", () => {
   });
 
   beforeEach(async () => {
+    ensureOpenShellProviderMock.mockReset();
+    ensureOpenShellProviderMock.mockResolvedValue(undefined);
     tempHome = await mkdtemp(join(tmpdir(), "neko-test-home-"));
     hermesHome = join(tempHome, ".hermes");
     process.env.HOME = tempHome;
@@ -311,6 +325,59 @@ describeIfDb("provisionHostConfig", () => {
 
     const env = await readFile(join(hermesHome, ".env"), "utf8");
     expect(env).toBe("");
+  });
+
+  it("keeps direct provisioning best-effort when OpenShell provider sync fails", async () => {
+    ensureOpenShellProviderMock.mockRejectedValueOnce(new Error("gateway unavailable"));
+    await seedDataSource(orgId);
+    await seedProvider(orgId, {
+      scope: "agent",
+      provider: "hermes",
+      config: { backend: "hermes" },
+    });
+    await seedProvider(orgId, {
+      scope: "primary",
+      provider: "google-gemini",
+      model: "gemini-pro-latest",
+      secrets: { apiKey: "test-gemini-key" },
+    });
+
+    await expect(provisionHostConfig(orgId)).resolves.toBeUndefined();
+    expect(ensureOpenShellProviderMock).toHaveBeenCalledTimes(1);
+
+    const yaml = await readFile(join(hermesHome, "config.yaml"), "utf8");
+    expect(yaml).toContain('provider: "gemini"');
+  });
+
+  it("retries memoized provisioning after an OpenShell provider sync failure", async () => {
+    const retryOrgId = uniqueOrgId("provision-retry");
+    await createTestOrg(retryOrgId);
+    try {
+      await seedDataSource(retryOrgId);
+      await seedProvider(retryOrgId, {
+        scope: "agent",
+        provider: "hermes",
+        config: { backend: "hermes" },
+      });
+      await seedProvider(retryOrgId, {
+        scope: "primary",
+        provider: "google-gemini",
+        model: "gemini-pro-latest",
+        secrets: { apiKey: "test-gemini-key" },
+      });
+      ensureOpenShellProviderMock
+        .mockRejectedValueOnce(new Error("gateway unavailable"))
+        .mockResolvedValueOnce(undefined);
+
+      await expect(ensureHostConfigProvisioned(retryOrgId)).rejects.toThrow(
+        "gateway unavailable",
+      );
+      await expect(ensureHostConfigProvisioned(retryOrgId)).resolves.toBeUndefined();
+
+      expect(ensureOpenShellProviderMock).toHaveBeenCalledTimes(2);
+    } finally {
+      await deleteTestOrg(retryOrgId);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- require OpenShell provider sync success on the memoized run provisioning path
- keep direct `provisionHostConfig` calls best-effort for worker boot and settings saves
- move chat run provisioning before run creation so transient gateway failures retry cleanly without leaving a run row
- add regression coverage for best-effort direct provisioning and retrying memoized provisioning after a sync failure

## Root cause
`provisionHostConfig` swallowed `provisionOpenShellRuntime` failures, so `ensureHostConfigProvisioned` cached the promise as successful even when the gateway-side provider was never created.

Closes #128

## Testing
- `pnpm --filter @neko/llm test`
- `pnpm --filter @neko/llm test -- host-provision.test.ts`
- `pnpm --filter @neko/web test -- work-runs.test.ts`
- `pnpm --filter @neko/web exec tsc -p tsconfig.json --noEmit --pretty false`

Note: local metadata Postgres was unreachable, so DB-backed tests in the targeted suites were skipped locally.