### PR TITLE
fix(agent): roll Hermes back to v0.14

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ CMD ["serve"]
 # and lives one layer up in `cli`.
 FROM base AS runtime-base
 ARG GRAPHJIN_VERSION=3.18.42
-ARG HERMES_AGENT_REF=3c27eb6234bf91b8ceee9e9071591b31e9b148cb
+ARG HERMES_AGENT_REF=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 ARG OPENSHELL_VERSION=0.0.54
 # TARGETARCH is auto-supplied by buildx (amd64 or arm64).
 ARG TARGETARCH
@@ -80,34 +80,31 @@ RUN curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/graphjin.tgz
     && rm /tmp/graphjin.tgz \
     && graphjin version
 # hermes: default agent backend (any provider). claude: claude-agent backend.
-# v0.20+ deliberately refuses wheel builds: keep the exact source checkout and
-# use its hash-locked editable environment, matching Hermes' supported install
-# model. `--compile-bytecode` keeps fresh ACP subprocess startup off Python's
-# runtime compilation path (OpenNeko starts one process per run).
-# The immutable runtime cannot self-update. Removing git metadata after the
-# commit assertion keeps background update checks from probing upstream.
+# Temporarily pinned back to v0.14.0: v0.20's native Gemini adapter promotes
+# JSON tool-result strings to structured functionResponse objects, where
+# Gemini 3 interprets JSON-Schema `$ref` values as multimodal part references.
+# v0.14.0 still supports a normal uv tool install. Its MCP adapter uses the
+# Pydantic JSON alias (`isError`) as a Python attribute, so patch that access
+# to the SDK's snake_case field after installation.
 RUN curl -LsSf --retry 5 --retry-delay 5 --retry-all-errors https://astral.sh/uv/install.sh \
-      | env UV_INSTALL_DIR=/usr/local/bin UV_NO_MODIFY_PATH=1 sh \
-    && mkdir -p /usr/local/lib/hermes-agent \
-    && git -C /usr/local/lib/hermes-agent init \
-    && git -C /usr/local/lib/hermes-agent remote add origin https://github.com/NousResearch/hermes-agent.git \
-    && git -C /usr/local/lib/hermes-agent fetch --depth 1 origin "${HERMES_AGENT_REF}" \
-    && git -C /usr/local/lib/hermes-agent checkout --detach FETCH_HEAD \
-    && test "$(git -C /usr/local/lib/hermes-agent rev-parse HEAD)" = "${HERMES_AGENT_REF}" \
-    && UV_PROJECT_ENVIRONMENT=/usr/local/uv/tools/hermes-agent \
+      | env UV_INSTALL_DIR=/usr/local/bin sh -s -- --no-modify-path \
+    && UV_TOOL_DIR=/usr/local/uv/tools \
+       UV_TOOL_BIN_DIR=/usr/local/bin \
        UV_PYTHON_INSTALL_DIR=/usr/local/uv/python \
        UV_CACHE_DIR=/tmp/uv-cache \
-       uv sync --project /usr/local/lib/hermes-agent --python 3.11 \
-         --extra acp --extra mcp --no-dev --locked --compile-bytecode \
-    && ln -s /usr/local/uv/tools/hermes-agent/bin/hermes /usr/local/bin/hermes \
-    && ln -s /usr/local/uv/tools/hermes-agent/bin/hermes-acp /usr/local/bin/hermes-acp \
-    && ln -s /usr/local/uv/tools/hermes-agent/bin/hermes-agent /usr/local/bin/hermes-agent \
+       uv tool install --python 3.11 \
+         --with mcp --with websockets \
+         "hermes-agent[acp] @ git+https://github.com/NousResearch/hermes-agent.git@${HERMES_AGENT_REF}" \
     && rm -rf /tmp/uv-cache /root/.cache/uv \
+    && sed -i 's/result\.isError/result.is_error/g' \
+         /usr/local/uv/tools/hermes-agent/lib/python3.11/site-packages/tools/mcp_tool.py \
+    && ! grep -q 'result\.isError' \
+         /usr/local/uv/tools/hermes-agent/lib/python3.11/site-packages/tools/mcp_tool.py \
     && hermes --version \
