### PR TITLE
fix(web): handle approvals without workflow runs

### DIFF
--- a/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
+++ b/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
@@ -53,7 +53,7 @@ type RecentAction = {
   target: string | null;
   status: string;
   riskLevel: string | null;
-  summary: string;
+  summary: string | null;
   approvedAt: string | null;
   createdAt: string;
 };

--- a/apps/web/src/app/actions/page.tsx
+++ b/apps/web/src/app/actions/page.tsx
@@ -13,6 +13,7 @@ import ActCard, {
 } from "@/components/ActCard";
 import { cn } from "@/lib/cn";
 import { formatSavedShort } from "@/lib/hours-saved";
+import { workflowDisplayName } from "@/lib/workflow-label";
 import {
   parseRecordUpdatePayload,
   RecordActionDiff,
@@ -29,7 +30,7 @@ type ActionRow = {
   target: string | null;
   payload: unknown;
   riskLevel: string | null;
-  summary: string;
+  summary: string | null;
   scope: string;
   status: string;
   minutesSaved: number | null;
@@ -115,7 +116,7 @@ function groupActions(actions: ActionRow[]): Group[] {
         runId: row.workflowRunId,
         runAt: row.runAt,
         trigger: row.triggeredByObservation?.title ?? null,
-        workflowName: row.workflow?.name ?? "the assistant",
+        workflowName: workflowDisplayName(row.workflow),
         state,
         rows: [row],
       });
@@ -390,7 +391,7 @@ function ActionReadingPane({
           {action.summary || action.kind}
         </h2>
         <div className="text-[12.5px] text-text2 mt-2 leading-[1.5]">
-          Proposed by <span className="text-text font-semibold">{action.workflow?.name ?? "the assistant"}</span>
+          Proposed by <span className="text-text font-semibold">{workflowDisplayName(action.workflow)}</span>
           {action.triggeredByObservation ? <> · triggered by “{action.triggeredByObservation.title}”</> : null}
         </div>
 

--- a/apps/web/src/app/api/briefing/findings/route.ts
+++ b/apps/web/src/app/api/briefing/findings/route.ts
@@ -11,6 +11,7 @@ import {
   gt,
   gte,
   muted_scope,
+  ne,
   notInArray,
   observation,
   sql,
@@ -19,6 +20,8 @@ import {
   workflow_run,
 } from "@neko/db";
 import { summarizeBriefing } from "@neko/llm";
+import { getCurrentActor } from "@/lib/actor";
+import { serializeBriefingApproval } from "@/lib/briefing-findings";
 import { getOrgId } from "@/lib/db";
 
 // 5-minute freshness window for the auto-generated live summary. If a row
@@ -97,7 +100,8 @@ const ACT_LIMIT = 8;
 const APPROVAL_LIMIT = 8;
 
 export async function GET() {
-  const orgId = await getOrgId();
+  const [orgId, actor] = await Promise.all([getOrgId(), getCurrentActor()]);
+  const canReadSourceConfig = actor.role === "admin";
 
   // 0. Active scope mutes (OL7) — matching finding cards are filtered
   // out of every tributary below until muted_until passes.
@@ -124,10 +128,13 @@ export async function GET() {
       createdAt: action_request.created_at,
       workflowId: workflow_definition.id,
       workflowName: workflow_definition.name,
+      pendingApprovalCount: sql<number>`count(*) over()::int`,
     })
     .from(action_request)
-    .innerJoin(workflow_run, eq(action_request.workflow_run_id, workflow_run.id))
-    .innerJoin(
+    // Chat-proposed admin actions do not carry a workflow_run_id. Keep them
+    // in the briefing just like /api/approvals does.
+    .leftJoin(workflow_run, eq(action_request.workflow_run_id, workflow_run.id))
+    .leftJoin(
       workflow_definition,
       eq(workflow_run.workflow_id, workflow_definition.id),
     )
@@ -135,6 +142,9 @@ export async function GET() {
       and(
         eq(action_request.org_id, orgId),
         eq(action_request.status, "pending_approval"),
+        ...(canReadSourceConfig
+          ? []
+          : [ne(action_request.kind, "source_config_admin")]),
       ),
     )
     .orderBy(desc(action_request.created_at))
@@ -146,6 +156,7 @@ export async function GET() {
     if (ra !== rb) return ra - rb;
     return b.createdAt.getTime() - a.createdAt.getTime();
   });
+  const pendingApprovalCount = approvals[0]?.pendingApprovalCount ?? 0;
 
   // 2. Recent mood=act findings — workflow_outputs from the last N hours.
   const since = new Date(Date.now() - RECENT_FINDING_WINDOW_HOURS * 3600 * 1000);
@@ -317,7 +328,7 @@ export async function GET() {
     try {
       summary = await summarizeBriefing(
         {
-          pendingApprovals: approvals.length,
+          pendingApprovals: pendingApprovalCount,
           actFindings: actRaw.length,
           watchFindings: watchRaw.length,
           goodRuns: goodCountRow?.count ?? 0,
@@ -332,7 +343,7 @@ export async function GET() {
     } catch (err) {
       console.warn("[briefing/findings] LLM summary failed, falling back:", err);
       summary = composeSummary({
-        pendingApprovals: approvals.length,
+        pendingApprovals: pendingApprovalCount,
         actFindings: actRaw.length,
         watchFindings: watchRaw.length,
         goodRuns: goodCountRow?.count ?? 0,
@@ -380,16 +391,7 @@ export async function GET() {
         }
       : null,
     awaitingYou: {
-      approvals: approvals.map((a) => ({
-        id: a.id,
-        kind: "approval" as const,
-        workflowRunId: a.workflowRunId,
-        workflow: { id: a.workflowId, name: a.workflowName },
-        title: a.summary || a.kind,
-        target: a.target,
-        riskLevel: a.riskLevel,
-        createdAt: a.createdAt.toISOString(),
-      })),
+      approvals: approvals.map(serializeBriefingApproval),
       actFindings: actRaw.map((o) => ({
         id: o.id,
         kind: "finding" as const,

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { applyMessage, getResolvedComponents } from "@/a2ui/surface";
-import type { A2UIMessage, SurfaceState, A2UIComponent } from "@/a2ui/types";
+import type { SurfaceState, A2UIComponent } from "@/a2ui/types";
 import type { BriefingCardProps } from "@/a2ui/catalog";
 import BriefingCard from "@/components/BriefingCard";
 import type { BriefingCardData } from "@/components/BriefingCard";
@@ -25,6 +25,11 @@ import HoursSavedHero, {
 import AgentLauncher from "@/components/AgentLauncher";
 import { formatSavedShort } from "@/lib/hours-saved";
 import { cn } from "@/lib/cn";
+import {
+  groupAwaiting,
+  type AwaitingPayload,
+} from "@/lib/dashboard-actions";
+import { readBriefingMessages } from "@/lib/briefing-messages";
 
 type ElevatedCard = {
   id: string;
@@ -79,25 +84,6 @@ type RecentActionsPayload = {
   windowHours: number;
 };
 
-type AwaitingRow = {
-  id: string;
-  workflowRunId: string;
-  workflow: { id: string; name: string };
-  triggeredByObservation: { title: string } | null;
-  kind: string;
-  target: string | null;
-  riskLevel: string | null;
-  summary: string;
-  status: string;
-  runAt: string;
-  payload: unknown;
-};
-
-type AwaitingPayload = {
-  actions: AwaitingRow[];
-  count: number;
-};
-
 function approverPhrase(
   kind: ReceiptRow["approverKind"],
   label: string | null,
@@ -105,60 +91,6 @@ function approverPhrase(
   if (kind === "operator") return label ? `you · ${label}` : "you";
   if (kind === "policy") return label ? `rule "${label}"` : "a rule";
   return "auto";
-}
-
-function groupAwaiting(
-  rows: AwaitingRow[],
-): Array<{ key: string; card: ActCardData }> {
-  const groups = new Map<
-    string,
-    {
-      key: string;
-      runId: string;
-      runAt: string;
-      trigger: string | null;
-      workflowName: string;
-      rows: ActRowData[];
-    }
-  >();
-  for (const r of rows) {
-    const tone: ActRowData["tone"] =
-      r.riskLevel === "high" || r.riskLevel === "critical" ? "action" : "watch";
-    const row: ActRowData = {
-      id: r.id,
-      tone,
-      headline: r.summary || r.kind,
-      detail: null,
-      target: r.target,
-      kind: r.kind,
-      payload: r.payload,
-      status: r.status,
-    };
-    const existing = groups.get(r.workflowRunId);
-    if (existing) {
-      existing.rows.push(row);
-    } else {
-      groups.set(r.workflowRunId, {
-        key: r.workflowRunId,
-        runId: r.workflowRunId,
-        runAt: r.runAt,
-        trigger: r.triggeredByObservation?.title ?? null,
-        workflowName: r.workflow.name,
-        rows: [row],
-      });
-    }
-  }
-  return Array.from(groups.values()).map((g) => ({
-    key: g.key,
-    card: {
-      runId: g.runId,
-      runAt: g.runAt,
-      trigger: g.trigger,
-      state: "awaiting",
-      workflowName: g.workflowName,
-      rows: g.rows,
-    },
-  }));
 }
 
 function groupReceipts(
@@ -352,7 +284,7 @@ export default function Dashboard() {
     if (!silent) setLoading(true);
     try {
       const res = await fetch(`/api/briefing?role=${r}`);
-      const messages: A2UIMessage[] = await res.json();
+      const messages = await readBriefingMessages(res);
 
       setSurfaces((prev) => {
         let next = prev;
@@ -361,6 +293,8 @@ export default function Dashboard() {
         }
         return next;
       });
+    } catch (err) {
+      console.warn("[dashboard] briefing refresh failed:", err);
     } finally {
       if (!silent) setLoading(false);
     }

--- a/apps/web/src/app/runs/[workflowRunId]/page.tsx
+++ b/apps/web/src/app/runs/[workflowRunId]/page.tsx
@@ -53,7 +53,7 @@ type RunDetailPayload = {
     scope: string;
     riskLevel: string | null;
     status: string;
-    summary: string;
+    summary: string | null;
     approvedAt: string | null;
     rejectionReason: string | null;
     createdAt: string;

--- a/apps/web/src/components/FindingCard.tsx
+++ b/apps/web/src/components/FindingCard.tsx
@@ -10,6 +10,7 @@ import remarkGfm from "remark-gfm";
 import { Card } from "@/components/ui/Card";
 import { Pill, type PillVariant } from "@/components/ui/Pill";
 import { cn } from "@/lib/cn";
+import { workflowDisplayName } from "@/lib/workflow-label";
 
 const MUTE_DURATIONS = ["1h", "24h", "7d"] as const;
 
@@ -17,7 +18,7 @@ export type FindingCardData = {
   id: string;
   kind: "approval" | "finding";
   workflowRunId: string | null;
-  workflow: { id: string; name: string };
+  workflow: { id: string; name: string } | null;
   title: string;
   body?: string | null;
   scope?: string | null;
@@ -160,7 +161,9 @@ export default function FindingCard({
       <div className="flex items-center gap-1.5 text-xs text-text3 flex-wrap">
         <span>
           from{" "}
-          <span className="text-text2 font-medium">{data.workflow.name}</span>
+          <span className="text-text2 font-medium">
+            {workflowDisplayName(data.workflow)}
+          </span>
         </span>
         <span className="opacity-50">·</span>
         <span className="font-mono text-xs text-text2">{formatRelative(data.createdAt)}</span>

--- a/apps/web/src/lib/briefing-findings.ts
+++ b/apps/web/src/lib/briefing-findings.ts
@@ -1,0 +1,33 @@
+import type { FindingCardData } from "@/components/FindingCard";
+
+export type BriefingApprovalRow = {
+  id: string;
+  workflowRunId: string | null;
+  kind: string;
+  target: string | null;
+  summary: string | null;
+  riskLevel: string | null;
+  createdAt: Date;
+  workflowId: string | null;
+  workflowName: string | null;
+};
+
+export function serializeBriefingApproval(
+  approval: BriefingApprovalRow,
+): FindingCardData {
+  return {
+    id: approval.id,
+    kind: "approval",
+    workflowRunId: approval.workflowRunId,
+    workflow: approval.workflowId
+      ? {
+          id: approval.workflowId,
+          name: approval.workflowName ?? "workflow",
+        }
+      : null,
+    title: approval.summary || approval.kind,
+    target: approval.target,
+    riskLevel: approval.riskLevel,
+    createdAt: approval.createdAt.toISOString(),
+  };
+}

--- a/apps/web/src/lib/briefing-messages.ts
+++ b/apps/web/src/lib/briefing-messages.ts
@@ -1,0 +1,47 @@
+import type { A2UIMessage } from "@/a2ui/types";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasString(value: Record<string, unknown>, key: string): boolean {
+  return typeof value[key] === "string";
+}
+
+export function isA2UIMessage(value: unknown): value is A2UIMessage {
+  if (!isRecord(value) || (value.version !== "v0.9" && value.version !== "v1.0")) {
+    return false;
+  }
+
+  if (isRecord(value.createSurface)) {
+    return (
+      hasString(value.createSurface, "surfaceId") &&
+      hasString(value.createSurface, "catalogId")
+    );
+  }
+  if (isRecord(value.updateComponents)) {
+    return (
+      hasString(value.updateComponents, "surfaceId") &&
+      Array.isArray(value.updateComponents.components)
+    );
+  }
+  if (isRecord(value.updateDataModel)) {
+    return hasString(value.updateDataModel, "surfaceId");
+  }
+  if (isRecord(value.deleteSurface)) {
+    return hasString(value.deleteSurface, "surfaceId");
+  }
+  return false;
+}
+
+export async function readBriefingMessages(response: Response): Promise<A2UIMessage[]> {
+  if (!response.ok) {
+    throw new Error(`Briefing request failed (HTTP ${response.status})`);
+  }
+
+  const body: unknown = await response.json();
+  if (!Array.isArray(body) || !body.every(isA2UIMessage)) {
+    throw new Error("Briefing response was not a valid A2UI message sequence");
+  }
+  return body;
+}

--- a/apps/web/src/lib/dashboard-actions.ts
+++ b/apps/web/src/lib/dashboard-actions.ts
@@ -1,0 +1,82 @@
+import type { ActCardData, ActRowData } from "@/components/ActCard";
+import { workflowDisplayName } from "@/lib/workflow-label";
+
+export type AwaitingRow = {
+  id: string;
+  workflowRunId: string | null;
+  workflow: { id: string; name: string } | null;
+  triggeredByObservation: { title: string } | null;
+  kind: string;
+  target: string | null;
+  riskLevel: string | null;
+  summary: string | null;
+  status: string;
+  runAt: string;
+  payload: unknown;
+};
+
+export type AwaitingPayload = {
+  actions: AwaitingRow[];
+  count: number;
+};
+
+/**
+ * Group workflow-backed approvals by run. Chat-proposed approvals have no
+ * workflow run, so each one gets its own card instead of sharing a null key.
+ */
+export function groupAwaiting(
+  rows: AwaitingRow[],
+): Array<{ key: string; card: ActCardData }> {
+  const groups = new Map<
+    string,
+    {
+      key: string;
+      runId: string | null;
+      runAt: string;
+      trigger: string | null;
+      workflowName: string;
+      rows: ActRowData[];
+    }
+  >();
+
+  for (const r of rows) {
+    const tone: ActRowData["tone"] =
+      r.riskLevel === "high" || r.riskLevel === "critical" ? "action" : "watch";
+    const row: ActRowData = {
+      id: r.id,
+      tone,
+      headline: r.summary || r.kind,
+      detail: null,
+      target: r.target,
+      kind: r.kind,
+      payload: r.payload,
+      status: r.status,
+    };
+    const key = r.workflowRunId ? `run:${r.workflowRunId}` : `action:${r.id}`;
+    const existing = groups.get(key);
+    if (existing) {
+      existing.rows.push(row);
+    } else {
+      groups.set(key, {
+        key,
+        runId: r.workflowRunId,
+        runAt: r.runAt,
+        trigger: r.triggeredByObservation?.title ?? null,
+        workflowName: workflowDisplayName(r.workflow),
+        rows: [row],
+      });
+    }
+  }
+
+  return Array.from(groups.values()).map((g) => ({
+    key: g.key,
+    card: {
+      runId: g.runId,
+      runAt: g.runAt,
+      trigger: g.trigger,
+      state: "awaiting",
+      workflowName: g.workflowName,
+      rows: g.rows,
+    },
+  }));
+}

--- a/apps/web/src/lib/workflow-label.ts
+++ b/apps/web/src/lib/workflow-label.ts
@@ -1,0 +1,7 @@
+export const NO_WORKFLOW_LABEL = "OpenNeko AI";
+
+export function workflowDisplayName(
+  workflow: { name: string } | null | undefined,
+): string {
+  return workflow?.name ?? NO_WORKFLOW_LABEL;
+}

--- a/apps/web/test/api/approvals-briefing-findings.test.ts
+++ b/apps/web/test/api/approvals-briefing-findings.test.ts
@@ -1,0 +1,162 @@
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import {
+  createTestOrg,
+  dbReachable,
+  deleteTestOrg,
+  uniqueOrgId,
+} from "@neko/db/test-helpers";
+import { action_request, briefing, db, pool } from "@neko/db";
+import { callRoute } from "../_helpers/route";
+
+const { mockGetOrgId, mockGetCurrentActor } = vi.hoisted(() => ({
+  mockGetOrgId: vi.fn(),
+  mockGetCurrentActor: vi.fn(),
+}));
+
+vi.mock("@/lib/db", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/db")>("@/lib/db");
+  return { ...actual, getOrgId: mockGetOrgId };
+});
+
+vi.mock("@/lib/actor", () => ({
+  getCurrentActor: mockGetCurrentActor,
+}));
+
+const reachable = await dbReachable();
+const describeIfDb = reachable ? describe : describe.skip;
+
+if (!reachable) {
+  console.warn(
+    "[api/approvals-briefing-findings] skipping: Postgres unreachable.",
+  );
+}
+
+describeIfDb("run-less approvals", () => {
+  let orgId: string;
+  let approvalsGET: typeof import("@/app/api/approvals/route").GET;
+  let findingsGET: typeof import("@/app/api/briefing/findings/route").GET;
+
+  beforeAll(async () => {
+    approvalsGET = (await import("@/app/api/approvals/route")).GET;
+    findingsGET = (await import("@/app/api/briefing/findings/route")).GET;
+  });
+
+  beforeEach(async () => {
+    orgId = uniqueOrgId("runless-approval");
+    await createTestOrg(orgId);
+    mockGetOrgId.mockResolvedValue(orgId);
+    mockGetCurrentActor.mockResolvedValue({ userId: "admin-1", role: "admin" });
+
+    // Keep the findings route on its read path; this test is about approval
+    // projection, not live-summary generation.
+    await db().insert(briefing).values({
+      org_id: orgId,
+      role: "_summary",
+      for_date: new Date().toISOString().slice(0, 10),
+      profile_version: 1,
+      summary_md: "One approval is queued.",
+      insights: [],
+    });
+  });
+
+  afterEach(async () => {
+    await deleteTestOrg(orgId);
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await pool().end();
+  });
+
+  it("appears in both approvals endpoints with a nullable workflow contract", async () => {
+    const [inserted] = await db()
+      .insert(action_request)
+      .values({
+        org_id: orgId,
+        scope: "admin.apps",
+        kind: "app_create",
+        payload: { name: "Support queue" },
+        risk_level: "medium",
+        status: "pending_approval",
+        summary: null,
+      })
+      .returning({ id: action_request.id });
+
+    const approvals = await callRoute(approvalsGET, {
+      url: "http://localhost/api/approvals?filter=awaiting",
+    });
+    expect(approvals.status).toBe(200);
+    expect(approvals.body).toMatchObject({
+      count: 1,
+      actions: [
+        {
+          id: inserted!.id,
+          workflowRunId: null,
+          workflow: null,
+          summary: null,
+        },
+      ],
+    });
+
+    const findings = await callRoute(findingsGET);
+    expect(findings.status).toBe(200);
+    expect(findings.body).toMatchObject({
+      awaitingYou: {
+        approvals: [
+          {
+            id: inserted!.id,
+            kind: "approval",
+            workflowRunId: null,
+            workflow: null,
+            title: "app_create",
+          },
+        ],
+      },
+    });
+  });
+
+  it("applies the same source-config visibility rule in both endpoints", async () => {
+    mockGetCurrentActor.mockResolvedValue({ userId: "member-1", role: "member" });
+    await db().insert(action_request).values([
+      {
+        org_id: orgId,
+        scope: "admin.sources",
+        kind: "source_config_admin",
+        status: "pending_approval",
+      },
+      {
+        org_id: orgId,
+        scope: "admin.apps",
+        kind: "app_create",
+        status: "pending_approval",
+      },
+    ]);
+
+    const approvals = await callRoute(approvalsGET, {
+      url: "http://localhost/api/approvals?filter=awaiting",
+    });
+    const findings = await callRoute(findingsGET);
+
+    expect(
+      (approvals.body as { actions: Array<{ kind: string }> }).actions.map(
+        (action) => action.kind,
+      ),
+    ).toEqual(["app_create"]);
+    expect(
+      (
+        findings.body as {
+          awaitingYou: { approvals: Array<{ title: string }> };
+        }
+      ).awaitingYou.approvals.map((approval) => approval.title),
+    ).toEqual(["app_create"]);
+  });
+});

--- a/apps/web/test/lib/briefing-findings.test.ts
+++ b/apps/web/test/lib/briefing-findings.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { serializeBriefingApproval } from "@/lib/briefing-findings";
+import { workflowDisplayName } from "@/lib/workflow-label";
+
+describe("briefing approval serialization", () => {
+  it("preserves a run-less approval without inventing a workflow", () => {
+    const approval = serializeBriefingApproval({
+      id: "action-1",
+      workflowRunId: null,
+      workflowId: null,
+      workflowName: null,
+      kind: "app_create",
+      target: null,
+      summary: null,
+      riskLevel: "medium",
+      createdAt: new Date("2026-08-17T10:00:00.000Z"),
+    });
+
+    expect(approval).toMatchObject({
+      id: "action-1",
+      kind: "approval",
+      workflowRunId: null,
+      workflow: null,
+      title: "app_create",
+    });
+    expect(workflowDisplayName(approval.workflow)).toBe("OpenNeko AI");
+  });
+});

--- a/apps/web/test/lib/briefing-messages.test.ts
+++ b/apps/web/test/lib/briefing-messages.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { readBriefingMessages } from "@/lib/briefing-messages";
+
+describe("readBriefingMessages", () => {
+  it("accepts a valid A2UI message sequence", async () => {
+    const messages = [
+      {
+        version: "v1.0",
+        createSurface: {
+          surfaceId: "briefing-ceo",
+          catalogId: "openneko",
+        },
+      },
+      {
+        version: "v1.0",
+        updateDataModel: {
+          surfaceId: "briefing-ceo",
+          value: {},
+        },
+      },
+    ];
+
+    await expect(readBriefingMessages(Response.json(messages))).resolves.toEqual(
+      messages,
+    );
+  });
+
+  it("rejects an HTTP error before applying its JSON body", async () => {
+    const response = Response.json(
+      { error: "database unavailable" },
+      { status: 503 },
+    );
+
+    await expect(readBriefingMessages(response)).rejects.toThrow("HTTP 503");
+  });
+
+  it("rejects non-array and malformed A2UI payloads", async () => {
+    await expect(
+      readBriefingMessages(Response.json({ error: "not a message list" })),
+    ).rejects.toThrow("valid A2UI message sequence");
+
+    await expect(
+      readBriefingMessages(
+        Response.json([{ version: "v1.0", updateComponents: null }]),
+      ),
+    ).rejects.toThrow("valid A2UI message sequence");
+  });
+});

--- a/apps/web/test/lib/dashboard-actions.test.ts
+++ b/apps/web/test/lib/dashboard-actions.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import {
+  groupAwaiting,
+  type AwaitingRow,
+} from "@/lib/dashboard-actions";
+
+function awaitingRow(overrides: Partial<AwaitingRow> = {}): AwaitingRow {
+  return {
+    id: "action-1",
+    workflowRunId: "run-1",
+    workflow: { id: "workflow-1", name: "Renewal monitor" },
+    triggeredByObservation: null,
+    kind: "email_send",
+    target: "ops@example.com",
+    riskLevel: "medium",
+    summary: "Send a renewal reminder",
+    status: "pending_approval",
+    runAt: "2026-08-17T10:00:00.000Z",
+    payload: {},
+    ...overrides,
+  };
+}
+
+describe("groupAwaiting", () => {
+  it("renders a run-less approval as its own OpenNeko AI card", () => {
+    const [group] = groupAwaiting([
+      awaitingRow({
+        workflowRunId: null,
+        workflow: null,
+        summary: null,
+        kind: "app_create",
+      }),
+    ]);
+
+    expect(group).toMatchObject({
+      key: "action:action-1",
+      card: {
+        runId: null,
+        workflowName: "OpenNeko AI",
+        state: "awaiting",
+        rows: [{ id: "action-1", headline: "app_create" }],
+      },
+    });
+  });
+
+  it("does not collapse separate run-less approvals into one card", () => {
+    const groups = groupAwaiting([
+      awaitingRow({ id: "action-1", workflowRunId: null, workflow: null }),
+      awaitingRow({ id: "action-2", workflowRunId: null, workflow: null }),
+    ]);
+
+    expect(groups.map((group) => group.key)).toEqual([
+      "action:action-1",
+      "action:action-2",
+    ]);
+    expect(groups.every((group) => group.card.rows.length === 1)).toBe(true);
+  });
+
+  it("still groups approvals produced by the same workflow run", () => {
+    const groups = groupAwaiting([
+      awaitingRow({ id: "action-1" }),
+      awaitingRow({ id: "action-2" }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({
+      key: "run:run-1",
+      card: {
+        runId: "run-1",
+        workflowName: "Renewal monitor",
+        rows: [{ id: "action-1" }, { id: "action-2" }],
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- handle chat-created approvals with null workflow and workflow-run references without crashing the dashboard
- label no-workflow approvals as OpenNeko AI and keep each in its own dashboard group
- include run-less approvals in briefing findings with consistent actor visibility and accurate pending totals
- validate briefing HTTP/A2UI response shapes before applying client updates
- align nullable action-summary types across affected web views

## Verification

- pnpm --filter @neko/web test — 360 tests passed
- pnpm --filter @neko/web typecheck
- ESLint on all changed files
- pnpm --filter @neko/web build