### PR TITLE
fix(ci): harden release recovery builds

### DIFF
--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Resolve release tag + build outcome
         id: ctx
+        env:
+          UPSTREAM_EVENT: ${{ github.event.workflow_run.event }}
+          UPSTREAM_TITLE: ${{ github.event.workflow_run.display_title }}
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
@@ -41,11 +44,25 @@ jobs:
             echo "build_ok=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # The binaries workflow runs on tag push, so its head_branch IS the
-          # tag. Don't resolve via the releases API: release-please pins
+          # Manual release recoveries run from a fix branch, so head_branch is
+          # not the image tag. The release workflow carries its requested tag
+          # in run-name for this downstream workflow to recover explicitly.
+          if [ "$UPSTREAM_EVENT" = "workflow_dispatch" ]; then
+            run_title_pattern='^openneko release binaries \(([^)]+)\)$'
+            if [[ "$UPSTREAM_TITLE" =~ $run_title_pattern ]]; then
+              tag="${BASH_REMATCH[1]}"
+            else
+              echo "::error::unable to resolve release tag from upstream run title: $UPSTREAM_TITLE"
+              exit 1
+            fi
+          else
+            # Tag-triggered release runs expose their tag as head_branch.
+            tag="${{ github.event.workflow_run.head_branch }}"
+          fi
+          # Release-triggered binary runs expose the tag as head_branch. Don't
+          # resolve via the releases API: release-please pins
           # target_commitish to a SHA, so filtering on "main" matches only
           # stale hand-made prereleases (this froze the smoke on v1.18.0-openshell.4).
-          tag="${{ github.event.workflow_run.head_branch }}"
           echo "tag=${tag:-}" >> "$GITHUB_OUTPUT"
           # Only gate stable releases — a '-' marks a prerelease, which is never "Latest".
           case "${tag:-}" in *-* | "") echo "stable=false" ;; *) echo "stable=true" ;; esac >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -1,4 +1,5 @@
 name: openneko release binaries
+run-name: openneko release binaries (${{ github.event.inputs.tag || github.event.release.tag_name }})
 
 on:
   release:
@@ -28,8 +29,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
-      # The build downloads several GitHub-hosted release assets. Keeping the
-      # fan-out bounded avoids secondary-rate-limit and release-CDN 503s.
+      # Four concurrent builders keeps release throughput reasonable while
+      # bounding pressure on GHCR and the Actions cache service.
       max-parallel: 4
       matrix:
         include:

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       # The build downloads several GitHub-hosted release assets. Keeping the
       # fan-out bounded avoids secondary-rate-limit and release-CDN 503s.
-      max-parallel: 2
+      max-parallel: 4
       matrix:
         include:
           - image: neko-web

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -28,6 +28,9 @@ jobs:
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
+      # The build downloads several GitHub-hosted release assets. Keeping the
+      # fan-out bounded avoids secondary-rate-limit and release-CDN 503s.
+      max-parallel: 2
       matrix:
         include:
           - image: neko-web
@@ -117,7 +120,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.inputs.tag || github.event.release.tag_name }}
+          # Manual recovery runs may contain CI hardening newer than the tag;
+          # release events continue to build the immutable tagged source.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.ref || github.event.release.tag_name }}
 
       - name: Resolve release tag
         id: tag