-    && /usr/local/uv/tools/hermes-agent/bin/python -c "from mcp.types import CallToolResult; import websockets; result = CallToolResult(content=[]); assert hasattr(result, 'isError')" \
+    && /usr/local/uv/tools/hermes-agent/bin/python -c "import hermes_cli; assert hermes_cli.__version__ == '0.14.0'" \
+    && /usr/local/uv/tools/hermes-agent/bin/python -c "from mcp.types import CallToolResult; import websockets; result = CallToolResult(content=[]); assert hasattr(result, 'is_error')" \
     && /usr/local/uv/tools/hermes-agent/bin/python -c "from acp_adapter.server import HermesACPAgent; import inspect; source = inspect.getsource(HermesACPAgent.prompt); assert 'usage=usage' in source, 'Hermes ACP prompt response must expose exact turn usage'" \
-    && echo "hermes MCP SDK present" \
-    && rm -rf /usr/local/lib/hermes-agent/.git
+    && echo "hermes v0.14 ACP/MCP runtime present"
 RUN npm install -g @anthropic-ai/claude-code
 # openshell: CLI to spawn + relay to agent sandboxes. Static musl, no deps.
 RUN OS_ARCH="$(case "${TARGETARCH}" in amd64) echo x86_64 ;; arm64) echo aarch64 ;; *) echo "${TARGETARCH}" ;; esac)" \

--- a/packages/llm/src/agent-backends/hermes-acp-client.ts
+++ b/packages/llm/src/agent-backends/hermes-acp-client.ts
@@ -1,7 +1,7 @@
 /**
  * Minimal JSON-RPC 2.0 client over a child process's stdio, scoped to the
  * subset of ACP (Agent Client Protocol) that Hermes' `acp` subcommand emits.
- * Frame schema validated against `hermes acp` v2026.8.3 (v0.20.0) —
+ * Frame schema validated against `hermes acp` v2026.5.16 (v0.14.0) —
  * notifications wrap their payload under `params.update` (NOT `params`
  * directly), and the discriminator is `params.update.sessionUpdate`.
  */

