### PR TITLE
Fix demo GraphJin authentication defaults

### DIFF
--- a/apps/openneko/assets/compose/demo.yml
+++ b/apps/openneko/assets/compose/demo.yml
@@ -113,6 +113,13 @@ services:
       NEKO_PG_PASSWORD: secret
       NEKO_PG_DATABASE: neko
       ADVENTUREWORKS_GRAPHJIN_ROOT: ${ADVENTUREWORKS_GRAPHJIN_ROOT:-http://graphjin:8080}
+      # This overlay always starts the JWT-protected sources config below, so
+      # seed the matching mode deterministically instead of relying on a
+      # post-start capability probe to discover it.
+      ADVENTUREWORKS_AUTH_MODE: jwt
+      # Reconcile installs whose demo source was seeded by an older release as
+      # anonymous. This only changes a source labelled AdventureWorks.
+      ADVENTUREWORKS_RECONCILE_AUTH_MODE: "1"
     volumes:
       - openneko-config:/config/openneko
     # --import tsx/esm so the seed's `import("@neko/secret-crypt")` (raw .ts
@@ -195,9 +202,14 @@ services:
     depends_on:
       graphjin:
         condition: service_started
+      # The worker patches GraphJin's per-org JWT secret during startup. Wait
+      # for its first provisioning pass before serving the demo UI.
+      worker:
+        condition: service_healthy
     environment:
       # The packaged demo overrides core's neutral config with its
       # AdventureWorks source-mode config in a dedicated volume.
+      OPENNEKO_STACK_MODE: demo
       OPENNEKO_GRAPHJIN_CONFIG: /graphjin-config/agentic.yml
       # Trial default: route every external action (e.g. send_webhook) to
       # the mock adapter so bundled workflows can propose Slack alerts
@@ -211,10 +223,15 @@ services:
     depends_on:
       graphjin:
         condition: service_started
+      # Ensure the known JWT mode is present before the worker provisions its
+      # actor-token config. This also repairs anonymous rows from older demos.
+      neko-adventureworks-seed:
+        condition: service_completed_successfully
     environment:
       NEKO_ACTIONS_DRY_RUN: ${NEKO_ACTIONS_DRY_RUN:-true}
       # Sources mode: the worker substitutes the per-org JWT secret into
       # the seeded GraphJin config at boot (host-provision).
+      OPENNEKO_STACK_MODE: demo
       OPENNEKO_GRAPHJIN_CONFIG: /graphjin-config/agentic.yml
     volumes:
       - graphjin-config:/graphjin-config

--- a/apps/openneko/assets/compose_parity_test.go
+++ b/apps/openneko/assets/compose_parity_test.go
@@ -202,3 +202,44 @@ func TestRecordsGraphJinEndpointsRemainPrivate(t *testing.T) {
 		}
 	}
 }
