### PR TITLE
fix(openshell): declare Docker IPAM gateway

### DIFF
--- a/apps/openneko/assets/compose/openshell.yml
+++ b/apps/openneko/assets/compose/openshell.yml
@@ -180,14 +180,18 @@ volumes:
 # OpenShell's Docker driver writes host.openshell.internal into /etc/hosts, so
 # a normal Compose DNS alias cannot route sandbox callbacks to the containerised
 # gateway. A small, project-specific network gives that gateway a stable private
-# address without publishing its mTLS port to the LAN. The CLI selects distinct
-# defaults per stack mode; direct Compose users can override all three values.
+# address without publishing its mTLS port to the LAN. OpenShell reads Docker's
+# IPAM Gateway field when it creates the sandbox runtime, so declare that field
+# instead of relying on Docker to synthesize it (some daemons leave it empty).
+# The CLI selects distinct defaults per stack mode; direct Compose users can
+# override all four values.
 networks:
   default:
     name: "${COMPOSE_PROJECT_NAME}_runtime"
     ipam:
       config:
         - subnet: "${OPENNEKO_DOCKER_SUBNET:-172.29.0.0/24}"
+          gateway: "${OPENNEKO_DOCKER_GATEWAY:-172.29.0.1}"
           # Keep dynamic service/sandbox allocation away from the gateway's
           # fixed .2 address (the CLI derives this range for custom subnets).
           ip_range: "${OPENNEKO_DOCKER_IP_RANGE:-172.29.0.128/25}"

