### PR TITLE
fix(cli): avoid migration wait race that breaks Deploy to VM; refresh openshell comments + add port-exposure test

### DIFF
--- a/apps/openneko/assets/compose/openshell.yml
+++ b/apps/openneko/assets/compose/openshell.yml
@@ -20,9 +20,10 @@
 #     all point inside it.
 #  3. The Docker driver attaches sandboxes to this Compose project's default
 #     network. The control plane resolves service names to private container
-#     IPs before creating sandbox policies. OpenShell itself always rewrites
-#     the supervisor callback to host.openshell.internal, so the gateway alone
-#     also needs a loopback-only host mapping. It is unreachable from the LAN;
+#     IPs before creating sandbox policies. Sandboxes reach the gateway by its
+#     Compose service name (openshell-gateway) over that network — the server
+#     cert carries it as a SAN — so the driver's grpc_endpoint uses it too. The
+#     gateway's host publish stays loopback-only: unreachable from the LAN;
 #     data services and brokers remain Docker-only.
 #  4. HOME MUST be a matched host-shared path (NOT /tmp). The gateway writes the
 #     per-sandbox JWT under $HOME/.local/state/openshell/... and the driver
@@ -119,8 +120,8 @@ services:
       XDG_DATA_HOME: ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/cache
       # Matched, host-shared HOME (requirement #4) — NOT /tmp.
       HOME: ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/home
-    # The OpenShell Docker driver hard-codes supervisor callbacks through its
-    # host alias. Bind only loopback: sandboxes can connect, LAN clients cannot.
+    # Sandboxes reach the gateway over the shared Compose network by service
+    # name; this host publish is loopback-only so LAN clients cannot reach it.
     ports:
       - "127.0.0.1:${OPENSHELL_PORT:-18080}:${OPENSHELL_PORT:-18080}"
     volumes:

--- a/apps/openneko/assets/compose_security_test.go
+++ b/apps/openneko/assets/compose_security_test.go
@@ -2,6 +2,8 @@ package assets
 
 import (
 	"io/fs"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -59,6 +61,73 @@ func readComposeForTest(t *testing.T, name string) (composeFileForTest, string) 
 		t.Fatalf("parse %s: %v", name, err)
 	}
 	return doc, string(raw)
