### PR TITLE
fix(records): accept authenticated GraphJin readiness responses

### DIFF
--- a/apps/openneko/assets/compose/core.yml
+++ b/apps/openneko/assets/compose/core.yml
@@ -187,7 +187,10 @@ services:
     expose:
       - "8090"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8090/api/v1/graphql"]
+      # Readiness is the endpoint accepting HTTP, not anonymous GraphQL access.
+      # Generated RBAC may intentionally answer this unauthenticated GET with a
+      # non-2xx status, so do not make curl fail on the response status itself.
+      test: ["CMD", "curl", "-sS", "-o", "/dev/null", "http://127.0.0.1:8090/api/v1/graphql"]
       interval: 10s
       timeout: 3s
       retries: 5
@@ -211,7 +214,9 @@ services:
     expose:
       - "8090"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8090/api/v1/graphql"]
+      # The private watch endpoint likewise rejects unauthenticated GraphQL;
+      # receiving an HTTP response is its readiness signal.
+      test: ["CMD", "curl", "-sS", "-o", "/dev/null", "http://127.0.0.1:8090/api/v1/graphql"]
       interval: 10s
       timeout: 3s
       retries: 5

--- a/apps/openneko/assets/compose_parity_test.go
+++ b/apps/openneko/assets/compose_parity_test.go
@@ -118,6 +118,23 @@ func withoutMount(mounts []string, ignored string) []string {
 	return filtered
 }
 
+func composeHealthcheckTest(t *testing.T, label, serviceName string, service composeParityService) []string {
+	t.Helper()
+	raw, ok := service.Healthcheck["test"].([]any)
+	if !ok {
+		t.Fatalf("%s %s healthcheck test is not a command: %#v", label, serviceName, service.Healthcheck["test"])
+	}
+	command := make([]string, len(raw))
+	for index, value := range raw {
+		argument, ok := value.(string)
+		if !ok {
+			t.Fatalf("%s %s healthcheck argument %d is not a string: %#v", label, serviceName, index, value)
+		}
+		command[index] = argument
+	}
+	return command
+}
+
 func TestSourceAndPackagedComposeStateInventoryMatch(t *testing.T) {
 	rootRaw, err := os.ReadFile("../../../compose.yml")
 	if err != nil {
@@ -167,6 +184,10 @@ func TestRecordsGraphJinEndpointsRemainPrivate(t *testing.T) {
 		"source":   loadComposeParityDocument(t, rootRaw),
 		"packaged": loadComposeParityDocument(t, packagedRaw),
 	} {
+		wantHealthcheck := []string{
+			"CMD", "curl", "-sS", "-o", "/dev/null",
+			"http://127.0.0.1:8090/api/v1/graphql",
+		}
 		for _, serviceName := range []string{"records-graphjin", "records-watch-graphjin"} {
 			service, ok := document.Services[serviceName]
 			if !ok {
@@ -174,6 +195,9 @@ func TestRecordsGraphJinEndpointsRemainPrivate(t *testing.T) {
 			}
 			if len(service.Ports) != 0 {
 				t.Errorf("%s %s must not publish host ports: %v", label, serviceName, service.Ports)
+			}
+			if got := composeHealthcheckTest(t, label, serviceName, service); !reflect.DeepEqual(got, wantHealthcheck) {
+				t.Errorf("%s %s healthcheck must accept an authenticated-error HTTP response as ready:\ngot:  %v\nwant: %v", label, serviceName, got, wantHealthcheck)
 			}
 		}
 	}

--- a/compose.yml
+++ b/compose.yml
@@ -202,7 +202,10 @@ services:
     expose:
       - "8090"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8090/api/v1/graphql"]
+      # Readiness is the endpoint accepting HTTP, not anonymous GraphQL access.
+      # Generated RBAC may intentionally answer this unauthenticated GET with a
+      # non-2xx status, so do not make curl fail on the response status itself.
+      test: ["CMD", "curl", "-sS", "-o", "/dev/null", "http://127.0.0.1:8090/api/v1/graphql"]
       interval: 10s
       timeout: 3s
       retries: 5
@@ -230,7 +233,9 @@ services:
     expose:
       - "8090"
     healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8090/api/v1/graphql"]
+      # The private watch endpoint likewise rejects unauthenticated GraphQL;
+      # receiving an HTTP response is its readiness signal.
+      test: ["CMD", "curl", "-sS", "-o", "/dev/null", "http://127.0.0.1:8090/api/v1/graphql"]
       interval: 10s
       timeout: 3s
       retries: 5


### PR DESCRIPTION
## Summary
- treat an HTTP response from records GraphJin as ready even when generated RBAC rejects the unauthenticated probe
- update both source and packaged production Compose definitions
- pin the intended readiness command in the Compose parity regression test

## Validation
- `docker compose config --quiet`
- `go vet ./...`
- `go test ./... -count=1`
- `go build ./...`
- `go test -tags=integration -count=1 -timeout 10m ./internal/db/...`