+
+func TestPackagedDemoBootstrapsJWTBeforeServingWeb(t *testing.T) {
+	raw, err := ComposeFS.ReadFile("compose/demo.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	demo := loadComposeParityDocument(t, raw)
+
+	seed := demo.Services["neko-adventureworks-seed"]
+	if got := seed.Environment["ADVENTUREWORKS_AUTH_MODE"]; got != "jwt" {
+		t.Fatalf("demo seed auth mode = %#v, want jwt", got)
+	}
+	if got := seed.Environment["ADVENTUREWORKS_RECONCILE_AUTH_MODE"]; got != "1" {
+		t.Fatalf("demo auth reconciliation = %#v, want 1", got)
+	}
+
+	worker := demo.Services["worker"]
+	if got := worker.DependsOn["neko-adventureworks-seed"].Condition; got != "service_completed_successfully" {
+		t.Fatalf("worker demo-seed dependency = %q, want service_completed_successfully", got)
+	}
+	web := demo.Services["web"]
+	if got := web.DependsOn["worker"].Condition; got != "service_healthy" {
+		t.Fatalf("web worker dependency = %q, want service_healthy", got)
+	}
+	for _, serviceName := range []string{"web", "worker"} {
+		if got := demo.Services[serviceName].Environment["OPENNEKO_STACK_MODE"]; got != "demo" {
+			t.Fatalf("%s stack mode = %#v, want demo", serviceName, got)
+		}
+	}
+
+	coreRaw, err := ComposeFS.ReadFile("compose/core.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	prod := loadComposeParityDocument(t, coreRaw)
+	for _, serviceName := range []string{"web", "worker"} {
+		if got, exists := prod.Services[serviceName].Environment["OPENNEKO_STACK_MODE"]; exists {
+			t.Fatalf("production %s unexpectedly sets OPENNEKO_STACK_MODE=%#v", serviceName, got)
+		}
+	}
+}

--- a/compose.adventureworks.yml
+++ b/compose.adventureworks.yml
@@ -175,6 +175,9 @@ services:
       NEKO_PG_PASSWORD: secret
       NEKO_PG_DATABASE: neko
       ADVENTUREWORKS_GRAPHJIN_ROOT: ${ADVENTUREWORKS_GRAPHJIN_ROOT:-http://graphjin:8080}
+      # Source checkout intentionally uses the legacy anonymous GraphJin
+      # config above; keep the persisted mode aligned with that server.
+      ADVENTUREWORKS_AUTH_MODE: none
       NO_PROXY: localhost,127.0.0.1,::1,neko-db,worker,web,graphjin,adventureworks-db,host.docker.internal,host.internal
       no_proxy: localhost,127.0.0.1,::1,neko-db,worker,web,graphjin,adventureworks-db,host.docker.internal,host.internal
     volumes:

--- a/packages/db/src/seed-adventureworks.mjs
+++ b/packages/db/src/seed-adventureworks.mjs
@@ -17,6 +17,9 @@ const DEFAULT_GRAPHJIN_ROOT =
   process.env.ADVENTUREWORKS_GRAPHJIN_ROOT?.trim() || "http://graphjin:8080";
 const GRAPHJIN_ROOT = DEFAULT_GRAPHJIN_ROOT.replace(/\/+$/, "");
 const UPDATE_DATA_SOURCE = process.env.ADVENTUREWORKS_UPDATE_DATA_SOURCE === "1";
+const RECONCILE_AUTH_MODE =
+  process.env.ADVENTUREWORKS_RECONCILE_AUTH_MODE === "1";
+const AUTH_MODE = process.env.ADVENTUREWORKS_AUTH_MODE === "jwt" ? "jwt" : "none";
 
 function configBase() {
   const xdg = process.env.XDG_CONFIG_HOME?.trim();
@@ -86,7 +89,11 @@ if (!orgId) {
 }
 
 const sourceRows = await client.query(
-  "select id from data_source where org_id = $1 order by created_at asc limit 1",
+  `select id, label
+     from data_source
+    where org_id = $1
+    order by (label = 'AdventureWorks') desc, created_at asc
+    limit 1`,
   [orgId],
 );
 const graphjinUrls = [
@@ -96,11 +103,14 @@ const graphjinUrls = [
 ];
 if (sourceRows.rowCount === 0) {
   await client.query(
-    `insert into data_source (org_id, kind, graphql_url, subscription_url, mcp_url, label)
-     values ($1, 'graphjin', $2, $3, $4, 'AdventureWorks')`,
-    [orgId, ...graphjinUrls],
+    `insert into data_source (
+       org_id, kind, graphql_url, subscription_url, mcp_url, label, auth_mode
+     ) values ($1, 'graphjin', $2, $3, $4, 'AdventureWorks', $5)`,
+    [orgId, ...graphjinUrls, AUTH_MODE],
   );
-  console.log("[seed-adventureworks] inserted GraphJin data source");
+  console.log(
+    `[seed-adventureworks] inserted GraphJin data source (auth_mode=${AUTH_MODE})`,
+  );
 } else if (UPDATE_DATA_SOURCE) {
   await client.query(
     `update data_source
@@ -108,11 +118,29 @@ if (sourceRows.rowCount === 0) {
            graphql_url = $2,
            subscription_url = $3,
            mcp_url = $4,
-           label = 'AdventureWorks'
+           label = 'AdventureWorks',
+           auth_mode = $5,
+           updated_at = now()
      where id = $1`,
-    [sourceRows.rows[0].id, ...graphjinUrls],
+    [sourceRows.rows[0].id, ...graphjinUrls, AUTH_MODE],
   );
-  console.log(`[seed-adventureworks] updated GraphJin data source to ${GRAPHJIN_ROOT}`);
+  console.log(
+    `[seed-adventureworks] updated GraphJin data source to ${GRAPHJIN_ROOT} (auth_mode=${AUTH_MODE})`,
+  );
+} else if (
+  RECONCILE_AUTH_MODE &&
+  sourceRows.rows[0]?.label === "AdventureWorks"
+) {
+  await client.query(
+    `update data_source
+        set auth_mode = $2,
+            updated_at = now()
+      where id = $1`,
+    [sourceRows.rows[0].id, AUTH_MODE],
+  );
+  console.log(
+    `[seed-adventureworks] reconciled GraphJin data source auth_mode=${AUTH_MODE}`,
+  );
 } else {
   console.log("[seed-adventureworks] data source already exists; leaving it unchanged");
 }

--- a/packages/llm/src/agent-error.ts
+++ b/packages/llm/src/agent-error.ts
@@ -16,6 +16,13 @@ export class UpstreamProviderError extends Error {
   }
 }
 
+export class DataSourceAuthorizationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "DataSourceAuthorizationError";
+  }
+}
+
 const PATTERNS: ReadonlyArray<{
   regex: RegExp;
   kind?: UpstreamProviderErrorKind;
@@ -24,7 +31,7 @@ const PATTERNS: ReadonlyArray<{
   { regex: /Authentication token has expired/i, kind: "auth" },
   { regex: /must authenticate again/i, kind: "auth" },
   { regex: /\bHTTP\s+401\b/i, kind: "auth" },
-  { regex: /\b(?:Unauthorized|invalid[_\s-]*api[_\s-]*key)\b/i, kind: "auth" },
+  { regex: /\binvalid[_\s-]*api[_\s-]*key\b/i, kind: "auth" },
 
   { regex: /Gemini\s+HTTP\s+(5\d{2})\b/i, kind: "5xx", provider: "google-gemini" },
   { regex: /Anthropic\s+HTTP\s+(5\d{2})\b/i, kind: "5xx", provider: "anthropic" },
@@ -39,6 +46,20 @@ function headingFor(kind: UpstreamProviderErrorKind, provider?: string): string 
     return `Provider authentication failed${providerLabel} — re-check the API key in /admin/settings/agent`;
   }
   return `Upstream provider unavailable${providerLabel}`;
+}
+
+export function detectDataSourceAuthorizationError(
+  stdout: string,
+): DataSourceAuthorizationError | null {
+  const head = stdout.slice(0, 1500).trim();
+  if (head.startsWith("{") || head.startsWith("```")) return null;
+  if (!/\b(?:blocked for role|graphjin\b[\s\S]*\bunauthorized)\b/i.test(head)) {
+    return null;
+  }
+  const detail = head.slice(0, 300).replace(/\s+/g, " ").trim();
+  return new DataSourceAuthorizationError(
+    `Data source authorization failed — verify the authentication mode in /admin/settings/data: ${detail}`,
+  );
 }
 
 export function detectUpstreamError(stdout: string): UpstreamProviderError | null {
@@ -57,4 +78,8 @@ export function detectUpstreamError(stdout: string): UpstreamProviderError | nul
     );
   }
   return null;
+}
+
+export function detectAgentExecutionError(stdout: string): Error | null {
+  return detectDataSourceAuthorizationError(stdout) ?? detectUpstreamError(stdout);
 }

