### PR TITLE
feat: SSO setup wizard + deployment-scoped Scalekit workspace connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,9 @@ design-preview/
 # the operator's installed plugins; not part of the source tree.
 openneko.plugins.json
 apps/*/openneko.plugins.json
+
+# Local dev bring-up artifacts (source checkout with a host worker):
+# plugin install dir, records-config bind mounts, and dev-only compose overrides
+.local/
+dev-volumes/
+compose.dev-overrides.yml

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -9,8 +9,8 @@ Every plugin runs inside an OpenShell sandbox with outbound network limited to i
 Any combination of:
 
 - **`action`** — typed handlers the agent invokes (e.g. Slack's `send_slack_message`).
-- **`auth`** — singleton SSO provider for the deployment (e.g. Scalekit). Lights up "Sign in with X" on `/signin`.
-- **`connect`** — per-operator OAuth (e.g. Google Workspace). Operators authorise their own account at `/integrations`; the worker injects the right credential per invocation.
+- **`auth`** — singleton SSO provider for the deployment (e.g. Scalekit). Lights up "Sign in with X" on `/signin`. The login gate engages only once the plugin's sign-in credentials are configured — until then the deployment stays in single-operator mode.
+- **`connect`** — OAuth for account-level integrations. Two credential scopes: `operator` (e.g. Google Workspace — each operator authorises their own account at `/integrations`) and `deployment` (e.g. Scalekit workspace — one admin consents once and the org-wide token backs every call, stored under a reserved secrets slot). The `mcp-oauth` flow drives MCP-OAuth-2.1 endpoints (resource/AS discovery + dynamic client registration + PKCE) with the in-flight state bridged through an `oauthState` echo.
 
 ## Installing
 
@@ -79,7 +79,7 @@ Flipping a switch off flags pre-existing installs — not yanked — so the regi
 
 ## Per-operator integrations (`/integrations`)
 
-Plugins with `connect` (Google Workspace today) authorise per-operator OAuth. Each operator visits `/integrations`, clicks **Connect**, runs OAuth in their browser, and their tokens land in their secrets slot. The worker injects the right operator's credential per invocation. Disconnect wipes the credential. Refresh-token rotation happens inside the plugin sandbox and gets persisted by the worker.
+Plugins with `connect` authorise OAuth. Operator-scoped connectors (Google Workspace today): each operator visits `/integrations`, clicks **Connect**, runs OAuth in their browser, and their tokens land in their secrets slot. Deployment-scoped connectors (Scalekit workspace): an admin authorises once at `/integrations` or from the SSO setup page; the credential lands in the reserved deployment slot and is injected on every tool call, pre-refreshed near expiry. Disconnect wipes the credential. Refresh-token rotation happens inside the plugin sandbox and gets persisted by the worker.
 
 ## Host support
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Apache-2.0 core, self-hosted, single Postgres. Take a backup, take it with you.
 
 ## Plugins
 
-Add new action kinds with sandboxed plugins — web search, Slack, Gmail, Shopify, Sheets, Telegram, and more.
+Add new action kinds with sandboxed plugins — web search, Slack, Gmail, Shopify, Sheets, Telegram, and more. Enterprise SSO comes from the Scalekit plugin: install it, authorize the workspace from **Admin → Settings → Single sign-on** (a guided checklist), and every Scalekit-backed IdP (Okta, Entra ID, Google Workspace…) lights up — plus the agent gains 35 workspace-management tools.
 
 - **Every plugin runs in an isolated microVM**, with outbound network limited to what its manifest declares.
 - **Secrets are scoped per plugin** and never reach the model context.
@@ -70,7 +70,7 @@ Add new action kinds with sandboxed plugins — web search, Slack, Gmail, Shopif
 Browse the [marketplace](https://open-neko.github.io/plugins/) · capability model, install policy, and host support in **[PLUGINS.md](PLUGINS.md)**.
 
 ```bash
-openneko install @open-neko/plugin-parallel-search
+openneko install @open-neko/plugin-scalekit
 ```
 
 ## Under the hood

--- a/apps/openneko/assets/migrations/0055_sso_setup.sql
+++ b/apps/openneko/assets/migrations/0055_sso_setup.sql
@@ -1,0 +1,38 @@
+-- SSO setup state machine + configurable group→role/persona mapping.
+--
+-- sso_setup tracks the one-time Scalekit/IdP admin flow: the agent (or the
+-- /settings/sso page) generates an admin portal link, the operator configures
+-- the downstream IdP, and a poller reads connection state back until the
+-- connection reports COMPLETED. One row per org (single-tenant today).
+--
+-- sso_group_mapping lets the operator override the default admin/admins/owners
+-- heuristic: a matched group drives app_user.role and the auto-provisioned
+-- per-user persona.
+
+create table if not exists sso_setup (
+  org_id text primary key references organization(id) on delete cascade,
+  status text not null default 'not_started',
+  portal_link text,
+  portal_link_expires_at timestamptz,
+  provider text,
+  last_polled_at timestamptz,
+  last_error text,
+  setup_completed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint sso_setup_status_check check (
+    status in ('not_started', 'awaiting_portal', 'polling', 'connected', 'failed')
+  )
+);
+
+create table if not exists sso_group_mapping (
+  org_id text not null references organization(id) on delete cascade,
+  provider text not null,
+  group_external_id text not null,
+  role text not null,
+  persona_role_template text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (org_id, provider, group_external_id),
+  constraint sso_group_mapping_role_check check (role in ('admin', 'member'))
+);

--- a/apps/openneko/assets/migrations/0056_sso_setup_scalekit_ids.sql
+++ b/apps/openneko/assets/migrations/0056_sso_setup_scalekit_ids.sql
@@ -1,0 +1,8 @@
+-- SSO setup gains the active Scalekit environment/organization identity
+-- (Dev by default; Prod is an explicit opt-in later). Kept on sso_setup so
+-- the poller + settings page agree on which environment they operate on.
+
+alter table if exists sso_setup
+  add column if not exists scalekit_environment_id text,
+  add column if not exists scalekit_organization_id text,
+  add column if not exists scalekit_environment_tier text;

--- a/apps/openneko/internal/plugin/install/install.go
+++ b/apps/openneko/internal/plugin/install/install.go
@@ -546,9 +546,10 @@ func convertCapabilities(c marketplace.Capabilities) manifest.Capabilities {
 	}
 	if c.Connect != nil {
 		out.Connect = &manifest.ConnectCapability{
-			ProviderLabel: c.Connect.ProviderLabel,
-			Scopes:        c.Connect.Scopes,
-			Flow:          c.Connect.Flow,
+			ProviderLabel:   c.Connect.ProviderLabel,
+			Scopes:          c.Connect.Scopes,
+			Flow:            c.Connect.Flow,
+			CredentialScope: c.Connect.CredentialScope,
 		}
 	}
 	if c.Channel != nil {

--- a/apps/openneko/internal/plugin/manifest/manifest.go
+++ b/apps/openneko/internal/plugin/manifest/manifest.go
@@ -46,6 +46,9 @@ type ConnectCapability struct {
 	ProviderLabel string   `json:"providerLabel"`
 	Scopes        []string `json:"scopes"`
 	Flow          string   `json:"flow,omitempty"`
+	// Deployment-scoped connectors store one org-wide credential under a
+	// reserved secrets slot instead of per-operator (mcp-oauth connectors).
+	CredentialScope string `json:"credentialScope,omitempty"`
 }
 
 // ChannelCapability — the plugin is a frontend (Slack, Telegram, voice, …).

--- a/apps/openneko/internal/plugin/marketplace/client.go
+++ b/apps/openneko/internal/plugin/marketplace/client.go
@@ -44,6 +44,10 @@ type ConnectCapability struct {
 	ProviderLabel string   `json:"providerLabel"`
 	Scopes        []string `json:"scopes"`
 	Flow          string   `json:"flow,omitempty"`
+	// Deployment-scoped connectors store one org-wide credential under a
+	// reserved secrets slot instead of per-operator. Introduced with the
+	// mcp-oauth flow (Scalekit workspace); default "operator" when absent.
+	CredentialScope string `json:"credentialScope,omitempty"`
 }
 
 // ChannelCapability — a frontend (Slack, Telegram, voice, …). Profile is

--- a/apps/web/src/app/admin/settings/page.tsx
+++ b/apps/web/src/app/admin/settings/page.tsx
@@ -138,6 +138,11 @@ export default async function SettingsPage() {
     },
   ];
   cards.push({
+    href: "/admin/settings/sso",
+    title: "Single sign-on",
+    copy: "Connect your IdP (Okta, Entra ID, and others) through Scalekit and map groups to roles.",
+  });
+  cards.push({
     href: "/admin/settings/security",
     title: "Security",
     copy: "Trust floor for plugin and skill installs — which marketplaces are allowed, whether unverified or community installs are permitted.",

--- a/apps/web/src/app/admin/settings/sso/SsoSetupForm.tsx
+++ b/apps/web/src/app/admin/settings/sso/SsoSetupForm.tsx
@@ -1,0 +1,666 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import AppHeader from "@/components/AppHeader";
+import CreatorCredit from "@/components/CreatorCredit";
+import PageHeading from "@/components/PageHeading";
+import SectionNav from "@/components/SectionNav";
+import { Button } from "@/components/ui/Button";
+import type {
+  SsoEnvironmentRow,
+  SsoOrganizationRow,
+  SsoSetupStatus,
+  SsoSetupStatusResult,
+} from "@/lib/sso-setup";
+
+const STATUS_LABEL: Record<SsoSetupStatus, string> = {
+  not_started: "Not started",
+  awaiting_portal: "Waiting for the IdP",
+  polling: "Checking the connection",
+  connected: "Connected",
+  failed: "Failed",
+};
+
+const HELP_CLS = "text-[13px] text-text3 leading-[1.45]";
+const INPUT_CLS =
+  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-[15px] font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
+
+function StepHeader({
+  step,
+  done,
+  title,
+}: {
+  step: number;
+  done: boolean;
+  title: string;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      {done ? (
+        <span
+          className="flex items-center justify-center w-5 h-5 rounded-full bg-accent text-bg text-[11px] font-bold"
+          aria-label="done"
+        >
+          ✓
+        </span>
+      ) : (
+        <span className="flex items-center justify-center w-5 h-5 rounded-full border-[1.5px] border-border text-text3 text-[11px] font-semibold">
+          {step}
+        </span>
+      )}
+      <span className="text-[14px] font-semibold text-text">{title}</span>
+      {done ? (
+        <span className="text-[11px] font-semibold text-accent">Done</span>
+      ) : null}
+    </div>
+  );
+}
+
+export default function SsoSetupForm({
+  initial,
+  loadError,
+  workspaceConnected,
+}: {
+  initial: SsoSetupStatusResult | null;
+  loadError: string | null;
+  workspaceConnected: boolean;
+}) {
+  const [status, setStatus] = useState<SsoSetupStatusResult | null>(initial);
+  const [environmentId, setEnvironmentId] = useState(
+    initial?.environmentId ?? "",
+  );
+  const [organizationId, setOrganizationId] = useState(
+    initial?.organizationId ?? "",
+  );
+  const [tier, setTier] = useState<string>(initial?.environmentTier ?? "dev");
+  const [envOptions, setEnvOptions] = useState<SsoEnvironmentRow[]>([]);
+  const [orgOptions, setOrgOptions] = useState<SsoOrganizationRow[]>([]);
+  const [pickerBusy, setPickerBusy] = useState(false);
+  const [editingStep, setEditingStep] = useState<number | null>(null);
+  const [environmentUrl, setEnvironmentUrl] = useState("");
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [generating, setGenerating] = useState(false);
+  const [checking, setChecking] = useState(false);
+  const [savingIds, setSavingIds] = useState(false);
+  const [savingCreds, setSavingCreds] = useState(false);
+  const [autofilling, setAutofilling] = useState(false);
+
+  async function autofillCredentials() {
+    if (!environmentId) return;
+    setAutofilling(true);
+    try {
+      const res = await fetch(
+        `/api/sso/setup/credentials-info?environmentId=${encodeURIComponent(environmentId)}`,
+        { cache: "no-store" },
+      );
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      const out = (await res.json()) as {
+        environmentUrl: string;
+        clientId: string;
+      };
+      setEnvironmentUrl(out.environmentUrl);
+      setClientId(out.clientId);
+      toast.success("Environment URL and client id filled in — paste the secret.");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
+    } finally {
+      setAutofilling(false);
+    }
+  }
+
+  // Once the workspace is connected, fetch the real environments and
+  // organizations so the admin picks from a list instead of pasting ids.
+  useEffect(() => {
+    if (!workspaceConnected || envOptions.length > 0) return;
+    let cancelled = false;
+    (async () => {
+      setPickerBusy(true);
+      try {
+        const res = await fetch("/api/sso/setup/environments", {
+          cache: "no-store",
+        });
+        if (!res.ok) {
+          const body = (await res.json().catch(() => null)) as { error?: string } | null;
+          throw new Error(body?.error ?? `HTTP ${res.status}`);
+        }
+        const { environments } = (await res.json()) as {
+          environments: SsoEnvironmentRow[];
+        };
+        if (cancelled) return;
+        setEnvOptions(environments);
+        if (environments.length > 0 && !initial?.environmentId) {
+          // Dev by default — free trial.
+          const dev =
+            environments.find((e) => e.tier === "DEV") ?? environments[0]!;
+          setEnvironmentId(dev.id);
+          setTier(dev.tier === "PRD" ? "prod" : "dev");
+        }
+      } catch {
+        // Fetch failure → fall back to manual id entry below.
+      } finally {
+        if (!cancelled) setPickerBusy(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceConnected, envOptions.length, initial?.environmentId]);
+
+  async function loadOrganizations(envId: string) {
+    if (!envId) return;
+    try {
+      const res = await fetch(
+        `/api/sso/setup/organizations?environmentId=${encodeURIComponent(envId)}`,
+        { cache: "no-store" },
+      );
+      if (!res.ok) return;
+      const { organizations } = (await res.json()) as {
+        organizations: SsoOrganizationRow[];
+      };
+      setOrgOptions(organizations);
+      if (organizations.length > 0 && !initial?.organizationId) {
+        setOrganizationId(organizations[0]!.id);
+      }
+    } catch {
+      // fall back to manual entry
+    }
+  }
+
+  // When the environment picker changes, refresh the organization list.
+  useEffect(() => {
+    if (envOptions.length > 0 && environmentId) {
+      void loadOrganizations(environmentId);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [environmentId, envOptions.length]);
+
+  function onEnvSelect(nextId: string) {
+    setEnvironmentId(nextId);
+    const env = envOptions.find((e) => e.id === nextId);
+    if (env) setTier(env.tier === "PRD" ? "prod" : "dev");
+  }
+
+  async function saveIds() {
+    setSavingIds(true);
+    try {
+      const res = await fetch("/api/sso/setup/ids", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ environmentId, organizationId, tier }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      setStatus((s) => ({
+        ...(s ?? emptyStatus()),
+        environmentId,
+        organizationId,
+        environmentTier: tier,
+      }));
+      setEditingStep(null);
+      toast.success("Environment set.");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSavingIds(false);
+    }
+  }
+
+  async function saveCredentials() {
+    setSavingCreds(true);
+    try {
+      const res = await fetch("/api/sso/setup/credentials", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ environmentUrl, clientId, clientSecret }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      setStatus((s) => ({ ...(s ?? emptyStatus()), signInConfigured: true }));
+      setClientSecret("");
+      setEditingStep(null);
+      toast.success("Credentials saved — sign-in is now live.");
+      // The login gate engages the moment credentials are saved. Send the
+      // admin to /signin (back here afterwards) so they finish setup in a
+      // real session — the first sign-in becomes the admin.
+      setTimeout(() => {
+        window.location.href = "/signin?returnTo=%2Fadmin%2Fsettings%2Fsso";
+      }, 900);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSavingCreds(false);
+    }
+  }
+
+  async function generate() {
+    setGenerating(true);
+    try {
+      const res = await fetch("/api/sso/setup/generate-portal-link", {
+        method: "POST",
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      const out = (await res.json()) as {
+        portalLink: string;
+        expiresAt: string | null;
+      };
+      setStatus((s) => ({
+        ...(s ?? emptyStatus()),
+        status: "awaiting_portal",
+        portalLink: out.portalLink,
+        portalLinkExpiresAt: out.expiresAt,
+        lastError: null,
+      }));
+      toast.success("Portal link generated.");
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
+    } finally {
+      setGenerating(false);
+    }
+  }
+
+  async function check() {
+    setChecking(true);
+    try {
+      const res = await fetch("/api/sso/setup/check", { method: "POST" });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      const out = (await res.json()) as {
+        status: SsoSetupStatus;
+        connection: SsoSetupStatusResult["connection"];
+        lastError: string | null;
+        setupCompletedAt: string | null;
+      };
+      setStatus((s) => ({
+        ...(s ?? emptyStatus()),
+        status: out.status,
+        connection: out.connection,
+        lastError: out.lastError,
+        setupCompletedAt: out.setupCompletedAt,
+      }));
+      if (out.status === "connected") {
+        toast.success("SSO is live.");
+      } else if (out.status === "awaiting_portal") {
+        toast.info("No connection yet — finish the IdP setup in the portal.");
+      } else if (out.status === "failed") {
+        toast.error(out.lastError ?? "Connection check failed.");
+      } else {
+        toast.info("Still in progress.");
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : String(e));
+    } finally {
+      setChecking(false);
+    }
+  }
+
+  async function copyLink() {
+    if (!status?.portalLink) return;
+    try {
+      await navigator.clipboard.writeText(status.portalLink);
+      toast.success("Link copied.");
+    } catch {
+      toast.error("Could not copy — select the link and copy manually.");
+    }
+  }
+
+  const step1Done = workspaceConnected;
+  const step2Done = Boolean(status?.environmentId && status?.organizationId);
+  const step3Done = status?.signInConfigured === true;
+  const step4Done = status?.status === "connected";
+
+  return (
+    <>
+      <div
+        className="root"
+        style={{ "--page-width": "min(1000px, 100%)" } as React.CSSProperties}
+      >
+        <AppHeader back={{ href: "/admin/settings", label: "All settings" }}>
+          <SectionNav current="admin" />
+        </AppHeader>
+
+        <PageHeading
+          eyebrow="Settings · SSO"
+          title="Single sign-on"
+          description="Connect your identity provider (Okta, Entra ID, and others) through Scalekit. The agent fetches the environment URL and client id for you; you paste the client secret once."
+        />
+
+        <section className="flex flex-col gap-6 mt-2">
+          {loadError ? (
+            <div className="rounded-xl border border-border bg-bg px-4 py-3">
+              <p className={HELP_CLS}>{loadError}</p>
+            </div>
+          ) : null}
+
+          {status?.lastError && status.status === "failed" ? (
+            <div className="rounded-xl border border-red-300 bg-bg px-4 py-3">
+              <p className={HELP_CLS}>{status.lastError}</p>
+            </div>
+          ) : null}
+
+          {/* Step 1 — workspace authorization */}
+          <div className="rounded-xl border border-border bg-bg px-4 py-4 flex flex-col gap-3">
+            <StepHeader
+              step={1}
+              done={step1Done}
+              title="Authorize the Scalekit workspace"
+            />
+            {step1Done ? (
+              <p className={HELP_CLS}>
+                Connected — the agent manages your Scalekit workspace
+                (environments, organizations, users, connections) with this
+                org-wide authorization.
+              </p>
+            ) : (
+              <>
+                <p className={HELP_CLS}>
+                  Opens Scalekit in your browser. Sign in or create the account
+                  there; the consent screen names the scopes and endpoint.
+                </p>
+                <a
+                  href="/api/integrations/connect/%40open-neko%2Fplugin-scalekit/start?returnTo=%2Fadmin%2Fsettings%2Fsso"
+                  className="inline-flex"
+                >
+                  <Button type="button">Connect Scalekit workspace</Button>
+                </a>
+              </>
+            )}
+          </div>
+
+          {/* Step 2 — environment selection */}
+          <div className="rounded-xl border border-border bg-bg px-4 py-4 flex flex-col gap-3">
+            <StepHeader
+              step={2}
+              done={step2Done}
+              title="Select the Scalekit environment"
+            />
+            {step2Done && editingStep !== 2 ? (
+              <>
+                <p className={HELP_CLS}>
+                  {status?.environmentTier === "prod" ? "Production" : "Development"}
+                  {" · "}
+                  {status?.environmentId}
+                  {" · org "}
+                  {status?.organizationId}
+                </p>
+                <div>
+                  <button
+                    type="button"
+                    className="text-[12px] text-text2 underline"
+                    onClick={() => setEditingStep(2)}
+                  >
+                    Change
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className={HELP_CLS}>
+                  {pickerBusy
+                    ? "Loading your Scalekit environments…"
+                    : envOptions.length > 0
+                      ? "These are the environments in your workspace. Development is the free trial — switch to Production when you go live. Environments are isolated, so you re-run the IdP setup there."
+                      : workspaceConnected
+                        ? "Couldn't load the environment list. Paste the ids from the Scalekit dashboard instead."
+                        : "Connect the workspace in step 1 and the list loads automatically."}
+                </p>
+                <div className="flex gap-2 flex-wrap items-center">
+                  {pickerBusy ? (
+                    <span className="flex items-center gap-2 text-[13px] text-text2">
+                      <span
+                        className="inline-block w-4 h-4 border-2 border-border border-t-accent rounded-full animate-spin"
+                        aria-hidden="true"
+                      />
+                      Loading environments…
+                    </span>
+                  ) : envOptions.length > 0 ? (
+                    <select
+                      className={`${INPUT_CLS} flex-1 min-w-[240px]`}
+                      value={environmentId}
+                      onChange={(e) => onEnvSelect(e.target.value)}
+                    >
+                      {envOptions.map((e) => (
+                        <option key={e.id} value={e.id}>
+                          {e.name ?? e.id} ({e.tier === "PRD" ? "Production" : "Development"})
+                          {e.domain ? ` — ${e.domain}` : ""}
+                        </option>
+                      ))}
+                    </select>
+                  ) : (
+                    <select
+                      className={`${INPUT_CLS} max-w-[180px]`}
+                      value={tier}
+                      onChange={(e) => setTier(e.target.value)}
+                    >
+                      <option value="dev">Development</option>
+                      <option value="prod">Production</option>
+                    </select>
+                  )}
+                  {envOptions.length > 0 && orgOptions.length > 0 ? (
+                    <select
+                      className={`${INPUT_CLS} flex-1 min-w-[200px]`}
+                      value={organizationId}
+                      onChange={(e) => setOrganizationId(e.target.value)}
+                    >
+                      {orgOptions.map((o) => (
+                        <option key={o.id} value={o.id}>
+                          {o.name ?? o.id}
+                        </option>
+                      ))}
+                    </select>
+                  ) : null}
+                  {envOptions.length === 0 && (
+                    <>
+                      <input
+                        className={`${INPUT_CLS} flex-1 min-w-[200px]`}
+                        placeholder="environmentId (env_…)"
+                        value={environmentId}
+                        onChange={(e) => setEnvironmentId(e.target.value)}
+                      />
+                      <input
+                        className={`${INPUT_CLS} flex-1 min-w-[200px]`}
+                        placeholder="organizationId (org_…)"
+                        value={organizationId}
+                        onChange={(e) => setOrganizationId(e.target.value)}
+                      />
+                    </>
+                  )}
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={saveIds}
+                    disabled={
+                      savingIds || pickerBusy || !environmentId || !organizationId
+                    }
+                  >
+                    {savingIds ? "Saving…" : "Set environment"}
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+
+          {/* Step 3 — sign-in credentials */}
+          <div className="rounded-xl border border-border bg-bg px-4 py-4 flex flex-col gap-3">
+            <StepHeader step={3} done={step3Done} title="Sign-in credentials" />
+            {step3Done && editingStep !== 3 ? (
+              <>
+                <p className={HELP_CLS}>Stored in the encrypted vault.</p>
+                <div>
+                  <button
+                    type="button"
+                    className="text-[12px] text-text2 underline"
+                    onClick={() => setEditingStep(3)}
+                  >
+                    Replace
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <p className={HELP_CLS}>
+                  The agent fetches the environment URL and client id for you.
+                  The client secret is shown only once — in Scalekit, under
+                  Settings → API Credentials for the selected environment.
+                  Pasting it here stores it straight in the vault, never through
+                  chat.
+                </p>
+                <div className="flex gap-2 flex-wrap items-center">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={autofillCredentials}
+                    disabled={autofilling || !environmentId}
+                  >
+                    {autofilling ? "Fetching…" : "Auto-fill from Scalekit"}
+                  </Button>
+                  <a
+                    href={
+                      environmentId
+                        ? `https://app.scalekit.com/ws/environments/${encodeURIComponent(environmentId)}/settings/api-credentials`
+                        : "https://app.scalekit.com"
+                    }
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-flex"
+                  >
+                    <Button type="button" variant="secondary">
+                      Find the secret in Scalekit ↗
+                    </Button>
+                  </a>
+                  <input
+                    className={`${INPUT_CLS} flex-1 min-w-[220px]`}
+                    placeholder="https://your-app.scalekit.com"
+                    value={environmentUrl}
+                    onChange={(e) => setEnvironmentUrl(e.target.value)}
+                  />
+                  <input
+                    className={`${INPUT_CLS} flex-1 min-w-[180px]`}
+                    placeholder="client_id (skc_…)"
+                    value={clientId}
+                    onChange={(e) => setClientId(e.target.value)}
+                  />
+                  <input
+                    type="password"
+                    className={`${INPUT_CLS} flex-1 min-w-[180px]`}
+                    placeholder="client_secret"
+                    value={clientSecret}
+                    onChange={(e) => setClientSecret(e.target.value)}
+                  />
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={saveCredentials}
+                    disabled={
+                      savingCreds || !environmentUrl || !clientId || !clientSecret
+                    }
+                  >
+                    {savingCreds ? "Saving…" : "Save credentials"}
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+
+          {/* Step 4 — IdP connection */}
+          <div className="rounded-xl border border-border bg-bg px-4 py-4 flex flex-col gap-3">
+            <StepHeader
+              step={4}
+              done={step4Done}
+              title="Connect the identity provider"
+            />
+            {step4Done ? (
+              <p className={HELP_CLS}>
+                SSO is live
+                {status?.provider ? ` via ${status.provider}` : ""}
+                {status?.setupCompletedAt
+                  ? ` — connected ${new Date(status.setupCompletedAt).toLocaleString()}`
+                  : ""}
+              </p>
+            ) : (
+              <>
+                <p className={HELP_CLS}>
+                  Optional for the trial — sign-in already works through
+                  Scalekit's hosted login. Generate a portal link to connect
+                  your company's own IdP (Okta, Entra ID…): open it, follow the
+                  guided setup, and the agent polls the connection until it's
+                  live.
+                </p>
+                {status?.portalLink ? (
+                  <div className="flex flex-col gap-2">
+                    <p className={HELP_CLS}>
+                      The link is single-use and expires in about a minute —
+                      once opened it stays valid for the session.
+                    </p>
+                    <div className="flex items-center gap-2">
+                      <code className="flex-1 truncate text-[13px] text-text2">
+                        {status.portalLink}
+                      </code>
+                      <Button type="button" variant="secondary" onClick={copyLink}>
+                        Copy
+                      </Button>
+                      <a href={status.portalLink} target="_blank" rel="noreferrer">
+                        <Button type="button">Open</Button>
+                      </a>
+                    </div>
+                  </div>
+                ) : null}
+                {status?.connection ? (
+                  <p className={HELP_CLS}>
+                    Provider: {status.connection.provider ?? "unknown"} ·{" "}
+                    {status.connection.status}
+                    {status.connection.enabled ? " · enabled" : ""}
+                  </p>
+                ) : null}
+                <div className="flex gap-2">
+                  <Button type="button" onClick={generate} disabled={generating}>
+                    {generating ? "Generating…" : "Generate portal link"}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={check}
+                    disabled={checking}
+                  >
+                    {checking ? "Checking…" : "Check connection"}
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+        </section>
+      </div>
+
+      <CreatorCredit />
+    </>
+  );
+}
+
+function emptyStatus(): SsoSetupStatusResult {
+  return {
+    status: "not_started",
+    portalLink: null,
+    portalLinkExpiresAt: null,
+    provider: null,
+    connection: null,
+    lastError: null,
+    setupCompletedAt: null,
+    environmentId: null,
+    organizationId: null,
+    environmentTier: null,
+    signInConfigured: false,
+  };
+}

--- a/apps/web/src/app/admin/settings/sso/page.tsx
+++ b/apps/web/src/app/admin/settings/sso/page.tsx
@@ -1,0 +1,43 @@
+import { connection } from "next/server";
+import { AdminDenied } from "@/app/admin/AdminShell";
+import { getCurrentActor } from "@/lib/actor";
+import { getOrgId } from "@/lib/db";
+import { getDeploymentConnectStatus } from "@/lib/integrations";
+import { getSsoSetupStatus } from "@/lib/sso-setup";
+import SsoSetupForm from "./SsoSetupForm";
+
+export default async function SettingsSsoPage() {
+  await connection();
+  const actor = await getCurrentActor();
+  if (actor.role !== "admin") return <AdminDenied />;
+
+  const orgId = await getOrgId();
+  const [status, deployment] = await Promise.all([
+    getSsoSetupStatus(orgId).catch(
+      (err) =>
+        ({
+          status: "not_started",
+          portalLink: null,
+          portalLinkExpiresAt: null,
+          provider: null,
+          connection: null,
+          lastError: err instanceof Error ? err.message : String(err),
+          setupCompletedAt: null,
+          environmentId: null,
+          organizationId: null,
+          environmentTier: null,
+          signInConfigured: false,
+        }) as Awaited<ReturnType<typeof getSsoSetupStatus>>,
+    ),
+    getDeploymentConnectStatus(),
+  ]);
+  return (
+    <SsoSetupForm
+      initial={status}
+      loadError={null}
+      workspaceConnected={deployment.some(
+        (d) => d.pluginName === "@open-neko/plugin-scalekit",
+      )}
+    />
+  );
+}

--- a/apps/web/src/app/api/integrations/connect/[plugin]/callback/route.ts
+++ b/apps/web/src/app/api/integrations/connect/[plugin]/callback/route.ts
@@ -78,6 +78,7 @@ export async function GET(
       state,
       codeVerifier: stored.codeVerifier,
       scopes: provider.scopes,
+      ...(stored.oauthState ? { oauthState: stored.oauthState } : {}),
     });
     return NextResponse.redirect(
       new URL(`${stored.returnPath}?connected=${encodeURIComponent(pluginName)}`, request.url),

--- a/apps/web/src/app/api/integrations/connect/[plugin]/start/route.ts
+++ b/apps/web/src/app/api/integrations/connect/[plugin]/start/route.ts
@@ -10,9 +10,11 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/auth";
+import { isDenied, requireAdminActor } from "@/lib/admin-auth";
 import {
   beginConnect,
   buildConnectCallbackUri,
+  DEPLOYMENT_CONNECT_OPERATOR_ID,
   listConnectProviders,
   newPkceVerifier,
   newStateToken,
@@ -23,10 +25,6 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ plugin: string }> },
 ) {
-  const user = await getCurrentUser();
-  if (!user) {
-    return NextResponse.json({ error: "not signed in" }, { status: 401 });
-  }
   const { plugin } = await params;
   const pluginName = decodeURIComponent(plugin);
   if (!pluginName) {
@@ -42,27 +40,57 @@ export async function GET(
       { status: 404 },
     );
   }
+  // Deployment-scoped connectors are org-level: an admin can authorize
+  // them before any SSO session exists (solo mode). Per-operator
+  // connectors still require a signed-in user.
+  if (provider.credentialScope === "deployment") {
+    const actor = await requireAdminActor();
+    if (isDenied(actor)) return actor;
+  } else {
+    const user = await getCurrentUser();
+    if (!user) {
+      return NextResponse.json({ error: "not signed in" }, { status: 401 });
+    }
+  }
+  // Deployment-scoped connectors use a reserved slot — the worker ignores
+  // the operator id and stores one org-wide credential.
+  const operatorId =
+    provider.credentialScope === "deployment"
+      ? DEPLOYMENT_CONNECT_OPERATOR_ID
+      : (await getCurrentUser())!.id;
   const url = new URL(request.url);
   const returnTo = url.searchParams.get("returnTo") ?? "/integrations";
   const state = newStateToken();
   const codeVerifier = newPkceVerifier();
   await writeConnectStateCookie({
     pluginName,
-    operatorId: user.id,
+    operatorId,
     state,
     codeVerifier,
     returnPath: returnTo,
   });
   const redirectUri = buildConnectCallbackUri(request.url, pluginName);
   try {
-    const { authorizationUrl } = await beginConnect(pluginName, {
-      operatorId: user.id,
+    const result = await beginConnect(pluginName, {
+      operatorId,
       redirectUri,
       state,
       scopes: provider.scopes,
       codeVerifier,
     });
-    return NextResponse.redirect(authorizationUrl, { status: 302 });
+    if (result.oauthState) {
+      // mcp-oauth: the plugin's in-flight state must survive the browser
+      // round-trip — stash it in a second signed cookie for the callback.
+      await writeConnectStateCookie({
+        pluginName,
+        operatorId,
+        state,
+        codeVerifier,
+        returnPath: returnTo,
+        oauthState: result.oauthState,
+      });
+    }
+    return NextResponse.redirect(result.authorizationUrl, { status: 302 });
   } catch (err) {
     return NextResponse.json(
       { error: err instanceof Error ? err.message : String(err) },

--- a/apps/web/src/app/api/integrations/disconnect/[plugin]/route.ts
+++ b/apps/web/src/app/api/integrations/disconnect/[plugin]/route.ts
@@ -1,23 +1,43 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/auth";
-import { disconnectConnector } from "@/lib/integrations";
+import { isDenied, requireAdminActor } from "@/lib/admin-auth";
+import {
+  DEPLOYMENT_CONNECT_OPERATOR_ID,
+  disconnectConnector,
+  listConnectProviders,
+} from "@/lib/integrations";
 
-/** POST /api/integrations/disconnect/[plugin] — drop the current operator's credential. */
+/**
+ * POST /api/integrations/disconnect/[plugin] — drop the current
+ * operator's credential. Deployment-scoped connectors drop the shared
+ * org-wide credential instead, and that path is admin-gated.
+ */
 export async function POST(
   _request: NextRequest,
   { params }: { params: Promise<{ plugin: string }> },
 ) {
-  const user = await getCurrentUser();
-  if (!user) {
-    return NextResponse.json({ error: "not signed in" }, { status: 401 });
-  }
   const { plugin } = await params;
   const pluginName = decodeURIComponent(plugin);
   if (!pluginName) {
     return NextResponse.json({ error: "plugin param required" }, { status: 400 });
   }
+  const user = await getCurrentUser();
+  const providers = await listConnectProviders();
+  const provider = providers.find((p) => p.pluginName === pluginName);
+  if (provider?.credentialScope === "deployment") {
+    // Org-level credential: admin-gated, and allowed in solo mode (no
+    // session yet — the admin may disconnect before SSO is configured).
+    const actor = await requireAdminActor();
+    if (isDenied(actor)) return actor;
+  } else if (!user) {
+    return NextResponse.json({ error: "not signed in" }, { status: 401 });
+  }
   try {
-    const removed = await disconnectConnector(pluginName, user.id);
+    const operatorId =
+      provider?.credentialScope === "deployment"
+        ? DEPLOYMENT_CONNECT_OPERATOR_ID
+        : (user?.id ?? "");
+    const removed = await disconnectConnector(pluginName, operatorId);
     return NextResponse.json({ removed });
   } catch (err) {
     return NextResponse.json(
@@ -26,3 +46,4 @@ export async function POST(
     );
   }
 }
+

--- a/apps/web/src/app/api/integrations/list/route.ts
+++ b/apps/web/src/app/api/integrations/list/route.ts
@@ -1,32 +1,55 @@
 import { NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/auth";
 import {
+  getDeploymentConnectStatus,
   getOperatorConnectStatus,
   listConnectProviders,
 } from "@/lib/integrations";
 
 /**
  * GET /api/integrations/list — combined view of installed connect
- * plugins + per-operator connection status. Used by the /integrations
- * page to render the table in one round-trip.
+ * plugins + connection status. Deployment-scoped connectors surface in
+ * a separate "workspace" section (one org-wide credential); the rest
+ * are per-operator. Used by the /integrations page in one round-trip.
  */
 export async function GET() {
   const user = await getCurrentUser();
   if (!user) {
     return NextResponse.json({ error: "not signed in" }, { status: 401 });
   }
-  const [providers, status] = await Promise.all([
+  const [providers, status, deploymentStatus] = await Promise.all([
     listConnectProviders(),
     getOperatorConnectStatus(user.id),
+    getDeploymentConnectStatus(),
   ]);
   const connectedByPlugin = new Map(status.map((s) => [s.pluginName, s]));
-  const rows = providers.map((p) => ({
-    pluginId: p.pluginId,
-    pluginName: p.pluginName,
-    providerLabel: p.providerLabel,
-    scopes: p.scopes,
-    connected: connectedByPlugin.has(p.pluginName),
-    connectedAt: connectedByPlugin.get(p.pluginName)?.connectedAt ?? null,
-  }));
-  return NextResponse.json({ providers: rows });
+  const deploymentConnectedByPlugin = new Map(
+    deploymentStatus.map((s) => [s.pluginName, s]),
+  );
+  const workspace = providers
+    .filter((p) => p.credentialScope === "deployment")
+    .map((p) => ({
+      pluginId: p.pluginId,
+      pluginName: p.pluginName,
+      providerLabel: p.providerLabel,
+      scopes: p.scopes,
+      flow: p.flow,
+      credentialScope: p.credentialScope,
+      connected: deploymentConnectedByPlugin.has(p.pluginName),
+      connectedAt:
+        deploymentConnectedByPlugin.get(p.pluginName)?.connectedAt ?? null,
+    }));
+  const connectors = providers
+    .filter((p) => p.credentialScope !== "deployment")
+    .map((p) => ({
+      pluginId: p.pluginId,
+      pluginName: p.pluginName,
+      providerLabel: p.providerLabel,
+      scopes: p.scopes,
+      flow: p.flow,
+      credentialScope: p.credentialScope,
+      connected: connectedByPlugin.has(p.pluginName),
+      connectedAt: connectedByPlugin.get(p.pluginName)?.connectedAt ?? null,
+    }));
+  return NextResponse.json({ workspace, connectors });
 }

--- a/apps/web/src/app/api/sso/setup/check/route.ts
+++ b/apps/web/src/app/api/sso/setup/check/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { getOrgId } from "@/lib/db";
+import { isDenied, requireAdminActor } from "@/lib/admin-auth";
+import { checkSsoConnection } from "@/lib/sso-setup";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  const allowed = await requireAdminActor();
+  if (isDenied(allowed)) return allowed;
+  try {
+    const orgId = await getOrgId();
+    return NextResponse.json(await checkSsoConnection(orgId));
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/sso/setup/credentials-info/route.ts
+++ b/apps/web/src/app/api/sso/setup/credentials-info/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getOrgId } from "@/lib/db";
+import { isDenied, requireAdminActor } from "@/lib/admin-auth";
+import { getSsoEnvironmentCredentials } from "@/lib/sso-setup";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  const allowed = await requireAdminActor();
+  if (isDenied(allowed)) return allowed;
+  const environmentId = request.nextUrl.searchParams.get("environmentId") ?? "";
+  if (!environmentId) {
+    return NextResponse.json(
+      { error: "environmentId query parameter is required" },
+      { status: 400 },
+    );
+  }
+  try {
+    const orgId = await getOrgId();
+    return NextResponse.json(
+      await getSsoEnvironmentCredentials(orgId, environmentId),
+    );
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/sso/setup/credentials/route.ts
+++ b/apps/web/src/app/api/sso/setup/credentials/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { getOrgId } from "@/lib/db";
+import { isDenied, requireAdminActor } from "@/lib/admin-auth";
+import { setSsoSignInCredentials } from "@/lib/sso-setup";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  const allowed = await requireAdminActor();
+  if (isDenied(allowed)) return allowed;
+  const body = (await request.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  const environmentUrl = body?.environmentUrl;
+  const clientId = body?.clientId;
+  const clientSecret = body?.clientSecret;
+  if (typeof environmentUrl !== "string" || !environmentUrl) {
+    return NextResponse.json(
+      { error: "environmentUrl (string) is required" },
+      { status: 400 },
+    );
+  }
+  if (typeof clientId !== "string" || !clientId) {
+    return NextResponse.json(
+      { error: "clientId (string) is required" },
+      { status: 400 },
+    );
+  }
+  if (typeof clientSecret !== "string" || !clientSecret) {
+    return NextResponse.json(
+      { error: "clientSecret (string) is required" },
+      { status: 400 },
+    );
+  }
+  try {
+    const orgId = await getOrgId();
+    await setSsoSignInCredentials(orgId, {
+      environmentUrl,
+      clientId,
+      clientSecret,
+    });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/sso/setup/environments/route.ts
+++ b/apps/web/src/app/api/sso/setup/environments/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import { getOrgId } from "@/lib/db";
+import { isDenied, requireAdminActor } from "@/lib/admin-auth";
+import { listSsoEnvironments } from "@/lib/sso-setup";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const allowed = await requireAdminActor();
+  if (isDenied(allowed)) return allowed;
+  try {
+    const orgId = await getOrgId();
+    return NextResponse.json({
+      environments: await listSsoEnvironments(orgId),
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/sso/setup/generate-portal-link/route.ts
+++ b/apps/web/src/app/api/sso/setup/generate-portal-link/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { getOrgId } from "@/lib/db";
+import { isDenied, requireAdminActor } from "@/lib/admin-auth";
+import { generateSsoPortalLink } from "@/lib/sso-setup";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  const allowed = await requireAdminActor();
+  if (isDenied(allowed)) return allowed;
+  try {
+    const orgId = await getOrgId();
+    return NextResponse.json(await generateSsoPortalLink(orgId));
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/sso/setup/ids/route.ts
+++ b/apps/web/src/app/api/sso/setup/ids/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { getOrgId } from "@/lib/db";
+import { isDenied, requireAdminActor } from "@/lib/admin-auth";
+import { setSsoScalekitIds } from "@/lib/sso-setup";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  const allowed = await requireAdminActor();
+  if (isDenied(allowed)) return allowed;
+  const body = (await request.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  const environmentId = body?.environmentId;
+  const organizationId = body?.organizationId;
+  const tier = body?.tier;
+  if (typeof environmentId !== "string" || !environmentId) {
+    return NextResponse.json(
+      { error: "environmentId (string) is required" },
+      { status: 400 },
+    );
+  }
+  if (typeof organizationId !== "string" || !organizationId) {
+    return NextResponse.json(
+      { error: "organizationId (string) is required" },
+      { status: 400 },
+    );
+  }
+  try {
+    const orgId = await getOrgId();
+    await setSsoScalekitIds(orgId, {
+      environmentId,
+      organizationId,
+      tier: typeof tier === "string" && tier ? tier : "dev",
+    });
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/sso/setup/organizations/route.ts
+++ b/apps/web/src/app/api/sso/setup/organizations/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getOrgId } from "@/lib/db";
+import { isDenied, requireAdminActor } from "@/lib/admin-auth";
+import { listSsoOrganizations } from "@/lib/sso-setup";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET(request: NextRequest) {
+  const allowed = await requireAdminActor();
+  if (isDenied(allowed)) return allowed;
+  const environmentId = request.nextUrl.searchParams.get("environmentId") ?? "";
+  if (!environmentId) {
+    return NextResponse.json(
+      { error: "environmentId query parameter is required" },
+      { status: 400 },
+    );
+  }
+  try {
+    const orgId = await getOrgId();
+    return NextResponse.json({
+      organizations: await listSsoOrganizations(orgId, environmentId),
+    });
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/api/sso/setup/status/route.ts
+++ b/apps/web/src/app/api/sso/setup/status/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { getOrgId } from "@/lib/db";
+import { isDenied, requireAdminActor } from "@/lib/admin-auth";
+import { getSsoSetupStatus } from "@/lib/sso-setup";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  const allowed = await requireAdminActor();
+  if (isDenied(allowed)) return allowed;
+  try {
+    const orgId = await getOrgId();
+    return NextResponse.json(await getSsoSetupStatus(orgId));
+  } catch (err) {
+    return NextResponse.json(
+      { error: err instanceof Error ? err.message : String(err) },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/web/src/app/integrations/IntegrationsList.tsx
+++ b/apps/web/src/app/integrations/IntegrationsList.tsx
@@ -12,12 +12,17 @@ type Row = {
   pluginName: string;
   providerLabel: string;
   scopes: string[];
+  flow: string;
+  credentialScope: string;
   connected: boolean;
   connectedAt: string | null;
 };
 
-export default function IntegrationsList({ initial }: { initial: Row[] }) {
-  const [rows, setRows] = useState<Row[]>(initial);
+type InitialState = { workspace: Row[]; connectors: Row[] };
+
+export default function IntegrationsList({ initial }: { initial: InitialState }) {
+  const [workspace, setWorkspace] = useState<Row[]>(initial.workspace);
+  const [connectors, setConnectors] = useState<Row[]>(initial.connectors);
   const [busy, setBusy] = useState<string | null>(null);
   const params = useSearchParams();
 
@@ -28,7 +33,7 @@ export default function IntegrationsList({ initial }: { initial: Row[] }) {
     if (ok) toast.success(`Connected ${ok}`);
   }, [params]);
 
-  async function disconnect(pluginName: string) {
+  async function disconnect(pluginName: string, isDeployment: boolean) {
     setBusy(pluginName);
     try {
       const res = await fetch(
@@ -39,13 +44,14 @@ export default function IntegrationsList({ initial }: { initial: Row[] }) {
         const body = (await res.json().catch(() => null)) as { error?: string } | null;
         throw new Error(body?.error ?? `HTTP ${res.status}`);
       }
-      setRows((prev) =>
+      const update = (prev: Row[]) =>
         prev.map((r) =>
           r.pluginName === pluginName
             ? { ...r, connected: false, connectedAt: null }
             : r,
-        ),
-      );
+        );
+      if (isDeployment) setWorkspace(update);
+      else setConnectors(update);
       toast.success(`Disconnected ${pluginName}`);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : String(e));
@@ -54,59 +60,100 @@ export default function IntegrationsList({ initial }: { initial: Row[] }) {
     }
   }
 
+  function RowView({
+    row,
+    isDeployment,
+  }: {
+    row: Row;
+    isDeployment: boolean;
+  }) {
+    return (
+      <li
+        key={row.pluginName}
+        className="flex items-center gap-4 p-4 rounded-xl border border-border bg-bg max-[480px]:items-stretch max-[480px]:flex-col"
+      >
+        <div className="flex-1 min-w-0">
+          <div className="font-semibold text-text">{row.providerLabel}</div>
+          <div className="text-[12px] text-text3 truncate">
+            {row.pluginName}
+          </div>
+          <div className="text-[12px] text-text3 mt-1 truncate">
+            Scopes: {row.scopes.join(", ")}
+          </div>
+          {row.connected && row.connectedAt && (
+            <div className="text-[12px] text-text2 mt-1">
+              Connected {new Date(row.connectedAt).toLocaleString()}
+            </div>
+          )}
+        </div>
+        {row.connected ? (
+          <Button
+            variant="secondary"
+            disabled={busy === row.pluginName}
+            onClick={() => disconnect(row.pluginName, isDeployment)}
+          >
+            {busy === row.pluginName ? "…" : "Disconnect"}
+          </Button>
+        ) : (
+          <a
+            href={`/api/integrations/connect/${encodeURIComponent(row.pluginName)}/start`}
+            className="inline-flex"
+          >
+            <Button>Connect</Button>
+          </a>
+        )}
+      </li>
+    );
+  }
+
   return (
     <div className="root">
       <AppHeader />
       <PageHeading
         eyebrow="Workspace connections"
         title="Integrations"
-        description="Connect external accounts for agent actions. Each operator authorizes independently, and credentials remain in this deployment."
+        description="Connect external accounts for agent actions. Credentials remain in this deployment."
       />
-      {rows.length === 0 ? (
+
+      {workspace.length > 0 && (
+        <>
+          <h2 className="mt-6 mb-2 text-[15px] font-semibold text-text">
+            Workspace connections
+          </h2>
+          <p className="text-[13px] text-text3 mb-2">
+            One org-wide authorization, consented once by an admin and shared
+            by every operator. Authorizing opens a browser consent screen that
+            names the scopes and the endpoint.
+          </p>
+          <ul className="flex flex-col gap-3">
+            {workspace.map((row) => (
+              <RowView key={row.pluginName} row={row} isDeployment />
+            ))}
+          </ul>
+        </>
+      )}
+
+      {connectors.length > 0 && (
+        <>
+          <h2 className="mt-6 mb-2 text-[15px] font-semibold text-text">
+            Per-operator connectors
+          </h2>
+          <p className="text-[13px] text-text3 mb-2">
+            Each operator authorizes independently with their own account.
+          </p>
+          <ul className="flex flex-col gap-3">
+            {connectors.map((row) => (
+              <RowView key={row.pluginName} row={row} isDeployment={false} />
+            ))}
+          </ul>
+        </>
+      )}
+
+      {workspace.length === 0 && connectors.length === 0 && (
         <p className="text-[14px] text-text3 mt-4">
           No connect-capable plugins installed. Install one with{" "}
           <code>openneko install &lt;name&gt;</code>.
         </p>
-      ) : (
-        <ul className="flex flex-col gap-3 mt-2">
-          {rows.map((row) => (
-            <li
-              key={row.pluginName}
-              className="flex items-center gap-4 p-4 rounded-xl border border-border bg-bg max-[480px]:items-stretch max-[480px]:flex-col"
-            >
-              <div className="flex-1 min-w-0">
-                <div className="font-semibold text-text">{row.providerLabel}</div>
-                <div className="text-[12px] text-text3 truncate">
-                  {row.pluginName}
-                </div>
-                <div className="text-[12px] text-text3 mt-1 truncate">
-                  Scopes: {row.scopes.join(", ")}
-                </div>
-                {row.connected && row.connectedAt && (
-                  <div className="text-[12px] text-text2 mt-1">
-                    Connected {new Date(row.connectedAt).toLocaleString()}
-                  </div>
-                )}
-              </div>
-              {row.connected ? (
-                <Button
-                  variant="secondary"
-                  disabled={busy === row.pluginName}
-                  onClick={() => disconnect(row.pluginName)}
-                >
-                  {busy === row.pluginName ? "…" : "Disconnect"}
-                </Button>
-              ) : (
-                <a
-                  href={`/api/integrations/connect/${encodeURIComponent(row.pluginName)}/start`}
-                  className="inline-flex"
-                >
-                  <Button>Connect</Button>
-                </a>
-              )}
-            </li>
-          ))}
-        </ul>
       )}
     </div>
   );

--- a/apps/web/src/app/integrations/page.tsx
+++ b/apps/web/src/app/integrations/page.tsx
@@ -1,7 +1,8 @@
 import { connection } from "next/server";
 import { redirect } from "next/navigation";
-import { getCurrentUser } from "@/lib/auth";
+import { getCurrentActor } from "@/lib/actor";
 import {
+  getDeploymentConnectStatus,
   getOperatorConnectStatus,
   listConnectProviders,
 } from "@/lib/integrations";
@@ -9,22 +10,37 @@ import IntegrationsList from "./IntegrationsList";
 
 export default async function IntegrationsPage() {
   await connection();
-  const user = await getCurrentUser();
-  if (!user) {
+  const actor = await getCurrentActor();
+  if (actor.role !== "admin") {
     redirect("/signin?returnTo=/integrations");
   }
-  const [providers, status] = await Promise.all([
+  const [providers, status, deploymentStatus] = await Promise.all([
     listConnectProviders(),
-    getOperatorConnectStatus(user.id),
+    actor.userId ? getOperatorConnectStatus(actor.userId) : Promise.resolve([]),
+    getDeploymentConnectStatus(),
   ]);
   const connectedByPlugin = new Map(status.map((s) => [s.pluginName, s]));
-  const rows = providers.map((p) => ({
+  const deploymentConnectedByPlugin = new Map(
+    deploymentStatus.map((s) => [s.pluginName, s]),
+  );
+  const rowFor = (
+    p: (typeof providers)[number],
+    map: Map<string, { connectedAt: string; scopes?: string[] }>,
+  ) => ({
     pluginId: p.pluginId,
     pluginName: p.pluginName,
     providerLabel: p.providerLabel,
     scopes: p.scopes,
-    connected: connectedByPlugin.has(p.pluginName),
-    connectedAt: connectedByPlugin.get(p.pluginName)?.connectedAt ?? null,
-  }));
-  return <IntegrationsList initial={rows} />;
+    flow: p.flow,
+    credentialScope: p.credentialScope,
+    connected: map.has(p.pluginName),
+    connectedAt: map.get(p.pluginName)?.connectedAt ?? null,
+  });
+  const workspace = providers
+    .filter((p) => p.credentialScope === "deployment")
+    .map((p) => rowFor(p, deploymentConnectedByPlugin));
+  const connectors = providers
+    .filter((p) => p.credentialScope !== "deployment")
+    .map((p) => rowFor(p, connectedByPlugin));
+  return <IntegrationsList initial={{ workspace, connectors }} />;
 }

--- a/apps/web/src/components/AppRail.tsx
+++ b/apps/web/src/components/AppRail.tsx
@@ -302,7 +302,7 @@ export default function AppRail() {
   useEffect(() => {
     if (hidden || RECORDS_VISUAL_TEST) return;
     let cancelled = false;
-    (async () => {
+    const load = async () => {
       try {
         const res = await fetch("/api/auth/session", { cache: "no-store" });
         if (cancelled || !res.ok) return;
@@ -319,9 +319,15 @@ export default function AppRail() {
       } catch {
         // Keep admin-only navigation hidden when identity cannot be resolved.
       }
-    })();
+    };
+    void load();
+    // Re-check periodically: the identity fetch is one-shot otherwise, and a
+    // worker blip at page load would leave the profile/signout block missing
+    // until a full reload.
+    const id = setInterval(load, 30_000);
     return () => {
       cancelled = true;
+      clearInterval(id);
     };
   }, [hidden]);
 
@@ -543,14 +549,16 @@ export default function AppRail() {
             <Link
               href="/onboarding"
               className="app-rail-user-profile"
-              title="Edit personal setup"
+              title="Profile"
             >
               <span className="app-rail-avatar" aria-hidden="true">
                 {initials(user)}
               </span>
               <span className="app-rail-user-copy">
                 <span className="app-rail-user-name">{user.name || user.email}</span>
-                <span className="app-rail-user-email">Personal setup</span>
+                <span className="app-rail-user-email">
+                  {user.name ? user.email : "Profile"}
+                </span>
               </span>
             </Link>
             <button

--- a/apps/web/src/lib/admin-auth.ts
+++ b/apps/web/src/lib/admin-auth.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import type { RunActor } from "@neko/llm/work";
 import { getCurrentActor } from "@/lib/actor";
+import { getAuthProvider } from "@/lib/auth";
 
 export function adminOnlyJson(): NextResponse {
   return NextResponse.json({ error: "admin only" }, { status: 403 });
@@ -9,13 +10,20 @@ export function adminOnlyJson(): NextResponse {
 /**
  * Admin gate for OpenNeko-native administration routes.
  *
- * getCurrentActor preserves solo/userless mode as admin. When SSO is active,
- * the proxy/session path resolves the signed-in app_user role before handlers
- * get here.
+ * getCurrentActor preserves solo/userless mode as admin while SSO is NOT
+ * configured. Once SSO sign-in is live (a provider is ready on
+ * /admin/auth/status), a request without a valid session is NOT the solo
+ * operator — it's an unauthenticated visitor — and is denied. The proxy
+ * exempts the SSO setup surfaces from the session gate precisely so this
+ * check can take over there.
  */
 export async function requireAdminActor(): Promise<RunActor | NextResponse> {
   const actor = await getCurrentActor();
   if (actor.role !== "admin") return adminOnlyJson();
+  if (actor.userId === null && (await getAuthProvider())) {
+    // SSO is live but the request carries no session: unauthenticated.
+    return adminOnlyJson();
+  }
   return actor;
 }
 

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -29,12 +29,15 @@ import {
   app_user,
   db,
   eq,
+  inArray,
   isNull,
   sql,
   sso_group,
+  sso_group_mapping,
   sso_group_membership,
 } from "@neko/db";
 import { getOrgId } from "@/lib/db";
+import { upsertOperatorProfile } from "@neko/llm/work";
 
 export const SESSION_COOKIE_NAME = "openneko_session";
 export const STATE_COOKIE_NAME = "openneko_sso_state";
@@ -269,6 +272,8 @@ export async function upsertUserFromIdentity(
   identity: AuthIdentity,
 ): Promise<{ id: string; email: string; name: string | null }> {
   const orgId = await getOrgId();
+  const provider = (await getAuthProvider())?.pluginName ?? "oidc";
+  const mapped = await resolveGroupRole(orgId, provider, identity.groups ?? []);
   // Primary lookup: sub. Anything matching wins, regardless of email
   // changes (people get married, change addresses — sub doesn't).
   const bySub = await db()
@@ -276,21 +281,27 @@ export async function upsertUserFromIdentity(
       id: app_user.id,
       email: app_user.email,
       name: app_user.name,
+      role: app_user.role,
     })
     .from(app_user)
     .where(and(eq(app_user.org_id, orgId), eq(app_user.sub, identity.sub)))
     .limit(1);
   if (bySub[0]) {
+    // A configured group mapping is authoritative on every sign-in; when
+    // none is configured, leave the existing role untouched.
+    const role = mapped.role ?? bySub[0].role;
     await db()
       .update(app_user)
       .set({
         email: identity.email,
         name: identity.name ?? null,
+        role,
         last_login_at: new Date(),
         updated_at: new Date(),
       })
       .where(eq(app_user.id, bySub[0].id));
     await syncSsoGroups({ orgId, userId: bySub[0].id, identity });
+    await provisionPersona({ orgId, userId: bySub[0].id, identity, mapped });
     return {
       id: bySub[0].id,
       email: identity.email,
@@ -304,21 +315,25 @@ export async function upsertUserFromIdentity(
       email: app_user.email,
       name: app_user.name,
       sub: app_user.sub,
+      role: app_user.role,
     })
     .from(app_user)
     .where(and(eq(app_user.org_id, orgId), eq(app_user.email, identity.email)))
     .limit(1);
   if (byEmail[0] && !byEmail[0].sub) {
+    const role = mapped.role ?? byEmail[0].role;
     await db()
       .update(app_user)
       .set({
         sub: identity.sub,
         name: identity.name ?? byEmail[0].name ?? null,
+        role,
         last_login_at: new Date(),
         updated_at: new Date(),
       })
       .where(eq(app_user.id, byEmail[0].id));
     await syncSsoGroups({ orgId, userId: byEmail[0].id, identity });
+    await provisionPersona({ orgId, userId: byEmail[0].id, identity, mapped });
     return {
       id: byEmail[0].id,
       email: identity.email,
@@ -336,10 +351,10 @@ export async function upsertUserFromIdentity(
   // Brand new user. Bootstrap the first active admin so installing an SSO
   // plugin cannot leave an org with no administrator.
   const newId = `usr_${randomBytes(9).toString("base64url")}`;
-  const role =
-    (await orgHasActiveAdmin(orgId))
-      ? defaultRoleForGroups(identity.groups ?? [])
-      : "admin";
+  const fallbackRole = heuristicRoleForGroups(identity.groups ?? []);
+  const role = (await orgHasActiveAdmin(orgId))
+    ? (mapped.role ?? fallbackRole)
+    : "admin";
   await db()
     .insert(app_user)
     .values({
@@ -352,6 +367,7 @@ export async function upsertUserFromIdentity(
       last_login_at: new Date(),
     });
   await syncSsoGroups({ orgId, userId: newId, identity });
+  await provisionPersona({ orgId, userId: newId, identity, mapped });
   return {
     id: newId,
     email: identity.email,
@@ -375,12 +391,11 @@ async function orgHasActiveAdmin(orgId: string): Promise<boolean> {
 }
 
 /**
- * Coarse-grained role mapping. Anyone with an `admin` or
- * `owners` group becomes admin; everyone else is `member`. Operators
- * with richer requirements override `app_user.role` directly until
- * we ship a configurable mapping screen.
+ * Coarse-grained fallback role mapping used only when no sso_group_mapping
+ * row matches. Anyone with an `admin` or `owners` group becomes admin;
+ * everyone else is `member`.
  */
-function defaultRoleForGroups(
+function heuristicRoleForGroups(
   groups: Array<string | { id: string; name?: string | null }>,
 ): string {
   const lower = new Set(
@@ -396,6 +411,59 @@ function defaultRoleForGroups(
     return "admin";
   }
   return "member";
+}
+
+/**
+ * Resolve a configurable role + persona template from sso_group_mapping for
+ * the user's groups. `role`/`persona` are null when nothing maps — the caller
+ * falls back to the heuristic and the current role, respectively.
+ */
+async function resolveGroupRole(
+  orgId: string,
+  provider: string,
+  groups: Array<string | { id: string; name?: string | null }>,
+): Promise<{ role: string | null; persona: string | null }> {
+  const externalIds = groups
+    .map((group) => (typeof group === "string" ? group : group.id).trim())
+    .filter((id) => id.length > 0);
+  if (externalIds.length === 0) return { role: null, persona: null };
+  const rows = await db()
+    .select({
+      role: sso_group_mapping.role,
+      persona_role_template: sso_group_mapping.persona_role_template,
+      group_external_id: sso_group_mapping.group_external_id,
+    })
+    .from(sso_group_mapping)
+    .where(
+      and(
+        eq(sso_group_mapping.org_id, orgId),
+        eq(sso_group_mapping.provider, provider),
+        inArray(sso_group_mapping.group_external_id, externalIds),
+      ),
+    );
+  if (rows.length === 0) return { role: null, persona: null };
+  const role = rows.some((r) => r.role === "admin") ? "admin" : "member";
+  const personaRow = rows.find((r) => r.persona_role_template) ?? null;
+  return { role, persona: personaRow?.persona_role_template ?? null };
+}
+
+/** Provision the user's per-user persona from the group mapping (idempotent). */
+async function provisionPersona(input: {
+  orgId: string;
+  userId: string;
+  identity: AuthIdentity;
+  mapped: { role: string | null; persona: string | null };
+}): Promise<void> {
+  const roleTemplate =
+    input.mapped.persona ??
+    (input.mapped.role === "admin" ? "Administrator" : "");
+  if (!roleTemplate) return;
+  await upsertOperatorProfile({
+    orgId: input.orgId,
+    userId: input.userId,
+    displayName: input.identity.name ?? null,
+    roleTemplate,
+  });
 }
 
 function normalizedIdentityGroups(identity: AuthIdentity): Array<{
@@ -479,7 +547,11 @@ async function syncSsoGroups(input: {
         (org_id, user_id, provider, tenant_id, external_group_ids)
       values (
         ${input.orgId}, ${input.userId}, ${provider}, ${tenantId},
-        ${groups.map((group) => group.externalId)}::text[]
+        (ARRAY[${sql.raw(
+          groups
+            .map((group) => `'${group.externalId.replace(/'/g, "''")}'`)
+            .join(","),
+        )}])::text[]
       )
     `);
   });

--- a/apps/web/src/lib/integrations.ts
+++ b/apps/web/src/lib/integrations.ts
@@ -19,6 +19,8 @@ export interface ConnectProvider {
   pluginName: string;
   providerLabel: string;
   scopes: string[];
+  flow: string;
+  credentialScope: string;
 }
 
 export interface ConnectStatus {
@@ -80,6 +82,20 @@ export async function getOperatorConnectStatus(
   }
 }
 
+export async function getDeploymentConnectStatus(): Promise<ConnectStatus[]> {
+  try {
+    const res = await fetch(
+      `${workerAdminBase()}/admin/connect/deployment/status`,
+      { cache: "no-store", signal: AbortSignal.timeout(2000) },
+    );
+    if (!res.ok) return [];
+    const body = (await res.json()) as { connected?: ConnectStatus[] };
+    return body.connected ?? [];
+  } catch {
+    return [];
+  }
+}
+
 export async function beginConnect(
   pluginName: string,
   params: {
@@ -89,12 +105,14 @@ export async function beginConnect(
     scopes: string[];
     codeVerifier: string;
   },
-): Promise<{ authorizationUrl: string }> {
+): Promise<{ authorizationUrl: string; oauthState?: string }> {
   const res = await fetch(`${workerAdminBase()}/admin/connect/begin`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ pluginName, params }),
-    signal: AbortSignal.timeout(15_000),
+    // First call after install pays the sandbox cold-start plus MCP-OAuth
+    // discovery + DCR round-trips — 15s is not enough on the first click.
+    signal: AbortSignal.timeout(60_000),
   });
   if (!res.ok) {
     const text = await res.text().catch(() => "");
@@ -102,7 +120,7 @@ export async function beginConnect(
       `connect plugin begin failed (${res.status}): ${text || res.statusText}`,
     );
   }
-  return (await res.json()) as { authorizationUrl: string };
+  return (await res.json()) as { authorizationUrl: string; oauthState?: string };
 }
 
 export async function completeConnect(
@@ -114,13 +132,14 @@ export async function completeConnect(
     state: string;
     codeVerifier: string;
     scopes: string[];
+    oauthState?: string;
   },
 ): Promise<ConnectorCredential> {
   const res = await fetch(`${workerAdminBase()}/admin/connect/complete`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ pluginName, params }),
-    signal: AbortSignal.timeout(30_000),
+    signal: AbortSignal.timeout(60_000),
   });
   if (!res.ok) {
     const text = await res.text().catch(() => "");
@@ -147,6 +166,19 @@ export async function disconnectConnector(
   return Boolean(body.removed);
 }
 
+/**
+ * Deployment-scoped connect uses a reserved operator slot — every admin
+ * sees the same org-wide credential.
+ */
+export function disconnectDeploymentConnector(
+  pluginName: string,
+): Promise<boolean> {
+  return disconnectConnector(pluginName, DEPLOYMENT_CONNECT_OPERATOR_ID);
+}
+
+/** Reserved operator id for deployment-scoped connect flows. */
+export const DEPLOYMENT_CONNECT_OPERATOR_ID = "deployment";
+
 // ─── State cookie ──────────────────────────────────────────────────────
 
 /**
@@ -162,6 +194,8 @@ export interface ConnectStateCookiePayload {
   state: string;
   codeVerifier: string;
   returnPath: string;
+  /** mcp-oauth: opaque state the plugin returned from begin (DCR + PKCE + endpoints). */
+  oauthState?: string;
 }
 
 export function newStateToken(): string {
@@ -225,7 +259,8 @@ function isStatePayload(value: unknown): value is ConnectStateCookiePayload {
     typeof v.operatorId === "string" &&
     typeof v.state === "string" &&
     typeof v.codeVerifier === "string" &&
-    typeof v.returnPath === "string"
+    typeof v.returnPath === "string" &&
+    (v.oauthState === undefined || typeof v.oauthState === "string")
   );
 }
 

--- a/apps/web/src/lib/sso-setup.ts
+++ b/apps/web/src/lib/sso-setup.ts
@@ -1,0 +1,173 @@
+// SSO admin-setup client — mirrors auth.ts's worker bridge. The web app
+// reaches the worker's /admin/sso/setup/* endpoints over loopback; the worker
+// drives the auth plugin's workspace MCP tools (portal link + connections).
+
+export type SsoSetupStatus =
+  | "not_started"
+  | "awaiting_portal"
+  | "polling"
+  | "connected"
+  | "failed";
+
+export interface SsoSetupConnection {
+  status: string;
+  provider: string | null;
+  enabled: boolean;
+}
+
+export interface SsoSetupStatusResult {
+  status: SsoSetupStatus;
+  portalLink: string | null;
+  portalLinkExpiresAt: string | null;
+  provider: string | null;
+  connection: SsoSetupConnection | null;
+  lastError: string | null;
+  setupCompletedAt: string | null;
+  environmentId: string | null;
+  organizationId: string | null;
+  environmentTier: string | null;
+  signInConfigured: boolean;
+}
+
+export interface SsoSetupCheckResult {
+  status: SsoSetupStatus;
+  connection: SsoSetupConnection | null;
+  lastError: string | null;
+  setupCompletedAt: string | null;
+}
+
+function workerAdminBase(): string {
+  const raw = process.env.WORKER_ADMIN_URL ?? "http://127.0.0.1:4100";
+  return raw.replace(/\/+$/, "");
+}
+
+async function readError(res: Response, label: string): Promise<Error> {
+  const text = await res.text().catch(() => "");
+  let detail = text;
+  try {
+    const parsed = JSON.parse(text) as { error?: string };
+    if (parsed.error) detail = parsed.error;
+  } catch {
+    // non-JSON body — use raw text.
+  }
+  return new Error(`${label} failed (${res.status}): ${detail || res.statusText}`);
+}
+
+async function postJson(
+  path: string,
+  body: Record<string, unknown>,
+  label: string,
+): Promise<unknown> {
+  const res = await fetch(`${workerAdminBase()}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(20_000),
+  });
+  if (!res.ok) throw await readError(res, label);
+  return res.json();
+}
+
+export async function getSsoSetupStatus(
+  orgId: string,
+): Promise<SsoSetupStatusResult> {
+  const res = await fetch(
+    `${workerAdminBase()}/admin/sso/setup/status?orgId=${encodeURIComponent(orgId)}`,
+    { method: "GET", cache: "no-store", signal: AbortSignal.timeout(2000) },
+  );
+  if (!res.ok) throw await readError(res, "SSO setup status");
+  return (await res.json()) as SsoSetupStatusResult;
+}
+
+export async function setSsoScalekitIds(
+  orgId: string,
+  input: { environmentId: string; organizationId: string; tier: string },
+): Promise<void> {
+  await postJson(
+    "/admin/sso/setup/ids",
+    { orgId, ...input },
+    "SSO environment selection",
+  );
+}
+
+export interface SsoEnvironmentRow {
+  id: string;
+  name: string | null;
+  tier: string | null;
+  domain: string | null;
+}
+
+export interface SsoOrganizationRow {
+  id: string;
+  name: string | null;
+}
+
+export async function listSsoEnvironments(
+  orgId: string,
+): Promise<SsoEnvironmentRow[]> {
+  const res = await fetch(
+    `${workerAdminBase()}/admin/sso/setup/environments?orgId=${encodeURIComponent(orgId)}`,
+    { method: "GET", cache: "no-store", signal: AbortSignal.timeout(30_000) },
+  );
+  if (!res.ok) throw await readError(res, "SSO environment list");
+  const body = (await res.json()) as { environments?: SsoEnvironmentRow[] };
+  return body.environments ?? [];
+}
+
+export async function listSsoOrganizations(
+  orgId: string,
+  environmentId: string,
+): Promise<SsoOrganizationRow[]> {
+  const res = await fetch(
+    `${workerAdminBase()}/admin/sso/setup/organizations?orgId=${encodeURIComponent(orgId)}&environmentId=${encodeURIComponent(environmentId)}`,
+    { method: "GET", cache: "no-store", signal: AbortSignal.timeout(30_000) },
+  );
+  if (!res.ok) throw await readError(res, "SSO organization list");
+  const body = (await res.json()) as { organizations?: SsoOrganizationRow[] };
+  return body.organizations ?? [];
+}
+
+export async function getSsoEnvironmentCredentials(
+  orgId: string,
+  environmentId: string,
+): Promise<{ environmentUrl: string; clientId: string }> {
+  const res = await fetch(
+    `${workerAdminBase()}/admin/sso/setup/credentials-info?orgId=${encodeURIComponent(orgId)}&environmentId=${encodeURIComponent(environmentId)}`,
+    { method: "GET", cache: "no-store", signal: AbortSignal.timeout(30_000) },
+  );
+  if (!res.ok) throw await readError(res, "SSO credentials fetch");
+  return (await res.json()) as { environmentUrl: string; clientId: string };
+}
+
+export async function setSsoSignInCredentials(
+  orgId: string,
+  input: { environmentUrl: string; clientId: string; clientSecret: string },
+): Promise<void> {
+  await postJson(
+    "/admin/sso/setup/credentials",
+    { orgId, ...input },
+    "SSO sign-in credentials",
+  );
+}
+
+export async function generateSsoPortalLink(
+  orgId: string,
+): Promise<{ portalLink: string; expiresAt: string | null }> {
+  const result = await postJson(
+    "/admin/sso/setup/generate-portal-link",
+    { orgId },
+    "SSO portal link generation",
+  );
+  return result as { portalLink: string; expiresAt: string | null };
+}
+
+export async function checkSsoConnection(
+  orgId: string,
+): Promise<SsoSetupCheckResult> {
+  const result = await postJson(
+    "/admin/sso/setup/check",
+    { orgId },
+    "SSO connection check",
+  );
+  return result as SsoSetupCheckResult;
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -137,10 +137,12 @@ export async function proxy(request: NextRequest): Promise<NextResponse> {
 }
 
 export const config = {
-  // Match everything except the SSO flow surfaces and static assets.
+  // Match everything except the SSO flow surfaces, the SSO setup
+  // surfaces (admin-gated internally — they must stay reachable before
+  // the first sign-in), and static assets.
   // Negative lookahead is a constant here so Next can statically
   // analyse it at build time (per the proxy.md API reference).
   matcher: [
-    "/((?!signin|api/auth/|_next/static/|_next/image/|favicon\\.ico).*)",
+    "/((?!signin|api/auth/|admin/settings/sso|api/sso/|integrations|api/integrations/|_next/static|_next/image|favicon\\.ico).*)",
   ],
 };

--- a/apps/web/test/api/integrations.test.ts
+++ b/apps/web/test/api/integrations.test.ts
@@ -165,18 +165,86 @@ describe("/api/integrations/disconnect/[plugin]", () => {
 });
 
 describe("/api/integrations/connect/[plugin]/start", () => {
-  it("401 when signed out", async () => {
+  it("401 when signed out (operator-scoped connector)", async () => {
     mockGetCurrentUser.mockResolvedValue(null);
+    fetchMock.mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.endsWith("/admin/connect/providers")) {
+        return jsonResponse(200, {
+          providers: [
+            {
+              pluginId: "open-neko-connector-google-workspace",
+              pluginName: "@open-neko/connector-google-workspace",
+              providerLabel: "Google Workspace",
+              scopes: ["gmail.send"],
+              flow: "oauth2-pkce",
+              credentialScope: "operator",
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
     const { GET } = await import(
       "@/app/api/integrations/connect/[plugin]/start/route"
     );
     const res = await callRoute(
       (req) =>
-        GET(req, { params: Promise.resolve({ plugin: "%40x%2Fy" }) }) as
-          | Promise<Response>
-          | Response,
+        GET(req, {
+          params: Promise.resolve({
+            plugin: encodeURIComponent("@open-neko/connector-google-workspace"),
+          }),
+        }) as Promise<Response> | Response,
     );
     expect(res.status).toBe(401);
+  });
+
+  it("deployment-scoped connectors are admin-gated, not user-gated", async () => {
+    // Signed out: the route must not 401/404 on user absence — it resolves
+    // the solo admin actor and proceeds to beginConnect (which fails here
+    // because the worker fetch is not stubbed → 502), proving the
+    // deployment-scope path is reachable before any SSO session exists.
+    mockGetCurrentUser.mockResolvedValue(null);
+    fetchMock.mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.endsWith("/admin/connect/providers")) {
+        return jsonResponse(200, {
+          providers: [
+            {
+              pluginId: "open-neko-plugin-scalekit",
+              pluginName: "@open-neko/plugin-scalekit",
+              providerLabel: "Scalekit workspace",
+              scopes: ["wks:read"],
+              flow: "mcp-oauth",
+              credentialScope: "deployment",
+            },
+          ],
+        });
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    });
+    const { GET } = await import(
+      "@/app/api/integrations/connect/[plugin]/start/route"
+    );
+    // The synthetic callRoute helper has no request scope, so cookies()
+    // throws once the route reaches the state-cookie write. That throw
+    // (or a 5xx) is fine — the assertion is that the auth gates did NOT
+    // reject the request.
+    let status: number | null = null;
+    try {
+      const res = await callRoute(
+        (req) =>
+          GET(req, {
+            params: Promise.resolve({
+              plugin: encodeURIComponent("@open-neko/plugin-scalekit"),
+            }),
+          }) as Promise<Response> | Response,
+      );
+      status = res.status;
+    } catch {
+      // passed the gates, then hit the request-scope-only cookie write.
+    }
+    expect(status === null || ![401, 404].includes(status)).toBe(true);
   });
 
   it("404 when plugin not installed", async () => {

--- a/apps/web/test/api/integrations.test.ts
+++ b/apps/web/test/api/integrations.test.ts
@@ -70,12 +70,16 @@ describe("/api/integrations/list", () => {
               pluginName: "@open-neko/connector-google-workspace",
               providerLabel: "Google Workspace",
               scopes: ["gmail.send"],
+              flow: "oauth2-pkce",
+              credentialScope: "operator",
             },
             {
-              pluginId: "open-neko-connector-github",
-              pluginName: "@open-neko/connector-github",
-              providerLabel: "GitHub",
-              scopes: ["repo:read"],
+              pluginId: "open-neko-plugin-scalekit",
+              pluginName: "@open-neko/plugin-scalekit",
+              providerLabel: "Scalekit workspace",
+              scopes: ["environment_read"],
+              flow: "mcp-oauth",
+              credentialScope: "deployment",
             },
           ],
         });
@@ -90,21 +94,33 @@ describe("/api/integrations/list", () => {
           ],
         });
       }
+      if (url.endsWith("/admin/connect/deployment/status")) {
+        return jsonResponse(200, {
+          connected: [
+            {
+              pluginName: "@open-neko/plugin-scalekit",
+              connectedAt: "2026-05-22T10:00:00Z",
+            },
+          ],
+        });
+      }
       throw new Error(`unexpected fetch: ${url}`);
     });
     const { GET } = await import("@/app/api/integrations/list/route");
     const res = await callRoute(GET);
     expect(res.status).toBe(200);
     const body = res.body as {
-      providers: Array<{ pluginName: string; connected: boolean; connectedAt: string | null }>;
+      workspace: Array<{ pluginName: string; connected: boolean }>;
+      connectors: Array<{ pluginName: string; connected: boolean }>;
     };
-    expect(body.providers).toHaveLength(2);
-    expect(body.providers.find((r) => r.pluginName === "@open-neko/connector-google-workspace")?.connected).toBe(
-      true,
+    expect(body.workspace).toHaveLength(1);
+    expect(body.workspace[0]!.pluginName).toBe("@open-neko/plugin-scalekit");
+    expect(body.workspace[0]!.connected).toBe(true);
+    expect(body.connectors).toHaveLength(1);
+    expect(body.connectors[0]!.pluginName).toBe(
+      "@open-neko/connector-google-workspace",
     );
-    expect(body.providers.find((r) => r.pluginName === "@open-neko/connector-github")?.connected).toBe(
-      false,
-    );
+    expect(body.connectors[0]!.connected).toBe(true);
   });
 });
 

--- a/apps/worker/src/admin-server.ts
+++ b/apps/worker/src/admin-server.ts
@@ -46,6 +46,12 @@ export interface AuthHandlerSurface {
     pluginName: string;
     providerLabel: string;
   } | null;
+  /**
+   * Whether sign-in is actually usable (all required env vars set).
+   * The web proxy gates on this, NOT on mere plugin presence — so the
+   * admin isn't locked out of the setup UI before SSO is configured.
+   */
+  authSignInReady(): boolean;
   beginAuth(params: {
     redirectUri: string;
     state: string;
@@ -70,14 +76,21 @@ export interface ConnectHandlerSurface {
     pluginName: string;
     providerLabel: string;
     scopes: string[];
+    flow: string;
+    credentialScope: string;
   }>;
   getOperatorConnectStatus(
     operatorId: string,
   ): Array<{ pluginName: string; connectedAt: string; scopes?: string[] }>;
+  getDeploymentConnectStatus(): Array<{
+    pluginName: string;
+    connectedAt: string;
+    scopes?: string[];
+  }>;
   beginConnect(
     pluginName: string,
     params: BeginConnectParams,
-  ): Promise<{ authorizationUrl: string }>;
+  ): Promise<{ authorizationUrl: string; oauthState?: string }>;
   completeConnect(
     pluginName: string,
     params: CompleteConnectParams,
@@ -87,6 +100,57 @@ export interface ConnectHandlerSurface {
     operatorId: string,
   ): Promise<ConnectorCredential>;
   disconnect(pluginName: string, operatorId: string): Promise<boolean>;
+}
+
+/**
+ * SSO admin-setup surface — the web app drives portal-link generation and
+ * connection polling through this. Wired to the SsoSetupService in index.ts.
+ */
+export interface SsoSetupHandlerSurface {
+  getStatus(orgId: string): Promise<{
+    status: string;
+    portalLink: string | null;
+    portalLinkExpiresAt: string | null;
+    provider: string | null;
+    connection: { status: string; provider: string | null; enabled: boolean } | null;
+    lastError: string | null;
+    setupCompletedAt: string | null;
+    environmentId: string | null;
+    organizationId: string | null;
+    environmentTier: string | null;
+    signInConfigured: boolean;
+  }>;
+  setScalekitIds(
+    orgId: string,
+    input: { environmentId: string; organizationId: string; tier: string },
+  ): Promise<void>;
+  listEnvironments(orgId: string): Promise<Array<{
+    id: string;
+    name: string | null;
+    tier: string | null;
+    domain: string | null;
+  }>>;
+  listOrganizations(
+    orgId: string,
+    environmentId: string,
+  ): Promise<Array<{ id: string; name: string | null }>>;
+  getEnvironmentCredentials(
+    orgId: string,
+    environmentId: string,
+  ): Promise<{ environmentUrl: string; clientId: string }>;
+  setSignInCredentials(
+    orgId: string,
+    input: { environmentUrl: string; clientId: string; clientSecret: string },
+  ): Promise<void>;
+  generatePortalLink(
+    orgId: string,
+  ): Promise<{ portalLink: string; expiresAt: string | null }>;
+  checkConnection(orgId: string): Promise<{
+    status: string;
+    connection: { status: string; provider: string | null; enabled: boolean } | null;
+    lastError: string | null;
+    setupCompletedAt: string | null;
+  }>;
 }
 
 /**
@@ -207,6 +271,12 @@ export type AdminHandlerOptions = {
    */
   connect?: ConnectHandlerSurface | null;
   /**
+   * SSO admin-setup surface — typically wired to the SsoSetupService.
+   * Absent when the plugin subsystem is disabled, in which case
+   * /admin/sso/setup/* routes return 503.
+   */
+  ssoSetup?: SsoSetupHandlerSurface | null;
+  /**
    * Channel surface — typically wired to the PluginRegistry + channel
    * delivery module. Absent when the plugin subsystem is disabled, in which
    * case channel routes return 503 / empty.
@@ -281,6 +351,7 @@ export function createAdminHandler(opts: AdminHandlerOptions = {}) {
   const auth = opts.auth ?? null;
   const plugins = opts.plugins ?? null;
   const connect = opts.connect ?? null;
+  const ssoSetup = opts.ssoSetup ?? null;
   const channels = opts.channels ?? null;
   const installPolicy = opts.installPolicy ?? null;
   const events = opts.events ?? null;
@@ -321,6 +392,50 @@ export function createAdminHandler(opts: AdminHandlerOptions = {}) {
       void handleAuthComplete(req, res, auth);
       return;
     }
+    if (req.method === "GET" && req.url?.split("?")[0] === "/admin/sso/setup/status") {
+      void handleSsoSetupStatus(req, res, ssoSetup);
+      return;
+    }
+    if (
+      req.method === "GET" &&
+      req.url?.split("?")[0] === "/admin/sso/setup/environments"
+    ) {
+      void handleSsoSetupEnvironments(req, res, ssoSetup);
+      return;
+    }
+    if (
+      req.method === "GET" &&
+      req.url?.split("?")[0] === "/admin/sso/setup/organizations"
+    ) {
+      void handleSsoSetupOrganizations(req, res, ssoSetup);
+      return;
+    }
+    if (
+      req.method === "GET" &&
+      req.url?.split("?")[0] === "/admin/sso/setup/credentials-info"
+    ) {
+      void handleSsoSetupCredentialsInfo(req, res, ssoSetup);
+      return;
+    }
+    if (req.method === "POST" && req.url === "/admin/sso/setup/ids") {
+      void handleSsoSetupIds(req, res, ssoSetup);
+      return;
+    }
+    if (req.method === "POST" && req.url === "/admin/sso/setup/credentials") {
+      void handleSsoSetupCredentials(req, res, ssoSetup);
+      return;
+    }
+    if (
+      req.method === "POST" &&
+      req.url === "/admin/sso/setup/generate-portal-link"
+    ) {
+      void handleSsoSetupGeneratePortalLink(req, res, ssoSetup);
+      return;
+    }
+    if (req.method === "POST" && req.url === "/admin/sso/setup/check") {
+      void handleSsoSetupCheck(req, res, ssoSetup);
+      return;
+    }
     if (
       req.method === "GET" &&
       req.url === "/admin/plugins/action-descriptors"
@@ -334,6 +449,10 @@ export function createAdminHandler(opts: AdminHandlerOptions = {}) {
     }
     if (req.method === "GET" && req.url === "/admin/connect/providers") {
       handleConnectProviders(res, connect);
+      return;
+    }
+    if (req.method === "GET" && req.url === "/admin/connect/deployment/status") {
+      handleDeploymentConnectStatus(res, connect);
       return;
     }
     const statusMatch = req.method === "GET" && req.url?.startsWith("/admin/connect/status/");
@@ -569,7 +688,10 @@ function handleAuthStatus(res: ServerResponse, auth: AuthHandlerSurface | null) 
     json(res, 200, { provider: null });
     return;
   }
-  const provider = auth.getAuthProvider();
+  // Only surface the provider once sign-in is configured — before that
+  // the deployment stays in single-operator mode so the admin can reach
+  // the setup UI and configure credentials.
+  const provider = auth.authSignInReady() ? auth.getAuthProvider() : null;
   json(res, 200, {
     provider: provider
       ? {
@@ -786,6 +908,227 @@ async function handleAuthComplete(
   }
 }
 
+// ─── SSO admin setup ────────────────────────────────────────────────────
+
+function ssoSetupOrgId(body: unknown, res: ServerResponse): string | null {
+  const orgId = (body as Record<string, unknown> | null)?.orgId;
+  if (typeof orgId !== "string" || !orgId) {
+    json(res, 400, { error: "orgId (string) is required" });
+    return null;
+  }
+  return orgId;
+}
+
+async function handleSsoSetupStatus(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ssoSetup: SsoSetupHandlerSurface | null,
+) {
+  if (!ssoSetup) {
+    json(res, 503, { error: "plugin subsystem disabled" });
+    return;
+  }
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const orgId = url.searchParams.get("orgId") ?? "";
+  if (!orgId) {
+    json(res, 400, { error: "orgId query parameter is required" });
+    return;
+  }
+  try {
+    json(res, 200, await ssoSetup.getStatus(orgId));
+  } catch (err) {
+    json(res, 500, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+async function handleSsoSetupEnvironments(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ssoSetup: SsoSetupHandlerSurface | null,
+) {
+  if (!ssoSetup) {
+    json(res, 503, { error: "plugin subsystem disabled" });
+    return;
+  }
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const orgId = url.searchParams.get("orgId") ?? "";
+  if (!orgId) {
+    json(res, 400, { error: "orgId query parameter is required" });
+    return;
+  }
+  try {
+    json(res, 200, { environments: await ssoSetup.listEnvironments(orgId) });
+  } catch (err) {
+    json(res, 500, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+async function handleSsoSetupOrganizations(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ssoSetup: SsoSetupHandlerSurface | null,
+) {
+  if (!ssoSetup) {
+    json(res, 503, { error: "plugin subsystem disabled" });
+    return;
+  }
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const orgId = url.searchParams.get("orgId") ?? "";
+  const environmentId = url.searchParams.get("environmentId") ?? "";
+  if (!orgId || !environmentId) {
+    json(res, 400, {
+      error: "orgId and environmentId query parameters are required",
+    });
+    return;
+  }
+  try {
+    json(res, 200, {
+      organizations: await ssoSetup.listOrganizations(orgId, environmentId),
+    });
+  } catch (err) {
+    json(res, 500, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+async function handleSsoSetupCredentialsInfo(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ssoSetup: SsoSetupHandlerSurface | null,
+) {
+  if (!ssoSetup) {
+    json(res, 503, { error: "plugin subsystem disabled" });
+    return;
+  }
+  const url = new URL(req.url ?? "/", "http://localhost");
+  const orgId = url.searchParams.get("orgId") ?? "";
+  const environmentId = url.searchParams.get("environmentId") ?? "";
+  if (!orgId || !environmentId) {
+    json(res, 400, {
+      error: "orgId and environmentId query parameters are required",
+    });
+    return;
+  }
+  try {
+    json(res, 200, await ssoSetup.getEnvironmentCredentials(orgId, environmentId));
+  } catch (err) {
+    json(res, 500, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+async function handleSsoSetupGeneratePortalLink(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ssoSetup: SsoSetupHandlerSurface | null,
+) {
+  if (!ssoSetup) {
+    json(res, 503, { error: "plugin subsystem disabled" });
+    return;
+  }
+  const body = await readJson(req).catch(() => null);
+  const orgId = ssoSetupOrgId(body, res);
+  if (!orgId) return;
+  try {
+    json(res, 200, await ssoSetup.generatePortalLink(orgId));
+  } catch (err) {
+    json(res, 500, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+async function handleSsoSetupIds(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ssoSetup: SsoSetupHandlerSurface | null,
+) {
+  if (!ssoSetup) {
+    json(res, 503, { error: "plugin subsystem disabled" });
+    return;
+  }
+  const body = (await readJson(req).catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  const orgId = ssoSetupOrgId(body, res);
+  if (!orgId) return;
+  const { environmentId, organizationId, tier } = body ?? {};
+  if (typeof environmentId !== "string" || !environmentId) {
+    json(res, 400, { error: "environmentId (string) is required" });
+    return;
+  }
+  if (typeof organizationId !== "string" || !organizationId) {
+    json(res, 400, { error: "organizationId (string) is required" });
+    return;
+  }
+  try {
+    await ssoSetup.setScalekitIds(orgId, {
+      environmentId,
+      organizationId,
+      tier: typeof tier === "string" && tier ? tier : "dev",
+    });
+    json(res, 200, { ok: true });
+  } catch (err) {
+    json(res, 500, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+async function handleSsoSetupCredentials(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ssoSetup: SsoSetupHandlerSurface | null,
+) {
+  if (!ssoSetup) {
+    json(res, 503, { error: "plugin subsystem disabled" });
+    return;
+  }
+  const body = (await readJson(req).catch(() => null)) as Record<
+    string,
+    unknown
+  > | null;
+  const orgId = ssoSetupOrgId(body, res);
+  if (!orgId) return;
+  const { environmentUrl, clientId, clientSecret } = body ?? {};
+  if (typeof environmentUrl !== "string" || !environmentUrl) {
+    json(res, 400, { error: "environmentUrl (string) is required" });
+    return;
+  }
+  if (typeof clientId !== "string" || !clientId) {
+    json(res, 400, { error: "clientId (string) is required" });
+    return;
+  }
+  if (typeof clientSecret !== "string" || !clientSecret) {
+    json(res, 400, { error: "clientSecret (string) is required" });
+    return;
+  }
+  try {
+    await ssoSetup.setSignInCredentials(orgId, {
+      environmentUrl,
+      clientId,
+      clientSecret,
+    });
+    json(res, 200, { ok: true });
+  } catch (err) {
+    json(res, 500, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+async function handleSsoSetupCheck(
+  req: IncomingMessage,
+  res: ServerResponse,
+  ssoSetup: SsoSetupHandlerSurface | null,
+) {
+  if (!ssoSetup) {
+    json(res, 503, { error: "plugin subsystem disabled" });
+    return;
+  }
+  const body = await readJson(req).catch(() => null);
+  const orgId = ssoSetupOrgId(body, res);
+  if (!orgId) return;
+  try {
+    json(res, 200, await ssoSetup.checkConnection(orgId));
+  } catch (err) {
+    json(res, 500, { error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
 // ─── Connect (per-operator OAuth) ──────────────────────────────────────
 
 function handleConnectProviders(
@@ -818,6 +1161,17 @@ function handleConnectStatus(
   json(res, 200, { connected: connect.getOperatorConnectStatus(operatorId) });
 }
 
+function handleDeploymentConnectStatus(
+  res: ServerResponse,
+  connect: ConnectHandlerSurface | null,
+) {
+  if (!connect) {
+    json(res, 200, { connected: [] });
+    return;
+  }
+  json(res, 200, { connected: connect.getDeploymentConnectStatus() });
+}
+
 async function handleConnectBegin(
   req: IncomingMessage,
   res: ServerResponse,
@@ -844,7 +1198,10 @@ async function handleConnectBegin(
   }
   try {
     const result = await connect.beginConnect(pluginName, params as BeginConnectParams);
-    json(res, 200, { authorizationUrl: result.authorizationUrl });
+    json(res, 200, {
+      authorizationUrl: result.authorizationUrl,
+      ...(result.oauthState ? { oauthState: result.oauthState } : {}),
+    });
   } catch (err) {
     json(res, 500, { error: err instanceof Error ? err.message : String(err) });
   }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -43,7 +43,12 @@ import {
 import {
   createAdminHandler,
   type RecordsImportHandlerSurface,
+  type SsoSetupHandlerSurface,
 } from "./admin-server.js";
+import {
+  SsoSetupService,
+  startSsoSetupPoller,
+} from "./sso/sso-setup-service.js";
 import {
   and,
   data_source,
@@ -392,6 +397,7 @@ async function runMetricRefreshSweep() {
 // without a server restart.
 let pluginRegistry: PluginRegistry | null = null;
 let recordsImportAdminSurface: RecordsImportHandlerSurface | null = null;
+let ssoSetupService: SsoSetupService | null = null;
 let actionRequestPreflightReady = false;
 function recordsImportSurface(): RecordsImportHandlerSurface {
   if (!recordsImportAdminSurface) {
@@ -399,10 +405,47 @@ function recordsImportSurface(): RecordsImportHandlerSurface {
   }
   return recordsImportAdminSurface;
 }
+function ssoSetupSurface(): SsoSetupHandlerSurface {
+  return {
+    getStatus: (orgId) => {
+      if (!ssoSetupService) throw new Error("SSO setup service not ready");
+      return ssoSetupService.getStatus(orgId);
+    },
+    setScalekitIds: (orgId, input) => {
+      if (!ssoSetupService) throw new Error("SSO setup service not ready");
+      return ssoSetupService.setScalekitIds(orgId, input);
+    },
+    listEnvironments: (orgId) => {
+      if (!ssoSetupService) throw new Error("SSO setup service not ready");
+      return ssoSetupService.listEnvironments(orgId);
+    },
+    listOrganizations: (orgId, environmentId) => {
+      if (!ssoSetupService) throw new Error("SSO setup service not ready");
+      return ssoSetupService.listOrganizations(orgId, environmentId);
+    },
+    getEnvironmentCredentials: (orgId, environmentId) => {
+      if (!ssoSetupService) throw new Error("SSO setup service not ready");
+      return ssoSetupService.getEnvironmentCredentials(orgId, environmentId);
+    },
+    setSignInCredentials: (orgId, input) => {
+      if (!ssoSetupService) throw new Error("SSO setup service not ready");
+      return ssoSetupService.setSignInCredentials(orgId, input);
+    },
+    generatePortalLink: (orgId) => {
+      if (!ssoSetupService) throw new Error("SSO setup service not ready");
+      return ssoSetupService.generatePortalLink(orgId);
+    },
+    checkConnection: (orgId) => {
+      if (!ssoSetupService) throw new Error("SSO setup service not ready");
+      return ssoSetupService.checkConnection(orgId);
+    },
+  };
+}
 const server = createServer(
   createAdminHandler({
     auth: {
       getAuthProvider: () => pluginRegistry?.getAuthProvider() ?? null,
+      authSignInReady: () => pluginRegistry?.authSignInReady() ?? false,
       beginAuth: (params) => {
         if (!pluginRegistry) {
           throw new Error("plugin registry not initialised");
@@ -476,6 +519,8 @@ const server = createServer(
       getConnectProviders: () => pluginRegistry?.getConnectProviders() ?? [],
       getOperatorConnectStatus: (operatorId) =>
         pluginRegistry?.getOperatorConnectStatus(operatorId) ?? [],
+      getDeploymentConnectStatus: () =>
+        pluginRegistry?.getDeploymentConnectStatus() ?? [],
       beginConnect: (pluginName, params) => {
         if (!pluginRegistry) throw new Error("plugin registry not initialised");
         return pluginRegistry.beginConnect(pluginName, params);
@@ -493,6 +538,7 @@ const server = createServer(
         return pluginRegistry.disconnect(pluginName, operatorId);
       },
     },
+    ssoSetup: ssoSetupSurface(),
     channels: {
       getChannelProviders: () => pluginRegistry?.getChannelProviders() ?? [],
       deliver: (pluginName, recipient, events) => {
@@ -689,6 +735,8 @@ pluginRegistry = new PluginRegistry({
 });
 await pluginRegistry.start();
 setPluginRegistryInstance(pluginRegistry);
+ssoSetupService = new SsoSetupService(() => pluginRegistry);
+startSsoSetupPoller({ service: ssoSetupService, orgId: ADMIN_ORG_ID });
 registerChannelOutputDelivery();
 await seedOpenNekoOpsWorkflow(ADMIN_ORG_ID);
 {

--- a/apps/worker/src/plugins/plugin-registry.ts
+++ b/apps/worker/src/plugins/plugin-registry.ts
@@ -27,6 +27,7 @@ import {
   watch as fsWatch,
 } from "node:fs";
 import { copyFile, mkdir, readFile } from "node:fs/promises";
+import { randomBytes } from "node:crypto";
 import { createRequire } from "node:module";
 import path from "node:path";
 import {
@@ -64,6 +65,7 @@ import {
   readFullSecretsFileSoft,
   type SecretsResolver,
   setOperatorCredential,
+  setSecret,
   unsetOperatorCredential,
   writeFullSecretsFile,
   type FullSecretsFile,
@@ -182,6 +184,13 @@ const EMPTY_STATE: ManifestState = {
 };
 
 const REFRESH_DEBOUNCE_MS = 200;
+
+/**
+ * Reserved secrets-store operator slot for deployment-scoped connect
+ * credentials. One org-wide credential consented by an admin, injected
+ * on every action call of a credentialScope:"deployment" connector.
+ */
+export const DEPLOYMENT_CONNECT_SLOT = "deployment";
 
 export class PluginRegistry {
   private runtime: PluginRuntime | null = null;
@@ -352,6 +361,27 @@ export class PluginRegistry {
   }
 
   /**
+   * Whether the auth plugin's sign-in flow is actually usable: every
+   * required env var declared by its manifest has a non-empty value.
+   * Until then the deployment stays in single-operator mode — the gate
+   * must not flip before the admin has configured sign-in, or they get
+   * locked out of the setup UI entirely.
+   */
+  authSignInReady(): boolean {
+    const provider = this.getAuthProvider();
+    if (!provider) return false;
+    const entry = this.state.entriesByPluginId.get(provider.pluginId);
+    if (!entry) return false;
+    const env = mergeEnv(entry, this.secrets);
+    for (const req of entry.permissions.env ?? []) {
+      if (req.required !== true) continue;
+      const value = env[req.key];
+      if (typeof value !== "string" || value.length === 0) return false;
+    }
+    return true;
+  }
+
+  /**
    * Drive the auth plugin's `begin_auth` over RPC. The web app calls
    * this through the worker admin endpoint; the registry handles VM
    * lifecycle + env injection exactly like an action call.
@@ -424,6 +454,76 @@ export class PluginRegistry {
     return { pluginId, entry };
   }
 
+  /**
+   * System-initiated action invocation — bypasses the agent's approval
+   * engine so core services (the SSO setup poller) can drive a plugin
+   * action directly. The plugin action handler sees a normal
+   * PluginActionRequest; `actorId` is null and `scope` is "internal".
+   * `orgId` is the caller's org for request bookkeeping.
+   */
+  async invokeAction(
+    pluginId: string,
+    kind: string,
+    payload: Record<string, unknown>,
+    orgId = "",
+  ): Promise<PluginActionOutcome> {
+    const entry = this.state.entriesByPluginId.get(pluginId);
+    if (!entry) {
+      throw new Error(
+        `plugin-registry: ${pluginId} not in current manifest (kind=${kind}) — has the plugin been removed?`,
+      );
+    }
+    if (!this.runtime) {
+      throw new Error("plugin-registry: runtime unavailable");
+    }
+    await this.ensureVm(pluginId, entry);
+    // Deployment-scoped connectors get the org-wide credential injected
+    // even for system-initiated calls (actorId null → operator scope is skipped).
+    const env = await this.injectConnectCredential(entry, null);
+    const params: PluginActionRequest = {
+      id: `sys_${randomBytes(9).toString("base64url")}`,
+      orgId,
+      actorId: null,
+      scope: "internal",
+      kind,
+      target: null,
+      summary: null,
+      payload,
+      riskLevel: null,
+    };
+    const response = await this.runtime.callRpc(
+      pluginId,
+      "execute_action",
+      JSON.stringify(ExecuteActionParams.parse({ request: params })),
+      { env },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `plugin ${pluginId} action ${kind} failed: ${response.error.code} ${response.error.message}`,
+      );
+    }
+    return ExecuteActionResult.parse(response.result).outcome;
+  }
+
+  /**
+   * Admin-initiated write of one plugin env secret into the encrypted
+   * vault (the settings page's sign-in credential entry). Re-derives the
+   * scrubber so the new value is redacted from agent output immediately.
+   */
+  async setPluginSecret(
+    pluginName: string,
+    key: string,
+    value: string,
+  ): Promise<void> {
+    const before: FullSecretsFile = { env: this.secrets, operators: this.operators };
+    const nextEnv = setSecret(before.env, pluginName, key, value);
+    this.secrets = nextEnv;
+    await writeFullSecretsFile({ env: nextEnv, operators: before.operators }, this.options.secretsConfigDir);
+    this.scrubber = createScrubber(
+      allSecretValuesFull({ env: nextEnv, operators: before.operators }),
+    );
+  }
+
   // ─── connect capability (per-operator OAuth) ─────────────────────────
 
   /**
@@ -436,12 +536,16 @@ export class PluginRegistry {
     pluginName: string;
     providerLabel: string;
     scopes: string[];
+    flow: string;
+    credentialScope: string;
   }> {
     const out: Array<{
       pluginId: string;
       pluginName: string;
       providerLabel: string;
       scopes: string[];
+      flow: string;
+      credentialScope: string;
     }> = [];
     for (const [pluginId, entry] of this.state.entriesByPluginId) {
       const decl = entry.capabilities.connect;
@@ -451,6 +555,8 @@ export class PluginRegistry {
         pluginName: entry.name,
         providerLabel: decl.providerLabel,
         scopes: decl.scopes,
+        flow: decl.flow,
+        credentialScope: decl.credentialScope,
       });
     }
     return out;
@@ -663,6 +769,42 @@ export class PluginRegistry {
   }
 
   /**
+   * Deployment-scoped connect status — the reserved-slot credential for
+   * connectors declaring credentialScope "deployment". The web renders
+   * these as a single workspace-level row instead of per-operator rows.
+   */
+  getDeploymentConnectStatus(): Array<{
+    pluginName: string;
+    connectedAt: string;
+    scopes?: string[];
+  }> {
+    const byPlugin = this.operators[DEPLOYMENT_CONNECT_SLOT] ?? {};
+    return Object.entries(byPlugin)
+      .map(([pluginName, cred]) => ({
+        pluginName,
+        connectedAt: cred.connectedAt,
+        scopes: cred.scopes,
+      }))
+      .sort((a, b) => a.pluginName.localeCompare(b.pluginName));
+  }
+
+  isDeploymentConnected(pluginName: string): boolean {
+    return this.operators[DEPLOYMENT_CONNECT_SLOT]?.[pluginName] != null;
+  }
+
+  /**
+   * Resolve the secrets-store operator slot a connector's credential
+   * lives under: deployment-scoped connectors always use the reserved
+   * deployment slot (whatever operatorId the web passed is ignored);
+   * operator-scoped connectors use the passed operatorId.
+   */
+  private connectSlotFor(entry: PluginManifestEntry, operatorId: string): string {
+    return entry.capabilities.connect?.credentialScope === "deployment"
+      ? DEPLOYMENT_CONNECT_SLOT
+      : operatorId;
+  }
+
+  /**
    * Per-operator connect status across every installed connector. Lets
    * the web app render the integrations page in one query.
    */
@@ -688,8 +830,9 @@ export class PluginRegistry {
   async beginConnect(
     pluginName: string,
     params: BeginConnectParams,
-  ): Promise<{ authorizationUrl: string }> {
+  ): Promise<{ authorizationUrl: string; oauthState?: string }> {
     const { pluginId, entry } = this.requireConnectPluginEntry(pluginName);
+    const operatorId = this.connectSlotFor(entry, params.operatorId);
     await this.ensureVm(pluginId, entry);
     const env = mergeEnv(entry, this.secrets);
     if (!this.runtime) {
@@ -698,7 +841,9 @@ export class PluginRegistry {
     const response = await this.runtime.callRpc(
       pluginId,
       "begin_connect",
-      JSON.stringify(BeginConnectRpcParams.parse({ params })),
+      JSON.stringify(
+        BeginConnectRpcParams.parse({ params: { ...params, operatorId } }),
+      ),
       { env },
     );
     if (!response.ok) {
@@ -711,7 +856,8 @@ export class PluginRegistry {
 
   /**
    * Drive the connect plugin's `complete_connect` RPC, then persist
-   * the returned credential under the operator's slot in the secrets
+   * the returned credential under the operator's slot (or the
+   * deployment slot for deployment-scoped connectors) in the secrets
    * file. The worker remains the only writer to secrets.json — the
    * plugin never touches disk directly.
    */
@@ -720,6 +866,7 @@ export class PluginRegistry {
     params: CompleteConnectParams,
   ): Promise<ConnectorCredential> {
     const { pluginId, entry } = this.requireConnectPluginEntry(pluginName);
+    const operatorId = this.connectSlotFor(entry, params.operatorId);
     await this.ensureVm(pluginId, entry);
     const env = mergeEnv(entry, this.secrets);
     if (!this.runtime) {
@@ -728,7 +875,9 @@ export class PluginRegistry {
     const response = await this.runtime.callRpc(
       pluginId,
       "complete_connect",
-      JSON.stringify(CompleteConnectRpcParams.parse({ params })),
+      JSON.stringify(
+        CompleteConnectRpcParams.parse({ params: { ...params, operatorId } }),
+      ),
       { env },
     );
     if (!response.ok) {
@@ -737,7 +886,7 @@ export class PluginRegistry {
       );
     }
     const credential = CompleteConnectRpcResult.parse(response.result).result.credential;
-    await this.persistOperatorCredential(params.operatorId, entry.name, credential);
+    await this.persistOperatorCredential(operatorId, entry.name, credential);
     return credential;
   }
 
@@ -752,14 +901,15 @@ export class PluginRegistry {
     operatorId: string,
   ): Promise<ConnectorCredential> {
     const { pluginId, entry } = this.requireConnectPluginEntry(pluginName);
+    const slot = this.connectSlotFor(entry, operatorId);
     const current = getOperatorCredential(
       { env: this.secrets, operators: this.operators },
-      operatorId,
+      slot,
       entry.name,
     );
     if (!current) {
       throw new Error(
-        `connect plugin ${entry.name}: no credential to refresh for operator ${operatorId}`,
+        `connect plugin ${entry.name}: no credential to refresh for operator ${slot}`,
       );
     }
     await this.ensureVm(pluginId, entry);
@@ -770,7 +920,7 @@ export class PluginRegistry {
     const response = await this.runtime.callRpc(
       pluginId,
       "refresh_connect",
-      JSON.stringify(RefreshConnectRpcParams.parse({ params: { operatorId, current } })),
+      JSON.stringify(RefreshConnectRpcParams.parse({ params: { operatorId: slot, current } })),
       { env },
     );
     if (!response.ok) {
@@ -783,7 +933,7 @@ export class PluginRegistry {
       ...credential,
       refreshedAt: credential.refreshedAt ?? new Date().toISOString(),
     };
-    await this.persistOperatorCredential(operatorId, entry.name, stamped);
+    await this.persistOperatorCredential(slot, entry.name, stamped);
     return stamped;
   }
 
@@ -795,8 +945,12 @@ export class PluginRegistry {
   async disconnect(pluginName: string, operatorId: string): Promise<boolean> {
     // Don't require the plugin to still be installed — a removed
     // plugin's orphaned credentials should still be cleanable.
+    const entry = [...this.state.entriesByPluginId.values()].find(
+      (e) => e.name === pluginName,
+    );
+    const slot = entry ? this.connectSlotFor(entry, operatorId) : operatorId;
     const before: FullSecretsFile = { env: this.secrets, operators: this.operators };
-    const { store, removed } = unsetOperatorCredential(before, operatorId, pluginName);
+    const { store, removed } = unsetOperatorCredential(before, slot, pluginName);
     if (!removed) return false;
     this.operators = store.operators;
     await writeFullSecretsFile(store, this.options.secretsConfigDir);
@@ -1090,27 +1244,8 @@ export class PluginRegistry {
         );
       }
       await this.ensureVm(pluginId, entry);
-      let env = mergeEnv(entry, this.secrets);
-      // For connect-capable plugins, inject the calling operator's
-      // credential as OPENNEKO_CONNECTOR_CREDENTIAL_TOKENS. The plugin's
-      // action handler reads + parses this env var to make the API call.
-      // Absent operator → no credential → action handler errors clearly
-      // (the operator must Connect via /integrations first).
       const actorId = (request as { actorId?: string | null }).actorId ?? null;
-      if (entry.capabilities.connect && actorId) {
-        const credential = getOperatorCredential(
-          { env: this.secrets, operators: this.operators },
-          actorId,
-          entry.name,
-        );
-        if (credential) {
-          env = {
-            ...env,
-            OPENNEKO_CONNECTOR_CREDENTIAL_TOKENS: JSON.stringify(credential.tokens),
-            OPENNEKO_OPERATOR_ID: actorId,
-          };
-        }
-      }
+      const env = await this.injectConnectCredential(entry, actorId);
       const params: PluginActionRequest = {
         id: request.id,
         orgId: request.orgId,
@@ -1142,6 +1277,61 @@ export class PluginRegistry {
         result: outcome.result ?? null,
       };
     };
+  }
+
+  /**
+   * Build the env bag for a connect-capable plugin's action call. For
+   * operator-scoped connectors the calling operator's credential is
+   * injected (absent operator → no credential). For deployment-scoped
+   * connectors the org-wide credential is injected on EVERY call,
+   * regardless of actor, and pre-refreshed via the plugin's
+   * refresh_connect RPC when its tokens are near expiry (persisted
+   * writeback, so the next call sees the fresh token).
+   */
+  private async injectConnectCredential(
+    entry: PluginManifestEntry,
+    actorId: string | null,
+  ): Promise<Record<string, string>> {
+    let env = mergeEnv(entry, this.secrets);
+    const decl = entry.capabilities.connect;
+    if (!decl) return env;
+    const deploymentScoped = decl.credentialScope === "deployment";
+    const operatorId = deploymentScoped ? DEPLOYMENT_CONNECT_SLOT : actorId;
+    if (!operatorId) return env;
+    let credential = getOperatorCredential(
+      { env: this.secrets, operators: this.operators },
+      operatorId,
+      entry.name,
+    );
+    if (credential && deploymentScoped && this.credentialNearExpiry(credential)) {
+      try {
+        credential = await this.refreshConnect(entry.name, operatorId);
+      } catch (err) {
+        console.warn(
+          `[plugin-registry] deployment credential pre-refresh for ${entry.name} failed: ${err instanceof Error ? err.message : err}`,
+        );
+      }
+    }
+    if (credential) {
+      env = {
+        ...env,
+        OPENNEKO_CONNECTOR_CREDENTIAL_TOKENS: JSON.stringify(credential.tokens),
+        OPENNEKO_OPERATOR_ID: operatorId,
+      };
+    }
+    return env;
+  }
+
+  /** Near-expiry check over the plugin-owned token blob (expires_at epoch ms). */
+  private credentialNearExpiry(credential: ConnectorCredential): boolean {
+    const tokens = credential.tokens as Record<string, unknown>;
+    const value = tokens.expires_at;
+    let epochMs: number | null = null;
+    if (typeof value === "number" && Number.isFinite(value)) epochMs = value;
+    else if (typeof value === "string" && /^\d+$/.test(value)) {
+      epochMs = Number(value);
+    }
+    return epochMs != null && epochMs < Date.now() + 60_000;
   }
 
   private async ensureVm(
@@ -1254,6 +1444,21 @@ export class PluginRegistry {
         await this.runtime.stop(pluginId).catch(() => {});
         throw new Error(
           `${entry.name}: manifest declares connect scopes [${[...declaredScopes].join(", ")}] but VM reports [${[...reportedScopes].join(", ")}]`,
+        );
+      }
+      if (registered.capabilities.connect.flow !== entry.capabilities.connect.flow) {
+        await this.runtime.stop(pluginId).catch(() => {});
+        throw new Error(
+          `${entry.name}: manifest declares connect flow ${entry.capabilities.connect.flow} but VM reports ${registered.capabilities.connect.flow}`,
+        );
+      }
+      if (
+        registered.capabilities.connect.credentialScope !==
+        entry.capabilities.connect.credentialScope
+      ) {
+        await this.runtime.stop(pluginId).catch(() => {});
+        throw new Error(
+          `${entry.name}: manifest declares connect credentialScope ${entry.capabilities.connect.credentialScope} but VM reports ${registered.capabilities.connect.credentialScope}`,
         );
       }
     }

--- a/apps/worker/src/sso/sso-setup-service.ts
+++ b/apps/worker/src/sso/sso-setup-service.ts
@@ -1,0 +1,459 @@
+// SSO admin-setup orchestration. The agent (or /admin/settings/sso) drives
+// the Scalekit workspace MCP tools through the auth plugin: generate an admin
+// portal link (guides the operator through IdP setup), then poll connection
+// state until it reports COMPLETED. The active environment defaults to Dev
+// (free trial); Prod is an explicit opt-in switch. Sign-in credentials
+// (env URL + client id + one-time secret) are written into the encrypted
+// vault by the admin-gated settings page.
+
+import { db, eq, organization, sso_setup } from "@neko/db";
+import type { PluginRegistry } from "../plugins/plugin-registry.js";
+
+export type SsoSetupStatus =
+  | "not_started"
+  | "awaiting_portal"
+  | "polling"
+  | "connected"
+  | "failed";
+
+export interface SsoSetupConnection {
+  status: string;
+  provider: string | null;
+  enabled: boolean;
+}
+
+export interface SsoSetupStatusResult {
+  status: SsoSetupStatus;
+  portalLink: string | null;
+  portalLinkExpiresAt: string | null;
+  provider: string | null;
+  connection: SsoSetupConnection | null;
+  lastError: string | null;
+  setupCompletedAt: string | null;
+  environmentId: string | null;
+  organizationId: string | null;
+  environmentTier: string | null;
+  signInConfigured: boolean;
+}
+
+const ACTIVE_POLL_STATUSES: ReadonlySet<SsoSetupStatus> = new Set([
+  "awaiting_portal",
+  "polling",
+]);
+
+interface SetupRow {
+  status: string;
+  portal_link: string | null;
+  portal_link_expires_at: Date | null;
+  provider: string | null;
+  last_error: string | null;
+  setup_completed_at: Date | null;
+  scalekit_environment_id: string | null;
+  scalekit_organization_id: string | null;
+  scalekit_environment_tier: string | null;
+}
+
+export class SsoSetupService {
+  constructor(private readonly getRegistry: () => PluginRegistry | null) {}
+
+  private registry(): PluginRegistry {
+    const r = this.getRegistry();
+    if (!r) throw new Error("plugin registry not initialised");
+    return r;
+  }
+
+  private authPlugin(): { pluginId: string; pluginName: string } {
+    const provider = this.registry().getAuthProvider();
+    if (!provider) {
+      throw new Error(
+        "no auth plugin installed — install one with `openneko install <name>` (e.g. @open-neko/plugin-scalekit)",
+      );
+    }
+    return { pluginId: provider.pluginId, pluginName: provider.pluginName };
+  }
+
+  private async invoke(
+    kind: string,
+    payload: Record<string, unknown>,
+    orgId: string,
+  ): Promise<{ text: string; isError: boolean }> {
+    const outcome = await this.registry().invokeAction(
+      this.authPlugin().pluginId,
+      kind,
+      payload,
+      orgId,
+    );
+    const result = (outcome.result ?? {}) as Record<string, unknown>;
+    const isError = result.isError === true;
+    const text = typeof result.text === "string" ? result.text : "";
+    if (isError || (!text && !result)) {
+      throw new Error(
+        text || `Scalekit tool ${kind} returned no result — is the workspace connected?`,
+      );
+    }
+    return { text, isError: false };
+  }
+
+  private async readRow(orgId: string): Promise<SetupRow | null> {
+    const [row] = await db()
+      .select({
+        status: sso_setup.status,
+        portal_link: sso_setup.portal_link,
+        portal_link_expires_at: sso_setup.portal_link_expires_at,
+        provider: sso_setup.provider,
+        last_error: sso_setup.last_error,
+        setup_completed_at: sso_setup.setup_completed_at,
+        scalekit_environment_id: sso_setup.scalekit_environment_id,
+        scalekit_organization_id: sso_setup.scalekit_organization_id,
+        scalekit_environment_tier: sso_setup.scalekit_environment_tier,
+      })
+      .from(sso_setup)
+      .where(eq(sso_setup.org_id, orgId))
+      .limit(1);
+    return row ?? null;
+  }
+
+  async getStatus(orgId: string): Promise<SsoSetupStatusResult> {
+    const row = await this.readRow(orgId);
+    const signInConfigured = this.signInConfigured();
+    if (!row) {
+      return {
+        status: "not_started",
+        portalLink: null,
+        portalLinkExpiresAt: null,
+        provider: null,
+        connection: null,
+        lastError: null,
+        setupCompletedAt: null,
+        environmentId: null,
+        organizationId: null,
+        environmentTier: null,
+        signInConfigured,
+      };
+    }
+    return {
+      status: row.status as SsoSetupStatus,
+      portalLink: row.portal_link,
+      portalLinkExpiresAt: row.portal_link_expires_at?.toISOString() ?? null,
+      provider: row.provider,
+      connection: null,
+      lastError: row.last_error,
+      setupCompletedAt: row.setup_completed_at?.toISOString() ?? null,
+      environmentId: row.scalekit_environment_id,
+      organizationId: row.scalekit_organization_id,
+      environmentTier: row.scalekit_environment_tier,
+      signInConfigured,
+    };
+  }
+
+  private signInConfigured(): boolean {
+    try {
+      const { pluginName } = this.authPlugin();
+      const env = this.registry().getPluginEnv(pluginName);
+      if (!env) return false;
+      return Boolean(
+        env.SCALEKIT_ENVIRONMENT_URL &&
+          env.SCALEKIT_CLIENT_ID &&
+          env.SCALEKIT_CLIENT_SECRET,
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Fetch the environment's sign-in credentials via the agent's
+   * `get_environment_credentials` tool (returns URL + client id; the
+   * secret is dashboard-only by Scalekit's design).
+   */
+  async getEnvironmentCredentials(
+    orgId: string,
+    environmentId: string,
+  ): Promise<{ environmentUrl: string; clientId: string }> {
+    const { text } = await this.invoke(
+      "get_environment_credentials",
+      { environmentId },
+      orgId,
+    );
+    const environmentUrl = /SCALEKIT_ENVIRONMENT_URL=(https:\/\/\S+)/.exec(
+      text,
+    )?.[1];
+    const clientId = /SCALEKIT_CLIENT_ID=(\S+)/.exec(text)?.[1];
+    if (!environmentUrl || !clientId) {
+      throw new Error(
+        `could not parse credentials from Scalekit's response: ${text.slice(0, 300)}`,
+      );
+    }
+    return { environmentUrl, clientId };
+  }
+
+  /**
+   * List the workspace's Scalekit environments via the agent's
+   * `list_environments` MCP tool, parsed back into structured rows for
+   * the settings page picker (no raw-id pasting).
+   */
+  async listEnvironments(orgId: string): Promise<Array<{
+    id: string;
+    name: string | null;
+    tier: string | null;
+    domain: string | null;
+  }>> {
+    const { text } = await this.invoke("list_environments", {}, orgId);
+    return text
+      .split("\n")
+      .map((row) => {
+        const id = /ID:\s*(\S+)/.exec(row)?.[1] ?? null;
+        const name = /Name:\s*([^|]+?)\s*\|/.exec(row)?.[1]?.trim() || null;
+        const tier = /Type:\s*(\w+)/.exec(row)?.[1] ?? null;
+        const domain = /Domain:\s*([^|]+?)\s*\|/.exec(row)?.[1]?.trim() || null;
+        return { id: id ?? "", name, tier, domain };
+      })
+      .filter((r) => r.id.length > 0);
+  }
+
+  /** List organizations under one environment via `list_organizations`. */
+  async listOrganizations(
+    orgId: string,
+    environmentId: string,
+  ): Promise<Array<{ id: string; name: string | null }>> {
+    const { text } = await this.invoke(
+      "list_organizations",
+      { environmentId },
+      orgId,
+    );
+    const out: Array<{ id: string; name: string | null }> = [];
+    for (const block of text.split(/Organization \d+:/)) {
+      const id = /ID:\s*(\S+)/.exec(block)?.[1];
+      const name = /Name:\s*([^\n]+)/.exec(block)?.[1]?.trim();
+      if (id) out.push({ id, name: name || null });
+    }
+    return out;
+  }
+
+  /** Pin the active Scalekit environment/organization (Dev default, Prod opt-in). */
+  async setScalekitIds(
+    orgId: string,
+    input: { environmentId: string; organizationId: string; tier: string },
+  ): Promise<void> {
+    if (!input.environmentId || !input.organizationId) {
+      throw new Error("environmentId and organizationId are required");
+    }
+    await db()
+      .insert(sso_setup)
+      .values({
+        org_id: orgId,
+        scalekit_environment_id: input.environmentId,
+        scalekit_organization_id: input.organizationId,
+        scalekit_environment_tier: input.tier,
+        updated_at: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: sso_setup.org_id,
+        set: {
+          scalekit_environment_id: input.environmentId,
+          scalekit_organization_id: input.organizationId,
+          scalekit_environment_tier: input.tier,
+          updated_at: new Date(),
+        },
+      });
+    await db()
+      .update(organization)
+      .set({ scalekit_org_id: input.organizationId, updated_at: new Date() })
+      .where(eq(organization.id, orgId));
+  }
+
+  /** Write the sign-in credentials into the encrypted vault (admin-gated). */
+  async setSignInCredentials(
+    orgId: string,
+    input: { environmentUrl: string; clientId: string; clientSecret: string },
+  ): Promise<void> {
+    void orgId;
+    if (!input.environmentUrl || !input.clientId || !input.clientSecret) {
+      throw new Error("environmentUrl, clientId and clientSecret are required");
+    }
+    const { pluginName } = this.authPlugin();
+    const registry = this.registry();
+    await registry.setPluginSecret(
+      pluginName,
+      "SCALEKIT_ENVIRONMENT_URL",
+      input.environmentUrl,
+    );
+    await registry.setPluginSecret(pluginName, "SCALEKIT_CLIENT_ID", input.clientId);
+    await registry.setPluginSecret(
+      pluginName,
+      "SCALEKIT_CLIENT_SECRET",
+      input.clientSecret,
+    );
+  }
+
+  private async resolveIds(
+    orgId: string,
+  ): Promise<{ environmentId: string; organizationId: string }> {
+    const row = await this.readRow(orgId);
+    if (row?.scalekit_environment_id && row?.scalekit_organization_id) {
+      return {
+        environmentId: row.scalekit_environment_id,
+        organizationId: row.scalekit_organization_id,
+      };
+    }
+    // Fallback: operator-provided env overrides on the auth plugin.
+    const { pluginName } = this.authPlugin();
+    const env = this.registry().getPluginEnv(pluginName) ?? {};
+    if (env.SCALEKIT_ENVIRONMENT_ID && env.SCALEKIT_ORGANIZATION_ID) {
+      return {
+        environmentId: env.SCALEKIT_ENVIRONMENT_ID,
+        organizationId: env.SCALEKIT_ORGANIZATION_ID,
+      };
+    }
+    throw new Error(
+      "Scalekit environment/organization not selected yet — run `get_environment_credentials` + `list_organizations` via the agent, or set them on the SSO settings page",
+    );
+  }
+
+  async generatePortalLink(
+    orgId: string,
+  ): Promise<{ portalLink: string; expiresAt: string | null }> {
+    const { environmentId, organizationId } = await this.resolveIds(orgId);
+    const { text } = await this.invoke(
+      "generate_admin_portal_link",
+      { environmentId, organizationId },
+      orgId,
+    );
+    const match = /Link:\s*(https?:\/\/[^\s]+)/.exec(text);
+    if (!match) {
+      throw new Error(
+        `Scalekit returned no portal link (${text.slice(0, 200)}). Verify the organization id.`,
+      );
+    }
+    const portalLink = match[1]!;
+    await db()
+      .insert(sso_setup)
+      .values({
+        org_id: orgId,
+        status: "awaiting_portal",
+        portal_link: portalLink,
+        portal_link_expires_at: null,
+        last_error: null,
+        updated_at: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: sso_setup.org_id,
+        set: {
+          status: "awaiting_portal",
+          portal_link: portalLink,
+          portal_link_expires_at: null,
+          last_error: null,
+          updated_at: new Date(),
+        },
+      });
+    return { portalLink, expiresAt: null };
+  }
+
+  async checkConnection(orgId: string): Promise<SsoSetupStatusResult> {
+    let connection: SsoSetupConnection | null = null;
+    let nextStatus: SsoSetupStatus;
+    let lastError: string | null = null;
+    try {
+      const { environmentId, organizationId } = await this.resolveIds(orgId);
+      const { text } = await this.invoke(
+        "list_organization_connections",
+        { environmentId, organizationId },
+        orgId,
+      );
+      const statuses = [...text.matchAll(/status:\s*(\w+)/g)].map(
+        (m) => m[1]!,
+      );
+      const providerMatch = /provider:\s*(\w+)/.exec(text);
+      if (statuses.some((s) => s === "COMPLETED")) {
+        connection = {
+          status: "connected",
+          provider: providerMatch?.[1] ?? null,
+          enabled: true,
+        };
+        nextStatus = "connected";
+      } else if (statuses.length > 0) {
+        connection = {
+          status: "in_progress",
+          provider: providerMatch?.[1] ?? null,
+          enabled: false,
+        };
+        nextStatus = "polling";
+      } else {
+        nextStatus = "awaiting_portal";
+      }
+    } catch (err) {
+      nextStatus = "failed";
+      lastError = err instanceof Error ? err.message : String(err);
+    }
+
+    const provider = connection?.provider ?? null;
+    const completedAt = nextStatus === "connected" ? new Date() : null;
+    await db()
+      .insert(sso_setup)
+      .values({
+        org_id: orgId,
+        status: nextStatus,
+        provider,
+        last_polled_at: new Date(),
+        last_error: lastError,
+        setup_completed_at: completedAt,
+        updated_at: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: sso_setup.org_id,
+        set: {
+          status: nextStatus,
+          provider,
+          last_polled_at: new Date(),
+          last_error: lastError,
+          setup_completed_at: completedAt,
+          updated_at: new Date(),
+        },
+      });
+
+    return {
+      status: nextStatus,
+      portalLink: null,
+      portalLinkExpiresAt: null,
+      provider,
+      connection,
+      lastError,
+      setupCompletedAt: completedAt?.toISOString() ?? null,
+      environmentId: null,
+      organizationId: null,
+      environmentTier: null,
+      signInConfigured: this.signInConfigured(),
+    };
+  }
+
+  /**
+   * Poll only while there is something to watch. Returns immediately
+   * (no plugin invoke) when the row is not in a polling state.
+   */
+  async poll(orgId: string): Promise<SsoSetupStatusResult> {
+    const current = await this.getStatus(orgId);
+    if (!ACTIVE_POLL_STATUSES.has(current.status)) {
+      return current;
+    }
+    return this.checkConnection(orgId);
+  }
+}
+
+export function startSsoSetupPoller(options: {
+  service: SsoSetupService;
+  orgId: string;
+  intervalMs?: number;
+}): { stop: () => void } {
+  const intervalMs = options.intervalMs ?? 30_000;
+  const timer = setInterval(() => {
+    options.service.poll(options.orgId).catch((err) => {
+      console.warn(
+        `[sso-setup] poll failed: ${err instanceof Error ? err.message : err}`,
+      );
+    });
+  }, intervalMs);
+  timer.unref?.();
+  return {
+    stop: () => clearInterval(timer),
+  };
+}

--- a/apps/worker/test/admin-server.test.ts
+++ b/apps/worker/test/admin-server.test.ts
@@ -335,6 +335,7 @@ describe("worker admin /admin/auth/*", () => {
     const srv = await startServer(
       createAdminHandler({
         auth: {
+          authSignInReady: () => true,
           getAuthProvider: () => ({
             pluginName: "@open-neko/plugin-scalekit",
             providerLabel: "Scalekit",
@@ -1111,6 +1112,89 @@ describe("worker channel routes", () => {
         headers: { "Content-Type": "application/json" },
         body: "{}",
       });
+      expect(res.status).toBe(503);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("GET /admin/sso/setup/status returns the setup state", async () => {
+    const srv = await startServer(
+      createAdminHandler({
+        ssoSetup: {
+          getStatus: async () => ({
+            status: "awaiting_portal",
+            portalLink: "https://scalekit.test/portal",
+            portalLinkExpiresAt: null,
+            provider: "OKTA",
+            connection: { status: "in_progress", provider: "OKTA", enabled: false },
+            lastError: null,
+            setupCompletedAt: null,
+            environmentId: "env_1",
+            organizationId: "org_1",
+            environmentTier: "dev",
+            signInConfigured: false,
+          }),
+          setScalekitIds: async () => {},
+          setSignInCredentials: async () => {},
+          listEnvironments: async () => [
+            { id: "env_1", name: "Dev", tier: "DEV", domain: "acme.scalekit.dev" },
+          ],
+          listOrganizations: async () => [{ id: "org_1", name: "Acme" }],
+          getEnvironmentCredentials: async () => ({
+            environmentUrl: "https://acme.scalekit.dev",
+            clientId: "skc_1",
+          }),
+          generatePortalLink: async () => ({
+            portalLink: "https://scalekit.test/portal",
+            expiresAt: null,
+          }),
+          checkConnection: async () => ({
+            status: "connected",
+            connection: { status: "connected", provider: "OKTA", enabled: true },
+            lastError: null,
+            setupCompletedAt: "2026-08-13T12:00:00Z",
+          }),
+        },
+      }),
+    );
+    try {
+      const status = await fetch(
+        `http://127.0.0.1:${srv.port}/admin/sso/setup/status?orgId=org-1`,
+      );
+      expect(status.status).toBe(200);
+      const body = (await status.json()) as { status: string; environmentTier: string };
+      expect(body.status).toBe("awaiting_portal");
+      expect(body.environmentTier).toBe("dev");
+
+      const envs = await fetch(
+        `http://127.0.0.1:${srv.port}/admin/sso/setup/environments?orgId=org-1`,
+      );
+      expect(envs.status).toBe(200);
+      const envBody = (await envs.json()) as {
+        environments: Array<{ tier: string }>;
+      };
+      expect(envBody.environments).toHaveLength(1);
+
+      const check = await fetch(`http://127.0.0.1:${srv.port}/admin/sso/setup/check`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ orgId: "org-1" }),
+      });
+      expect(check.status).toBe(200);
+      const checkBody = (await check.json()) as { status: string };
+      expect(checkBody.status).toBe("connected");
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("sso setup endpoints return 503 when surface absent", async () => {
+    const srv = await startServer(createAdminHandler());
+    try {
+      const res = await fetch(
+        `http://127.0.0.1:${srv.port}/admin/sso/setup/status?orgId=org-1`,
+      );
       expect(res.status).toBe(503);
     } finally {
       await srv.close();

--- a/apps/worker/test/plugins/plugin-registry.test.ts
+++ b/apps/worker/test/plugins/plugin-registry.test.ts
@@ -1393,6 +1393,282 @@ describe("PluginRegistry — connect capability", () => {
   });
 });
 
+// ─── deployment-scoped connect (mcp-oauth) ─────────────────────────────
+
+const SCALEKIT_CONNECT_NAME = "@open-neko/plugin-scalekit";
+const SCALEKIT_CONNECT_SCOPES = [
+  "wks:read",
+  "wks:write",
+  "env:read",
+  "env:write",
+  "org:read",
+  "org:write",
+];
+
+function manifestWithDeploymentConnectEntry(extraCapabilities: Record<string, unknown> = {}) {
+  return {
+    schema: "https://open-neko.github.io/plugins/manifest.schema.json",
+    plugins: [
+      {
+        name: SCALEKIT_CONNECT_NAME,
+        version: "1.0.0",
+        integrity: FAKE_INTEGRITY,
+        permissions: {
+          network: ["*.scalekit.com", "*.scalekit.dev"],
+          env: [
+            {
+              key: "SCALEKIT_ENVIRONMENT_URL",
+              required: true,
+              secret: false,
+              description: "Environment URL.",
+            },
+            {
+              key: "SCALEKIT_CLIENT_ID",
+              required: true,
+              secret: false,
+              description: "Client id.",
+            },
+            {
+              key: "SCALEKIT_CLIENT_SECRET",
+              required: true,
+              secret: true,
+              description: "Client secret.",
+            },
+          ],
+        },
+        capabilities: {
+          connect: {
+            providerLabel: "Scalekit workspace",
+            scopes: SCALEKIT_CONNECT_SCOPES,
+            flow: "mcp-oauth",
+            credentialScope: "deployment",
+          },
+          ...extraCapabilities,
+        },
+      },
+    ],
+  };
+}
+
+function deploymentConnectRegisterResponse(): RpcResponse {
+  return rpcOk({
+    protocol: RPC_PROTOCOL_VERSION,
+    pluginName: SCALEKIT_CONNECT_NAME,
+    pluginVersion: "1.0.0",
+    capabilities: {
+      connect: {
+        providerLabel: "Scalekit workspace",
+        scopes: SCALEKIT_CONNECT_SCOPES,
+        flow: "mcp-oauth",
+        credentialScope: "deployment",
+      },
+      action: {
+        kinds: [{ kind: "list_environments", description: "List environments." }],
+      },
+    },
+  });
+}
+
+describe("PluginRegistry — deployment-scoped connect", () => {
+  let repoRoot: string;
+  let workRoot: string;
+  let secretsConfigDir: string;
+  let runnerPath: string;
+  let captured: Map<string, ActionAdapter>;
+
+  beforeEach(async () => {
+    repoRoot = await mkdtemp(path.join(tmpdir(), "openneko-repo-"));
+    workRoot = await mkdtemp(path.join(tmpdir(), "openneko-vmwork-"));
+    secretsConfigDir = await mkdtemp(path.join(tmpdir(), "openneko-secrets-"));
+    runnerPath = path.join(repoRoot, "fake-runner.js");
+    await writeFakeRunner(runnerPath);
+    captured = new Map();
+    setDefaultActionAdapter(mockActionAdapter);
+  });
+
+  afterEach(async () => {
+    await rm(repoRoot, { recursive: true, force: true });
+    await rm(workRoot, { recursive: true, force: true });
+    await rm(secretsConfigDir, { recursive: true, force: true });
+    setDefaultActionAdapter(mockActionAdapter);
+  });
+
+  function newRegistry(runtime: PluginRuntime) {
+    return new PluginRegistry({
+      repoRoot,
+      workRoot,
+      secretsConfigDir,
+      runtime,
+      resolveRunner: () => runnerPath,
+      onAdapter: (kind, adapter) => captured.set(kind, adapter),
+    });
+  }
+
+  async function writeDeploymentConnectManifest(): Promise<void> {
+    await writeFile(
+      path.join(repoRoot, "openneko.plugins.json"),
+      JSON.stringify(
+        manifestWithDeploymentConnectEntry({
+          action: {
+            kinds: [{ kind: "list_environments", description: "List environments." }],
+          },
+        }),
+      ),
+      "utf8",
+    );
+  }
+
+  it("beginConnect rewrites the operator id to the deployment slot", async () => {
+    await writeDeploymentConnectManifest();
+    const runtime = new FakeRuntime({
+      responses: {
+        register: deploymentConnectRegisterResponse(),
+        begin_connect: rpcOk({
+          result: { authorizationUrl: "https://mcp.scalekit.com/oauth?stub=1", oauthState: "st" },
+        }),
+      },
+    });
+    const reg = newRegistry(runtime);
+    await reg.start();
+    const out = await reg.beginConnect(SCALEKIT_CONNECT_NAME, {
+      operatorId: "usr_some-operator",
+      redirectUri: "https://app.example.com/integrations/callback",
+      state: "csrf-1",
+      scopes: [],
+      codeVerifier: "verifier-xyz",
+    });
+    expect(out.oauthState).toBe("st");
+    const beginRpc = runtime.rpcs.find((r) => r.method === "begin_connect");
+    expect(beginRpc?.paramsJson).toContain('"operatorId":"deployment"');
+    expect(beginRpc?.paramsJson).not.toContain("usr_some-operator");
+    await reg.stop();
+  });
+
+  it("completeConnect persists under the deployment slot", async () => {
+    await writeDeploymentConnectManifest();
+    const runtime = new FakeRuntime({
+      responses: {
+        register: deploymentConnectRegisterResponse(),
+        complete_connect: rpcOk({
+          result: {
+            credential: {
+              tokens: { access_token: "at-1", refresh_token: "rt-1" },
+              scopes: SCALEKIT_CONNECT_SCOPES,
+              connectedAt: "2026-08-13T10:00:00Z",
+            },
+          },
+        }),
+      },
+    });
+    const reg = newRegistry(runtime);
+    await reg.start();
+    await reg.completeConnect(SCALEKIT_CONNECT_NAME, {
+      operatorId: "usr_some-operator",
+      code: "c",
+      redirectUri: "https://x",
+      state: "x",
+      scopes: [],
+      oauthState: "st",
+    });
+    expect(reg.getDeploymentConnectStatus()).toEqual([
+      {
+        pluginName: SCALEKIT_CONNECT_NAME,
+        connectedAt: "2026-08-13T10:00:00Z",
+        scopes: SCALEKIT_CONNECT_SCOPES,
+      },
+    ]);
+    expect(reg.isOperatorConnected("usr_some-operator", SCALEKIT_CONNECT_NAME)).toBe(false);
+    await reg.stop();
+  });
+
+  it("injects the deployment credential on action calls regardless of actor", async () => {
+    await writeDeploymentConnectManifest();
+    const runtime = new FakeRuntime({
+      responses: {
+        register: deploymentConnectRegisterResponse(),
+        complete_connect: rpcOk({
+          result: {
+            credential: {
+              tokens: { access_token: "at-1", expires_at: String(Date.now() + 3_600_000) },
+              connectedAt: "2026-08-13T10:00:00Z",
+            },
+          },
+        }),
+        execute_action: rpcOk({ outcome: { result: { text: "ok" } } }),
+      },
+    });
+    const reg = newRegistry(runtime);
+    await reg.start();
+    await reg.completeConnect(SCALEKIT_CONNECT_NAME, {
+      operatorId: "usr_irrelevant",
+      code: "c",
+      redirectUri: "https://x",
+      state: "x",
+      scopes: [],
+      oauthState: "st",
+    });
+    const adapter = captured.get("list_environments");
+    expect(adapter).toBeDefined();
+    const rpcIndex = runtime.rpcs.length;
+    const result = await adapter!({
+      request: {
+        id: "req-1",
+        orgId: "org-1",
+        actorId: null,
+        scope: "internal",
+        kind: "list_environments",
+        target: null,
+        summary: null,
+        payload: {},
+        riskLevel: null,
+      },
+    });
+    expect(result.result).toEqual({ text: "ok" });
+    const execRpc = runtime.rpcs[rpcIndex];
+    expect(execRpc?.method).toBe("execute_action");
+    const env = (execRpc as { env?: Record<string, string> }).env ?? {};
+    const injected = JSON.parse(env.OPENNEKO_CONNECTOR_CREDENTIAL_TOKENS ?? "{}") as Record<string, unknown>;
+    expect(injected.access_token).toBe("at-1");
+    expect(env.OPENNEKO_OPERATOR_ID).toBe("deployment");
+    await reg.stop();
+  });
+
+  it("authSignInReady flips only once every required env var is set", async () => {
+    await writeFile(
+      path.join(repoRoot, "openneko.plugins.json"),
+      JSON.stringify({
+        schema: "https://open-neko.github.io/plugins/manifest.schema.json",
+        plugins: [
+          {
+            name: SCALEKIT_CONNECT_NAME,
+            version: "1.0.0",
+            integrity: FAKE_INTEGRITY,
+            permissions: {
+              network: ["*.scalekit.com", "*.scalekit.dev"],
+              env: [
+                { key: "SCALEKIT_ENVIRONMENT_URL", required: true, secret: false, description: "d" },
+                { key: "SCALEKIT_CLIENT_ID", required: true, secret: false, description: "d" },
+                { key: "SCALEKIT_CLIENT_SECRET", required: true, secret: true, description: "d" },
+              ],
+            },
+            capabilities: { auth: { providerLabel: "Scalekit" } },
+          },
+        ],
+      }),
+      "utf8",
+    );
+    const reg = newRegistry(new FakeRuntime());
+    await reg.start();
+    expect(reg.authSignInReady()).toBe(false);
+    await reg.setPluginSecret(SCALEKIT_CONNECT_NAME, "SCALEKIT_ENVIRONMENT_URL", "https://acme.scalekit.com");
+    await reg.setPluginSecret(SCALEKIT_CONNECT_NAME, "SCALEKIT_CLIENT_ID", "skc_1");
+    expect(reg.authSignInReady()).toBe(false);
+    await reg.setPluginSecret(SCALEKIT_CONNECT_NAME, "SCALEKIT_CLIENT_SECRET", "secret-1");
+    expect(reg.authSignInReady()).toBe(true);
+    await reg.stop();
+  });
+});
+
 // ─── Policy flagging (M4) ──────────────────────────────────────────────
 
 describe("PluginRegistry — install-policy flagging", () => {

--- a/db/migrations/0055_sso_setup.sql
+++ b/db/migrations/0055_sso_setup.sql
@@ -1,0 +1,38 @@
+-- SSO setup state machine + configurable group→role/persona mapping.
+--
+-- sso_setup tracks the one-time Scalekit/IdP admin flow: the agent (or the
+-- /settings/sso page) generates an admin portal link, the operator configures
+-- the downstream IdP, and a poller reads connection state back until the
+-- connection reports COMPLETED. One row per org (single-tenant today).
+--
+-- sso_group_mapping lets the operator override the default admin/admins/owners
+-- heuristic: a matched group drives app_user.role and the auto-provisioned
+-- per-user persona.
+
+create table if not exists sso_setup (
+  org_id text primary key references organization(id) on delete cascade,
+  status text not null default 'not_started',
+  portal_link text,
+  portal_link_expires_at timestamptz,
+  provider text,
+  last_polled_at timestamptz,
+  last_error text,
+  setup_completed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint sso_setup_status_check check (
+    status in ('not_started', 'awaiting_portal', 'polling', 'connected', 'failed')
+  )
+);
+
+create table if not exists sso_group_mapping (
+  org_id text not null references organization(id) on delete cascade,
+  provider text not null,
+  group_external_id text not null,
+  role text not null,
+  persona_role_template text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (org_id, provider, group_external_id),
+  constraint sso_group_mapping_role_check check (role in ('admin', 'member'))
+);

--- a/db/migrations/0056_sso_setup_scalekit_ids.sql
+++ b/db/migrations/0056_sso_setup_scalekit_ids.sql
@@ -1,0 +1,8 @@
+-- SSO setup gains the active Scalekit environment/organization identity
+-- (Dev by default; Prod is an explicit opt-in later). Kept on sso_setup so
+-- the poller + settings page agree on which environment they operate on.
+
+alter table if exists sso_setup
+  add column if not exists scalekit_environment_id text,
+  add column if not exists scalekit_organization_id text,
+  add column if not exists scalekit_environment_tier text;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -122,6 +122,49 @@ export const sso_group_membership = pgTable(
   }),
 );
 
+// One-time SSO admin-setup state machine (portal link → poll → connected).
+export const sso_setup = pgTable(
+  "sso_setup",
+  {
+    org_id: text("org_id")
+      .primaryKey()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    status: text("status").notNull().default("not_started"),
+    portal_link: text("portal_link"),
+    portal_link_expires_at: ts("portal_link_expires_at"),
+    provider: text("provider"),
+    last_polled_at: ts("last_polled_at"),
+    last_error: text("last_error"),
+    setup_completed_at: ts("setup_completed_at"),
+    scalekit_environment_id: text("scalekit_environment_id"),
+    scalekit_organization_id: text("scalekit_organization_id"),
+    scalekit_environment_tier: text("scalekit_environment_tier"),
+    created_at: ts("created_at").notNull().defaultNow(),
+    updated_at: ts("updated_at").notNull().defaultNow(),
+  },
+);
+
+// Configurable group → role/persona mapping (overrides the default heuristic).
+export const sso_group_mapping = pgTable(
+  "sso_group_mapping",
+  {
+    org_id: text("org_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    provider: text("provider").notNull(),
+    group_external_id: text("group_external_id").notNull(),
+    role: text("role").notNull(),
+    persona_role_template: text("persona_role_template"),
+    created_at: ts("created_at").notNull().defaultNow(),
+    updated_at: ts("updated_at").notNull().defaultNow(),
+  },
+  (t) => ({
+    pk: primaryKey({
+      columns: [t.org_id, t.provider, t.group_external_id],
+    }),
+  }),
+);
+
 // Availability mirror for the records-engine registry. The records database
 // remains authoritative for app definitions; metadata consumers use this
 // narrow projection for navigation, orchestration, and degraded-state checks.

--- a/packages/plugin-types/src/connect.ts
+++ b/packages/plugin-types/src/connect.ts
@@ -18,6 +18,29 @@ import { z } from "zod";
 export const ConnectScope = z.string().min(1).max(256);
 
 /**
+ * OAuth flow type the worker should drive. v1 was oauth2-pkce only
+ * (pre-registered client, code_verifier minted by the core). v2 adds
+ * mcp-oauth for MCP-OAuth-2.1 endpoints (Scalekit workspace): the
+ * plugin does resource/AS discovery + dynamic client registration in
+ * `begin`, serializes its in-flight state into the returned
+ * `oauthState`, and the core echoes it back on `complete`.
+ */
+export const ConnectFlow = z.enum(["oauth2-pkce", "mcp-oauth"]);
+
+export type ConnectFlow = z.infer<typeof ConnectFlow>;
+
+/**
+ * Who the stored credential belongs to. "operator" (default): each
+ * operator authorizes their own account. "deployment": one admin
+ * consents once and the org-wide token backs every action call,
+ * regardless of which operator triggered it (stored under a reserved
+ * slot in the secrets file).
+ */
+export const ConnectCredentialScope = z.enum(["operator", "deployment"]);
+
+export type ConnectCredentialScope = z.infer<typeof ConnectCredentialScope>;
+
+/**
  * Opaque-from-OpenNeko's-perspective token blob produced by the
  * plugin's complete_connect handler. The plugin owns the shape
  * (access_token, refresh_token, expires_in, id_token vary by
@@ -70,6 +93,14 @@ export const BeginConnectResult = z.object({
    * response_type, state, redirect_uri, code_challenge, code_challenge_method, etc.).
    */
   authorizationUrl: z.string().min(1),
+  /**
+   * Opaque in-flight OAuth state (mcp-oauth flow): the plugin
+   * serializes its discovered endpoints + DCR client registration +
+   * PKCE verifier here because the runner is stateless between
+   * begin_connect and complete_connect. The core stores and echoes it
+   * back verbatim in CompleteConnectParams.
+   */
+  oauthState: z.string().max(65536).optional(),
 });
 
 export type BeginConnectResult = z.infer<typeof BeginConnectResult>;
@@ -86,6 +117,8 @@ export const CompleteConnectParams = z.object({
   codeVerifier: z.string().min(1).nullable().optional(),
   /** Scopes the operator originally requested (passed-through for binding). */
   scopes: z.array(ConnectScope).default([]),
+  /** Echo of the oauthState the plugin returned from begin_connect. */
+  oauthState: z.string().max(65536).optional(),
 });
 
 export type CompleteConnectParams = z.infer<typeof CompleteConnectParams>;

--- a/packages/plugin-types/src/define-plugin.ts
+++ b/packages/plugin-types/src/define-plugin.ts
@@ -14,6 +14,8 @@ import {
   BeginConnectResult,
   CompleteConnectParams,
   CompleteConnectResult,
+  ConnectCredentialScope,
+  ConnectFlow,
   RefreshConnectParams,
   RefreshConnectResult,
 } from "./connect.js";
@@ -98,7 +100,8 @@ export interface AuthCapabilityImpl {
 export interface ConnectCapabilityImpl {
   providerLabel: string;
   scopes: string[];
-  flow?: "oauth2-pkce";
+  flow?: ConnectFlow;
+  credentialScope?: ConnectCredentialScope;
   begin: BeginConnectHandler;
   complete: CompleteConnectHandler;
   refresh?: RefreshConnectHandler;

--- a/packages/plugin-types/src/manifest.ts
+++ b/packages/plugin-types/src/manifest.ts
@@ -1,7 +1,11 @@
 import { z } from "zod";
 import { PluginActionDeclaration } from "./action.js";
 import { ChannelCapabilityDeclaration } from "./channel.js";
-import { ConnectScope } from "./connect.js";
+import {
+  ConnectCredentialScope,
+  ConnectFlow,
+  ConnectScope,
+} from "./connect.js";
 
 export const HostPattern = z
   .string()
@@ -37,10 +41,10 @@ export const PluginEnvRequirement = z.object({
   description: z.string().min(1).max(280),
   /**
    * How a secret reaches the plugin VM. "egress": held gateway-side and
-   * substituted by the proxy onto outbound requests — the box sees only a
-   * placeholder (for credentials sent to an external API, e.g. a bot token).
-   * "box" (default): the value lives in the VM, for secrets compared locally
-   * and never sent out (e.g. a webhook signing secret).
+   * substituted by the egress proxy onto outbound requests — the box sees only
+   * a placeholder (for credentials sent to an external API, e.g. a bot token).
+   * "box" (default): the value lives in the VM, for secrets the plugin compares
+   * locally and never sends out (e.g. a webhook signing secret).
    */
   inject: z.enum(["egress", "box"]).optional(),
 });
@@ -111,8 +115,19 @@ export const ConnectCapabilityDeclaration = z.object({
   providerLabel: z.string().min(1),
   /** OAuth scopes the connector will request at consent time. */
   scopes: z.array(ConnectScope).min(1),
-  /** Flow type the worker should drive. v1 supports oauth2-pkce only. */
-  flow: z.enum(["oauth2-pkce"]).default("oauth2-pkce"),
+  /**
+   * Flow type the worker should drive. oauth2-pkce (default): the core
+   * mints the code_verifier against a pre-registered client. mcp-oauth:
+   * the plugin does MCP-OAuth-2.1 discovery + DCR and bridges begin →
+   * complete via the oauthState echo.
+   */
+  flow: ConnectFlow.default("oauth2-pkce"),
+  /**
+   * "operator" (default): per-operator credentials. "deployment": one
+   * org-wide credential consented by an admin, injected on every
+   * action call and stored under a reserved secrets slot.
+   */
+  credentialScope: ConnectCredentialScope.default("operator"),
 });
 
 export type ConnectCapabilityDeclaration = z.infer<typeof ConnectCapabilityDeclaration>;

--- a/packages/plugin-types/src/runner.ts
+++ b/packages/plugin-types/src/runner.ts
@@ -102,6 +102,7 @@ function buildRegisterResult(plugin: PluginDefinition): RegisterResult {
             providerLabel: caps.connect.providerLabel,
             scopes: caps.connect.scopes,
             flow: caps.connect.flow ?? "oauth2-pkce",
+            credentialScope: caps.connect.credentialScope ?? "operator",
           }
         : undefined,
       channel: caps.channel


### PR DESCRIPTION
## What

Completes the Scalekit SSO + workspace-management story end to end, verified live against a real Scalekit workspace.

### DB
- `sso_setup` state machine (portal link → poll → connected) + Scalekit environment/organization identity; `sso_group_mapping` for configurable group→role/persona mapping. Migrations 0055 + 0056 (synced into CLI assets).

### Plugin contract (vendored)
- `flow: mcp-oauth` + `credentialScope: deployment` + `oauthState` begin/complete bridge — synced with @open-neko/plugin-types 0.8.0.

### Worker
- Deployment-scoped connect: reserved secrets slot, credential injection on every tool call (incl. system invokes) with pre-refresh writeback; `setPluginSecret` (vault writes from the setup UI); `authSignInReady` — the login gate engages only when sign-in is actually configured, so the admin isn't locked out of setup.
- `SsoSetupService`: environment/organization picker rows, credential auto-fetch, portal-link generation + connection polling through the agent's workspace tools; background poller.
- Admin routes: `/admin/sso/setup/*`, deployment connect status.

### Web
- `/admin/settings/sso`: 4-step checklist with done states — workspace consent → environment picker (Dev default, Prod switch) → credential auto-fill + secret entry (deep-links to the dashboard credentials page) → IdP portal link + connection status. Loading states, disabled-until-ready buttons.
- `/integrations`: workspace vs per-operator sections; `oauthState` threaded through the connect cookie dance; solo-admin access for deployment connectors.
- Proxy exemptions for setup surfaces + `requireAdminActor` hardening (sessionless denied once SSO is live).
- `auth.ts`: group→role mapping from `sso_group_mapping`, per-user persona provisioning, empty-group audit insert fix.
- AppRail: session re-check poll + profile label fix.

### CLI (Go)
- Preserve `flow` + `credentialScope` through the marketplace→manifest round-trip (they were silently dropped).

### Docs + tests
- PLUGINS.md + README updated. New tests: deployment-scoped connect routing/injection/authSignInReady (registry), SSO setup routes (admin-server), connect gate ordering (web).

## Testing
- Typecheck (worker + web) ✓; worker 92 tests ✓; web 35 tests ✓.
- Live end-to-end against a real Scalekit workspace: consent → vault → 35 agent tools → environment picker → credential auto-fill → portal link → connection polling → SSO sign-in as first admin.

Pairs with open-neko/plugins#57 (plugin v1.0.0).