### PR TITLE
fix(openshell): resolve Hermes egress executable

### DIFF
--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -127,6 +127,30 @@ jobs:
             done
           done
 
+      - name: Verify Hermes egress executable contract
+        if: ${{ steps.ctx.outputs.build_ok == 'true' }}
+        env:
+          OPENNEKO_VERSION: ${{ steps.ctx.outputs.tag }}
+        run: |
+          set -euo pipefail
+          resolve_interpreter() {
+            docker run --rm --entrypoint sh "$1" -lc \
+              'realpath /usr/local/uv/tools/hermes-agent/bin/python'
+          }
+          worker_binary=$(resolve_interpreter \
+            "ghcr.io/open-neko/neko-worker:$OPENNEKO_VERSION")
+          agent_binary=$(resolve_interpreter \
+            "ghcr.io/open-neko/agent:$OPENNEKO_VERSION")
+          configured_binary=$(docker run --rm --entrypoint node \
+            "ghcr.io/open-neko/neko-worker:$OPENNEKO_VERSION" \
+            --import tsx/esm --input-type=module --eval \
+            'import { resolveHermesModelBinary } from "@neko/llm"; console.log(resolveHermesModelBinary())')
+          echo "worker Hermes executable: $worker_binary"
+          echo "agent Hermes executable:  $agent_binary"
+          echo "OpenNeko policy executable: $configured_binary"
+          test "$worker_binary" = "$agent_binary"
+          test "$configured_binary" = "$agent_binary"
+
       - name: openneko start (detached) against pre-pulled images
         if: ${{ steps.ctx.outputs.build_ok == 'true' }}
         env:

--- a/apps/openneko/assets/compose/openshell.yml
+++ b/apps/openneko/assets/compose/openshell.yml
@@ -142,6 +142,9 @@ services:
       OPENNEKO_AGENT_IMAGE: ${OPENNEKO_AGENT_IMAGE:-ghcr.io/open-neko/agent:${OPENNEKO_VERSION:-latest}}
       # provider / egress host / connecting binary / key-env are derived from the
       # org's model config by provisionHostConfig — no per-deploy egress wiring.
+      # Keep an operator override for emergency compatibility with custom agent
+      # images; an empty value lets runtime auto-resolution choose the binary.
+      OPENNEKO_AGENT_MODEL_BINARY: ${OPENNEKO_AGENT_MODEL_BINARY:-}
       OPENSHELL_GATEWAY: openneko
       # The sandbox shares this Compose network and receives the broker's
       # private container IP, without crossing the host network.
@@ -161,6 +164,7 @@ services:
   web:
     environment:
       OPENNEKO_AGENT_IMAGE: ${OPENNEKO_AGENT_IMAGE:-ghcr.io/open-neko/agent:${OPENNEKO_VERSION:-latest}}
+      OPENNEKO_AGENT_MODEL_BINARY: ${OPENNEKO_AGENT_MODEL_BINARY:-}
       OPENSHELL_GATEWAY: openneko
       OPENNEKO_SANDBOX_SHARED_NETWORK: "1"
       OPENNEKO_BROKER_PORT: ${OPENNEKO_WEB_BROKER_PORT:-4198}

--- a/packages/llm/src/host-provision.ts
+++ b/packages/llm/src/host-provision.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from "node:fs";
 import { mkdir, writeFile, chmod } from "node:fs/promises";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
@@ -12,6 +13,7 @@ const HERMES_DELEGATION_DEFAULT_MAX_ITERATIONS = 50;
 const HERMES_DELEGATION_DEFAULT_MAX_CONCURRENT_CHILDREN = 3;
 const HERMES_DELEGATION_DEFAULT_MAX_SPAWN_DEPTH = 1;
 const HERMES_DELEGATION_DEFAULT_CHILD_TIMEOUT_SECONDS = 0;