--- a/apps/openneko/assets/compose_security_test.go
+++ b/apps/openneko/assets/compose_security_test.go
@@ -215,6 +215,7 @@ func TestPackagedComposeKeepsRuntimeTrafficOnDockerNetwork(t *testing.T) {
 		`ipv4_address: "${OPENSHELL_GATEWAY_IP:-172.29.0.2}"`,
 		`name: "${COMPOSE_PROJECT_NAME}_runtime"`,
 		`subnet: "${OPENNEKO_DOCKER_SUBNET:-172.29.0.0/24}"`,
+		`gateway: "${OPENNEKO_DOCKER_GATEWAY:-172.29.0.1}"`,
 		`ip_range: "${OPENNEKO_DOCKER_IP_RANGE:-172.29.0.128/25}"`,
 	} {
 		if !strings.Contains(raw, required) {

--- a/apps/openneko/internal/cli/openshell_test.go
+++ b/apps/openneko/internal/cli/openshell_test.go
@@ -37,16 +37,18 @@ func TestOpenShellStateDirOverride(t *testing.T) {
 
 func TestConfigureOpenShellNetworkUsesDistinctModeDefaults(t *testing.T) {
 	for _, tc := range []struct {
-		mode       compose.Mode
-		wantSubnet string
-		wantIP     string
+		mode        compose.Mode
+		wantSubnet  string
+		wantGateway string
+		wantIP      string
 	}{
-		{compose.ModeProd, "172.29.0.0/24", "172.29.0.2"},
-		{compose.ModeDev, "172.29.1.0/24", "172.29.1.2"},
-		{compose.ModeDemo, "172.29.2.0/24", "172.29.2.2"},
+		{compose.ModeProd, "172.29.0.0/24", "172.29.0.1", "172.29.0.2"},
+		{compose.ModeDev, "172.29.1.0/24", "172.29.1.1", "172.29.1.2"},
+		{compose.ModeDemo, "172.29.2.0/24", "172.29.2.1", "172.29.2.2"},
 	} {
 		t.Run(string(tc.mode), func(t *testing.T) {
 			t.Setenv(openShellNetworkSubnetEnv, "")
+			t.Setenv(openShellNetworkGatewayEnv, "")
 			t.Setenv(openShellNetworkIPRangeEnv, "")
 			t.Setenv(openShellGatewayIPEnv, "")
 			if err := configureOpenShellNetwork(tc.mode); err != nil {
@@ -54,6 +56,9 @@ func TestConfigureOpenShellNetworkUsesDistinctModeDefaults(t *testing.T) {
 			}
 			if got := os.Getenv(openShellNetworkSubnetEnv); got != tc.wantSubnet {
 				t.Fatalf("subnet = %q, want %q", got, tc.wantSubnet)
+			}
+			if got := os.Getenv(openShellNetworkGatewayEnv); got != tc.wantGateway {
+				t.Fatalf("network gateway = %q, want %q", got, tc.wantGateway)
 			}
 			if got := os.Getenv(openShellGatewayIPEnv); got != tc.wantIP {
 				t.Fatalf("gateway IP = %q, want %q", got, tc.wantIP)
@@ -68,6 +73,7 @@ func TestConfigureOpenShellNetworkUsesDistinctModeDefaults(t *testing.T) {
 
 func TestConfigureOpenShellNetworkDerivesCustomGatewayIP(t *testing.T) {
 	t.Setenv(openShellNetworkSubnetEnv, "10.77.8.0/24")
+	t.Setenv(openShellNetworkGatewayEnv, "")
 	t.Setenv(openShellNetworkIPRangeEnv, "")
 	t.Setenv(openShellGatewayIPEnv, "")
 	if err := configureOpenShellNetwork(compose.ModeProd); err != nil {
@@ -76,6 +82,9 @@ func TestConfigureOpenShellNetworkDerivesCustomGatewayIP(t *testing.T) {
 	if got := os.Getenv(openShellGatewayIPEnv); got != "10.77.8.2" {
 		t.Fatalf("gateway IP = %q, want 10.77.8.2", got)
 	}
+	if got := os.Getenv(openShellNetworkGatewayEnv); got != "10.77.8.1" {
+		t.Fatalf("network gateway = %q, want 10.77.8.1", got)
+	}
 	if got := os.Getenv(openShellNetworkIPRangeEnv); got != "10.77.8.128/25" {
 		t.Fatalf("dynamic IP range = %q, want 10.77.8.128/25", got)
 	}
@@ -83,11 +92,23 @@ func TestConfigureOpenShellNetworkDerivesCustomGatewayIP(t *testing.T) {
 
 func TestConfigureOpenShellNetworkRejectsGatewayOutsideSubnet(t *testing.T) {
 	t.Setenv(openShellNetworkSubnetEnv, "10.77.8.0/24")
+	t.Setenv(openShellNetworkGatewayEnv, "")
 	t.Setenv(openShellNetworkIPRangeEnv, "")
 	t.Setenv(openShellGatewayIPEnv, "10.88.0.2")
 	err := configureOpenShellNetwork(compose.ModeProd)
 	if err == nil || !strings.Contains(err.Error(), openShellGatewayIPEnv) {
 		t.Fatalf("error = %v, want %s validation", err, openShellGatewayIPEnv)
+	}
+}
+
+func TestConfigureOpenShellNetworkRejectsBridgeGatewayOutsideSubnet(t *testing.T) {
+	t.Setenv(openShellNetworkSubnetEnv, "10.77.8.0/24")
+	t.Setenv(openShellNetworkGatewayEnv, "10.88.0.1")
+	t.Setenv(openShellNetworkIPRangeEnv, "")
+	t.Setenv(openShellGatewayIPEnv, "")
+	err := configureOpenShellNetwork(compose.ModeProd)
+	if err == nil || !strings.Contains(err.Error(), openShellNetworkGatewayEnv) {
+		t.Fatalf("error = %v, want %s validation", err, openShellNetworkGatewayEnv)
 	}
 }
 

--- a/apps/openneko/internal/cli/start.go
+++ b/apps/openneko/internal/cli/start.go
@@ -232,6 +232,7 @@ func configureOpenShellStateDir() error {
 
 const (
 	openShellNetworkSubnetEnv  = "OPENNEKO_DOCKER_SUBNET"
+	openShellNetworkGatewayEnv = "OPENNEKO_DOCKER_GATEWAY"
 	openShellNetworkIPRangeEnv = "OPENNEKO_DOCKER_IP_RANGE"
 	openShellGatewayIPEnv      = "OPENSHELL_GATEWAY_IP"
 )
@@ -244,7 +245,8 @@ const (
 //
 // Each stack mode gets a distinct /24 so prod/dev/demo can coexist. Operators
 // with an overlapping host route can override OPENNEKO_DOCKER_SUBNET; when the
-// gateway IP is omitted we derive the second usable address from that subnet.
+// Docker bridge gateway or OpenShell gateway IP is omitted we derive the first
+// and second usable addresses from that subnet, respectively.
 func configureOpenShellNetwork(mode compose.Mode) error {
 	subnet := os.Getenv(openShellNetworkSubnetEnv)
 	if subnet == "" {
@@ -273,6 +275,19 @@ func configureOpenShellNetwork(mode compose.Mode) error {
 		return fmt.Errorf("%s must be contained by %s (got %q)", openShellNetworkIPRangeEnv, subnet, dynamicRange)
 	}
 
+	networkGateway := os.Getenv(openShellNetworkGatewayEnv)
+	if networkGateway == "" {
+		networkGateway = prefix.Addr().Next().String()
+		if err := os.Setenv(openShellNetworkGatewayEnv, networkGateway); err != nil {
+			return err
+		}
+	}
+	bridgeAddress, err := netip.ParseAddr(networkGateway)
+	if err != nil || !bridgeAddress.Is4() || !prefix.Contains(bridgeAddress) || pool.Contains(bridgeAddress) ||
+		bridgeAddress == prefix.Addr() || bridgeAddress == lastIPv4Address(prefix) {
+		return fmt.Errorf("%s must be a usable address in %s outside %s (got %q)", openShellNetworkGatewayEnv, subnet, dynamicRange, networkGateway)
+	}
+
 	gatewayIP := os.Getenv(openShellGatewayIPEnv)
 	if gatewayIP == "" {
 		// Docker reserves the first usable address for the network gateway.
@@ -283,7 +298,7 @@ func configureOpenShellNetwork(mode compose.Mode) error {
 	}
 	address, err := netip.ParseAddr(gatewayIP)
 	if err != nil || !address.Is4() || !prefix.Contains(address) || pool.Contains(address) ||
-		address == prefix.Addr() || address == prefix.Addr().Next() ||
+		address == prefix.Addr() || address == bridgeAddress ||
 		address == lastIPv4Address(prefix) {
 		return fmt.Errorf("%s must be a usable address in %s outside %s (got %q)", openShellGatewayIPEnv, subnet, dynamicRange, gatewayIP)
 	}


### PR DESCRIPTION
## Summary

- declare the Docker bridge gateway explicitly in the OpenShell runtime network
- derive and validate that gateway for default and custom subnets
- keep the bridge gateway distinct from the fixed OpenShell container address

## Root cause

OpenShell 0.0.54 refuses to initialize its Docker compute runtime when Docker network inspection returns a subnet without an IPAM Gateway field. Docker synthesizes the gateway on neko-vm, but the GitHub Actions runner omitted it, leaving openshell-gateway in a restart loop.

## Verification

- go test ./... in apps/openneko
- rendered default prod Compose config includes gateway 172.29.0.1 and OpenShell address 172.29.0.2
- rendered custom Compose config includes gateway 10.77.8.1 and OpenShell address 10.77.8.2

This is the recovery fix for the failed v2.26.2 post-release smoke.