### PR TITLE
fix(llm): recover from orphaned sandbox collisions

### DIFF
--- a/packages/llm/src/work/sandbox-launcher.ts
+++ b/packages/llm/src/work/sandbox-launcher.ts
@@ -596,29 +596,40 @@ function makeSandboxCore(
         type: "status",
         message: "Starting secure agent sandbox…",
       });
-      await run(
-        [
-          "sandbox",
-          "create",
-          "--name",
-          name,
-          "--from",
-          opts.agentImage,
-          "--no-tty",
-          "--no-auto-providers",
-          ...(opts.modelProvider ? ["--provider", opts.modelProvider] : []),
-          "--policy",
-          policyFile,
-          "--upload",
-          // OpenShell nests basename(LOCAL_PATH) under SANDBOX_PATH.
-          `${staged.orgRoot}:${path.posix.dirname(boxOrgRoot)}`,
-          "--no-git-ignore",
-          "--",
-          "node",
-          "--version",
-        ],
-        180_000,
-      );
+      const createArgs = [
+        "sandbox",
+        "create",
+        "--name",
+        name,
+        "--from",
+        opts.agentImage,
+        "--no-tty",
+        "--no-auto-providers",
+        ...(opts.modelProvider ? ["--provider", opts.modelProvider] : []),
+        "--policy",
+        policyFile,
+        "--upload",
+        // OpenShell nests basename(LOCAL_PATH) under SANDBOX_PATH.
+        `${staged.orgRoot}:${path.posix.dirname(boxOrgRoot)}`,
+        "--no-git-ignore",
+        "--",
+        "node",
+        "--version",
+      ];
+      try {
+        await run(createArgs, 180_000);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (!message.includes("already exists")) throw error;
+
+        // Run names are deterministic so a durable queue retry can collide
+        // with an OpenShell sandbox orphaned by a worker restart or deploy.
+        // Replace only that exact run sandbox, then let the normal finally
+        // path own cleanup for the newly created instance.
+        log(`replacing stale agent sandbox after name collision: ${name}`);
+        await runCleanup(["sandbox", "delete", name], 60_000);
+        await run(createArgs, 180_000);
+      }
       sandboxCreated = true;
 
       log(

--- a/packages/llm/test/sandbox-launcher.test.ts
+++ b/packages/llm/test/sandbox-launcher.test.ts
@@ -22,10 +22,13 @@ import type { RunWorkflowAgentBackendInput } from "../src/workflows/agent-core";
  */
 const h = vi.hoisted(() => {
   const calls: { args: string[] }[] = [];
-  const state = { holdExec: false };
+  const state = { holdExec: false, collideOnNextCreate: false };
   function spawn(_cmd: string, args: string[]) {
     calls.push({ args });
     const isExec = args.includes("exec");
+    const createCollision =
+      args.includes("create") && state.collideOnNextCreate;
+    if (createCollision) state.collideOnNextCreate = false;
     const reg = (store: Record<string, Array<(...a: unknown[]) => void>>) =>
       (ev: string, cb: (...a: unknown[]) => void) => {
         (store[ev] ??= []).push(cb);
@@ -36,7 +39,11 @@ const h = vi.hoisted(() => {
       ...a: unknown[]
     ) => (store[ev] ?? []).forEach((cb) => cb(...a));
     const ch: Record<string, Array<(...a: unknown[]) => void>> = {};
-    const stderr = Readable.from([]);
+    const stderr = Readable.from(
+      createCollision
+        ? ["Error: × sandbox 'work-run-1' already exists\n"]
+        : [],
+    );
     const lines = isExec
       ? [
           'noise before\n',
@@ -48,7 +55,7 @@ const h = vi.hoisted(() => {
     const closeOnce = () => {
       if (closed) return;
       closed = true;
-      fire(ch, "close", 0);
+      fire(ch, "close", createCollision ? 1 : 0);
     };
     const stdout = Readable.from(lines);
     if (!isExec || !state.holdExec) {
@@ -338,6 +345,7 @@ describe("makeSandboxRunCore", () => {
   beforeEach(() => {
     h.calls.length = 0;
     h.state.holdExec = false;
+    h.state.collideOnNextCreate = false;
     jobCapture.jobs.length = 0;
     jobCapture.policies.length = 0;
   });
@@ -398,6 +406,32 @@ describe("makeSandboxRunCore", () => {
     expect(execCall?.args.join(" ")).toContain("agent-sandbox/entry.ts");
     // the credential alias references the OpenShell-injected var at runtime, never a value:
     expect(execCall?.args.join(" ")).toContain('export GEMINI_API_KEY="$api_key"');
+  });
+
+  it("replaces an orphaned sandbox when a durable retry collides on the run name", async () => {
+    h.state.collideOnNextCreate = true;
+    const runCore = makeSandboxRunCore({
+      agentImage: "ghcr.io/open-neko/agent:test",
+      onLog: () => {},
+    });
+
+    await runCore(fakeInput(async () => {}));
+
+    const lifecycle = h.calls
+      .map((call) =>
+        call.args.find((arg) =>
+          ["create", "exec", "download", "delete"].includes(arg),
+        ),
+      )
+      .filter(Boolean);
+    expect(lifecycle).toEqual([
+      "create",
+      "delete",
+      "create",
+      "exec",
+      "download",
+      "delete",
+    ]);
   });
 
   it("aborts the live exec and deletes the whole sandbox without downloading artifacts", async () => {


### PR DESCRIPTION
## Summary

- detect deterministic OpenShell sandbox-name collisions on durable job retries
- delete only the colliding stale run sandbox and retry creation once
- keep the replacement sandbox under the existing guaranteed cleanup path
- add regression coverage for create, stale delete, recreate, execute, and final delete

## Root cause

A worker deployment can interrupt an active job while OpenShell persists its sandbox. pg-boss retries the same run ID, which reuses the same `job-<run-id>` name. Previously creation failed before `sandboxCreated` was set, so cleanup never ran and every retry collided forever.

## Verification

- `pnpm --filter @neko/worker typecheck`
- `pnpm --filter @neko/llm test` — 559 passed, 122 database-dependent tests skipped
- `git diff --check`