+const HERMES_PYTHON_ENTRYPOINT = "/usr/local/uv/tools/hermes-agent/bin/python";
 
 type StoredRow = {
   provider: string;
@@ -338,6 +340,25 @@ function readBoolEnv(name: string, fallback: boolean): boolean {
   return fallback;
 }
 
+/**
+ * OpenShell binds network policy to the caller reported by /proc/<pid>/exe.
+ * Hermes is a Python console script, so that identity is the fully resolved
+ * uv-managed interpreter, not /usr/local/bin/hermes or its versionless
+ * symlink. Resolve it from the runtime image instead of pinning a Python patch
+ * version that can change when uv refreshes its managed 3.11 installation.
+ */
+export function resolveHermesModelBinary(
+  entrypoint = HERMES_PYTHON_ENTRYPOINT,
+): string {
+  try {
+    return realpathSync(entrypoint);
+  } catch {
+    // Local source-only tooling may provision config without the container
+    // toolchain installed. Production images assert this entrypoint exists.
+    return entrypoint;
+  }
+}
+
 function hermesDelegationConfigLines(): string[] {
   const maxIterations = readIntEnv(
     "OPENNEKO_AGENT_DELEGATION_MAX_ITERATIONS",
@@ -431,9 +452,8 @@ const PROVIDER_API_HOSTS: Record<string, string> = {
 /**
  * Derive the agent-sandbox egress from the org's model config: the API host
  * (explicit base_url, else the provider default) + models.dev for hermes model
- * resolution; the connecting binary (per backend + arch — egress matches the
- * resolved path); the env var the backend reads. Binary paths track the agent
- * image's pinned cpython.
+ * resolution; the exact connecting binary (egress matches /proc/<pid>/exe);
+ * and the env var the backend reads.
  */
 function deriveAgentEgress(
   row: StoredRow,
@@ -451,12 +471,11 @@ function deriveAgentEgress(
   }
   host ??= PROVIDER_API_HOSTS[row.provider];
   const isClaude = backend === "claude-agent";
-  const arch = process.arch === "arm64" ? "aarch64" : "x86_64";
   return {
     hosts: [...(host ? [host] : []), ...(isClaude ? [] : ["models.dev"])],
     binary: isClaude
       ? "/usr/local/lib/node_modules/@anthropic-ai/claude-code/bin/claude.exe"
-      : `/usr/local/uv/python/cpython-3.11.15-linux-${arch}-gnu/bin/python3.11`,
+      : resolveHermesModelBinary(),
     keyEnv: isClaude ? "ANTHROPIC_API_KEY" : mapHermesProvider(row.provider).keyVar,
   };
 }
@@ -498,7 +517,7 @@ async function provisionOpenShellRuntime(orgId: string, backend: string): Promis
     gatewayEndpoint: process.env.OPENSHELL_GATEWAY_ENDPOINT || undefined,
   });
   console.log(
-    `[host-provision] OpenShell agent runtime self-configured: provider="${process.env.OPENNEKO_AGENT_MODEL_PROVIDER}" egress="${hosts.join(",")}" keyEnv=${keyEnv}`,
+    `[host-provision] OpenShell agent runtime self-configured: provider="${process.env.OPENNEKO_AGENT_MODEL_PROVIDER}" egress="${hosts.join(",")}" binary="${process.env.OPENNEKO_AGENT_MODEL_BINARY}" keyEnv=${keyEnv}`,
   );
 }
 

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -37,6 +37,7 @@ export {
 export {
   ensureHostConfigProvisioned,
   provisionHostConfig,
+  resolveHermesModelBinary,
 } from "./host-provision";
 export {
   prefetchKnowledgePack,

--- a/packages/llm/test/host-provision.test.ts
+++ b/packages/llm/test/host-provision.test.ts
@@ -1,4 +1,13 @@
-import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import { tmpdir, platform } from "node:os";
 import { join } from "node:path";
 import {
@@ -26,6 +35,7 @@ import {
   hermesHomeForOrg,
   patchGraphjinSourcesJwtSecret,
   provisionHostConfig,
+  resolveHermesModelBinary,
   shouldReconcileDemoSourceAuthMode,
 } from "../src/host-provision";
 import { ensureOpenShellProvider } from "../src/work/sandbox-launcher";
@@ -73,6 +83,30 @@ const ORIGINAL_DELEGATION_ENV = Object.fromEntries(
   DELEGATION_ENV_KEYS.map((key) => [key, process.env[key]]),
 );
 const ensureOpenShellProviderMock = vi.mocked(ensureOpenShellProvider);
+
+describe("resolveHermesModelBinary", () => {
+  it("returns the exact interpreter behind Hermes' uv entrypoint", async () => {
+    const root = await mkdtemp(join(tmpdir(), "neko-hermes-python-"));
+    try {
+      const interpreter = join(root, "cpython-3.11.16", "bin", "python3.11");
+      const entrypoint = join(root, "hermes-python");
+      await mkdir(join(root, "cpython-3.11.16", "bin"), { recursive: true });
+      await writeFile(interpreter, "python");
+      await symlink(interpreter, entrypoint);
+
+      expect(resolveHermesModelBinary(entrypoint)).toBe(
+        await realpath(interpreter),
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it("does not reintroduce a guessed Python patch version when absent", () => {
+    const missing = "/missing/hermes-agent/bin/python";
+    expect(resolveHermesModelBinary(missing)).toBe(missing);
+  });
+});
 
 describe("patchGraphjinSourcesJwtSecret", () => {
   it("replaces a source-mode placeholder", () => {


### PR DESCRIPTION
## What changed

- resolve Hermes' actual uv-managed Python interpreter at worker/web startup instead of hard-coding Python 3.11.15
- pass an emergency Compose override through to worker and web
- make post-release smoke compare OpenNeko's configured policy binary with the worker and agent image executables
- log the selected non-secret egress binary

## Root cause

OpenShell authorizes egress using the exact executable reported by `/proc/<pid>/exe`. v2.26.3 ships Hermes on Python 3.11.16, while OpenNeko allowed a removed Python 3.11.15 path. Sandboxes and callbacks therefore came up, but Hermes could not reach Gemini and returned an empty profile.

## Verification

- production diagnostic with the corrected binary completed the real Adventure Works profiler in 68s (5,005 chars)
- `pnpm --filter @neko/llm test`: 622 passed
- `pnpm --filter @neko/worker typecheck`: passed
- `go test ./...` in `apps/openneko`: passed