--- a/packages/llm/test/hermes-install-contract.test.ts
+++ b/packages/llm/test/hermes-install-contract.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
-const HERMES_REF = "3c27eb6234bf91b8ceee9e9071591b31e9b148cb";
+const HERMES_REF = "a91a57fa5a13d516c38b07a141a9ce8a3daabeb0";
 
 describe("Hermes install contract", () => {
   it("keeps container and local development on the same exact upstream ref", async () => {
@@ -14,32 +14,33 @@ describe("Hermes install contract", () => {
 
     expect(dockerfile).toContain(`ARG HERMES_AGENT_REF=${HERMES_REF}`);
     expect(installer).toContain(`HERMES_AGENT_REF="\${HERMES_AGENT_REF:-${HERMES_REF}}"`);
-    expect(dockerfile).toContain("uv sync --project /usr/local/lib/hermes-agent");
-    expect(installer).toContain('"$hermes_uv" sync --project "$HERMES_AGENT_INSTALL_DIR"');
-    expect(dockerfile).toContain("--extra acp --extra mcp --no-dev --locked");
-    expect(installer).toContain("--extra acp --extra mcp --no-dev --locked");
-    expect(installer).toContain("uv 0.12 or newer");
-    expect(installer).toContain('"$hermes_uv" sync');
+    expect(dockerfile).toContain("uv tool install --python 3.11");
+    expect(installer).toContain("uv tool install --force --python 3.11");
+    expect(dockerfile).toContain("--with mcp --with websockets");
+    expect(installer).toContain("--with mcp --with websockets");
+    expect(dockerfile).not.toContain("uv sync --project /usr/local/lib/hermes-agent");
+    expect(installer).not.toContain("uv 0.12 or newer");
+    expect(dockerfile).toContain("hermes_cli.__version__ == '0.14.0'");
+    expect(installer).toContain("HERMES_AGENT_VERSION=\"0.14.0\"");
   });
 
-  it("uses Hermes' pinned MCP dependency and preserves the SDK's isError field", async () => {
+  it("patches v0.14's MCP adapter for the SDK's snake_case is_error field", async () => {
     const [dockerfile, installer] = await Promise.all([
       readFile(`${REPO_ROOT}Dockerfile`, "utf8"),
       readFile(`${REPO_ROOT}scripts/install-clis.sh`, "utf8"),
     ]);
 
-    expect(dockerfile).not.toContain("uv tool install");
-    expect(dockerfile).not.toContain("--with mcp");
-    expect(dockerfile).not.toContain("result.is_error");
-    expect(dockerfile).toContain("hasattr(result, 'isError')");
+    expect(dockerfile).toContain("result.is_error");
+    expect(installer).toContain("result.is_error");
+    expect(dockerfile).toContain("hasattr(result, 'is_error')");
+    expect(installer).toContain("hasattr(result, 'is_error')");
     expect(dockerfile).toContain("assert 'usage=usage' in source");
     expect(installer).toContain("assert 'usage=usage' in source");
   });
 
-  it("keeps the runtime immutable and disables network-backed lazy installs", async () => {
+  it("disables network-backed lazy installs in the runtime", async () => {
     const dockerfile = await readFile(`${REPO_ROOT}Dockerfile`, "utf8");
 
-    expect(dockerfile).toContain("rm -rf /usr/local/lib/hermes-agent/.git");
     expect(dockerfile).toContain("HERMES_DISABLE_LAZY_INSTALLS=1");
   });
 });

--- a/scripts/install-clis.sh
+++ b/scripts/install-clis.sh
@@ -15,10 +15,9 @@ set -euo pipefail
 
 GRAPHJIN_VERSION="${GRAPHJIN_VERSION:-3.18.42}"
 # Pin Hermes to the same ref baked into the Dockerfile so local-dev installs
-# match what ships in the container image. v2026.8.3 / v0.20.0.
-HERMES_AGENT_REF="${HERMES_AGENT_REF:-3c27eb6234bf91b8ceee9e9071591b31e9b148cb}"
-HERMES_AGENT_INSTALL_DIR="${HERMES_AGENT_INSTALL_DIR:-${HERMES_HOME:-$HOME/.hermes}/hermes-agent}"
-HERMES_UV_INSTALL_DIR="${HERMES_UV_INSTALL_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/openneko/uv}"
+# match what ships in the container image. v2026.5.16 / v0.14.0.
+HERMES_AGENT_REF="${HERMES_AGENT_REF:-a91a57fa5a13d516c38b07a141a9ce8a3daabeb0}"
+HERMES_AGENT_VERSION="0.14.0"
 
 SKIP_GRAPHJIN=false
 SKIP_CLAUDE=false
@@ -36,24 +35,6 @@ done
 
 log() { printf '\033[1;36m==>\033[0m %s\n' "$*"; }
 have() { command -v "$1" >/dev/null 2>&1; }
-
-# Hermes v0.20's uv configuration requires the newer resolver/config parser.
-# uv 0.4 (still common in older Homebrew installations) ignores part of the
-# project config and cannot resolve the locked environment.
-uv_supports_hermes() {
-  uv_candidate="$1"
-  [ -x "$uv_candidate" ] || return 1
-  uv_version="$("$uv_candidate" --version 2>/dev/null | awk '{print $2}')"
-  uv_major="${uv_version%%.*}"
-  uv_remainder="${uv_version#*.}"
-  uv_minor="${uv_remainder%%.*}"
-  case "$uv_major:$uv_minor" in
-    *[!0-9:]*|:|*:)
-      return 1
-      ;;
-  esac
-  [ "$uv_major" -gt 0 ] || [ "$uv_minor" -ge 12 ]
-}
 
 uname_s=$(uname -s)
 case "$uname_s" in
@@ -100,83 +81,59 @@ if ! $SKIP_CLAUDE && ! have claude; then
 fi
 
 # ─── hermes (Nous Research) ────────────────────────────────────────────
-# Hermes is a Python tool installed from its source checkout via uv. Needs
-# Python 3.11+ + git. v0.20+ refuses wheel builds, so keep the exact checkout
-# and use its locked editable environment, matching the supported upstream
-# install model and the Dockerfile. Do not accept an arbitrary existing
-# `hermes`: that silently made local development exercise a different ACP
-# contract than production.
-hermes_matches_ref() {
-  [ -x "$HERMES_AGENT_INSTALL_DIR/venv/bin/hermes" ] \
-    && [ -d "$HERMES_AGENT_INSTALL_DIR/.git" ] \
-    && [ "$(git -C "$HERMES_AGENT_INSTALL_DIR" rev-parse HEAD 2>/dev/null)" = "$HERMES_AGENT_REF" ] \
-    && have hermes \
-    && [ "$(command -v hermes)" -ef "$HERMES_AGENT_INSTALL_DIR/venv/bin/hermes" ]
+# Hermes v0.14.0 supports a normal uv tool install. Check the active executable
+# so running this installer also replaces an existing v0.20 installation.
+hermes_matches_version() {
+  have hermes && hermes --version 2>/dev/null | grep -Eq '(^|[^0-9])0\.14\.0([^0-9]|$)'
 }
 
-if ! $SKIP_HERMES && ! hermes_matches_ref; then
+if ! $SKIP_HERMES && ! hermes_matches_version; then
   log "installing hermes (Nous Research) @ ${HERMES_AGENT_REF:0:8}"
   if [ "$os" = linux ] && have apt-get; then
     sudo apt-get update -qq
     sudo apt-get install -y -qq python3 python3-venv python3-dev libffi-dev git build-essential ripgrep ffmpeg
   fi
-  hermes_uv=""
-  if have uv && uv_supports_hermes "$(command -v uv)"; then
-    hermes_uv="$(command -v uv)"
-  elif uv_supports_hermes "$HERMES_UV_INSTALL_DIR/uv"; then
-    hermes_uv="$HERMES_UV_INSTALL_DIR/uv"
-  else
-    log "installing current uv for Hermes (uv 0.12+ required)"
-    mkdir -p "$HERMES_UV_INSTALL_DIR"
-    curl -LsSf --retry 5 --retry-delay 5 --retry-all-errors https://astral.sh/uv/install.sh \
-      | env UV_INSTALL_DIR="$HERMES_UV_INSTALL_DIR" UV_NO_MODIFY_PATH=1 sh
-    hermes_uv="$HERMES_UV_INSTALL_DIR/uv"
-    if ! uv_supports_hermes "$hermes_uv"; then
-      echo "Hermes requires uv 0.12 or newer; installed binary is incompatible" >&2
-      exit 1
+  if ! have uv; then
+    log "installing uv"
+    if [ "$os" = macos ] && have brew; then
+      brew install uv
+    else
+      curl -LsSf https://astral.sh/uv/install.sh | sudo env UV_INSTALL_DIR=/usr/local/bin sh -s -- --no-modify-path
     fi
   fi
-  if [ -e "$HERMES_AGENT_INSTALL_DIR" ] && [ ! -d "$HERMES_AGENT_INSTALL_DIR/.git" ]; then
-    echo "hermes install path exists but is not a git checkout: $HERMES_AGENT_INSTALL_DIR" >&2
-    exit 1
-  fi
-  if [ -d "$HERMES_AGENT_INSTALL_DIR/.git" ] \
-    && ! git -C "$HERMES_AGENT_INSTALL_DIR" diff --quiet --ignore-submodules --; then
-    echo "hermes checkout has local changes; refusing to overwrite: $HERMES_AGENT_INSTALL_DIR" >&2
-    exit 1
-  fi
-  if [ ! -d "$HERMES_AGENT_INSTALL_DIR/.git" ]; then
-    mkdir -p "$HERMES_AGENT_INSTALL_DIR"
-    git -C "$HERMES_AGENT_INSTALL_DIR" init
-    git -C "$HERMES_AGENT_INSTALL_DIR" remote add origin https://github.com/NousResearch/hermes-agent.git
-  fi
-  git -C "$HERMES_AGENT_INSTALL_DIR" fetch --depth 1 origin "$HERMES_AGENT_REF"
-  git -C "$HERMES_AGENT_INSTALL_DIR" checkout --detach FETCH_HEAD
-  if [ "$(git -C "$HERMES_AGENT_INSTALL_DIR" rev-parse HEAD)" != "$HERMES_AGENT_REF" ]; then
-    echo "hermes checkout did not resolve expected ref $HERMES_AGENT_REF" >&2
-    exit 1
-  fi
 
-  UV_PROJECT_ENVIRONMENT="$HERMES_AGENT_INSTALL_DIR/venv" \
-    "$hermes_uv" sync --project "$HERMES_AGENT_INSTALL_DIR" --python 3.11 \
-      --extra acp --extra mcp --no-dev --locked --compile-bytecode
+  uv tool install --force --python 3.11 \
+    --with mcp --with websockets \
+    "hermes-agent[acp] @ git+https://github.com/NousResearch/hermes-agent.git@${HERMES_AGENT_REF}"
 
-  hermes_bin_dir="$($hermes_uv tool dir --bin)"
-  mkdir -p "$hermes_bin_dir"
-  ln -sf "$HERMES_AGENT_INSTALL_DIR/venv/bin/hermes" "$hermes_bin_dir/hermes"
-  ln -sf "$HERMES_AGENT_INSTALL_DIR/venv/bin/hermes-acp" "$hermes_bin_dir/hermes-acp"
-  ln -sf "$HERMES_AGENT_INSTALL_DIR/venv/bin/hermes-agent" "$hermes_bin_dir/hermes-agent"
+  hermes_tool_root="$(uv tool dir)/hermes-agent"
+  hermes_python="$hermes_tool_root/bin/python"
+  hermes_mcp_tool="$hermes_tool_root/lib/python3.11/site-packages/tools/mcp_tool.py"
+  if [ ! -f "$hermes_mcp_tool" ]; then
+    echo "hermes v${HERMES_AGENT_VERSION} MCP adapter was not installed at $hermes_mcp_tool" >&2
+    exit 1
+  fi
+  if grep -q 'result\.isError' "$hermes_mcp_tool"; then
+    sed -i.bak 's/result\.isError/result.is_error/g' "$hermes_mcp_tool"
+    rm -f "$hermes_mcp_tool.bak"
+  fi
+  if grep -q 'result\.isError' "$hermes_mcp_tool"; then
+    echo "hermes v${HERMES_AGENT_VERSION} MCP adapter compatibility patch failed" >&2
+    exit 1
+  fi
   hash -r
-  if ! hermes_matches_ref; then
-    echo "hermes install completed but expected ref ${HERMES_AGENT_REF:0:8} is not active on PATH" >&2
+  if ! hermes_matches_version; then
+    echo "hermes install completed but v${HERMES_AGENT_VERSION} is not active on PATH" >&2
     exit 1
   fi
-  "$HERMES_AGENT_INSTALL_DIR/venv/bin/python" -c \
-    "from mcp.types import CallToolResult; result = CallToolResult(content=[]); assert hasattr(result, 'isError')"
-  "$HERMES_AGENT_INSTALL_DIR/venv/bin/python" -c \
+  "$hermes_python" -c \
+    "import hermes_cli; assert hermes_cli.__version__ == '${HERMES_AGENT_VERSION}'"
+  "$hermes_python" -c \
+    "from mcp.types import CallToolResult; result = CallToolResult(content=[]); assert hasattr(result, 'is_error')"
+  "$hermes_python" -c \
     "from acp_adapter.server import HermesACPAgent; import inspect; source = inspect.getsource(HermesACPAgent.prompt); assert 'usage=usage' in source, 'Hermes ACP prompt response must expose exact turn usage'"
 elif ! $SKIP_HERMES; then
-  log "hermes already matches ${HERMES_AGENT_REF:0:8}"
+  log "hermes already matches v${HERMES_AGENT_VERSION}"
 fi
 
 log "done. installed:"


### PR DESCRIPTION
## Summary

- pin Hermes Agent to v0.14.0 (`a91a57fa5a13d516c38b07a141a9ce8a3daabeb0`) in the container and local CLI installer
- restore the v0.14 `uv tool install` path and MCP `isError`/`is_error` compatibility patch
- keep the newer OpenNeko MCP routing and other post-upgrade changes intact

## Why

Hermes v0.20 promotes Gemini tool-result JSON into native `functionResponse` parts. Gemini can then interpret JSON Schema references such as `#/$defs/components` as multimodal part references and reject the request with HTTP 400 `INVALID_ARGUMENT`. This temporarily restores the previously working v0.14 runtime while the adapter incompatibility is addressed upstream.

## Validation

- clean isolated installation of the pinned Git ref reports Hermes Agent v0.14.0
- verified ACP exact-usage support and the MCP adapter patch against the current resolver
- `pnpm --filter @neko/llm test`: 608 passed, 127 integration tests skipped because Postgres was unavailable
- `bash -n scripts/install-clis.sh` and `shellcheck scripts/install-clis.sh`