+}
+
+// repoRootForTest walks up from the test's working directory until it finds the
+// directory holding the top-level compose.yml.
+func repoRootForTest(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "compose.yml")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("could not locate repo root: no compose.yml found walking up from the test directory")
+		}
+		dir = parent
+	}
+}
+
+// TestDevComposeExposesOnlyWebToHost guards the top-level (development) Compose
+// files that run on the Linux host. web is the only service allowed to publish
+// on all interfaces (0.0.0.0); every other host-published port must stay bound
+// to the 127.0.0.1 loopback, so only web is reachable from the LAN. Globbing
+// compose*.yml means any new overlay is covered automatically.
+func TestDevComposeExposesOnlyWebToHost(t *testing.T) {
+	const webPublish = "${OPENNEKO_WEB_BIND_ADDRESS:-0.0.0.0}:${OPENNEKO_PORT:-3000}:8080"
+
+	files, err := filepath.Glob(filepath.Join(repoRootForTest(t), "compose*.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no top-level compose*.yml files found")
+	}
+
+	sawWeb := false
+	for _, path := range files {
+		name := filepath.Base(path)
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var doc composeFileForTest
+		if err := yaml.Unmarshal(raw, &doc); err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		for service, spec := range doc.Services {
+			for _, entry := range spec.Ports {
+				if service == "web" {
+					if entry != webPublish {
+						t.Fatalf("%s: web publishes %q, want only %q", name, entry, webPublish)
+					}
+					sawWeb = true
+					continue
+				}
+				if !strings.HasPrefix(entry, "127.0.0.1:") {
+					t.Fatalf("%s: service %q publishes host port %q on a non-loopback interface; only web may bind the LAN", name, service, entry)
+				}
+			}
+		}
+	}
+	if !sawWeb {
+		t.Fatal("expected the web service to publish its host port in the top-level compose files")
+	}
 }
 
 func TestPackagedComposeExposesOnlyWebToLAN(t *testing.T) {

--- a/apps/openneko/internal/cli/start.go
+++ b/apps/openneko/internal/cli/start.go
@@ -136,20 +136,22 @@ func bringUpStack(ctx context.Context, cmd *cobra.Command, mode compose.Mode, op
 		quietPull = []string{"--quiet-pull"}
 	}
 
-	// Stage 1: run the existing one-shot migration service inside Docker. Its
-	// dependency waits for neko-db's healthcheck, and `compose wait` propagates
-	// its exit code. The same command provisions the gateway's dedicated DB role
-	// even when --skip-migrate asks it to skip schema changes. No database port
-	// needs to cross the Docker network boundary.
-	up1 := append([]string{"up", "-d"}, pullFlag...)
-	up1 = append(up1, quietPull...)
-	up1 = append(up1, "neko-migrate")
-	if code, err := sup.Run(ctx, project, files, up1, os.Stdout, os.Stderr); err != nil {
-		return err
-	} else if code != 0 {
-		return WithExit(code, nil)
-	}
-	if code, err := sup.Run(ctx, project, files, []string{"wait", "neko-migrate"}, os.Stdout, os.Stderr); err != nil {
+	// Stage 1: run the one-shot migration to completion and capture its exit
+	// code directly. `run --rm` starts neko-db (its healthcheck dependency),
+	// runs the migrate command in the foreground, and returns its exit status.
+	//
+	// We deliberately do NOT use `up -d neko-migrate` + a separate
+	// `compose wait`: on a re-deploy against an already-migrated database the
+	// migration is a fast no-op that exits before the separate `wait` can
+	// observe it, so `compose wait` reports "no containers for project" and
+	// exits non-zero — surfacing as a spurious "database preparation failed".
+	// A foreground `run` has no such race. The same command provisions the
+	// gateway's dedicated DB role even when --skip-migrate skips schema changes.
+	// No database port needs to cross the Docker network boundary.
+	migrateArgs := append([]string{"run", "--rm", "-T"}, pullFlag...)
+	migrateArgs = append(migrateArgs, quietPull...)
+	migrateArgs = append(migrateArgs, "neko-migrate")
+	if code, err := sup.Run(ctx, project, files, migrateArgs, os.Stdout, os.Stderr); err != nil {
 		return err
 	} else if code != 0 {
 		return WithExit(code, fmt.Errorf("database preparation failed"))

--- a/compose.openshell.yml
+++ b/compose.openshell.yml
@@ -20,9 +20,10 @@
 #     all point inside it.
 #  3. The Docker driver attaches sandboxes to this Compose project's default
 #     network. The control plane resolves service names to private container
-#     IPs before creating sandbox policies. OpenShell itself always rewrites
-#     the supervisor callback to host.openshell.internal, so the gateway alone
-#     also needs a loopback-only host mapping. It is unreachable from the LAN;
+#     IPs before creating sandbox policies. Sandboxes reach the gateway by its
+#     Compose service name (openshell-gateway) over that network — the server
+#     cert carries it as a SAN — so the driver's grpc_endpoint uses it too. The
+#     gateway's host publish stays loopback-only: unreachable from the LAN;
 #     data services and brokers remain Docker-only.
 #  4. HOME MUST be a matched host-shared path (NOT /tmp). The gateway writes the
 #     per-sandbox JWT under $HOME/.local/state/openshell/... and the driver
@@ -119,8 +120,8 @@ services:
       XDG_DATA_HOME: ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/cache
       # Matched, host-shared HOME (requirement #4) — NOT /tmp.
       HOME: ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/home
-    # The OpenShell Docker driver hard-codes supervisor callbacks through its
-    # host alias. Bind only loopback: sandboxes can connect, LAN clients cannot.
+    # Sandboxes reach the gateway over the shared Compose network by service
+    # name; this host publish is loopback-only so LAN clients cannot reach it.
     ports:
       - "127.0.0.1:${OPENSHELL_PORT:-18080}:${OPENSHELL_PORT:-18080}"
     volumes:


### PR DESCRIPTION
## Summary

Three related changes, the first of which fixes the currently-failing **Deploy to VM** job.

### 1. `fix(cli)`: run migrations with `compose run` to avoid a wait race on redeploy
`openneko start` brought up the `neko-migrate` one-shot detached (`up -d`) and then ran a separate `docker compose wait neko-migrate` to capture its exit code. On a re-deploy against an **already-migrated** database the migration is a fast no-op that exits *before* the separate `wait` attaches, so `compose wait` reports `no containers for project` and exits non-zero. The CLI surfaces that as a spurious `database preparation failed`.

This is exactly what broke the last Deploy to VM run (on the long-lived production host the DB is always already migrated, so it fails deterministically — not flaky infra). The failing step was introduced when the migrate flow was changed to the `up -d` + `compose wait` two-step.

Replaced it with a single foreground `docker compose run --rm -T neko-migrate`, which starts `neko-db` as a healthcheck dependency, runs the migration to completion, and returns its real exit code with **no wait race**. The migrate command still provisions the gateway's dedicated DB role, and the `--skip-migrate` path is unchanged.

### 2. `docs(openshell)`: refresh stale gateway networking comments
The recent switch of the docker-driver `grpc_endpoint` to the `openshell-gateway` Compose service left the surrounding comments describing the old `host.openshell.internal` supervisor-callback rewrite and loopback-mapping rationale, which no longer match the code. Requirement #3 and the gateway-`ports` comment now describe sandboxes reaching the gateway by its Compose service name over the shared network (the server cert carries that SAN); the host publish stays loopback-only so the LAN can't reach it.

### 3. `test(compose)`: assert only `web` binds a non-loopback host port in dev compose
The packaged compose files already have `TestPackagedComposeExposesOnlyWebToLAN`, but the top-level development compose files (`compose.yml` and its overlays) were untested — they publish loopback debug ports for the databases and graphjin, so dropping a `127.0.0.1:` prefix would silently expose a service to the LAN. `TestDevComposeExposesOnlyWebToHost` globs every top-level `compose*.yml` (so new overlays are covered automatically) and asserts `web` is the only service allowed to bind all interfaces (`0.0.0.0`) while every other host-published port stays loopback-bound.

## Testing
- `go build ./...`, `go vet ./internal/cli/`, and the `cli` / `compose` / `assets` test packages all pass.
- `gofmt` clean.
- No existing test asserted the old `up -d` + `wait` command sequence, so nothing broke.
- Verified the new port-exposure test fails as intended when a loopback binding is flipped to `0.0.0.0`.

## Deployment note
The Deploy to VM job installs the **released** CLI binary, so the `compose run` fix only takes effect once a release containing it is cut and installed on the VM — merging this to `main` will not retroactively fix an in-flight deploy of an earlier release.