### PR TITLE
feat(web): improve mobile navigation and responsive layouts

### DIFF
--- a/apps/web/src/app/(work)/work/WorkSidebar.tsx
+++ b/apps/web/src/app/(work)/work/WorkSidebar.tsx
@@ -25,11 +25,11 @@ export default function WorkSidebar() {
   const [threads, setThreads] = useState<ThreadSummary[]>([]);
   const [loadingThreads, setLoadingThreads] = useState(true);
   const [pendingCount, setPendingCount] = useState(0);
-  // Collapsed on mobile while a thread is open so the conversation, not the
-  // thread list, is the first thing on screen. Desktop ignores this (CSS).
-  const [threadsExpanded, setThreadsExpanded] = useState(true);
+  // Start collapsed on mobile so Ask opens directly onto the working surface.
+  // Desktop ignores this state because its thread list is always visible.
+  const [threadsExpanded, setThreadsExpanded] = useState(false);
   useEffect(() => {
-    setThreadsExpanded(!activeThreadId);
+    setThreadsExpanded(false);
   }, [activeThreadId]);
 
   const refresh = useCallback(async () => {

--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -1565,7 +1565,7 @@ function PendingMemoryPanel({
   const item = pending[0];
   if (!item) return null;
   return (
-    <div className="flex items-center justify-between gap-3 border border-border bg-white/80 rounded-2xl px-3 py-2.5 shadow-soft">
+    <div className="flex items-center justify-between gap-3 border border-border bg-white/80 rounded-2xl px-3 py-2.5 shadow-soft max-[560px]:items-stretch max-[560px]:flex-col">
       <div className="min-w-0 text-[12.5px] leading-[1.45] text-text2">
         <div className="text-[10.5px] font-bold tracking-[0.13em] uppercase text-text3 mb-0.5">Memory suggestion</div>
         <div>{item.draftText}</div>
@@ -1573,7 +1573,7 @@ function PendingMemoryPanel({
           <div className="mt-1 text-text3 text-[11px]">+{pending.length - 1} more</div>
         ) : null}
       </div>
-      <div className="inline-flex gap-[7px] flex-wrap justify-end flex-shrink-0 [&_button]:h-[30px] [&_button]:rounded-[10px] [&_button]:border [&_button]:border-border [&_button]:bg-card [&_button]:text-text2 [&_button]:inline-flex [&_button]:items-center [&_button]:justify-center [&_button]:gap-1 [&_button]:px-2 [&_button]:text-[11px] [&_button]:cursor-pointer [&_button]:transition-all [&_button]:duration-200 [&_button:hover]:border-accent [&_button:hover]:text-accent">
+      <div className="inline-flex min-w-0 gap-[7px] flex-wrap justify-end flex-shrink-0 max-[560px]:justify-start [&_button]:h-[30px] [&_button]:max-w-full [&_button]:rounded-[10px] [&_button]:border [&_button]:border-border [&_button]:bg-card [&_button]:text-text2 [&_button]:inline-flex [&_button]:items-center [&_button]:justify-center [&_button]:gap-1 [&_button]:px-2 [&_button]:text-[11px] [&_button]:cursor-pointer [&_button]:transition-all [&_button]:duration-200 [&_button:hover]:border-accent [&_button:hover]:text-accent">
         <button type="button" onClick={() => onDecide(item.id, "decline")} title="Dismiss">
           <X size={14} />
         </button>
@@ -2075,11 +2075,11 @@ function ActionApprovalCard({
 
   return (
     <div className="border border-border bg-card rounded-2xl px-4 py-3.5 text-[13px] flex flex-col gap-2.5">
-      <div className="flex items-baseline justify-between gap-3">
+      <div className="flex min-w-0 items-baseline justify-between gap-3 max-[480px]:items-start max-[480px]:flex-col max-[480px]:gap-1">
         <div className="font-display text-[11px] font-bold uppercase tracking-[0.14em] text-text3">
           Agent says
         </div>
-        <code className="font-mono text-[11px] text-text3">
+        <code className="min-w-0 max-w-full font-mono text-[11px] text-text3 [overflow-wrap:anywhere]">
           {approval.actionKind}
         </code>
       </div>

--- a/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
+++ b/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
@@ -726,11 +726,11 @@ function WorkflowDetail({
         ) : (
           <ul className="list-none p-0 mt-0 mb-1.5 flex flex-col gap-1.5">
             {policies.map((p) => (
-              <li key={p.id} className="flex items-center gap-2 text-[12.5px]">
-                <span className="font-mono text-[11.5px] text-text2">{p.name}</span>
+              <li key={p.id} className="flex min-w-0 items-start gap-2 text-[12.5px]">
+                <span className="min-w-0 flex-1 font-mono text-[11.5px] text-text2 [overflow-wrap:anywhere]">{p.name}</span>
                 <span
                   className={cn(
-                    "text-[9.5px] font-bold tracking-[0.13em] uppercase px-1.5 py-0.5 rounded-full ml-auto",
+                    "shrink-0 whitespace-nowrap text-[9.5px] font-bold tracking-[0.13em] uppercase px-1.5 py-0.5 rounded-full ml-auto",
                     policyModeClass(p.mode),
                   )}
                 >
@@ -787,15 +787,15 @@ function WorkflowDetail({
             {recentActions.map((a) => (
               <li key={a.id} className="border border-border bg-neutral-soft rounded-lg px-2.5 py-2">
                 <div className="flex items-center gap-2 flex-wrap text-[12.5px]">
-                  <span className="font-semibold text-text">{a.kind}</span>
+                  <span className="min-w-0 font-semibold text-text [overflow-wrap:anywhere]">{a.kind}</span>
                   {a.target && (
-                    <span className="font-mono text-[11.5px] text-text2">
+                    <span className="min-w-0 font-mono text-[11.5px] text-text2 [overflow-wrap:anywhere]">
                       {a.target}
                     </span>
                   )}
                   <span
                     className={cn(
-                      "ml-auto text-[10.5px] font-bold tracking-[0.08em] uppercase px-2 py-0.5 rounded-full",
+                      "ml-auto shrink-0 whitespace-nowrap text-[10.5px] font-bold tracking-[0.08em] uppercase px-2 py-0.5 rounded-full",
                       actionPillClass(a.status),
                     )}
                   >

--- a/apps/web/src/app/admin/rules/RulesClient.tsx
+++ b/apps/web/src/app/admin/rules/RulesClient.tsx
@@ -289,11 +289,11 @@ function PolicyCard({
       as="li"
       className={cn("px-5 py-4.5", !policy.enabled && "opacity-60")}
     >
-      <div className="flex items-center justify-between gap-3 mb-2">
-        <div className="font-display text-[17px] font-bold tracking-[-0.01em] text-text">
+      <div className="flex items-center justify-between gap-3 mb-2 max-[560px]:items-start max-[560px]:flex-col">
+        <div className="min-w-0 max-w-full font-display text-[17px] font-bold tracking-[-0.01em] text-text [overflow-wrap:anywhere]">
           {policy.name}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex max-w-full items-center gap-2 flex-wrap max-[560px]:self-stretch">
           <Pill variant={modePillVariant(policy.mode)}>
             {describeMode(policy.mode)}
           </Pill>
@@ -351,7 +351,7 @@ function Row({
   children: React.ReactNode;
 }) {
   return (
-    <div className="grid grid-cols-[110px_minmax(0,1fr)] gap-2.5 items-baseline">
+    <div className="grid grid-cols-[110px_minmax(0,1fr)] gap-2.5 items-baseline max-[480px]:grid-cols-1 max-[480px]:gap-0.5">
       <dt className="text-[10.5px] font-bold tracking-[0.13em] uppercase text-text3">
         {label}
       </dt>
@@ -441,21 +441,21 @@ function InstalledPluginsSection({
                 return (
                   <div
                     key={descriptor.kind}
-                    className="flex items-center justify-between gap-3 px-3 py-2 rounded-[10px] bg-neutral-soft"
+                    className="flex min-w-0 items-center justify-between gap-3 px-3 py-2 rounded-[10px] bg-neutral-soft max-[640px]:items-stretch max-[640px]:flex-col"
                   >
                     <div className="flex flex-col gap-0.5 min-w-0">
-                      <code className="font-mono text-[12px] text-text">
+                      <code className="font-mono text-[12px] text-text [overflow-wrap:anywhere]">
                         {descriptor.kind}
                       </code>
-                      <span className="text-[11px] text-text3 truncate">
+                      <span className="text-[11px] text-text3 truncate max-[640px]:whitespace-normal max-[640px]:[overflow-wrap:anywhere]">
                         {descriptor.description}
                       </span>
                     </div>
-                    <div className="flex items-center gap-2 flex-none">
+                    <div className="flex min-w-0 items-center justify-end gap-2 flex-wrap max-[640px]:justify-start">
                       <Pill variant={modePillVariant(mode)}>
                         {describeMode(mode)}
                       </Pill>
-                      <span className="text-[10.5px] text-text3">
+                      <span className="min-w-0 text-[10.5px] text-text3 [overflow-wrap:anywhere]">
                         {describeDefaultMode(descriptor.default_mode)}
                       </span>
                       {policyId ? (

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -14,6 +14,7 @@
 @import "./styles/_actions.css";
 @import "./styles/_act-card.css";
 @import "./styles/_responsive.css";
+@import "./styles/_dock.css";
 
 @theme {
   --color-bg: #FAFAF7;

--- a/apps/web/src/app/integrations/IntegrationsList.tsx
+++ b/apps/web/src/app/integrations/IntegrationsList.tsx
@@ -72,7 +72,7 @@ export default function IntegrationsList({ initial }: { initial: Row[] }) {
           {rows.map((row) => (
             <li
               key={row.pluginName}
-              className="flex items-center gap-4 p-4 rounded-xl border border-border bg-bg"
+              className="flex items-center gap-4 p-4 rounded-xl border border-border bg-bg max-[480px]:items-stretch max-[480px]:flex-col"
             >
               <div className="flex-1 min-w-0">
                 <div className="font-semibold text-text">{row.providerLabel}</div>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Archivo, Manrope } from "next/font/google";
 import { Toaster } from "sonner";
 import { DensityProvider } from "@/components/DensityProvider";
+import CommandDock from "@/components/CommandDock";
 import "./globals.css";
 
 // Set data-density before paint from the persisted choice (default compact),
@@ -43,6 +44,7 @@ export default function RootLayout({
       </head>
       <body>
         <DensityProvider>{children}</DensityProvider>
+        <CommandDock />
         <Toaster
           position="bottom-right"
           expand

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -43,8 +43,10 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: DENSITY_INIT }} />
       </head>
       <body>
-        <DensityProvider>{children}</DensityProvider>
-        <CommandDock />
+        <DensityProvider>
+          {children}
+          <CommandDock />
+        </DensityProvider>
         <Toaster
           position="bottom-right"
           expand

--- a/apps/web/src/app/styles/_chrome.css
+++ b/apps/web/src/app/styles/_chrome.css
@@ -166,6 +166,14 @@ html {
 /* ─── PILLS (segmented tab/selector — e.g. business-profile, role views) ─── */
 .pills { display: flex; flex-wrap: wrap; gap: 8px; }
 .pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  max-width: 100%;
+  min-height: 38px;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-family: var(--font-body), 'Manrope', sans-serif;
   font-size: 13.5px;
   font-weight: 600;

--- a/apps/web/src/app/styles/_dock.css
+++ b/apps/web/src/app/styles/_dock.css
@@ -1,230 +1,540 @@
-/* ─────────────────────────────────────────────────────────────
-   COMMAND DOCK — thumb-first nav for small screens.
-   The phone form of the section nav: a floating, frosted bar of
-   five destinations pinned to the bottom reach-zone. Hidden above
-   720px, where the top-bar nav takes over. Brand tokens only;
-   the purple active dot reuses the nav's existing active motif.
-   ───────────────────────────────────────────────────────────── */
-
+/* Thumb-first app navigation. The dock exists only on phones; wider layouts
+   retain the existing header navigation. */
 .cdock-wrap {
   display: none;
 }
 
 @media (max-width: 720px) {
   .cdock-wrap {
-    display: block;
     position: fixed;
-    left: 0;
-    right: 0;
-    bottom: 0;
+    inset: auto 0 0;
     z-index: 120;
-    padding: 8px 14px calc(10px + env(safe-area-inset-bottom, 0px));
+    display: block;
+    padding: 8px 12px calc(8px + env(safe-area-inset-bottom, 0px));
     pointer-events: none;
   }
+
   .cdock-wrap > * {
     pointer-events: auto;
   }
 
   .cdock {
+    position: relative;
+    z-index: 2;
+    width: min(100%, 480px);
+    min-height: 68px;
+    margin: 0 auto;
     display: flex;
     align-items: flex-end;
     justify-content: space-between;
     gap: 2px;
-    background: color-mix(in srgb, var(--card) 82%, transparent);
-    backdrop-filter: blur(16px);
-    -webkit-backdrop-filter: blur(16px);
-    border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+    padding: 8px 8px 7px;
+    background: color-mix(in srgb, var(--card) 88%, transparent);
+    backdrop-filter: blur(18px) saturate(1.15);
+    -webkit-backdrop-filter: blur(18px) saturate(1.15);
+    border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
     border-radius: 24px;
-    padding: 9px 10px 8px;
     box-shadow:
       0 2px 8px rgba(20, 18, 12, 0.06),
       0 18px 40px -10px rgba(20, 18, 12, 0.22);
   }
 
   .cdock-item {
-    flex: 1;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+
+  .cdock-item {
+    position: relative;
+    flex: 1 1 0;
+    min-width: 0;
+    min-height: 50px;
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 4px;
-    position: relative;
-    padding: 3px 0 2px;
+    justify-content: center;
+    gap: 5px;
+    padding: 5px 2px 3px;
     border: 0;
+    border-radius: 14px;
     background: transparent;
     color: var(--text3);
     text-decoration: none;
     cursor: pointer;
-    transition: color 0.16s;
+    transition: color 0.16s ease, background 0.16s ease, transform 0.16s ease;
   }
+
   .cdock-item svg {
     width: 21px;
     height: 21px;
-    display: block;
+    flex: 0 0 auto;
   }
+
   .cdock-lbl {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
     font-family: var(--font-body), "Manrope", sans-serif;
-    font-weight: 600;
     font-size: 9.5px;
-    letter-spacing: 0.01em;
+    font-weight: 600;
+    letter-spacing: 0;
     line-height: 1;
+    white-space: nowrap;
   }
+
   .cdock-item.is-active {
     color: var(--text);
   }
+
   .cdock-item.is-active .cdock-lbl {
-    font-weight: 700;
+    font-weight: 800;
   }
+
   .cdock-item.is-active::before {
     content: "";
     position: absolute;
-    top: -7px;
+    top: -5px;
     width: 5px;
     height: 5px;
     border-radius: 50%;
     background: var(--accent);
   }
 
-  /* Raised center action — Ask. */
-  .cdock-center {
-    flex: 0 0 auto;
-    margin: 0 4px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    text-decoration: none;
-  }
-  .cdock-fab {
-    width: 50px;
-    height: 50px;
-    border-radius: 17px;
-    background: var(--accent);
-    color: #fff;
-    display: grid;
-    place-items: center;
-    margin-top: -16px;
-    box-shadow: 0 4px 14px -2px color-mix(in srgb, var(--accent) 55%, transparent);
-    transition: transform 0.16s, box-shadow 0.16s;
-  }
-  .cdock-fab svg {
-    width: 23px;
-    height: 23px;
-  }
-  .cdock-fab:active {
-    transform: scale(0.95);
-  }
-  .cdock-fab.is-active {
-    background: var(--text);
-  }
-  .cdock-lbl-center {
-    margin-top: 3px;
-    color: var(--text);
-    font-weight: 700;
+  .cdock-item:active {
+    background: var(--neutral-soft);
+    transform: scale(0.97);
   }
 
-  /* Live pending-approvals badge. */
+  .cdock-item:focus-visible,
+  .cdock-sheet-row:focus-visible,
+  .cdock-sheet-close:focus-visible,
+  .cdock-sheet-out:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
   .cdock-badge {
     position: absolute;
-    top: -3px;
+    top: 0;
     right: 50%;
-    transform: translateX(20px);
-    min-width: 16px;
-    height: 16px;
-    padding: 0 4px;
-    border-radius: 999px;
-    background: var(--danger);
-    color: #fff;
-    font-weight: 600;
-    font-size: 9.5px;
-    line-height: 1;
+    transform: translateX(21px);
+    min-width: 17px;
+    height: 17px;
+    padding-inline: 4px;
     display: grid;
     place-items: center;
     border: 1.5px solid var(--card);
+    border-radius: 999px;
+    background: var(--danger);
+    color: #fff;
+    font-size: 9px;
+    font-weight: 800;
+    line-height: 1;
   }
 
-  /* "More" sheet — secondary destinations, popped above the dock. */
+  .cdock-scrim {
+    position: fixed;
+    inset: 0;
+    z-index: 1;
+    border: 0;
+    background: rgba(31, 28, 23, 0.3);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
+    animation: cdock-scrim-in 0.18s ease both;
+  }
+
   .cdock-sheet {
-    position: absolute;
-    right: 14px;
-    left: 14px;
-    bottom: calc(100% - 6px);
-    margin-bottom: 8px;
-    background: var(--card);
-    border: 1px solid var(--border);
-    border-radius: 18px;
-    box-shadow:
-      0 2px 8px rgba(20, 18, 12, 0.06),
-      0 24px 60px -16px rgba(20, 18, 12, 0.28);
+    position: fixed;
+    z-index: 3;
+    left: max(12px, calc((100vw - 480px) / 2));
+    right: max(12px, calc((100vw - 480px) / 2));
+    bottom: calc(90px + env(safe-area-inset-bottom, 0px));
+    max-height: min(72dvh, calc(100dvh - 112px - env(safe-area-inset-bottom, 0px)));
+    overflow-y: auto;
+    overscroll-behavior: contain;
     padding: 8px;
+    border: 1px solid var(--border);
+    border-radius: 22px;
+    background: var(--card);
+    box-shadow:
+      0 2px 8px rgba(20, 18, 12, 0.08),
+      0 28px 70px -18px rgba(20, 18, 12, 0.38);
+    animation: cdock-rise 0.2s cubic-bezier(0.2, 0.75, 0.2, 1) both;
+  }
+
+  .cdock-sheet:focus {
+    outline: none;
+  }
+
+  .cdock-sheet-grab {
+    width: 36px;
+    height: 4px;
+    margin: 2px auto 8px;
+    border-radius: 999px;
+    background: var(--border);
+  }
+
+  .cdock-sheet-head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 4px 8px 12px;
+  }
+
+  .cdock-sheet-head h2 {
+    margin: 0;
+    font-family: var(--font-display), "Archivo", sans-serif;
+    font-size: 20px;
+    font-weight: 800;
+    letter-spacing: -0.025em;
+    color: var(--text);
+  }
+
+  .cdock-sheet-head p {
+    margin: 3px 0 0;
+    font-size: 11.5px;
+    line-height: 1.45;
+    color: var(--text3);
+  }
+
+  .cdock-sheet-close {
+    width: 38px;
+    height: 38px;
+    flex: 0 0 auto;
+    display: grid;
+    place-items: center;
+    border: 0;
+    border-radius: 12px;
+    background: var(--neutral-soft);
+    color: var(--text2);
+    cursor: pointer;
+  }
+
+  .cdock-sheet-close svg {
+    width: 18px;
+    height: 18px;
+  }
+
+  .cdock-sheet-list {
     display: grid;
     gap: 2px;
-    animation: cdock-rise 0.18s cubic-bezier(0.4, 0, 0.2, 1) both;
   }
-  @keyframes cdock-rise {
-    from {
-      opacity: 0;
-      transform: translateY(8px);
-    }
-    to {
-      opacity: 1;
-      transform: none;
-    }
-  }
+
   .cdock-sheet-row {
+    min-height: 58px;
     display: flex;
-    flex-direction: column;
-    gap: 1px;
-    padding: 11px 13px;
-    border-radius: 12px;
-    text-decoration: none;
+    align-items: center;
+    gap: 12px;
+    padding: 9px 10px;
+    border-radius: 14px;
     color: var(--text);
-    transition: background 0.15s;
+    text-decoration: none;
+    transition: background 0.15s ease, transform 0.15s ease;
   }
+
   .cdock-sheet-row:active {
     background: var(--neutral-soft);
+    transform: scale(0.99);
   }
+
   .cdock-sheet-row.is-active {
     background: var(--accent-soft);
   }
-  .cdock-sheet-row.is-active .cdock-sheet-label {
-    color: var(--accent);
-  }
-  .cdock-sheet-label {
-    font-family: var(--font-display), "Archivo", sans-serif;
-    font-weight: 700;
-    font-size: 14px;
-    letter-spacing: -0.01em;
-  }
-  .cdock-sheet-desc {
-    font-size: 11.5px;
-    color: var(--text3);
-  }
-  .cdock-sheet-out {
-    margin-top: 4px;
-    padding: 12px;
-    border: 0;
-    border-top: 1px solid var(--border);
-    background: transparent;
-    color: var(--danger);
-    font-family: var(--font-display), "Archivo", sans-serif;
-    font-weight: 700;
-    font-size: 13.5px;
-    cursor: pointer;
-    border-radius: 0 0 10px 10px;
+
+  .cdock-sheet-icon {
+    width: 38px;
+    height: 38px;
+    flex: 0 0 auto;
+    display: grid;
+    place-items: center;
+    border-radius: 12px;
+    background: var(--neutral-soft);
+    color: var(--text2);
   }
 
-  /* The top-strip section nav is replaced by the dock on phones. The
-     `.app-header` prefix outranks the base `.topbar-nav` rule that would
-     otherwise re-show it via the cascade. The density toggle (no meaning at
-     one column — it lives in the More sheet) and the inline credit are
-     dropped too, leaving a clean brand + version header. */
-  .app-header .topbar-nav,
-  .app-header .density-seg,
-  .app-header .topbar-credit {
+  .cdock-sheet-row.is-active .cdock-sheet-icon {
+    background: color-mix(in srgb, var(--accent) 14%, var(--card));
+    color: var(--accent);
+  }
+
+  .cdock-sheet-icon svg {
+    width: 19px;
+    height: 19px;
+  }
+
+  .cdock-sheet-copy {
+    min-width: 0;
+    display: grid;
+    gap: 2px;
+  }
+
+  .cdock-sheet-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-family: var(--font-display), "Archivo", sans-serif;
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    white-space: nowrap;
+  }
+
+  .cdock-sheet-desc {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    color: var(--text3);
+    font-size: 11px;
+    white-space: nowrap;
+  }
+
+  .cdock-sheet-chevron {
+    width: 16px;
+    height: 16px;
+    margin-left: auto;
+    flex: 0 0 auto;
+    color: var(--text3);
+  }
+
+  .cdock-sheet-settings {
+    margin-top: 8px;
+    padding: 12px 8px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    border-top: 1px solid var(--border);
+    color: var(--text2);
+    font-size: 11px;
+    font-weight: 700;
+  }
+
+  .cdock-sheet-settings .density-seg {
+    display: inline-flex;
+  }
+
+  .cdock-sheet-settings .density-seg button {
+    min-width: 40px;
+    min-height: 36px;
+    justify-content: center;
+    padding-inline: 10px;
+  }
+
+  .cdock-sheet-settings .density-seg button span {
     display: none;
   }
 
-  /* Lift the sticky Ask composer clear of the dock so they never overlap. */
+  .cdock-sheet-out {
+    width: 100%;
+    min-height: 46px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    border: 0;
+    border-radius: 13px;
+    background: var(--danger-soft);
+    color: var(--danger);
+    font-family: var(--font-display), "Archivo", sans-serif;
+    font-size: 13.5px;
+    font-weight: 700;
+    cursor: pointer;
+  }
+
+  .cdock-sheet-out svg {
+    width: 16px;
+    height: 16px;
+  }
+
+  /* Mobile content hierarchy: the dock replaces the duplicated header nav.
+     Ask keeps an explicit, labeled thread control in the working surface. */
+  .app-header .topbar-nav,
+  .app-header > .topbar-inner > .density-seg,
+  .app-header .topbar-credit,
+  .app-header .topbar-signout {
+    display: none;
+  }
+
+  .app-header {
+    padding-block: 7px;
+  }
+
+  .app-header .topbar-inner {
+    min-height: 42px;
+    flex-wrap: nowrap;
+    gap: 9px;
+  }
+
+  .app-header .topbar-ver {
+    margin-left: auto;
+  }
+
+  .app-header .settings-backlink {
+    max-width: 44vw;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .app-header .topbar-inner:has(.settings-backlink) .topbar-brand,
+  .app-header .topbar-inner:has(.settings-backlink) .topbar-ver {
+    display: none;
+  }
+
+  .app-header .topbar-inner:has(.settings-backlink) .settings-backlink {
+    max-width: 100%;
+    margin-right: auto;
+  }
+
+  .work-layout {
+    width: 100%;
+    margin-left: 0;
+    transform: none;
+  }
+
+  .work-sidebar {
+    position: static;
+    max-height: none;
+    padding: 0;
+    gap: 8px;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .work-layout:not(.has-rail) .work-sidebar {
+    display: none;
+  }
+
+  .work-sidebar-head {
+    min-height: 46px;
+    padding: 0;
+    gap: 8px;
+  }
+
+  .work-threads-toggle {
+    min-height: 44px;
+    flex: 1;
+    justify-content: flex-start;
+    padding: 0 14px;
+    border: 1px solid var(--border);
+    border-radius: 14px;
+    background: var(--card);
+    color: var(--text2);
+    cursor: pointer;
+    box-shadow: var(--shadow-soft);
+  }
+
+  .work-threads-toggle:active {
+    background: var(--neutral-soft);
+  }
+
+  .work-threads-chevron {
+    display: inline-flex;
+    margin-left: auto;
+  }
+
+  .work-sidebar-head .work-icon-btn.is-ghost {
+    width: 44px;
+    height: 44px;
+    flex: 0 0 auto;
+    border-color: var(--border);
+    border-radius: 14px;
+    background: var(--card);
+    color: var(--accent);
+    box-shadow: var(--shadow-soft);
+  }
+
+  .work-thread-list {
+    max-height: min(42dvh, 360px);
+    flex: none;
+    margin: 0;
+    padding: 7px;
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    background: var(--card);
+    box-shadow: var(--shadow-soft);
+  }
+
+  .work-thread-list.is-collapsed {
+    display: none;
+  }
+
+  .work-thread-row-main {
+    min-height: 52px;
+  }
+
+  .work-sidebar-footer {
+    display: none;
+  }
+
   .work-composer {
-    bottom: calc(78px + env(safe-area-inset-bottom, 0px));
+    bottom: calc(86px + env(safe-area-inset-bottom, 0px));
+  }
+
+  html {
+    scroll-padding-bottom: calc(172px + env(safe-area-inset-bottom, 0px));
+  }
+
+  [data-sonner-toaster][data-y-position="bottom"] {
+    bottom: calc(92px + env(safe-area-inset-bottom, 0px)) !important;
+  }
+}
+
+@media (max-width: 360px) {
+  .cdock-wrap {
+    padding-inline: 8px;
+  }
+
+  .cdock {
+    padding-inline: 5px;
+  }
+
+  .cdock-item {
+    padding-inline: 0;
+  }
+
+  .cdock-sheet {
+    left: 8px;
+    right: 8px;
+  }
+}
+
+@media (max-width: 720px) and (max-height: 560px) {
+  .cdock-sheet {
+    max-height: calc(100dvh - 102px - env(safe-area-inset-bottom, 0px));
+  }
+
+  .cdock-sheet-head p {
+    display: none;
+  }
+
+  .cdock-sheet-row {
+    min-height: 52px;
+  }
+}
+
+@keyframes cdock-rise {
+  from {
+    opacity: 0;
+    transform: translateY(14px) scale(0.985);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes cdock-scrim-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cdock-item,
+  .cdock-sheet,
+  .cdock-scrim,
+  .cdock-sheet-row {
+    animation: none;
+    transition: none;
   }
 }

--- a/apps/web/src/app/styles/_dock.css
+++ b/apps/web/src/app/styles/_dock.css
@@ -1,0 +1,230 @@
+/* ─────────────────────────────────────────────────────────────
+   COMMAND DOCK — thumb-first nav for small screens.
+   The phone form of the section nav: a floating, frosted bar of
+   five destinations pinned to the bottom reach-zone. Hidden above
+   720px, where the top-bar nav takes over. Brand tokens only;
+   the purple active dot reuses the nav's existing active motif.
+   ───────────────────────────────────────────────────────────── */
+
+.cdock-wrap {
+  display: none;
+}
+
+@media (max-width: 720px) {
+  .cdock-wrap {
+    display: block;
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 120;
+    padding: 8px 14px calc(10px + env(safe-area-inset-bottom, 0px));
+    pointer-events: none;
+  }
+  .cdock-wrap > * {
+    pointer-events: auto;
+  }
+
+  .cdock {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 2px;
+    background: color-mix(in srgb, var(--card) 82%, transparent);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+    border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+    border-radius: 24px;
+    padding: 9px 10px 8px;
+    box-shadow:
+      0 2px 8px rgba(20, 18, 12, 0.06),
+      0 18px 40px -10px rgba(20, 18, 12, 0.22);
+  }
+
+  .cdock-item {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+    position: relative;
+    padding: 3px 0 2px;
+    border: 0;
+    background: transparent;
+    color: var(--text3);
+    text-decoration: none;
+    cursor: pointer;
+    transition: color 0.16s;
+  }
+  .cdock-item svg {
+    width: 21px;
+    height: 21px;
+    display: block;
+  }
+  .cdock-lbl {
+    font-family: var(--font-body), "Manrope", sans-serif;
+    font-weight: 600;
+    font-size: 9.5px;
+    letter-spacing: 0.01em;
+    line-height: 1;
+  }
+  .cdock-item.is-active {
+    color: var(--text);
+  }
+  .cdock-item.is-active .cdock-lbl {
+    font-weight: 700;
+  }
+  .cdock-item.is-active::before {
+    content: "";
+    position: absolute;
+    top: -7px;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: var(--accent);
+  }
+
+  /* Raised center action — Ask. */
+  .cdock-center {
+    flex: 0 0 auto;
+    margin: 0 4px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-decoration: none;
+  }
+  .cdock-fab {
+    width: 50px;
+    height: 50px;
+    border-radius: 17px;
+    background: var(--accent);
+    color: #fff;
+    display: grid;
+    place-items: center;
+    margin-top: -16px;
+    box-shadow: 0 4px 14px -2px color-mix(in srgb, var(--accent) 55%, transparent);
+    transition: transform 0.16s, box-shadow 0.16s;
+  }
+  .cdock-fab svg {
+    width: 23px;
+    height: 23px;
+  }
+  .cdock-fab:active {
+    transform: scale(0.95);
+  }
+  .cdock-fab.is-active {
+    background: var(--text);
+  }
+  .cdock-lbl-center {
+    margin-top: 3px;
+    color: var(--text);
+    font-weight: 700;
+  }
+
+  /* Live pending-approvals badge. */
+  .cdock-badge {
+    position: absolute;
+    top: -3px;
+    right: 50%;
+    transform: translateX(20px);
+    min-width: 16px;
+    height: 16px;
+    padding: 0 4px;
+    border-radius: 999px;
+    background: var(--danger);
+    color: #fff;
+    font-weight: 600;
+    font-size: 9.5px;
+    line-height: 1;
+    display: grid;
+    place-items: center;
+    border: 1.5px solid var(--card);
+  }
+
+  /* "More" sheet — secondary destinations, popped above the dock. */
+  .cdock-sheet {
+    position: absolute;
+    right: 14px;
+    left: 14px;
+    bottom: calc(100% - 6px);
+    margin-bottom: 8px;
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 18px;
+    box-shadow:
+      0 2px 8px rgba(20, 18, 12, 0.06),
+      0 24px 60px -16px rgba(20, 18, 12, 0.28);
+    padding: 8px;
+    display: grid;
+    gap: 2px;
+    animation: cdock-rise 0.18s cubic-bezier(0.4, 0, 0.2, 1) both;
+  }
+  @keyframes cdock-rise {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: none;
+    }
+  }
+  .cdock-sheet-row {
+    display: flex;
+    flex-direction: column;
+    gap: 1px;
+    padding: 11px 13px;
+    border-radius: 12px;
+    text-decoration: none;
+    color: var(--text);
+    transition: background 0.15s;
+  }
+  .cdock-sheet-row:active {
+    background: var(--neutral-soft);
+  }
+  .cdock-sheet-row.is-active {
+    background: var(--accent-soft);
+  }
+  .cdock-sheet-row.is-active .cdock-sheet-label {
+    color: var(--accent);
+  }
+  .cdock-sheet-label {
+    font-family: var(--font-display), "Archivo", sans-serif;
+    font-weight: 700;
+    font-size: 14px;
+    letter-spacing: -0.01em;
+  }
+  .cdock-sheet-desc {
+    font-size: 11.5px;
+    color: var(--text3);
+  }
+  .cdock-sheet-out {
+    margin-top: 4px;
+    padding: 12px;
+    border: 0;
+    border-top: 1px solid var(--border);
+    background: transparent;
+    color: var(--danger);
+    font-family: var(--font-display), "Archivo", sans-serif;
+    font-weight: 700;
+    font-size: 13.5px;
+    cursor: pointer;
+    border-radius: 0 0 10px 10px;
+  }
+
+  /* The top-strip section nav is replaced by the dock on phones. The
+     `.app-header` prefix outranks the base `.topbar-nav` rule that would
+     otherwise re-show it via the cascade. The density toggle (no meaning at
+     one column — it lives in the More sheet) and the inline credit are
+     dropped too, leaving a clean brand + version header. */
+  .app-header .topbar-nav,
+  .app-header .density-seg,
+  .app-header .topbar-credit {
+    display: none;
+  }
+
+  /* Lift the sticky Ask composer clear of the dock so they never overlap. */
+  .work-composer {
+    bottom: calc(78px + env(safe-area-inset-bottom, 0px));
+  }
+}

--- a/apps/web/src/app/styles/_modal.css
+++ b/apps/web/src/app/styles/_modal.css
@@ -3,6 +3,14 @@
    ConfirmModal.tsx as utility classes. These keyframes stay here because
    utility arbitrary-value animations (animate-[modal-fade_...]) reference
    them by name. */
+.confirm-modal-root {
+  /* body > * establishes the app's base stacking context. The portal root
+     needs its own higher layer so a dialog opened from the mobile dock is
+     not trapped underneath that dock's sheet and scrim. */
+  position: relative;
+  z-index: 1000;
+}
+
 @keyframes modal-fade {
   from { opacity: 0; }
   to { opacity: 1; }

--- a/apps/web/src/app/styles/_responsive.css
+++ b/apps/web/src/app/styles/_responsive.css
@@ -17,6 +17,24 @@ body { overflow-x: hidden; }
 .work-bubble, .work-markdown, .builder-msg, .run-output-card,
 .settings-card { overflow-wrap: anywhere; }
 
+/* Intrinsic sizing is the most common source of mobile overflow: grid and
+   flex children otherwise keep the min-content width of long identifiers. */
+.root,
+.root > *,
+.brief-grid > *,
+.settings-grid > *,
+.work-layout > *,
+.builder-layout > *,
+.triage-layout > *,
+.settings-card-head > *,
+.run-header-row > * {
+  min-width: 0;
+}
+
+.root :where(input, textarea, select) {
+  max-width: 100%;
+}
+
 /* ── TABLET LANDSCAPE & BELOW ── */
 @media (max-width: 1024px) {
   /* Work page gets a 240px sidebar to claw back content room
@@ -56,6 +74,11 @@ body { overflow-x: hidden; }
   .pill { padding: 10px 16px; font-size: 14px; }
   .workflows-new-btn, .run-followup-btn { padding: 10px 16px; font-size: 14px; }
   .act-row-btn, .workflow-drawer-btn { padding: 10px 16px; font-size: 14px; }
+  .act-row-btn, .workflow-drawer-btn, .modal-btn {
+    max-width: 100%;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
 
   /* Hover-reveal actions are always visible — there is no hover. */
   .iactions, .work-bubble-actions { opacity: 1; }

--- a/apps/web/src/app/styles/_work.css
+++ b/apps/web/src/app/styles/_work.css
@@ -1063,6 +1063,8 @@ textarea.work-a2ui-input { resize: vertical; }
 }
 .work-a2ui-checkbox,
 .work-a2ui-check-option {
+  min-width: 0;
+  max-width: 100%;
   display: inline-flex;
   align-items: center;
   gap: 8px;
@@ -1081,6 +1083,13 @@ textarea.work-a2ui-input { resize: vertical; }
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 999px;
+  overflow: hidden;
+}
+.work-a2ui-chips .work-a2ui-check-option span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .work-a2ui-tabs { min-width: 0; }
 .work-a2ui-tab-list {
@@ -1123,6 +1132,9 @@ textarea.work-a2ui-input { resize: vertical; }
   cursor: pointer;
   font-size: 12.5px;
   font-weight: 600;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  text-align: center;
   transition: background 0.14s ease, border-color 0.14s ease;
 }
 .work-a2ui-button .work-a2ui-text { color: inherit; font: inherit; }
@@ -1168,7 +1180,8 @@ textarea.work-a2ui-input { resize: vertical; }
   border-radius: 10px;
 }
 .work-openapi-summary-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
-.work-openapi-summary-head strong { display: block; color: var(--text); font-size: 13px; }
+.work-openapi-summary-head > div { min-width: 0; }
+.work-openapi-summary-head strong { display: block; color: var(--text); font-size: 13px; overflow-wrap: anywhere; }
 .work-openapi-summary-head span { color: var(--text3); font-size: 11px; }
 .work-openapi-summary-head .work-openapi-ready { color: var(--good, #067647); font-weight: 700; }
 .work-openapi-summary dl { display: grid; gap: 7px; margin: 12px 0 0; }
@@ -1183,9 +1196,25 @@ textarea.work-a2ui-input { resize: vertical; }
   line-height: 1.55;
 }
 .work-managed-files-list { display: grid; gap: 5px; }
-.work-managed-files-list li { display: flex; justify-content: space-between; gap: 12px; }
+.work-managed-files-list li { display: flex; min-width: 0; justify-content: space-between; gap: 12px; }
 .work-managed-files-list code {
+  min-width: 0;
+  overflow-wrap: anywhere;
   color: var(--text3);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 10.5px;
+}
+
+@media (max-width: 520px) {
+  .work-openapi-summary-head,
+  .work-managed-files-list li {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 5px;
+  }
+
+  .work-openapi-summary dl > div {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
 }

--- a/apps/web/src/components/CommandDock.tsx
+++ b/apps/web/src/components/CommandDock.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
+
+// Thumb-first navigation for small screens. Replaces the top-strip section nav
+// on phones: five primary destinations with Ask raised as a center action, a
+// live badge on Actions, and a "More" sheet that folds in the secondary
+// surfaces. Hidden on >720px (the top bar keeps its nav there) and on the
+// auth/onboarding routes, which have no app chrome.
+//
+// One nav model, ergonomically reshaped per size — the phone form of the same
+// rail the wider layouts use.
+
+const SECONDARY = [
+  { href: "/business-profile", label: "Business Profile", desc: "How your business runs" },
+  { href: "/memory", label: "Memory", desc: "Pinned facts & learned rules" },
+  { href: "/skills", label: "Skills", desc: "What OpenNeko can do" },
+  { href: "/integrations", label: "Integrations", desc: "Slack, Gmail, Stripe…" },
+  { href: "/admin", label: "Admin", desc: "Users, model, data sources" },
+];
+
+function isActive(pathname: string, base: string) {
+  if (base === "/") return pathname === "/";
+  return pathname === base || pathname.startsWith(`${base}/`);
+}
+
+export default function CommandDock() {
+  const pathname = usePathname() ?? "/";
+  const [pending, setPending] = useState(0);
+  const [moreOpen, setMoreOpen] = useState(false);
+  const moreRef = useRef<HTMLDivElement | null>(null);
+
+  // Pending-approvals badge — same poll the section nav uses, so the count
+  // stays live whether you reach Actions from the top bar or the dock.
+  useEffect(() => {
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const res = await fetch("/api/approvals?countOnly=true", { cache: "no-store" });
+        if (cancelled || !res.ok) return;
+        const data = (await res.json()) as { count?: number };
+        setPending(data.count ?? 0);
+      } catch {
+        // best-effort; ignore network blips
+      }
+    };
+    void tick();
+    const id = setInterval(tick, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  // Close the More sheet on outside taps. (Navigation closes it via the
+  // onClick handlers below, so there's no setState-in-effect on pathname.)
+  useEffect(() => {
+    if (!moreOpen) return;
+    const onDown = (e: PointerEvent) => {
+      if (moreRef.current && !moreRef.current.contains(e.target as Node)) {
+        setMoreOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", onDown);
+    return () => document.removeEventListener("pointerdown", onDown);
+  }, [moreOpen]);
+
+  async function handleSignOut() {
+    try {
+      await fetch("/api/auth/logout", { method: "POST" });
+    } finally {
+      window.location.href = "/signin";
+    }
+  }
+
+  // No app chrome on the auth / onboarding flows.
+  if (pathname.startsWith("/signin") || pathname.startsWith("/onboarding")) {
+    return null;
+  }
+
+  const moreActive = SECONDARY.some((s) => isActive(pathname, s.href));
+
+  return (
+    <div className="cdock-wrap" ref={moreRef}>
+      {moreOpen && (
+        <div className="cdock-sheet" role="menu" aria-label="More destinations">
+          {SECONDARY.map((s) => (
+            <Link
+              key={s.href}
+              href={s.href}
+              role="menuitem"
+              onClick={() => setMoreOpen(false)}
+              className={`cdock-sheet-row${isActive(pathname, s.href) ? " is-active" : ""}`}
+            >
+              <span className="cdock-sheet-label">{s.label}</span>
+              <span className="cdock-sheet-desc">{s.desc}</span>
+            </Link>
+          ))}
+          <button type="button" className="cdock-sheet-out" onClick={handleSignOut}>
+            Sign out
+          </button>
+        </div>
+      )}
+
+      <nav className="cdock" aria-label="Primary">
+        <Link
+          href="/"
+          onClick={() => setMoreOpen(false)}
+          className={`cdock-item${isActive(pathname, "/") ? " is-active" : ""}`}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+            <path d="M4 11.5 12 4l8 7.5" />
+            <path d="M6 10v9h12v-9" strokeLinecap="round" />
+          </svg>
+          <span className="cdock-lbl">Briefing</span>
+        </Link>
+
+        <Link
+          href="/workflows"
+          onClick={() => setMoreOpen(false)}
+          className={`cdock-item${isActive(pathname, "/workflows") ? " is-active" : ""}`}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+            <rect x="3.5" y="6" width="17" height="11" rx="3" />
+            <path d="M8 20l3-3" strokeLinecap="round" />
+          </svg>
+          <span className="cdock-lbl">Workflows</span>
+        </Link>
+
+        <Link href="/work" onClick={() => setMoreOpen(false)} className="cdock-center" aria-label="Ask">
+          <span className={`cdock-fab${isActive(pathname, "/work") ? " is-active" : ""}`}>
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+              <path
+                d="M12 3a9 9 0 0 1 0 18 9.3 9.3 0 0 1-3.8-.8L3 21l1-4.4A9 9 0 0 1 12 3Z"
+                strokeLinejoin="round"
+              />
+              <path d="M8.5 11h7M8.5 14h4" strokeLinecap="round" />
+            </svg>
+          </span>
+          <span className="cdock-lbl cdock-lbl-center">Ask</span>
+        </Link>
+
+        <Link
+          href="/actions"
+          onClick={() => setMoreOpen(false)}
+          className={`cdock-item${isActive(pathname, "/actions") ? " is-active" : ""}`}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
+            <path d="M5 12.5l4 4 10-10" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+          <span className="cdock-lbl">Actions</span>
+          {pending > 0 && (
+            <span className="cdock-badge font-mono" aria-label={`${pending} pending`}>
+              {pending}
+            </span>
+          )}
+        </Link>
+
+        <button
+          type="button"
+          className={`cdock-item${moreActive || moreOpen ? " is-active" : ""}`}
+          aria-expanded={moreOpen}
+          aria-haspopup="menu"
+          onClick={() => setMoreOpen((v) => !v)}
+        >
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+            <circle cx="6" cy="12" r="1.4" />
+            <circle cx="12" cy="12" r="1.4" />
+            <circle cx="18" cy="12" r="1.4" />
+          </svg>
+          <span className="cdock-lbl">More</span>
+        </button>
+      </nav>
+    </div>
+  );
+}

--- a/apps/web/src/components/CommandDock.tsx
+++ b/apps/web/src/components/CommandDock.tsx
@@ -3,69 +3,93 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
+import { ChevronRight, Ellipsis, LogOut, X } from "lucide-react";
+import DensityToggle from "@/components/DensityToggle";
+import {
+  PRIMARY_NAV,
+  SECONDARY_NAV,
+  hideAppChrome,
+  isActive,
+  useApprovalsCount,
+  type NavDestination,
+} from "@/lib/nav";
 
-// Thumb-first navigation for small screens. Replaces the top-strip section nav
-// on phones: five primary destinations with Ask raised as a center action, a
-// live badge on Actions, and a "More" sheet that folds in the secondary
-// surfaces. Hidden on >720px (the top bar keeps its nav there) and on the
-// auth/onboarding routes, which have no app chrome.
-//
-// One nav model, ergonomically reshaped per size — the phone form of the same
-// rail the wider layouts use.
+type OpenSheet = "more" | null;
 
-const SECONDARY = [
-  { href: "/business-profile", label: "Business Profile", desc: "How your business runs" },
-  { href: "/memory", label: "Memory", desc: "Pinned facts & learned rules" },
-  { href: "/skills", label: "Skills", desc: "What OpenNeko can do" },
-  { href: "/integrations", label: "Integrations", desc: "Slack, Gmail, Stripe…" },
-  { href: "/admin", label: "Admin", desc: "Users, model, data sources" },
-];
+const dockDestination = (href: string) => {
+  const destination = PRIMARY_NAV.find((item) => item.href === href);
+  if (!destination) throw new Error(`Missing dock destination: ${href}`);
+  return destination;
+};
 
-function isActive(pathname: string, base: string) {
-  if (base === "/") return pathname === "/";
-  return pathname === base || pathname.startsWith(`${base}/`);
+const DASHBOARD = dockDestination("/");
+const WORKFLOWS = dockDestination("/workflows");
+const ASK = dockDestination("/work");
+const ACTIONS = dockDestination("/actions");
+
+function DockLink({
+  item,
+  pathname,
+  pending = 0,
+  onNavigate,
+}: {
+  item: NavDestination;
+  pathname: string;
+  pending?: number;
+  onNavigate: () => void;
+}) {
+  const active = isActive(pathname, item.href);
+  const Icon = item.icon;
+
+  return (
+    <Link
+      href={item.href}
+      className={`cdock-item${active ? " is-active" : ""}`}
+      aria-current={active ? "page" : undefined}
+      onClick={onNavigate}
+    >
+      <Icon aria-hidden="true" strokeWidth={1.9} />
+      <span className="cdock-lbl">{item.shortLabel}</span>
+      {item.href === "/actions" && pending > 0 ? (
+        <span className="cdock-badge font-mono" aria-label={`${pending} pending`}>
+          {pending > 99 ? "99+" : pending}
+        </span>
+      ) : null}
+    </Link>
+  );
 }
 
 export default function CommandDock() {
   const pathname = usePathname() ?? "/";
-  const [pending, setPending] = useState(0);
-  const [moreOpen, setMoreOpen] = useState(false);
-  const moreRef = useRef<HTMLDivElement | null>(null);
+  const hidden = hideAppChrome(pathname);
+  const pending = useApprovalsCount(!hidden);
+  const [openSheet, setOpenSheet] = useState<OpenSheet>(null);
+  const sheetRef = useRef<HTMLElement | null>(null);
+  const triggerRef = useRef<HTMLAnchorElement | HTMLButtonElement | null>(null);
 
-  // Pending-approvals badge — same poll the section nav uses, so the count
-  // stays live whether you reach Actions from the top bar or the dock.
   useEffect(() => {
-    let cancelled = false;
-    const tick = async () => {
-      try {
-        const res = await fetch("/api/approvals?countOnly=true", { cache: "no-store" });
-        if (cancelled || !res.ok) return;
-        const data = (await res.json()) as { count?: number };
-        setPending(data.count ?? 0);
-      } catch {
-        // best-effort; ignore network blips
+    if (!openSheet) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const frame = requestAnimationFrame(() => sheetRef.current?.focus());
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.key === "Escape" &&
+        !document.querySelector(".confirm-modal-root")
+      ) {
+        setOpenSheet(null);
       }
     };
-    void tick();
-    const id = setInterval(tick, 30_000);
+    document.addEventListener("keydown", onKeyDown);
+
     return () => {
-      cancelled = true;
-      clearInterval(id);
+      cancelAnimationFrame(frame);
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", onKeyDown);
+      triggerRef.current?.focus({ preventScroll: true });
     };
-  }, []);
-
-  // Close the More sheet on outside taps. (Navigation closes it via the
-  // onClick handlers below, so there's no setState-in-effect on pathname.)
-  useEffect(() => {
-    if (!moreOpen) return;
-    const onDown = (e: PointerEvent) => {
-      if (moreRef.current && !moreRef.current.contains(e.target as Node)) {
-        setMoreOpen(false);
-      }
-    };
-    document.addEventListener("pointerdown", onDown);
-    return () => document.removeEventListener("pointerdown", onDown);
-  }, [moreOpen]);
+  }, [openSheet]);
 
   async function handleSignOut() {
     try {
@@ -75,101 +99,123 @@ export default function CommandDock() {
     }
   }
 
-  // No app chrome on the auth / onboarding flows.
-  if (pathname.startsWith("/signin") || pathname.startsWith("/onboarding")) {
-    return null;
+  function closeSheet() {
+    setOpenSheet(null);
   }
 
-  const moreActive = SECONDARY.some((s) => isActive(pathname, s.href));
+  if (hidden) return null;
+
+  const moreActive = SECONDARY_NAV.some((item) => isActive(pathname, item.href));
+  const askActive = isActive(pathname, ASK.href);
+  const AskIcon = ASK.icon;
 
   return (
-    <div className="cdock-wrap" ref={moreRef}>
-      {moreOpen && (
-        <div className="cdock-sheet" role="menu" aria-label="More destinations">
-          {SECONDARY.map((s) => (
-            <Link
-              key={s.href}
-              href={s.href}
-              role="menuitem"
-              onClick={() => setMoreOpen(false)}
-              className={`cdock-sheet-row${isActive(pathname, s.href) ? " is-active" : ""}`}
-            >
-              <span className="cdock-sheet-label">{s.label}</span>
-              <span className="cdock-sheet-desc">{s.desc}</span>
-            </Link>
-          ))}
-          <button type="button" className="cdock-sheet-out" onClick={handleSignOut}>
-            Sign out
-          </button>
-        </div>
-      )}
+    <div className="cdock-wrap">
+      {openSheet ? (
+        <>
+          <button
+            type="button"
+            className="cdock-scrim"
+            aria-label="Close navigation sheet"
+            onClick={closeSheet}
+          />
+          <section
+            ref={sheetRef}
+            id="cdock-more-sheet"
+            className="cdock-sheet is-more"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="cdock-more-title"
+            tabIndex={-1}
+          >
+            <div className="cdock-sheet-grab" aria-hidden="true" />
+            <div className="cdock-sheet-head">
+              <div>
+                <h2 id="cdock-more-title">More</h2>
+                <p>Knowledge, connections, and workspace settings.</p>
+              </div>
+              <button
+                type="button"
+                className="cdock-sheet-close"
+                aria-label="Close"
+                onClick={closeSheet}
+              >
+                <X aria-hidden="true" strokeWidth={2} />
+              </button>
+            </div>
 
-      <nav className="cdock" aria-label="Primary">
+            <nav className="cdock-sheet-list" aria-label="More destinations">
+              {SECONDARY_NAV.map((item) => {
+                const active = isActive(pathname, item.href);
+                const Icon = item.icon;
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    onClick={closeSheet}
+                    aria-current={active ? "page" : undefined}
+                    className={`cdock-sheet-row${active ? " is-active" : ""}`}
+                  >
+                    <span className="cdock-sheet-icon">
+                      <Icon aria-hidden="true" strokeWidth={1.9} />
+                    </span>
+                    <span className="cdock-sheet-copy">
+                      <span className="cdock-sheet-label">{item.label}</span>
+                      <span className="cdock-sheet-desc">{item.description}</span>
+                    </span>
+                    <ChevronRight className="cdock-sheet-chevron" aria-hidden="true" />
+                  </Link>
+                );
+              })}
+            </nav>
+            <div className="cdock-sheet-settings">
+              <span>Layout density</span>
+              <DensityToggle />
+            </div>
+            <button type="button" className="cdock-sheet-out" onClick={handleSignOut}>
+              <LogOut aria-hidden="true" strokeWidth={2} />
+              <span>Sign out</span>
+            </button>
+          </section>
+        </>
+      ) : null}
+
+      <nav className="cdock" aria-label="Primary navigation">
+        <DockLink item={DASHBOARD} pathname={pathname} onNavigate={closeSheet} />
+        <DockLink item={WORKFLOWS} pathname={pathname} onNavigate={closeSheet} />
+
         <Link
-          href="/"
-          onClick={() => setMoreOpen(false)}
-          className={`cdock-item${isActive(pathname, "/") ? " is-active" : ""}`}
+          href={ASK.href}
+          onClick={closeSheet}
+          className={`cdock-item cdock-ask${askActive ? " is-active" : ""}`}
+          aria-label="Ask OpenNeko"
+          aria-current={askActive ? "page" : undefined}
         >
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
-            <path d="M4 11.5 12 4l8 7.5" />
-            <path d="M6 10v9h12v-9" strokeLinecap="round" />
-          </svg>
-          <span className="cdock-lbl">Briefing</span>
+          <AskIcon aria-hidden="true" strokeWidth={1.9} />
+          <span className="cdock-lbl">Ask</span>
         </Link>
 
-        <Link
-          href="/workflows"
-          onClick={() => setMoreOpen(false)}
-          className={`cdock-item${isActive(pathname, "/workflows") ? " is-active" : ""}`}
-        >
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
-            <rect x="3.5" y="6" width="17" height="11" rx="3" />
-            <path d="M8 20l3-3" strokeLinecap="round" />
-          </svg>
-          <span className="cdock-lbl">Workflows</span>
-        </Link>
-
-        <Link href="/work" onClick={() => setMoreOpen(false)} className="cdock-center" aria-label="Ask">
-          <span className={`cdock-fab${isActive(pathname, "/work") ? " is-active" : ""}`}>
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-              <path
-                d="M12 3a9 9 0 0 1 0 18 9.3 9.3 0 0 1-3.8-.8L3 21l1-4.4A9 9 0 0 1 12 3Z"
-                strokeLinejoin="round"
-              />
-              <path d="M8.5 11h7M8.5 14h4" strokeLinecap="round" />
-            </svg>
-          </span>
-          <span className="cdock-lbl cdock-lbl-center">Ask</span>
-        </Link>
-
-        <Link
-          href="/actions"
-          onClick={() => setMoreOpen(false)}
-          className={`cdock-item${isActive(pathname, "/actions") ? " is-active" : ""}`}
-        >
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" aria-hidden="true">
-            <path d="M5 12.5l4 4 10-10" strokeLinecap="round" strokeLinejoin="round" />
-          </svg>
-          <span className="cdock-lbl">Actions</span>
-          {pending > 0 && (
-            <span className="cdock-badge font-mono" aria-label={`${pending} pending`}>
-              {pending}
-            </span>
-          )}
-        </Link>
+        <DockLink
+          item={ACTIONS}
+          pathname={pathname}
+          pending={pending}
+          onNavigate={closeSheet}
+        />
 
         <button
+          ref={(node) => {
+            if (openSheet === "more") triggerRef.current = node;
+          }}
           type="button"
-          className={`cdock-item${moreActive || moreOpen ? " is-active" : ""}`}
-          aria-expanded={moreOpen}
-          aria-haspopup="menu"
-          onClick={() => setMoreOpen((v) => !v)}
+          className={`cdock-item${moreActive || openSheet === "more" ? " is-active" : ""}`}
+          aria-expanded={openSheet === "more"}
+          aria-controls="cdock-more-sheet"
+          onClick={(event) => {
+            triggerRef.current = event.currentTarget;
+            setOpenSheet((current) => (current === "more" ? null : "more"));
+          }}
         >
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
-            <circle cx="6" cy="12" r="1.4" />
-            <circle cx="12" cy="12" r="1.4" />
-            <circle cx="18" cy="12" r="1.4" />
-          </svg>
+          <Ellipsis aria-hidden="true" strokeWidth={2.2} />
           <span className="cdock-lbl">More</span>
         </button>
       </nav>

--- a/apps/web/src/components/ConfirmModal.tsx
+++ b/apps/web/src/components/ConfirmModal.tsx
@@ -41,6 +41,7 @@ export function confirmDialog(options: ConfirmDialogOptions): Promise<boolean> {
   cleanup();
   return new Promise<boolean>((resolve) => {
     const container = document.createElement("div");
+    container.className = "confirm-modal-root";
     document.body.appendChild(container);
     activeContainer = container;
     const root = createRoot(container);

--- a/apps/web/src/components/FindingCard.tsx
+++ b/apps/web/src/components/FindingCard.tsx
@@ -137,7 +137,7 @@ export default function FindingCard({
       }}
     >
       <div className="flex items-start justify-between gap-3 mb-1.5">
-        <h3 className="font-display text-[17px] font-bold tracking-[-0.01em] text-text leading-snug m-0">
+        <h3 className="min-w-0 font-display text-[17px] font-bold tracking-[-0.01em] text-text leading-snug m-0 [overflow-wrap:anywhere]">
           {data.title}
         </h3>
         <Pill variant={pillVariant} className="flex-shrink-0">

--- a/apps/web/src/components/ui/Pill.tsx
+++ b/apps/web/src/components/ui/Pill.tsx
@@ -16,17 +16,27 @@ type PillProps = {
   className?: string;
 } & ComponentPropsWithoutRef<"span">;
 
-export function Pill({ variant = "muted", className, ...props }: PillProps) {
+export function Pill({
+  variant = "muted",
+  className,
+  children,
+  title,
+  ...props
+}: PillProps) {
   return (
     <span
       className={cn(
-        "inline-flex items-center px-2.5 py-1 rounded-full",
+        "inline-flex min-w-0 max-w-full min-h-6 shrink-0 items-center px-2.5 py-1 rounded-full",
+        "overflow-hidden text-ellipsis whitespace-nowrap leading-none",
         "text-[11px] font-extrabold tracking-[0.08em] uppercase",
         "border",
         VARIANTS[variant],
         className,
       )}
+      title={title ?? (typeof children === "string" ? children : undefined)}
       {...props}
-    />
+    >
+      {children}
+    </span>
   );
 }

--- a/apps/web/src/lib/nav.tsx
+++ b/apps/web/src/lib/nav.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { LucideIcon } from "lucide-react";
+import {
+  BookOpen,
+  Brain,
+  CheckCircle2,
+  Home,
+  MessageCircle,
+  MonitorPlay,
+  Plug,
+  Puzzle,
+  Settings,
+} from "lucide-react";
+
+export type NavDestination = {
+  href: string;
+  label: string;
+  shortLabel: string;
+  description?: string;
+  icon: LucideIcon;
+  group?: "primary" | "knowledge" | "workspace";
+};
+
+export const PRIMARY_NAV: NavDestination[] = [
+  {
+    href: "/",
+    label: "Dashboard",
+    shortLabel: "Dashboard",
+    description: "Today, decisions, and signals",
+    icon: Home,
+    group: "primary",
+  },
+  {
+    href: "/work",
+    label: "Ask",
+    shortLabel: "Ask",
+    description: "Ask OpenNeko anything",
+    icon: MessageCircle,
+    group: "primary",
+  },
+  {
+    href: "/workflows",
+    label: "Workflows",
+    shortLabel: "Flows",
+    description: "Watchers and automation",
+    icon: MonitorPlay,
+    group: "primary",
+  },
+  {
+    href: "/actions",
+    label: "Actions",
+    shortLabel: "Actions",
+    description: "Approvals and receipts",
+    icon: CheckCircle2,
+    group: "primary",
+  },
+];
+
+export const SECONDARY_NAV: NavDestination[] = [
+  {
+    href: "/business-profile",
+    label: "Business Profile",
+    shortLabel: "Profile",
+    description: "How your business runs",
+    icon: BookOpen,
+    group: "knowledge",
+  },
+  {
+    href: "/memory",
+    label: "Memory",
+    shortLabel: "Memory",
+    description: "Pinned facts and learned rules",
+    icon: Brain,
+    group: "knowledge",
+  },
+  {
+    href: "/skills",
+    label: "Skills",
+    shortLabel: "Skills",
+    description: "What OpenNeko can do",
+    icon: Puzzle,
+    group: "knowledge",
+  },
+  {
+    href: "/integrations",
+    label: "Integrations",
+    shortLabel: "Connect",
+    description: "Slack, Gmail, Stripe, and more",
+    icon: Plug,
+    group: "workspace",
+  },
+  {
+    href: "/admin",
+    label: "Admin",
+    shortLabel: "Admin",
+    description: "Users, model, and data sources",
+    icon: Settings,
+    group: "workspace",
+  },
+];
+
+export const ALL_NAV = [...PRIMARY_NAV, ...SECONDARY_NAV];
+
+export function isActive(pathname: string, base: string) {
+  if (base === "/") return pathname === "/";
+  return pathname === base || pathname.startsWith(`${base}/`);
+}
+
+export function hideAppChrome(pathname: string) {
+  return pathname.startsWith("/signin") || pathname.startsWith("/onboarding");
+}
+
+export function useApprovalsCount(enabled = true) {
+  const [pending, setPending] = useState(0);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const tick = async () => {
+      try {
+        const res = await fetch("/api/approvals?countOnly=true", {
+          cache: "no-store",
+        });
+        if (cancelled || !res.ok) return;
+        const data = (await res.json()) as { count?: number };
+        setPending(data.count ?? 0);
+      } catch {
+        // Best effort; the badge simply stays at its last known value.
+      }
+    };
+
+    void tick();
+    const id = setInterval(tick, 30_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [enabled]);
+
+  return pending;
+}


### PR DESCRIPTION
## Summary

- add a thumb-friendly mobile command dock and More sheet
- expose an explicit, collapsed-by-default thread list on mobile Ask
- fix modal stacking, safe areas, touch targets, and redundant mobile navigation
- harden pills, identifiers, cards, forms, and detail rows against narrow layouts and long content

## Verification

- `pnpm --filter @neko/web typecheck`
- Vitest: 20 files passed, 177 tests passed; database-dependent tests skipped when metadata Postgres was unavailable
- `git diff --check`
- manually reviewed through the local mobile preview