--- a/packages/llm/src/agent-validate-loop.ts
+++ b/packages/llm/src/agent-validate-loop.ts
@@ -1,5 +1,5 @@
 import type { AgentBackend } from "./agent-backend";
-import { detectUpstreamError } from "./agent-error";
+import { detectAgentExecutionError } from "./agent-error";
 
 type AgentRunOptions = Parameters<AgentBackend["run"]>[0];
 
@@ -40,8 +40,8 @@ export async function runValidatedAgentTurn<T>(
         result.error ?? `${opts.backend.id} returned status=${result.status}`,
       );
     }
-    const upstream = detectUpstreamError(result.finalText);
-    if (upstream) throw upstream;
+    const executionError = detectAgentExecutionError(result.finalText);
+    if (executionError) throw executionError;
     try {
       return {
         value: opts.validate(result.finalText),

--- a/packages/llm/src/host-provision.ts
+++ b/packages/llm/src/host-provision.ts
@@ -104,6 +104,7 @@ async function provisionGraphJin(orgId: string): Promise<void> {
 const SOURCES_SECRET_PLACEHOLDER = "REPLACE_WITH_PER_ORG_SECRET_B64";
 const SOURCES_JWT_SECRET_RE =
   /(^auth:\s*\n\s+type:\s*jwt\s*\n\s+jwt:\s*\n(?:\s+#.*\n)*\s+secret:\s*")([^"]*)(")/m;
+const LEGACY_PACKAGED_DEMO_GRAPHJIN_CONFIG = "/graphjin-config/agentic.yml";
 
 export function patchGraphjinSourcesJwtSecret(
   raw: string,
@@ -120,6 +121,22 @@ export function patchGraphjinSourcesJwtSecret(
 }
 
 /**
+ * Existing v2.25 demo installs do not carry OPENNEKO_STACK_MODE because their
+ * compose file is embedded in the older host CLI. The dedicated demo mount is
+ * therefore retained as a backward-compatible discriminator. Production uses
+ * /config/graphjin/agentic.yml and must keep its capability-probe behavior.
+ */
+export function shouldReconcileDemoSourceAuthMode(
+  configPath: string | undefined,
+  configContent: string,
+  stackMode?: string,
+): boolean {
+  const isDemo =
+    stackMode === "demo" || configPath === LEGACY_PACKAGED_DEMO_GRAPHJIN_CONFIG;
+  return isDemo && SOURCES_JWT_SECRET_RE.test(configContent);
+}
+
+/**
  * Sources-mode (agentic) bootstrap. Two halves, both idempotent:
  *
  * 1. When the deployment mounts the GraphJin config into the worker
@@ -128,15 +145,16 @@ export function patchGraphjinSourcesJwtSecret(
  *    secret-key. Named local volumes can outlive a secret-key rotation,
  *    so this repairs stale concrete secrets as well as placeholders.
  *
- * 2. Probe the default data source with a minted service token: if the
- *    server answers a gj_catalog query, it runs agentic sources mode —
- *    flip data_source.auth_mode to 'jwt' so GJ4 actor tokens and the
- *    slim catalog knowledge layering switch on automatically. Legacy
- *    servers fail the probe (no gj_catalog root) and stay 'none'.
+ * 2. The packaged demo is known to run this JWT template, so reconcile its
+ *    AdventureWorks row directly (including upgrades driven by the older
+ *    v2.25 CLI). Other modes keep capability detection: probe the default
+ *    source with a service token and only flip auth_mode to 'jwt' when it
+ *    answers gj_catalog. Legacy servers remain 'none'.
  */
 async function provisionGraphjinSourcesMode(orgId: string): Promise<void> {
   const cfgPath = process.env.OPENNEKO_GRAPHJIN_CONFIG?.trim();
   let wroteSecret = false;
+  let reconcileDemoAuthMode = false;
   if (cfgPath) {
     const { readFile } = await import("node:fs/promises");
     try {
@@ -145,6 +163,11 @@ async function provisionGraphjinSourcesMode(orgId: string): Promise<void> {
       const patched = patchGraphjinSourcesJwtSecret(
         raw,
         graphjinSigningSecretB64(orgId),
+      );
+      reconcileDemoAuthMode = shouldReconcileDemoSourceAuthMode(
+        cfgPath,
+        patched.content,
+        process.env.OPENNEKO_STACK_MODE,
       );
       if (patched.changed) {
         await writeFile(cfgPath, patched.content, "utf8");
@@ -167,11 +190,29 @@ async function provisionGraphjinSourcesMode(orgId: string): Promise<void> {
       graphqlUrl: data_source.graphql_url,
     })
     .from(data_source)
-    .where(eq(data_source.org_id, orgId))
+    .where(
+      reconcileDemoAuthMode
+        ? and(
+            eq(data_source.org_id, orgId),
+            eq(data_source.label, "AdventureWorks"),
+          )
+        : eq(data_source.org_id, orgId),
+    )
     .orderBy(desc(data_source.is_default), data_source.created_at)
     .limit(1);
   if (!src?.graphqlUrl) return;
-  if (src.authMode === "jwt" && !wroteSecret) return;
+  let authMode = src.authMode;
+  if (reconcileDemoAuthMode && authMode !== "jwt") {
+    await db()
+      .update(data_source)
+      .set({ auth_mode: "jwt", updated_at: new Date() })
+      .where(eq(data_source.id, src.id));
+    authMode = "jwt";
+    console.log(
+      "[host-provision] reconciled packaged demo data source auth_mode=jwt",
+    );
+  }
+  if (authMode === "jwt" && !wroteSecret) return;
 
   const { mintGraphjinToken } = await import("./graphjin/token");
   const token = mintGraphjinToken({ orgId, userId: null, role: "service" });
@@ -202,7 +243,7 @@ async function provisionGraphjinSourcesMode(orgId: string): Promise<void> {
         const rows = body.data?.gj_catalog;
         const answered = Array.isArray(rows) ? rows.length > 0 : Boolean(rows);
         if (answered && !body.errors?.length) {
-          if (src.authMode !== "jwt") {
+          if (authMode !== "jwt") {
             await db()
               .update(data_source)
               .set({ auth_mode: "jwt", updated_at: new Date() })

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -28,7 +28,10 @@ export {
 } from "./agent-backend-resolver";
 export { cancelAllAgents, registerAgentCanceller } from "./agent-shutdown";
 export {
+  DataSourceAuthorizationError,
   UpstreamProviderError,
+  detectAgentExecutionError,
+  detectDataSourceAuthorizationError,
   detectUpstreamError,
 } from "./agent-error";
 export {

--- a/packages/llm/test/agent-error.test.ts
+++ b/packages/llm/test/agent-error.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import {
+  detectAgentExecutionError,
+  detectDataSourceAuthorizationError,
+  detectUpstreamError,
+} from "../src/agent-error";
+
+describe("detectUpstreamError", () => {
+  it("classifies explicit provider authentication failures", () => {
+    const error = detectUpstreamError("OpenAI HTTP 401: invalid API key");
+
+    expect(error?.kind).toBe("auth");
+    expect(error?.message).toContain("Provider authentication failed");
+  });
+
+  it("does not relabel GraphJin authorization failures as provider auth", () => {
+    const output =
+      "GraphJin query failed: unauthorized: table productcategory is blocked for role anon";
+
+    expect(detectUpstreamError(output)).toBeNull();
+    expect(detectDataSourceAuthorizationError(output)?.message).toContain(
+      "Data source authorization failed",
+    );
+    expect(detectAgentExecutionError(output)?.name).toBe(
+      "DataSourceAuthorizationError",
+    );
+  });
+
+  it("does not classify an unscoped unauthorized message as provider auth", () => {
+    expect(detectUpstreamError("Unauthorized to read the requested table")).toBeNull();
+  });
+});

--- a/packages/llm/test/agent-validate-loop.test.ts
+++ b/packages/llm/test/agent-validate-loop.test.ts
@@ -80,4 +80,20 @@ describe("runValidatedAgentTurn (GJ2)", () => {
     ).rejects.toThrow("boom");
     expect((backend.run as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
   });
+
+  it("reports GraphJin authorization failures as data-source errors", async () => {
+    const { backend } = fakeBackend([
+      "GraphJin query failed: unauthorized: table productcategory is blocked for role anon",
+    ]);
+
+    await expect(
+      runValidatedAgentTurn({
+        backend,
+        run: runOpts,
+        label: "t",
+        validate: (t) => JSON.parse(t),
+      }),
+    ).rejects.toThrow("Data source authorization failed");
+    expect((backend.run as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(1);
+  });
 });

--- a/packages/llm/test/host-provision.test.ts
+++ b/packages/llm/test/host-provision.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir, platform } from "node:os";
 import { join } from "node:path";
 import {
@@ -26,8 +26,10 @@ import {
   hermesHomeForOrg,
   patchGraphjinSourcesJwtSecret,
   provisionHostConfig,
+  shouldReconcileDemoSourceAuthMode,
 } from "../src/host-provision";
 import { ensureOpenShellProvider } from "../src/work/sandbox-launcher";
+import { graphjinSigningSecretB64 } from "../src/graphjin/token";
 
 vi.mock("../src/work/sandbox-launcher", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../src/work/sandbox-launcher")>();
@@ -122,6 +124,50 @@ describe("patchGraphjinSourcesJwtSecret", () => {
       changed: false,
       content: raw,
     });
+  });
+});
+
+describe("shouldReconcileDemoSourceAuthMode", () => {
+  const jwtConfig = `auth:
+  type: jwt
+  jwt:
+    secret: "demo-secret"
+`;
+
+  it("recognizes the mount used by older packaged demo compose files", () => {
+    expect(
+      shouldReconcileDemoSourceAuthMode(
+        "/graphjin-config/agentic.yml",
+        jwtConfig,
+        "",
+      ),
+    ).toBe(true);
+  });
+
+  it("recognizes an explicitly marked demo with a custom config path", () => {
+    expect(
+      shouldReconcileDemoSourceAuthMode("/custom/agentic.yml", jwtConfig, "demo"),
+    ).toBe(true);
+  });
+
+  it("does not reconcile the production GraphJin config", () => {
+    expect(
+      shouldReconcileDemoSourceAuthMode(
+        "/config/graphjin/agentic.yml",
+        jwtConfig,
+        "",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not trust a demo config that is not JWT-enabled", () => {
+    expect(
+      shouldReconcileDemoSourceAuthMode(
+        "/graphjin-config/agentic.yml",
+        "auth:\n  type: none\n",
+        "",
+      ),
+    ).toBe(false);
   });
 });
 
@@ -327,6 +373,39 @@ describeIfDb("provisionHostConfig", () => {
 
   it("does not throw when no data source exists (graphjin write skipped)", async () => {
     await expect(provisionHostConfig(orgId)).resolves.toBeUndefined();
+  });
+
+  it("repairs an existing packaged-demo AdventureWorks source deterministically", async () => {
+    const configPath = join(tempHome, "agentic.yml");
+    await writeFile(
+      configPath,
+      `auth:
+  type: jwt
+  jwt:
+    secret: "${graphjinSigningSecretB64(orgId)}"
+`,
+      "utf8",
+    );
+    await seedDataSource(orgId, { label: "AdventureWorks" });
+
+    const previousPath = process.env.OPENNEKO_GRAPHJIN_CONFIG;
+    const previousMode = process.env.OPENNEKO_STACK_MODE;
+    process.env.OPENNEKO_GRAPHJIN_CONFIG = configPath;
+    process.env.OPENNEKO_STACK_MODE = "demo";
+    try {
+      await provisionHostConfig(orgId);
+    } finally {
+      if (previousPath === undefined) delete process.env.OPENNEKO_GRAPHJIN_CONFIG;
+      else process.env.OPENNEKO_GRAPHJIN_CONFIG = previousPath;
+      if (previousMode === undefined) delete process.env.OPENNEKO_STACK_MODE;
+      else process.env.OPENNEKO_STACK_MODE = previousMode;
+    }
+
+    const [source] = await db()
+      .select({ authMode: data_source.auth_mode })
+      .from(data_source)
+      .where(eq(data_source.org_id, orgId));
+    expect(source?.authMode).toBe("jwt");
   });
 
   it("writes hermes config under ~/.config/openneko/hermes/{orgId} when HERMES_HOME is unset", async () => {


### PR DESCRIPTION
## Summary

- seed and reconcile the packaged AdventureWorks demo with JWT authentication
- let upgraded worker images heal v2.25 demo installs that still use the older embedded Compose file
- sequence demo startup so seeding and worker provisioning complete before the web UI starts
- report GraphJin authorization failures as data-source errors instead of provider API-key failures
- keep production on its existing config path and capability-probe behavior, with no demo reconciliation

## Validation

- pnpm --filter @neko/llm test (616 passed, 128 database-dependent tests skipped)
- worker and web TypeScript checks
- Go asset, CLI, and Compose tests
- effective demo Compose validation
- seed script syntax validation

Fixes #195