### PR TITLE
[codex] add openneko upgrade command

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -71,6 +71,7 @@ Browse the marketplace at [open-neko.github.io/plugins](https://open-neko.github
 ```bash
 openneko setup [--mode prod|dev|demo]  # guided: preflight + bring-up + configure
 openneko start [--mode prod|dev|demo] [--detach]
+openneko upgrade [--version vX.Y.Z] [--mode auto|prod|dev|demo]
 openneko status                    # docker compose ps proxy
 openneko logs [service…] [-f]
 openneko stop [--volumes]          # --volumes wipes data
@@ -103,7 +104,37 @@ Docker — already required to run OpenNeko.
 
 ## Upgrade
 
-`openneko` upgrades by replacing the binary. The new binary embeds bumped image pins and new migrations; both apply on the next `openneko start`. No `openneko upgrade` subcommand — subscribe to [release notifications](https://github.com/open-neko/openneko/releases) for pushes.
+`openneko upgrade` is the normal stack upgrade path. It:
+
+1. Pulls the latest OpenNeko service, agent, and plugin-base images.
+2. Detects the mode recorded by your last `setup` or `start` (`prod`, `dev`, or `demo`) and recreates that stack detached.
+3. Runs pending migrations through the stack's `neko-migrate` container.
+4. Removes old OpenNeko image tags and dangling image layers unless you pass `--no-prune`.
+
+Run it from the same install directory you use for `openneko start`:
+
+```bash
+cd ~/openneko
+openneko upgrade
+```
+
+Install a specific image version/tag:
+
+```bash
+openneko upgrade --version v1.18.0
+# "1.18.0" is accepted too and is normalized to "v1.18.0".
+```
+
+If you are upgrading an older install without a saved mode marker, pass the
+mode explicitly:
+
+```bash
+openneko upgrade --mode demo
+```
+
+The command persists the selected image tag in `.openneko/runtime/.image-version`,
+so later `openneko start` runs the same tag. Upgrading the host binary is still
+recommended when a release includes CLI changes.
 
 ### macOS
 
@@ -111,8 +142,7 @@ Docker — already required to run OpenNeko.
 brew update
 brew upgrade openneko
 cd ~/openneko
-openneko stop                          # leaves volumes intact
-openneko start --mode demo --detach    # use the same --mode you started with
+openneko upgrade
 ```
 
 > **Installed before 1.17.2?** Those releases shipped a Homebrew *formula*; 1.17.2+ ships a *cask*, so `brew upgrade openneko` won't move you across. Switch once:
@@ -132,8 +162,7 @@ ARCH=$(uname -m | sed 's/x86_64/amd64/; s/aarch64/arm64/')
 curl -fsSL "https://github.com/open-neko/openneko/releases/download/$TAG/openneko_${TAG#v}_linux_$ARCH.tar.gz" | tar -xz openneko
 sudo install -m 0755 openneko /usr/local/bin/ && rm -f openneko
 cd ~/openneko
-openneko stop
-openneko start --mode demo --detach
+openneko upgrade
 ```
 
 ### What `openneko start` does

--- a/apps/openneko/README.md
+++ b/apps/openneko/README.md
@@ -32,6 +32,7 @@ You also need Docker (Docker Desktop on macOS, Docker Engine on Linux).
 ```bash
 openneko setup [--mode prod|dev|demo]   # guided install: preflight + bring-up + configure
 openneko start [--mode prod|dev|demo] [--detach]
+openneko upgrade [--version vX.Y.Z] [--mode auto|prod|dev|demo]
 openneko stop [--volumes]
 openneko status
 openneko logs [service…] [-f]
@@ -50,6 +51,10 @@ The binary materializes its embedded compose files to `.openneko/runtime/`
 in the current working directory before invoking `docker compose`. A
 project- or user-level override at `~/.config/openneko/compose.override.yml`
 is appended automatically when present.
+
+`openneko upgrade` pulls newer service images plus the agent/plugin-base
+images, recreates the recorded stack mode, runs migrations, prunes old
+OpenNeko image tags, and persists the selected image tag for later starts.
 
 ### Plugin + skill management
 

--- a/apps/openneko/internal/cli/cli_test.go
+++ b/apps/openneko/internal/cli/cli_test.go
@@ -23,7 +23,7 @@ func TestExitCodeFor(t *testing.T) {
 
 func TestRootHasAllCommands(t *testing.T) {
 	root := NewRoot()
-	want := []string{"setup", "init", "install", "remove", "list", "doctor", "marketplace", "secrets", "version", "start", "stop", "status", "logs", "migrate", "seed", "reset"}
+	want := []string{"setup", "init", "install", "remove", "list", "doctor", "marketplace", "secrets", "version", "start", "upgrade", "stop", "status", "logs", "migrate", "seed", "reset"}
 	got := map[string]bool{}
 	for _, c := range root.Commands() {
 		got[c.Name()] = true

--- a/apps/openneko/internal/cli/root.go
+++ b/apps/openneko/internal/cli/root.go
@@ -69,7 +69,7 @@ func NewRoot() *cobra.Command {
 
 Getting started: setup (guided install — preflight, bring-up, configure).
 Plugin ops: init, install, list, remove, marketplace, secrets, doctor.
-Stack ops:  start, stop, logs, status, migrate, seed, reset.`,
+Stack ops:  start, upgrade, stop, logs, status, migrate, seed, reset.`,
 		Version:       version.Version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
@@ -93,6 +93,7 @@ Stack ops:  start, stop, logs, status, migrate, seed, reset.`,
 		newSecretsCmd(),
 		newVersionCmd(),
 		newStartCmd(),
+		newUpgradeCmd(),
 		newStopCmd(),
 		newStatusCmd(),
 		newLogsCmd(),

--- a/apps/openneko/internal/cli/start.go
+++ b/apps/openneko/internal/cli/start.go
@@ -70,12 +70,21 @@ func bringUpStack(ctx context.Context, cmd *cobra.Command, mode compose.Mode, op
 	if m == "" {
 		m = compose.ModeProd
 	}
+	sup := compose.New(assets.ComposeFS)
 	// Pin compose's image tags to this binary's version unless the caller has
-	// already set OPENNEKO_VERSION — that lets the smoke workflow (which builds
-	// openneko fresh from source, so its embedded version is "0.0.0-dev") test
-	// against a real release tag.
+	// already set OPENNEKO_VERSION or an install-level image version marker.
+	// That lets the smoke workflow (which builds openneko fresh from source, so
+	// its embedded version is "0.0.0-dev") test against a real release tag, and
+	// lets `openneko upgrade --version ...` keep using the requested tag.
 	if os.Getenv("OPENNEKO_VERSION") == "" {
-		_ = os.Setenv("OPENNEKO_VERSION", "v"+version.Version)
+		imageVersion, err := sup.ImageVersion()
+		if err != nil {
+			return err
+		}
+		if imageVersion == "" {
+			imageVersion = "v" + version.Version
+		}
+		_ = os.Setenv("OPENNEKO_VERSION", imageVersion)
 	}
 
 	// SEC9: OpenShell is the only agent runtime.
@@ -83,7 +92,6 @@ func bringUpStack(ctx context.Context, cmd *cobra.Command, mode compose.Mode, op
 		return err
 	}
 
-	sup := compose.New(assets.ComposeFS)
 	files, err := sup.Materialize(m)
 	if err != nil {
 		return err

--- a/apps/openneko/internal/cli/upgrade.go
+++ b/apps/openneko/internal/cli/upgrade.go
@@ -1,0 +1,257 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-neko/neko/apps/openneko/assets"
+	"github.com/open-neko/neko/apps/openneko/internal/compose"
+)
+
+func newUpgradeCmd() *cobra.Command {
+	var mode string
+	var imageVersion string
+	var noPrune bool
+
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Pull newer OpenNeko images and update the current stack",
+		Long: `Pull newer OpenNeko component images, recreate the current stack, and clean
+up old OpenNeko image tags.
+
+By default the command targets the latest image tag and uses the mode recorded
+by the last setup/start. Use --version to pin a specific image tag, and --mode
+when upgrading an install whose mode marker is missing.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			ctx, cancel := context.WithCancel(cmd.Context())
+			defer cancel()
+			return runUpgrade(ctx, cmd, upgradeOptions{
+				mode:         mode,
+				imageVersion: imageVersion,
+				noPrune:      noPrune,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&mode, "mode", "auto", "Stack mode to upgrade: auto|prod|dev|demo")
+	cmd.Flags().StringVar(&imageVersion, "version", "", "OpenNeko image tag/version to install (default: latest; accepts 1.2.3 or v1.2.3)")
+	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Keep old OpenNeko image tags after the upgrade")
+	return cmd
+}
+
+type upgradeOptions struct {
+	mode         string
+	imageVersion string
+	noPrune      bool
+}
+
+func runUpgrade(ctx context.Context, cmd *cobra.Command, opts upgradeOptions) error {
+	out := cmd.OutOrStdout()
+	errOut := cmd.ErrOrStderr()
+	target := normalizeUpgradeImageVersion(opts.imageVersion)
+
+	sup := compose.New(assets.ComposeFS)
+	m, defaulted, err := resolveUpgradeMode(opts.mode, sup)
+	if err != nil {
+		return err
+	}
+	if defaulted {
+		fmt.Fprintln(errOut, "warning: no saved stack mode found; assuming prod. Re-run with --mode dev or --mode demo if this install used another mode.")
+	}
+
+	previous, hadPrevious := os.LookupEnv("OPENNEKO_VERSION")
+	if err := os.Setenv("OPENNEKO_VERSION", target); err != nil {
+		return err
+	}
+	defer func() {
+		if hadPrevious {
+			_ = os.Setenv("OPENNEKO_VERSION", previous)
+		} else {
+			_ = os.Unsetenv("OPENNEKO_VERSION")
+		}
+	}()
+
+	files, err := sup.Materialize(m)
+	if err != nil {
+		return err
+	}
+	project, err := sup.ProjectName(m)
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(out, "Upgrading OpenNeko %s stack to image tag %s\n", m, target)
+	fmt.Fprintln(out, "Pulling stack images...")
+	if code, err := sup.Run(ctx, project, files, []string{"pull"}, os.Stdout, os.Stderr); err != nil {
+		return err
+	} else if code != 0 {
+		return WithExit(code, nil)
+	}
+
+	for _, image := range extraUpgradeImageRefs(target) {
+		fmt.Fprintf(out, "Pulling %s...\n", image)
+		if err := sup.PullImage(ctx, image, os.Stdout, os.Stderr); err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintln(out, "Restarting stack with upgraded images...")
+	if err := restartUpgradedStack(ctx, sup, project, files); err != nil {
+		return err
+	}
+
+	if err := sup.WriteImageVersion(target); err != nil {
+		return err
+	}
+
+	if !opts.noPrune {
+		fmt.Fprintln(out, "Cleaning up old OpenNeko images...")
+		if err := pruneOldOpenNekoImages(ctx, target, os.Stdout, os.Stderr); err != nil {
+			fmt.Fprintf(errOut, "warning: old image cleanup failed: %v\n", err)
+		}
+		if err := pruneDanglingImages(ctx, os.Stdout, os.Stderr); err != nil {
+			fmt.Fprintf(errOut, "warning: dangling image cleanup failed: %v\n", err)
+		}
+	}
+
+	fmt.Fprintf(out, "Upgrade complete. Future starts will use image tag %s.\n", target)
+	return nil
+}
+
+func restartUpgradedStack(ctx context.Context, sup *compose.Supervisor, project string, files []string) error {
+	if err := configureOpenShellStateDir(); err != nil {
+		return err
+	}
+	configureOpenShellDBURL()
+	code, err := sup.Run(ctx, project, files, []string{"up", "-d", "--pull", "never", "--remove-orphans"}, os.Stdout, os.Stderr)
+	if err != nil {
+		return err
+	}
+	if code != 0 {
+		return WithExit(code, nil)
+	}
+	return nil
+}
+
+func resolveUpgradeMode(flag string, sup *compose.Supervisor) (compose.Mode, bool, error) {
+	mode := strings.TrimSpace(flag)
+	if mode != "" && mode != "auto" {
+		switch compose.Mode(mode) {
+		case compose.ModeProd, compose.ModeDev, compose.ModeDemo:
+			return compose.Mode(mode), false, nil
+		default:
+			return "", false, fmt.Errorf("--mode must be one of: auto, prod, dev, demo (got %q)", flag)
+		}
+	}
+	project, err := sup.ProjectName("")
+	if err != nil {
+		return "", false, err
+	}
+	if detected, ok := compose.ModeFromProjectName(project); ok {
+		return detected, false, nil
+	}
+	return compose.ModeProd, true, nil
+}
+
+var semverishImageVersion = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+.*$`)
+
+func normalizeUpgradeImageVersion(raw string) string {
+	v := strings.TrimSpace(raw)
+	if v == "" {
+		return "latest"
+	}
+	if semverishImageVersion.MatchString(v) {
+		return "v" + v
+	}
+	return v
+}
+
+func extraUpgradeImageRefs(version string) []string {
+	return uniqueStrings([]string{
+		agentImageRef(os.Getenv("OPENNEKO_AGENT_IMAGE"), version),
+		pluginBaseImageRef(os.Getenv("OPENNEKO_PLUGIN_BASE_IMAGE"), version),
+	})
+}
+
+func pluginBaseImageRef(override, version string) string {
+	if override != "" {
+		return override
+	}
+	return "ghcr.io/open-neko/plugin-base:" + version
+}
+
+func pruneOldOpenNekoImages(ctx context.Context, targetTag string, stdout, stderr *os.File) error {
+	cmd := exec.CommandContext(ctx, "docker", "image", "ls", "--format", "{{.Repository}}:{{.Tag}}")
+	out, err := cmd.Output()
+	if err != nil {
+		return err
+	}
+	for _, ref := range oldOpenNekoImageRefs(string(out), targetTag) {
+		rm := exec.CommandContext(ctx, "docker", "image", "rm", ref)
+		rm.Stdout = stdout
+		rm.Stderr = stderr
+		if err := rm.Run(); err != nil {
+			fmt.Fprintf(stderr, "warning: kept old image %s (%v)\n", ref, err)
+		}
+	}
+	return nil
+}
+
+func pruneDanglingImages(ctx context.Context, stdout, stderr *os.File) error {
+	cmd := exec.CommandContext(ctx, "docker", "image", "prune", "-f")
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	return cmd.Run()
+}
+
+func oldOpenNekoImageRefs(imageListOutput, targetTag string) []string {
+	repos := openNekoImageRepos()
+	var out []string
+	seen := map[string]bool{}
+	for _, line := range strings.Split(imageListOutput, "\n") {
+		ref := strings.TrimSpace(line)
+		if ref == "" || seen[ref] {
+			continue
+		}
+		repo, tag, ok := strings.Cut(ref, ":")
+		if !ok || tag == "" || tag == "<none>" {
+			continue
+		}
+		if !repos[repo] || tag == targetTag {
+			continue
+		}
+		seen[ref] = true
+		out = append(out, ref)
+	}
+	return out
+}
+
+func openNekoImageRepos() map[string]bool {
+	return map[string]bool{
+		"ghcr.io/open-neko/neko-cli":      true,
+		"ghcr.io/open-neko/neko-graphjin": true,
+		"ghcr.io/open-neko/neko-web":      true,
+		"ghcr.io/open-neko/neko-worker":   true,
+		"ghcr.io/open-neko/agent":         true,
+		"ghcr.io/open-neko/plugin-base":   true,
+	}
+}
+
+func uniqueStrings(in []string) []string {
+	var out []string
+	seen := map[string]bool{}
+	for _, s := range in {
+		if s = strings.TrimSpace(s); s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}

--- a/apps/openneko/internal/cli/upgrade_test.go
+++ b/apps/openneko/internal/cli/upgrade_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/open-neko/neko/apps/openneko/internal/compose"
+)
+
+func TestNormalizeUpgradeImageVersion(t *testing.T) {
+	tests := map[string]string{
+		"":                      "latest",
+		"  ":                    "latest",
+		"latest":                "latest",
+		"v1.2.3":                "v1.2.3",
+		"1.2.3":                 "v1.2.3",
+		"1.2.3-rc.1+build.123":  "v1.2.3-rc.1+build.123",
+		"sha-1234567890abcdef":  "sha-1234567890abcdef",
+		"release-candidate-tag": "release-candidate-tag",
+	}
+	for in, want := range tests {
+		if got := normalizeUpgradeImageVersion(in); got != want {
+			t.Fatalf("normalizeUpgradeImageVersion(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestResolveUpgradeMode(t *testing.T) {
+	s := &compose.Supervisor{RuntimeDir: t.TempDir()}
+	if _, err := s.ProjectName(compose.ModeDemo); err != nil {
+		t.Fatal(err)
+	}
+	mode, defaulted, err := resolveUpgradeMode("auto", s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode != compose.ModeDemo || defaulted {
+		t.Fatalf("mode=%q defaulted=%v, want demo false", mode, defaulted)
+	}
+
+	mode, defaulted, err = resolveUpgradeMode("prod", s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode != compose.ModeProd || defaulted {
+		t.Fatalf("mode=%q defaulted=%v, want prod false", mode, defaulted)
+	}
+
+	_, _, err = resolveUpgradeMode("bogus", s)
+	if err == nil {
+		t.Fatal("expected invalid mode error")
+	}
+}
+
+func TestResolveUpgradeModeDefaultsProdWithoutMarker(t *testing.T) {
+	s := &compose.Supervisor{RuntimeDir: t.TempDir()}
+	mode, defaulted, err := resolveUpgradeMode("auto", s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode != compose.ModeProd || !defaulted {
+		t.Fatalf("mode=%q defaulted=%v, want prod true", mode, defaulted)
+	}
+}
+
+func TestOldOpenNekoImageRefs(t *testing.T) {
+	in := `
+ghcr.io/open-neko/neko-web:v1.0.0
+ghcr.io/open-neko/neko-web:v2.0.0
+ghcr.io/open-neko/neko-worker:v1.0.0
+ghcr.io/open-neko/agent:<none>
+postgres:16-alpine
+ghcr.io/open-neko/plugin-base:v0.9.0
+ghcr.io/open-neko/plugin-base:v0.9.0
+`
+	want := []string{
+		"ghcr.io/open-neko/neko-web:v1.0.0",
+		"ghcr.io/open-neko/neko-worker:v1.0.0",
+		"ghcr.io/open-neko/plugin-base:v0.9.0",
+	}
+	if got := oldOpenNekoImageRefs(in, "v2.0.0"); !reflect.DeepEqual(got, want) {
+		t.Fatalf("oldOpenNekoImageRefs = %#v, want %#v", got, want)
+	}
+}
+
+func TestExtraUpgradeImageRefsDedupesOverrides(t *testing.T) {
+	t.Setenv("OPENNEKO_AGENT_IMAGE", "custom/agent:v1")
+	t.Setenv("OPENNEKO_PLUGIN_BASE_IMAGE", "custom/agent:v1")
+	got := extraUpgradeImageRefs("v2.0.0")
+	want := []string{"custom/agent:v1"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("extraUpgradeImageRefs = %#v, want %#v", got, want)
+	}
+}

--- a/apps/openneko/internal/compose/compose.go
+++ b/apps/openneko/internal/compose/compose.go
@@ -27,6 +27,11 @@ const (
 	ModeDemo Mode = "demo"
 )
 
+const (
+	projectNameMarker  = ".project-name"
+	imageVersionMarker = ".image-version"
+)
+
 // Supervisor is the host-side controller; assets are the embedded files the
 // supervisor materializes before running compose.
 type Supervisor struct {
@@ -116,9 +121,9 @@ func (s *Supervisor) ProjectName(modeIfStarting Mode) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	marker := filepath.Join(rt, ".project-name")
+	marker := filepath.Join(rt, projectNameMarker)
 	if modeIfStarting != "" {
-		name := "openneko-" + string(modeIfStarting)
+		name := ProjectNameForMode(modeIfStarting)
 		_ = os.MkdirAll(rt, 0o755)
 		_ = os.WriteFile(marker, []byte(name+"\n"), 0o644)
 		return name, nil
@@ -130,6 +135,58 @@ func (s *Supervisor) ProjectName(modeIfStarting Mode) (string, error) {
 		}
 	}
 	return "openneko", nil
+}
+
+// ProjectNameForMode is the canonical compose project name for a stack mode.
+func ProjectNameForMode(mode Mode) string {
+	if mode == "" {
+		mode = ModeProd
+	}
+	return "openneko-" + string(mode)
+}
+
+// ModeFromProjectName recovers the stack mode from a project marker written by
+// ProjectName. The bool is false for legacy names or unrelated projects.
+func ModeFromProjectName(project string) (Mode, bool) {
+	const prefix = "openneko-"
+	if !strings.HasPrefix(project, prefix) {
+		return "", false
+	}
+	switch m := Mode(strings.TrimPrefix(project, prefix)); m {
+	case ModeProd, ModeDev, ModeDemo:
+		return m, true
+	default:
+		return "", false
+	}
+}
+
+// ImageVersion reads the persisted image tag for this install. An empty string
+// means callers should use their normal default.
+func (s *Supervisor) ImageVersion() (string, error) {
+	rt, err := s.runtimeDir()
+	if err != nil {
+		return "", err
+	}
+	b, err := os.ReadFile(filepath.Join(rt, imageVersionMarker))
+	if errors.Is(err, fs.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(b)), nil
+}
+
+// WriteImageVersion persists the image tag subsequent starts should use.
+func (s *Supervisor) WriteImageVersion(version string) error {
+	rt, err := s.runtimeDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(rt, 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(rt, imageVersionMarker), []byte(strings.TrimSpace(version)+"\n"), 0o644)
 }
 
 // Run shells out to `docker compose -p <project> -f <files…> <args…>`,
@@ -183,6 +240,11 @@ func (s *Supervisor) EnsureImage(ctx context.Context, image string, stdout, stde
 	if exec.CommandContext(ctx, "docker", "image", "inspect", image).Run() == nil {
 		return nil // already local
 	}
+	return s.PullImage(ctx, image, stdout, stderr)
+}
+
+// PullImage always asks Docker for the image ref, even if a local tag exists.
+func (s *Supervisor) PullImage(ctx context.Context, image string, stdout, stderr *os.File) error {
 	cmd := exec.CommandContext(ctx, "docker", "pull", image)
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr

--- a/apps/openneko/internal/compose/compose_test.go
+++ b/apps/openneko/internal/compose/compose_test.go
@@ -87,3 +87,52 @@ func TestMaterializeUnknownMode(t *testing.T) {
 		t.Fatal("expected error for unknown mode")
 	}
 }
+
+func TestProjectNameModeRoundTrip(t *testing.T) {
+	isolateConfig(t)
+	dir := t.TempDir()
+	s := &Supervisor{AssetsFS: sampleFS(), RuntimeDir: dir, GOOS: "linux"}
+
+	project, err := s.ProjectName(ModeDemo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if project != "openneko-demo" {
+		t.Fatalf("project = %q", project)
+	}
+	readBack, err := s.ProjectName("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if readBack != project {
+		t.Fatalf("readBack = %q, want %q", readBack, project)
+	}
+	mode, ok := ModeFromProjectName(readBack)
+	if !ok || mode != ModeDemo {
+		t.Fatalf("mode = %q ok=%v", mode, ok)
+	}
+}
+
+func TestImageVersionMarker(t *testing.T) {
+	isolateConfig(t)
+	dir := t.TempDir()
+	s := &Supervisor{AssetsFS: sampleFS(), RuntimeDir: dir, GOOS: "linux"}
+
+	v, err := s.ImageVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != "" {
+		t.Fatalf("empty marker = %q", v)
+	}
+	if err := s.WriteImageVersion("v1.2.3"); err != nil {
+		t.Fatal(err)
+	}
+	v, err = s.ImageVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != "v1.2.3" {
+		t.Fatalf("image version = %q", v)
+	}
+}


### PR DESCRIPTION
## Summary
- add openneko upgrade with mode detection, optional --version, image pulls, restart, migrations, and pruning
- persist selected image versions so later starts/upgrades preserve the chosen tag unless OPENNEKO_VERSION is set
- restart through compose so rotated Docker-only database credentials keep working during upgrades
- document the upgrade workflow and cover CLI/compose behavior with tests

## Validation
- GOCACHE=/private/tmp/openneko-gocache go test ./... -count=1
- local demo upgrade to v2.14.0 using /private/tmp/openneko-local upgrade --mode demo --version v2.14.0
- /private/tmp/openneko-local status reported serving with localhost:3000 returning HTTP 200
- upgrade pruned old OpenNeko images and reclaimed 5.056GB