### PR TITLE
fix(web): bundle fonts for reproducible builds

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fontsource-variable/archivo": "5.3.0",
+    "@fontsource-variable/manrope": "5.3.0",
     "@neko/channels": "workspace:*",
     "@neko/db": "workspace:*",
     "@neko/interaction": "workspace:*",

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -19,6 +19,11 @@
 @import "./styles/_responsive.css";
 @import "./styles/_dock.css";
 
+:root {
+  --font-display: "Archivo Variable";
+  --font-body: "Manrope Variable";
+}
+
 @theme {
   --color-bg: #FAFAF7;
   --color-card: #FFFFFF;
@@ -52,9 +57,8 @@
   --shadow-lift: 0 1px 2px rgba(20,18,12,0.04), 0 18px 48px -16px rgba(20,18,12,0.16);
 }
 
-/* font-display / font-body utilities — defined as @utility so they pick up the
-   Next.js font CSS variables at runtime rather than capturing them at @theme
-   resolution time. */
+/* font-display / font-body utilities use the bundled Fontsource variable
+   fonts, so production builds never depend on Google Fonts availability. */
 @utility font-display {
   font-family: var(--font-display), 'Archivo', sans-serif;
 }
@@ -245,7 +249,6 @@ html[data-density="compact"] .triage-pane {
   .topbar-spacer { display: none; }
   .topbar-nav { order: 3; width: 100%; overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; }
 }
-
 
 
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,9 +1,10 @@
 import type { Metadata, Viewport } from "next";
-import { Archivo, Manrope } from "next/font/google";
 import { Toaster } from "sonner";
 import { DensityProvider } from "@/components/DensityProvider";
 import AppRail from "@/components/AppRail";
 import CommandDock from "@/components/CommandDock";
+import "@fontsource-variable/archivo/wght.css";
+import "@fontsource-variable/manrope/wght.css";
 import "./globals.css";
 import "./styles/_operations.css";
 import "./styles/_library.css";
@@ -11,17 +12,6 @@ import "./styles/_library.css";
 // Set data-density before paint from the persisted choice (default compact),
 // so the dense layout never flashes the comfortable one on load.
 const DENSITY_INIT = `(function(){try{var d=localStorage.getItem('neko-density');document.documentElement.setAttribute('data-density',d==='comfortable'?'comfortable':'compact');}catch(e){document.documentElement.setAttribute('data-density','compact');}})();`;
-
-const display = Archivo({
-  variable: "--font-display",
-  subsets: ["latin"],
-  weight: ["600", "700", "800", "900"],
-});
-
-const body = Manrope({
-  variable: "--font-body",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "OpenNeko",
@@ -41,7 +31,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" data-density="compact" className={`${display.variable} ${body.variable}`}>
+    <html lang="en" data-density="compact">
       <head>
         <script dangerouslySetInnerHTML={{ __html: DENSITY_INIT }} />
       </head>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,12 @@ importers:
 
   apps/web:
     dependencies:
+      '@fontsource-variable/archivo':
+        specifier: 5.3.0
+        version: 5.3.0
+      '@fontsource-variable/manrope':
+        specifier: 5.3.0
+        version: 5.3.0
       '@neko/channels':
         specifier: workspace:*
         version: link:../../packages/channels
@@ -883,6 +889,12 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@fontsource-variable/archivo@5.3.0':
+    resolution: {integrity: sha512-HogK8FJelrD1o7TlZlkIVtHgc20bO5PZRWE7mUeUTdMN055alznQV6/00J00IBeu8FQAH4s3zW9UJNvKExXf+g==}
+
+  '@fontsource-variable/manrope@5.3.0':
+    resolution: {integrity: sha512-6D5dgokHsWDDMtmXHznKa0hK229NN+1a4BLPmUCLqcO1Pw5EEhWY5RFt0AcXnVRAljFFPfRtLkJePQj6LSsV6g==}
 
   '@hono/node-server@1.19.14':
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
@@ -4585,6 +4597,10 @@ snapshots:
     dependencies:
       '@eslint/core': 0.17.0
       levn: 0.4.1
+
+  '@fontsource-variable/archivo@5.3.0': {}
+
+  '@fontsource-variable/manrope@5.3.0': {}
 
   '@hono/node-server@1.19.14(hono@4.12.16)':
     dependencies:


### PR DESCRIPTION
## Summary
- replace `next/font/google` with bundled Archivo and Manrope variable WOFF2 assets
- preserve the existing display/body CSS variables
- remove Google Fonts availability from the production build path

## Verification
- `pnpm --filter @neko/web build`
- `pnpm --filter @neko/web test` (250 passed, 101 integration tests skipped without Postgres)