### PR TITLE
fix(records): initialize GraphJin config volume ownership

### DIFF
--- a/apps/openneko/assets/compose/core.yml
+++ b/apps/openneko/assets/compose/core.yml
@@ -154,12 +154,32 @@ services:
       - ${OPENNEKO_HOST_CONFIG_DIR:?OPENNEKO_HOST_CONFIG_DIR is required}:/restore/host-config
       - ${OPENNEKO_BACKUP_REPOSITORY:?OPENNEKO_BACKUP_REPOSITORY is required}:/var/lib/pgbackrest
 
+  # One-shot ownership repair for the generated records config volume. Docker
+  # creates a fresh named volume as root before the non-root worker mounts it;
+  # this also repairs volumes created by an older release during upgrades.
+  records-graphjin-config-init:
+    image: ghcr.io/open-neko/neko-worker:${OPENNEKO_VERSION:-latest}
+    user: "0:0"
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        mkdir -p /config/watch
+        chown -R neko:neko /config
+        chmod 0700 /config /config/watch
+    volumes:
+      - openneko-records-graphjin:/config
+    restart: "no"
+
   # Starts only when a complete generated config exists in its private volume;
   # the image entrypoint exits before binding a port if the config is absent.
   records-graphjin:
     image: ghcr.io/open-neko/records-graphjin:${OPENNEKO_VERSION:-latest}
     restart: unless-stopped
     depends_on:
+      records-graphjin-config-init:
+        condition: service_completed_successfully
       records-db:
         condition: service_healthy
     volumes:
@@ -180,6 +200,8 @@ services:
     image: ghcr.io/open-neko/records-graphjin:${OPENNEKO_VERSION:-latest}
     restart: unless-stopped
     depends_on:
+      records-graphjin-config-init:
+        condition: service_completed_successfully
       records-db:
         condition: service_healthy
     environment:

--- a/apps/openneko/internal/cli/status.go
+++ b/apps/openneko/internal/cli/status.go
@@ -42,12 +42,13 @@ const (
 // missing long-running services drive the verdict. Keep in sync with the
 // `restart: "no"` services in assets/compose/{core,demo,openshell}.yml.
 var oneShotJobs = map[string]bool{
-	"neko-migrate":             true,
-	"adventureworks-init":      true,
-	"graphjin-config-init":     true,
-	"neko-adventureworks-seed": true,
-	"openshell-certgen":        true,
-	"openshell-reg":            true,
+	"neko-migrate":                 true,
+	"adventureworks-init":          true,
+	"graphjin-config-init":         true,
+	"records-graphjin-config-init": true,
+	"neko-adventureworks-seed":     true,
+	"openshell-certgen":            true,
+	"openshell-reg":                true,
 }
 
 func newStatusCmd() *cobra.Command {

--- a/apps/openneko/internal/cli/status_test.go
+++ b/apps/openneko/internal/cli/status_test.go
@@ -19,6 +19,7 @@ func TestClassifyStack(t *testing.T) {
 			{Service: "neko-graphjin", State: "running", Health: "healthy"},
 			{Service: "neko-db", State: "running", Health: "healthy"},
 			{Service: "neko-migrate", State: "exited", ExitCode: 0},
+			{Service: "records-graphjin-config-init", State: "exited", ExitCode: 0},
 		}, serving},
 		{"running without a healthcheck counts as serving", []composeService{
 			{Service: "web", State: "running", Health: ""},

--- a/compose.yml
+++ b/compose.yml
@@ -164,6 +164,26 @@ services:
       - ${OPENNEKO_HOST_CONFIG_DIR:-./.openneko/host-config}:/restore/host-config
       - ${OPENNEKO_BACKUP_REPOSITORY:-./.openneko/backups}:/var/lib/pgbackrest
 
+  # One-shot ownership repair for the generated records config volume. Docker
+  # creates a fresh named volume as root before the non-root worker mounts it;
+  # this also repairs volumes created by an older release during upgrades.
+  records-graphjin-config-init:
+    build:
+      context: .
+      target: worker
+    user: "0:0"
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        mkdir -p /config/watch
+        chown -R neko:neko /config
+        chmod 0700 /config /config/watch
+    volumes:
+      - openneko-records-graphjin:/config
+    restart: "no"
+
   # Dedicated records data plane. Its supervisor stays stopped until the
   # worker has generated a complete, live-catalog-derived RBAC config into the
   # shared volume, and stops again around every schema projection.
@@ -173,6 +193,8 @@ services:
       target: records-graphjin
     restart: unless-stopped
     depends_on:
+      records-graphjin-config-init:
+        condition: service_completed_successfully
       records-db:
         condition: service_healthy
     volumes:
@@ -197,6 +219,8 @@ services:
       target: records-graphjin
     restart: unless-stopped
     depends_on:
+      records-graphjin-config-init:
+        condition: service_completed_successfully
       records-db:
         condition: service_healthy
     environment:


### PR DESCRIPTION
## Summary

- initialize the shared records GraphJin config volume as root before non-root worker startup
- create and secure the dedicated watch config directory
- make both records GraphJin services wait for successful initialization
- classify the initializer as a completed one-shot in `openneko status`

## Root cause

Release v2.23.0 smoke exposed a fresh-volume permission failure: worker UID 1001 crash-looped with `EACCES` creating `/config/records-graphjin/watch`, blocking records GraphJin startup and VM deployment.

## Validation

- source/packaged compose parity tests
- full OpenNeko Go format, vet, test, and build workflow
- fresh named-volume Docker probe: initializer exited 0 and worker UID 1001 wrote both config directories (`1001:999:700`)
- `docker compose config --quiet`