@@ -147,7 +152,9 @@ jobs:
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=ghcr.io/open-neko/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ matrix.image }}-${{ steps.archkey.outputs.value }}
-          cache-to: type=gha,scope=${{ matrix.image }}-${{ steps.archkey.outputs.value }},mode=max
+          # Cache service outages must not invalidate an image already pushed
+          # successfully to GHCR.
+          cache-to: type=gha,scope=${{ matrix.image }}-${{ steps.archkey.outputs.value }},mode=max,ignore-error=true
 
       - name: Stash digest for the merge step
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       git unzip postgresql-client openssh-client \
     && rm -rf /var/lib/apt/lists/*
 # graphjin: every in-process agent turn queries the data source via `graphjin cli`.
-RUN curl -fsSL --retry 5 --retry-delay 5 --retry-all-errors -o /tmp/graphjin.tgz \
+RUN curl -fsSL --retry 10 --retry-delay 5 --retry-all-errors -o /tmp/graphjin.tgz \
       "https://github.com/dosco/graphjin/releases/download/v${GRAPHJIN_VERSION}/graphjin_${GRAPHJIN_VERSION}_linux_${TARGETARCH}.tar.gz" \
     && tar -xzf /tmp/graphjin.tgz -C /usr/local/bin graphjin \
     && rm /tmp/graphjin.tgz \
@@ -108,7 +108,7 @@ RUN curl -LsSf --retry 5 --retry-delay 5 --retry-all-errors https://astral.sh/uv
 RUN npm install -g @anthropic-ai/claude-code
 # openshell: CLI to spawn + relay to agent sandboxes. Static musl, no deps.
 RUN OS_ARCH="$(case "${TARGETARCH}" in amd64) echo x86_64 ;; arm64) echo aarch64 ;; *) echo "${TARGETARCH}" ;; esac)" \
-    && curl -fsSL -o /tmp/openshell.tgz \
+    && curl -fsSL --retry 10 --retry-delay 5 --retry-all-errors -o /tmp/openshell.tgz \
       "https://github.com/NVIDIA/OpenShell/releases/download/v${OPENSHELL_VERSION}/openshell-${OS_ARCH}-unknown-linux-musl.tar.gz" \
     && tar -xzf /tmp/openshell.tgz -C /usr/local/bin openshell \
     && rm /tmp/openshell.tgz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,8 +62,12 @@ CMD ["serve"]
 # and lives one layer up in `cli`.
 FROM base AS runtime-base
 ARG GRAPHJIN_VERSION=3.18.42
+ARG GRAPHJIN_ASSET_AMD64=470534811
+ARG GRAPHJIN_ASSET_ARM64=470534772
 ARG HERMES_AGENT_REF=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 ARG OPENSHELL_VERSION=0.0.54
+ARG OPENSHELL_ASSET_AMD64=436365845
+ARG OPENSHELL_ASSET_ARM64=436365844
 # TARGETARCH is auto-supplied by buildx (amd64 or arm64).
 ARG TARGETARCH
 # unzip + postgresql-client: db/load-adventureworks-baked.sh (demo seed, runs in
@@ -74,8 +78,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       git unzip postgresql-client openssh-client \
     && rm -rf /var/lib/apt/lists/*
 # graphjin: every in-process agent turn queries the data source via `graphjin cli`.
-RUN curl -fsSL --retry 10 --retry-delay 5 --retry-all-errors -o /tmp/graphjin.tgz \
-      "https://github.com/dosco/graphjin/releases/download/v${GRAPHJIN_VERSION}/graphjin_${GRAPHJIN_VERSION}_linux_${TARGETARCH}.tar.gz" \
+# Asset IDs are the immutable v${GRAPHJIN_VERSION} linux tarballs; the API
+# endpoint avoids transient failures from GitHub's browser-download CDN.
+RUN GRAPHJIN_ASSET_ID="$(case "${TARGETARCH}" in amd64) echo "${GRAPHJIN_ASSET_AMD64}" ;; arm64) echo "${GRAPHJIN_ASSET_ARM64}" ;; *) exit 1 ;; esac)" \
+    && curl -fsSL --retry 10 --retry-delay 5 --retry-all-errors \
+      -H 'Accept: application/octet-stream' -o /tmp/graphjin.tgz \
+      "https://api.github.com/repos/dosco/graphjin/releases/assets/${GRAPHJIN_ASSET_ID}" \
     && tar -xzf /tmp/graphjin.tgz -C /usr/local/bin graphjin \
     && rm /tmp/graphjin.tgz \
     && graphjin version
@@ -107,9 +115,10 @@ RUN curl -LsSf --retry 5 --retry-delay 5 --retry-all-errors https://astral.sh/uv
     && echo "hermes v0.14 ACP/MCP runtime present"
 RUN npm install -g @anthropic-ai/claude-code
 # openshell: CLI to spawn + relay to agent sandboxes. Static musl, no deps.
-RUN OS_ARCH="$(case "${TARGETARCH}" in amd64) echo x86_64 ;; arm64) echo aarch64 ;; *) echo "${TARGETARCH}" ;; esac)" \
+RUN OPENSHELL_ASSET_ID="$(case "${TARGETARCH}" in amd64) echo "${OPENSHELL_ASSET_AMD64}" ;; arm64) echo "${OPENSHELL_ASSET_ARM64}" ;; *) exit 1 ;; esac)" \
     && curl -fsSL --retry 10 --retry-delay 5 --retry-all-errors -o /tmp/openshell.tgz \
-      "https://github.com/NVIDIA/OpenShell/releases/download/v${OPENSHELL_VERSION}/openshell-${OS_ARCH}-unknown-linux-musl.tar.gz" \
+      -H 'Accept: application/octet-stream' \
+      "https://api.github.com/repos/NVIDIA/OpenShell/releases/assets/${OPENSHELL_ASSET_ID}" \
     && tar -xzf /tmp/openshell.tgz -C /usr/local/bin openshell \
     && rm /tmp/openshell.tgz \
     && openshell --version


### PR DESCRIPTION
## Summary
- fetch pinned GraphJin and OpenShell archives through GitHub release asset API endpoints to bypass browser-download CDN failures
- tolerate Actions cache export failures and allow four concurrent image builds
- preserve the requested release tag across manually dispatched recovery builds so smoke and VM deploy chain correctly

## Validation
- recovery release run 31632419828 completed successfully: 20 architecture image builds, 10 multi-arch manifests, and GoReleaser
- explicit v2.25.2 production smoke run 31633913800 passed
- VM deploy run 31634196295 passed; CLI updated from 2.25.1 to v2.25.2, stack reported serving, HTTP smoke returned 200
- workflow YAML parses and shell tag-resolution cases pass
- `docker buildx build --check .` passed