### PR TITLE
feat(packs): add Magento solution pack and web UI system

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,6 +32,13 @@
 .agents
 .claude
 
+# Repo-local runtime state. These directories can contain encrypted secret
+# stores, backup archives, generated binaries, and evaluation artifacts; none
+# belongs in a production image or even in the build-context upload.
+.openneko
+.local
+dev-volumes
+
 # Compose stack artefacts (the production image doesn't need them)
 compose.yml
 compose.adventureworks.yml

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ apps/web/.cache/
 apps/web/test-results/
 apps/web/playwright-report/
 
-docs/
+/docs/
 .turbo/
 dist/
 build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,6 +149,7 @@ COPY packages/db/package.json packages/db/package.json
 COPY packages/evals/package.json packages/evals/package.json
 COPY packages/interaction/package.json packages/interaction/package.json
 COPY packages/llm/package.json packages/llm/package.json
+COPY packages/packs/package.json packages/packs/package.json
 COPY packages/plugin-install/package.json packages/plugin-install/package.json
 COPY packages/plugin-types/package.json packages/plugin-types/package.json
 COPY packages/records/package.json packages/records/package.json
@@ -257,7 +258,8 @@ CMD ["node", "apps/web/server.js"]
 # web/Next, keeps src + tsx + @neko/llm (with assets) + onnxruntime. Same
 # mechanism as agent-deploy; rooted at /app, so the entry is /app/src/index.ts.
 FROM build AS worker-deploy
-RUN pnpm --filter @neko/worker deploy --prod /out/worker-app
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm --filter @neko/worker deploy --prod /out/worker-app
 
 # The worker runs from source via tsx (not a build step). It serves /health +
 # admin endpoints on port 4100 for liveness probes.
@@ -297,6 +299,8 @@ COPY --from=worker-deploy --chown=neko:neko /out/worker-app ./
 # Whole db/ (not just migrations): seeds + load-adventureworks-baked.sh
 # are needed for `openneko start --mode demo`'s adventureworks-init step.
 COPY --chown=neko:neko db ./db
+# Embedded first-party solution packs are loaded and validated by the worker.
+COPY --chown=neko:neko packs ./packs
 COPY --chown=neko:neko entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 # Vendor the openneko Go binary so the agent's Bash tool inside the worker
@@ -327,7 +331,8 @@ CMD ["node", "--import", "tsx/esm", "src/index.ts"]
 # Trimmed prod closure of @neko/worker: drops web/Next.js + devDeps + other
 # apps' sources; keeps tsx, @neko/llm (with its assets), and the claude SDK.
 FROM build AS agent-deploy
-RUN pnpm --filter @neko/worker deploy --prod /out/agent-app
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm --filter @neko/worker deploy --prod /out/agent-app
 # OpenNeko's logical MCP servers share one multiplexed bridge process per
 # agent run. Bundle it to plain JS as well: that avoids tsx startup/RSS and
 # lets entry.ts launch it from arbitrary sandbox working directories.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -234,8 +234,9 @@ OPENNEKO_PORT=3001 OPENNEKO_DB_PORT=55432 OPENNEKO_GRAPHJIN_PORT=8090 \
 ```bash
 git clone https://github.com/open-neko/openneko.git
 cd neko
-docker compose -f compose.yml -f compose.adventureworks.yml up -d --build
-docker compose -f compose.yml -f compose.adventureworks.yml run --rm neko-adventureworks-seed
+export OPENSHELL_STATE_DIR="$PWD/.openneko/openshell"
+docker compose -f compose.yml -f compose.openshell.yml -f compose.adventureworks.yml up -d --build
+docker compose -f compose.yml -f compose.openshell.yml -f compose.adventureworks.yml run --rm neko-adventureworks-seed
 ```
 
 ### Live trial data
@@ -244,7 +245,7 @@ The source compose trickles fresh sales orders into the sample DB every 10 minut
 
 ```bash
 AW_SIM_INTERVAL_SEC=300 AW_SIM_ORDERS_MIN=1 AW_SIM_ORDERS_MAX=5 \
-  docker compose -f compose.yml -f compose.adventureworks.yml up -d
+  docker compose -f compose.yml -f compose.openshell.yml -f compose.adventureworks.yml up -d
 ```
 
 Disable the trickle: `AW_SIM_ENABLED=0`. Wire real webhooks past trial: `NEKO_ACTIONS_DRY_RUN=false`.
@@ -260,7 +261,7 @@ The seed pre-loads three watchers:
 To see the loop without waiting for an organic dip, fire the Germany scenario (stops new orders for territory 8 for three hours):
 
 ```bash
-docker compose -f compose.yml -f compose.adventureworks.yml \
+docker compose -f compose.yml -f compose.openshell.yml -f compose.adventureworks.yml \
   exec adventureworks-scenario-injector \
   /scripts/scenario-injector.sh fire germany-revenue-drop
 ```

--- a/MAGENTO_PACK_IMPLEMENTATION_PLAN.md
+++ b/MAGENTO_PACK_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,1152 @@
+# OpenNeko Magento solution pack — implementation plan
+
+Status: proposed
+Prepared: 2026-08-20
+First pack: Magento Open Source / Adobe Commerce 2.4.x
+Next consumer: WooCommerce pack
+Upstream dependency: the
+[GraphJin OpenAPI mutation plan](../../GraphJin/OPENAPI_MUTATIONS_IMPLEMENTATION_PLAN.md)
+
+## 1. Outcome
+
+Ship Magento as the first production-grade OpenNeko solution pack. Installing
+the pack gives an organization:
+
+- A least-privilege, read-only Magento MariaDB analytics source.
+- A curated Magento REST source for a small set of governed writes.
+- Deterministic Magento metrics and metric cards.
+- Magento workflows and polling watchers.
+- Focused Magento operator skills for performance reviews, individual order
+  investigations, fulfillment triage, refund/cancellation analysis, inventory
+  checks, and platform-health diagnosis.
+- Preflight checks, health checks, upgrade/uninstall behavior, artifact
+  provenance, documentation, and regression tests.
+
+The work also creates the reusable pack substrate required by WooCommerce and
+later packs. The existing demo-pack installer is not extended into this role;
+demo packs remain isolated demonstrations, while solution packs are composable,
+versioned product extensions.
+
+### V1 non-goals
+
+- A public third-party pack marketplace or remote registry.
+- Executing arbitrary scripts supplied by a pack.
+- Importing Magento's entire authenticated REST schema.
+- A Magento extension/module for webhooks; V1 watchers poll through GraphJin.
+- Conversion analytics without an explicitly connected traffic source.
+- Cancel, refund, shipment, customer, payment, or inventory write operations.
+- Automatic creation of database or Magento Integration credentials using an
+  administrator password.
+
+## 2. Release dependency
+
+The Magento pack contains two independently usable capability groups:
+
+1. **Analytics:** read-only MariaDB, metrics, workflows, watchers, skills.
+2. **Operator:** governed Magento REST actions executed through
+   GraphJin OpenAPI mutations.
+
+They are not separate install profiles. Installing `magento` always
+installs the complete declared artifact set, including action definitions and
+policies. Capability readiness is evaluated separately: missing or invalid
+write credentials leave the operator capability blocked without making the
+installation partial or failed.
+
+The analytics work and pack substrate may be developed against a local GraphJin
+canary. The production Magento pack must not make its installed operator action
+executable until GraphJin has published a tagged release satisfying the upstream
+plan. That release must also contain the table-column blocklist enforcement fix
+required by the analytics source. OpenNeko's post-install check deliberately
+queries a blocked `sales_order.customer_email` field and fails closed unless
+GraphJin rejects it; a version number alone is not accepted as privacy evidence.
+
+Release order:
+
+```text
+GraphJin mutation implementation
+  -> GraphJin tests and Magento canary
+  -> tagged GraphJin minor release + images/assets
+  -> OpenNeko GraphJin pin upgrade
+  -> OpenNeko compatibility soak
+  -> Magento governed-action end-to-end test
+  -> Magento pack release
+```
+
+OpenNeko must never ship this pack against `dosco/graphjin:latest`, a local
+commit image, or a guessed future version.
+
+## 3. Standing product and architecture decisions
+
+1. **Solution packs coexist.** Magento, Stripe, Slack, and other packs may be
+   installed together. There is no `primary-demo` exclusivity rule.
+2. **OpenNeko owns the runtime; packs own declarations.** Lifecycle, validation,
+   policy, secrets, approvals, and audit code lives in OpenNeko. A pack contains
+   declarative assets and narrowly scoped tests, not arbitrary install scripts.
+3. **First-party packs live in this repository for V1.** Use
+   `packs/magento/`; package/repository distribution can be separated after the
+   manifest and signing contract stabilizes.
+4. **No raw metadata SQL bootstrap.** All pack artifacts are applied through
+   typed stores/control-plane services and recorded with provenance.
+5. **No arbitrary pack code.** V1 manifests cannot execute shell, JavaScript,
+   SQL, or container commands supplied by a pack.
+6. **Database reads are defense in depth.** A dedicated MariaDB account has
+   SELECT-only grants; GraphJin is also read-only and uses a table/column
+   allowlist.
+7. **API writes are actions, not agent tools.** The model proposes a semantic
+   OpenNeko action. Only an approved worker execution receives a short-lived
+   GraphJin role token and invokes the fixed pack operation.
+8. **Direct GraphJin mutation remains blocked in agent sandboxes.** Do not relax
+   `graphjin-guard.ts` or allow raw `curl` as part of this feature.
+9. **Magento credentials are least privilege.** Runtime uses a Magento
+   Integration bearer token and a dedicated analytics DB credential. Magento
+   admin credentials and Adobe Marketplace/Composer keys are not pack inputs.
+10. **Metrics are deterministic.** Shipped cards execute a declared saved query
+    and result mapping; an LLM may explain a metric but does not invent its value
+    on each refresh.
+11. **Writes start with one low-risk operation.** V1 installs only an internal
+    order-comment action. Its definition and approval policy are always
+    installed; execution readiness depends on GraphJin and Magento API
+    preflight. Hold/unhold follows after soak; cancel, refund, shipment, and
+    inventory mutation remain disabled.
+12. **Upgrade preserves user work.** A pack may update or remove only an
+    unchanged artifact it owns. Drift becomes an explicit conflict or detached
+    user artifact.
+13. **Installation and readiness are separate.** Optional capability failures
+    produce `blocked`/`degraded` readiness with a reason and remediation. They
+    never cause OpenNeko to omit that capability's artifacts.
+
+## 4. Repository layout
+
+Create the reusable runtime and first pack with this shape:
+
+```text
+packages/packs/
+  src/
+    manifest.ts
+    schema.ts
+    canonicalize.ts
+    planner.ts
+    installer.ts
+    drift.ts
+    health.ts
+    artifact-adapters/
+  test/
+
+packs/
+  schema/solution-pack.v1.schema.json
+  magento/
+    pack.yaml
+    graphjin/
+      sources.yaml
+      relationships.yaml
+      specs/magento-operator-v1.yaml
+      saved-queries/
+    metrics/
+    workflows/
+    watchers/
+    actions/
+    policies/
+    skills/
+      magento-review-performance/
+      magento-investigate-order/
+      magento-triage-fulfillment/
+      magento-investigate-refunds/
+      magento-check-inventory/
+      magento-diagnose-platform-health/
+      # Each directory contains SKILL.md plus only its focused references.
+    migrations/
+    fixtures/
+    evals/
+    docs/
+
+apps/worker/src/packs/
+apps/worker/src/actions/adapters/graphjin-api-operation.ts
+apps/openneko/cmd/openneko/pack*.go
+apps/web/.../packs/
+```
+
+`packages/packs` is a private workspace package consumed by the worker and
+tests. The Go CLI is a client of the worker/admin control plane; it does not
+write metadata Postgres directly.
+
+## 5. Pack manifest V1
+
+Illustrative contract:
+
+```yaml
+apiVersion: openneko.app/v1
+kind: SolutionPack
+metadata:
+  id: magento
+  name: Magento
+  version: 0.1.0
+  publisher: openneko
+  category: commerce
+
+compatibility:
+  openneko: ">=OPENNEKO_PACK_VERSION <NEXT_BREAKING_VERSION"
+  graphjin:
+    analytics: ">=3.18.42 <4.0.0"
+    operator: ">=GRAPHJIN_OPENAPI_MUTATION_VERSION"
+  applications:
+    - id: magento
+      editions: [open-source, adobe-commerce]
+      versions: ">=2.4.6 <2.5.0"
+  databases:
+    - engine: mariadb
+      versions: ">=10.6"
+    - engine: mysql
+      versions: ">=8.0"
+
+inputs:
+  - key: magento.base_url
+    type: url
+    required: true
+  - key: magento.store_code
+    type: string
+    default: all
+  - key: magento.table_prefix
+    type: string
+    default: ""
+  - key: magento.base_currency
+    type: string
+    discover: true
+  - key: magento.timezone
+    type: timezone
+    discover: true
+  - key: database.connectivity_mode
+    type: enum
+    values: [external_network, host_gateway, remote]
+  - key: database.host
+    type: string
+    required: true
+  - key: database.port
+    type: integer
+    default: 3306
+  - key: database.name
+    type: string
+    required: true
+
+secrets:
+  - key: database.analytics_username
+    purpose: graphjin_source
+  - key: database.analytics_password
+    purpose: graphjin_source
+  - key: magento.integration_token
+    purpose: graphjin_api_auth
+    required: false
+
+artifacts:
+  graphjin:
+    sources: graphjin/sources.yaml
+    relationships: graphjin/relationships.yaml
+    specs: [graphjin/specs/magento-operator-v1.yaml]
+    savedQueries: graphjin/saved-queries/
+  metrics: metrics/
+  workflows: workflows/
+  watchers: watchers/
+  actions: actions/
+  policies: policies/
+  skills:
+    - skills/magento-review-performance
+    - skills/magento-investigate-order
+    - skills/magento-triage-fulfillment
+    - skills/magento-investigate-refunds
+    - skills/magento-check-inventory
+    - skills/magento-diagnose-platform-health
+
+health:
+  requiredPreflight: [mariadb_connect, mariadb_read_only, magento_version]
+  readiness:
+    operator: [graphjin_mutations, magento_api_token, magento_api_acl]
+  postInstall: [graphjin_reload, analytics_smoke]
+  postWriteCanary: [internal_comment_reconciled]
+```
+
+Manifest rules:
+
+- Unknown fields fail validation.
+- Paths are relative, normalized, and cannot escape the pack root.
+- Every artifact has a stable pack-local key and canonical content hash.
+- Semver ranges are evaluated before any write.
+- Secrets are references; values never appear in the normalized manifest,
+  install plan, model context, logs, or `pack_artifact` rows.
+- V1 accepts only an embedded, trusted first-party pack. The schema nevertheless
+  reserves publisher, signature, and digest metadata for later distribution.
+- Pack IDs are simple globally unique slugs (`magento`, `woocommerce`,
+  `security`). Category and publisher are separate metadata, not part of the
+  ID or CLI command.
+- Artifact IDs remain globally stable under the pack slug
+  (`magento.metric.net_invoiced_revenue`).
+- Artifact declarations are unconditional. Inputs and secrets may affect
+  runtime readiness/configuration, but cannot filter metrics, workflows,
+  watchers, actions, policies, or skills out of the install plan.
+
+## 6. Metadata and ownership model
+
+Add migrations and Drizzle models for the following tables.
+
+### `pack_install`
+
+| Column | Purpose |
+|---|---|
+| `id` | Installation UUID. |
+| `org_id` | Owning organization. |
+| `pack_id` | Namespaced manifest ID. |
+| `version` | Desired/installed pack version. |
+| `status` | `planning`, `installing`, `installed`, `upgrading`, `failed`, `removing`, `removed`. |
+| `manifest_hash` | Canonical manifest/bundle hash. |
+| `source` | `embedded` in V1; later registry/file/URL. |
+| `installed_by_user_id` | Human actor. |
+| `operation_id` | Current install/upgrade saga ID. |
+| `last_error` | Redacted terminal error. |
+| timestamps | Created, updated, installed, removed. |
+
+One non-removed `(org_id, pack_id)` installation may exist at a time.
+
+### `pack_artifact`
+
+| Column | Purpose |
+|---|---|
+| `id` | Artifact ownership UUID. |
+| `pack_install_id`, `org_id` | Installation scope. |
+| `artifact_kind` | source, spec, saved_query, metric, workflow, watcher, action, policy, skill. |
+| `artifact_key` | Stable pack-local key. |
+| `target_ref` | Actual OpenNeko/GraphJin artifact ID or path. |
+| `desired_hash` | Hash from the currently installed pack version. |
+| `last_applied_hash` | Hash written by the last successful operation. |
+| `ownership` | `managed`, `modified`, `detached`, `retired`. |
+| `readiness` | `ready`, `blocked`, `degraded`, or `not_applicable`. |
+| `readiness_reason` | Stable non-secret reason code plus remediation metadata. |
+| `previous_snapshot` | Encrypted or redacted rollback material where appropriate. |
+| `metadata` | Non-secret adapter metadata. |
+| timestamps | Created, updated, detached. |
+
+Unique key: `(org_id, artifact_kind, target_ref)`.
+
+### `pack_operation`
+
+Record plan/apply/compensation history:
+
+- ID, install ID, org, type, actor, status, requested version
+- redacted plan JSON and plan hash
+- started/completed timestamps
+- failure phase and redacted error
+- compensation status
+
+Append important transitions to the existing audit chain.
+
+### Drift rules
+
+For update or uninstall, calculate the current canonical artifact hash:
+
+- Current hash equals `last_applied_hash`: pack may update/remove it.
+- Current hash differs: mark `modified`; default plan preserves it and reports a
+  conflict.
+- User chooses detach: pack relinquishes ownership and never deletes it.
+- Admin explicitly chooses overwrite: record the decision and old snapshot,
+  then apply the pack version.
+- Artifact already owned by another pack: hard conflict unless the manifest
+  declares an exact dependency/shared-owner contract. V1 does not support
+  shared ownership.
+
+## 7. Pack lifecycle and control plane
+
+Expose these user operations:
+
+```text
+openneko pack list
+openneko pack inspect magento
+openneko pack plan magento [--upgrade]
+openneko pack install magento
+openneko pack configure magento
+openneko pack status magento
+openneko pack doctor magento
+openneko pack upgrade magento
+openneko pack uninstall magento
+```
+
+Required flags/behavior:
+
+- `--output json` for automation.
+- `--dry-run` is an alias for plan and never requests secret values.
+- Interactive secure prompts for secrets; non-interactive mode accepts secret
+  references, not command-line plaintext.
+- There is no analytics/operator profile picker and no per-component selection.
+  `install` applies every declared pack artifact.
+- The default install flow does not stop for a “will install N metrics/actions”
+  inventory screen. The explicit `plan` command remains available for change
+  control, upgrades, conflicts, and machine-readable automation.
+- An omitted Magento Integration token is allowed. The installed operator
+  action is marked blocked until `pack configure` supplies a valid token and
+  readiness checks pass.
+- `--detach-modified` and `--overwrite-modified` require an explicit artifact
+  list and admin confirmation.
+- `--keep-data` is the default uninstall behavior. Pack-created OpenNeko
+  secrets are removed only when unchanged and unreferenced. On GraphJin 3.18,
+  uninstall revokes all access to pack sources and retains their inert
+  source/table metadata because the control plane cannot safely delete it;
+  upgrade this to true source removal once the required GraphJin API ships.
+- No destructive `--force` shortcut in V1.
+
+The CLI calls authenticated worker admin endpoints. Add plan, apply, status,
+doctor, and uninstall endpoints with admin authorization and idempotency keys.
+All mutations go through `AgentControlPlane`/the same audited action boundary as
+other administrative writes.
+
+### Install/upgrade saga
+
+1. Load the embedded bundle and validate manifest/schema/path/digest.
+2. Check OpenNeko, GraphJin, Magento, and database compatibility.
+3. Resolve non-secret inputs and secret references.
+4. Run required read-only preflight checks from the actual GraphJin/worker
+   network. Evaluate optional capability readiness without filtering artifacts
+   or failing the install.
+5. Calculate a deterministic create/update/noop/conflict/retire plan.
+6. Persist the approved `pack_operation` and acquire an org+pack advisory lock.
+7. Snapshot affected managed artifacts and the GraphJin config files.
+8. Stage specs, source fragments, relationships, and saved queries in a private
+   temporary location; validate the resulting GraphJin configuration.
+9. Atomically materialize GraphJin files/config and reload GraphJin.
+10. Apply metadata artifacts in a database transaction through typed adapters.
+11. Install skills atomically into the org/team skill layer.
+12. Run post-install health/smoke checks and persist readiness for every
+    capability/artifact.
+13. Mark artifact ownership and installation status only after all checks pass.
+14. On failure, restore GraphJin files and prior metadata snapshots, reload,
+    mark the operation failed, and report any incomplete compensation.
+
+Do not claim a single transaction across Postgres and GraphJin files. This is a
+durable saga with explicit compensation and idempotent phases.
+
+## 8. Work breakdown
+
+Sequence and indicative size (`S` = days, `M` = roughly one to two weeks,
+`L` = multi-week; estimates exclude the GraphJin release wait):
+
+| Item | Size | Depends on | Hard gate produced |
+|---|---:|---|---|
+| ON-0 baseline/contracts | S | none | Pin and behavior baseline |
+| ON-1 pack engine/provenance | L | ON-0 | Safe install/upgrade foundation |
+| ON-2 control plane/CLI/UI | L | ON-1 | Supported operator lifecycle |
+| ON-3 analytics source | M | ON-1 | Read-only data plane |
+| ON-4 curated OAS3 | M | ON-0 | Reviewed API contract |
+| ON-5 deterministic metrics | L | ON-3 | Repeatable cards |
+| ON-6 workflows/watchers/skills | M | ON-1/ON-3/ON-5 | Pack intelligence content |
+| ON-8 GraphJin upgrade | M | upstream GraphJin release | Released mutation runtime |
+| ON-7 governed action | L | ON-2/ON-4/ON-8 | Safe Magento write path |
+| ON-9 full E2E/evals | L | ON-3 through ON-8 | Release evidence |
+| ON-10 release | M | ON-9 | Shippable pack |
+
+ON-1, ON-3/ON-5, and ON-4 can use separate implementation lanes. ON-7 remains
+hard-blocked on ON-8 even if it works against a local GraphJin canary.
+
+### ON-0 — Baseline and contract tests
+
+Deliverables:
+
+- Capture the current OpenNeko version, all GraphJin pins, pack-related schema,
+  action policy behavior, OpenAPI importer behavior, metric refresh behavior,
+  watcher behavior, and multi-skill installation behavior.
+- Add a manifest fixture and failing tests that describe V1 before the engine is
+  implemented.
+- Add a version-pin inventory test so future GraphJin upgrades cannot update
+  only some locations.
+- Record the local Magento version/database facts used for development without
+  storing credentials.
+
+Exit criteria: tests demonstrate the missing pack lifecycle and enumerate every
+GraphJin pin that must move together.
+
+### ON-1 — Manifest parser, planner, and provenance schema
+
+Implementation:
+
+1. Create `@neko/packs` with strict Zod/JSON-schema validation.
+2. Implement canonical JSON/YAML normalization and SHA-256 hashing.
+3. Add `pack_install`, `pack_artifact`, and `pack_operation` migrations,
+   Drizzle schema, stores, and audit-chain events.
+4. Implement artifact adapter interfaces:
+   - `inspectCurrent`
+   - `validateDesired`
+   - `plan`
+   - `apply`
+   - `restore`
+   - `remove`
+5. Add adapters for GraphJin source/spec/query files, metric, workflow, watcher,
+   action definition, action policy, and skills.
+6. Implement create/update/noop/conflict/retire planning and drift policy.
+7. Add an advisory lock and idempotent operation phase markers.
+8. Prohibit scripts/executables and reject path traversal, symlinks escaping the
+   bundle, duplicate stable keys, and undeclared references.
+
+Exit criteria:
+
+- Reinstalling the same pack is a no-op.
+- A simulated mid-install failure restores prior state.
+- Modified user artifacts survive upgrade/uninstall by default.
+- Two unrelated packs install concurrently without artifact collision.
+
+### ON-2 — Admin control plane, CLI, and operator experience
+
+Implementation:
+
+1. Add worker admin endpoints for list/inspect/plan/apply/status/doctor/remove.
+2. Enforce admin actor, request idempotency, operation locking, and audit.
+3. Add the Go CLI commands listed in section 7.
+4. Route secret entry through the existing encrypted secret store; never include
+   values in plan JSON.
+5. Add deterministic plan output grouped by creates, updates, conflicts,
+   retired artifacts, required inputs, and health checks for the explicit
+   `plan`/upgrade flows. The normal install UX treats the pack as one product,
+   not a checklist of components.
+6. Add a pack administration center after CLI behavior is stable. Its Magento
+   page is the day-2 home: capability health and remediation, last successful
+   metric refresh, connection recheck, store scope/timezone/currency, watcher
+   thresholds and enable/disable controls, workflow schedules, credential
+   rotation, available update, drift conflicts, and safe uninstall. Keep
+   artifact counts and GraphJin implementation details behind an advanced
+   disclosure. The default surface speaks in outcomes such as Store insights,
+   Alerts, Automations, and Approved Magento changes. It never asks a store
+   operator to understand "mutations," "write runtimes," or "operator
+   capabilities."
+7. Show Magento access in plain language: `View only` when OpenNeko can analyze
+   but cannot change the store, and `Approved changes available` when at least
+   one named change is ready. Do not offer one broad "allow mutations" switch.
+   Each shipped change type gets its own explicit control and explanation. V1's
+   only control is `Allow private notes on orders`; inventory, refunds,
+   cancellations, and shipments have no switch because those changes are not
+   present in the pack.
+8. Keep `openneko pack manage magento` as the headless/SSH equivalent of that
+   page, with status, doctor results, and exact next commands in one response.
+
+Exit criteria: a fresh production stack can plan and install a fixture pack
+without direct database access or raw bootstrap SQL.
+
+### ON-3 — Magento connectivity and read-only analytics source
+
+#### Credential setup
+
+The pack requires for analytics:
+
+- `magento_analytics`: a distinct MariaDB/MySQL account with only the SELECT
+  grants needed by the curated analytics surface.
+
+A Magento Integration token with the smallest API ACL used by installed
+operations is optional at installation time and required only for operator
+readiness. If absent, the complete pack still installs and the action remains
+blocked with remediation available through `pack status`, `pack doctor`, and
+`pack configure`.
+
+The pack must not request or persist:
+
+- Magento admin username/password
+- Adobe Marketplace public/private keys
+- Composer `auth.json`
+- the Magento application database user's broad credential
+
+Provide a reviewed DBA script/runbook that creates the analytics account. V1
+does not automatically use a database-admin credential. The doctor command
+verifies database grants with read-only probes and must fail the required
+analytics preflight if CREATE/INSERT/UPDATE/DELETE/ALTER are possible through
+the configured account. A missing/invalid API token is a blocked operator-
+readiness result, not an installation failure.
+
+#### Container/network modes
+
+Support:
+
+1. `external_network` — preferred for stacks on the same Docker/OrbStack host;
+   the Magento DB joins a named shared network and GraphJin uses its network
+   alias.
+2. `host_gateway` — GraphJin connects through `host.docker.internal` to an
+   explicitly published DB port.
+3. `remote` — normal DNS/TLS endpoint.
+
+The installer does not silently publish MariaDB or attach a foreign container
+to a network. `doctor` tests connectivity from the GraphJin container and gives
+the exact remediation for the chosen mode.
+
+#### GraphJin source
+
+Render a source with:
+
+```yaml
+kind: database
+type: mysql
+read_only: true
+analytics_mode: true
+capabilities:
+  data.read: true
+  data.write: false
+  schema.read: true
+  schema.write: false
+access:
+  read: authenticated
+  write: blocked
+  delete: blocked
+```
+
+Use an allowlisted Magento analytics surface. Initial tables/views include only
+what the shipped queries require, such as:
+
+- `sales_order`, `sales_order_item`
+- `sales_invoice`, `sales_invoice_item`
+- `sales_creditmemo`, `sales_creditmemo_item`
+- `sales_shipment`, `sales_shipment_item`
+- `catalog_product_entity` and only required EAV attribute tables
+- `catalog_category_product`
+- `inventory_source_item`, `inventory_reservation`
+- `cataloginventory_stock_item` / applicable stock view
+- `store`, `store_group`, `store_website`
+- `cron_schedule`, `indexer_state`
+
+Explicitly block admin, authorization, OAuth, password/reset, quote-payment,
+payment, vault, and unnecessary customer PII tables/columns. Avoid direct
+customer table exposure unless a reviewed metric requires minimized fields.
+
+Preflight detects Magento table prefix, SQL mode, Magento version, timezone,
+websites/stores, base currencies, MSI presence, and required table/column
+availability. A non-empty table prefix is rendered into the saved-query/source
+artifacts rather than assumed away.
+
+Exit criteria:
+
+- Analytics queries work from the GraphJin container.
+- An attempted write is denied by both GraphJin and MariaDB.
+- Sensitive tables/columns are absent from GraphJin discovery.
+- Multistore, timezone, and currency choices are visible in the install plan.
+
+### ON-4 — Curated Magento OpenAPI 3 contract
+
+Magento 2.4.x exposes an authenticated Swagger 2 schema; current GraphJin and
+OpenNeko consume OpenAPI 3. The pack build therefore owns a curated conversion.
+
+Implementation:
+
+1. Add a build tool that fetches the authenticated Magento schema, selects only
+   operation IDs/paths on a reviewed allowlist, converts them to OAS3, normalizes
+   component names, and emits deterministic YAML.
+2. Never store the bearer token or the full authenticated schema in the pack.
+3. Validate the emitted file with OpenNeko's importer and GraphJin's loader.
+4. Diff path, method, parameters, body schema, response codes, and Magento ACL
+   source against the checked-in curated spec.
+5. Fail CI when a supported Magento version changes the curated contract.
+
+V1 curated operations:
+
+- `GET /V1/orders/{id}` or its exact Magento service equivalent, for
+  precondition/reconciliation.
+- `POST /V1/orders/{id}/comments`, for an internal order comment.
+
+The POST operation is explicitly exposed as a GraphJin mutation and restricted
+to the short-lived `magento_action_executor` role. `api.delete` is false.
+
+The spec, API-source artifact, action, and policy are installed whether or not a
+token exists. Without a ready token/ACL, render the runtime source in a
+non-executable posture (`api.write: false` and no executor readiness) and prove
+in tests that the unresolved secret reference cannot break GraphJin boot. After
+`pack configure` stores a valid token, the pack engine re-renders the same owned
+source artifact, reloads GraphJin, reruns readiness, and enables execution. It
+does not install a second “operator component.”
+
+Exit criteria: the curated spec is small, hand-reviewable, deterministic,
+OpenAPI 3 compatible, and contains no unapproved mutation.
+
+### ON-5 — Deterministic metric execution
+
+Current metric refresh is agent-driven. Add a deterministic mode without
+removing the existing agent mode.
+
+Schema change:
+
+- Add `metric.execution_mode` (`agent` or `saved_query`).
+- Add `metric.definition_json`, `definition_version`, and `definition_hash`.
+- A saved-query definition contains source, saved query name, variables,
+  expected result kind, result path, unit/currency, and freshness threshold.
+- Validate the definition on write; do not execute arbitrary JavaScript
+  transforms. Saved queries should return the final aggregate/series shape.
+
+Worker change:
+
+- `metric-refresh.ts` executes declared saved queries directly for
+  `saved_query` metrics, validates the result shape, stores a snapshot, and lets
+  the LLM optionally explain the already-computed value.
+- Record query definition hash, source freshness, duration, and error class on
+  the snapshot/run metadata.
+
+Initial metric set and definitions:
+
+| Metric | Definition |
+|---|---|
+| Net invoiced revenue | Sum of `base_total_invoiced - base_total_refunded` in the selected period/store scope. |
+| Orders placed | Distinct orders created in period; cancellation displayed separately. |
+| Average order value | Net invoiced revenue divided by distinct invoiced orders; null when denominator is zero. |
+| Refund rate | `base_total_refunded / base_total_invoiced`; explicitly a value rate, not count rate. |
+| Cancellation rate | Cancelled orders divided by orders placed. |
+| Fulfillment backlog | Paid, non-cancelled order quantities not shipped/refunded. |
+| Fulfillment age | Median and oldest age of backlog orders. |
+| Sales by store | Base-currency net invoiced revenue grouped by store. |
+| Top products/SKUs | Invoiced item value and quantity; refund effects remain in the separate refund metrics. |
+| Low/out-of-stock SKUs | Clearly labeled source-quantity approximation unless salable-quantity/MSI reservation calculation is validated. |
+| Cron health | Failed/stuck Magento cron jobs over the chosen window. |
+| Indexer health | Non-valid indexer states and age. |
+| Data freshness | Age of newest order/cron observation and last successful refresh. |
+
+Do not ship conversion-rate metrics without traffic/session data. Do not ship
+gross-margin metrics unless cost completeness passes a preflight threshold.
+
+Exit criteria:
+
+- Repeated refresh against unchanged fixtures yields the same value and shape.
+- Currency, timezone, period boundary, zero denominator, refunds, cancellation,
+  and multistore tests are explicit.
+- Metric cards display their calculation note and freshness.
+
+### ON-6 — Workflows, watchers, and task-focused skills
+
+#### Workflows
+
+Install stable, versioned definitions for:
+
+- Daily commerce briefing
+- Fulfillment exceptions
+- Low-stock investigation and replenishment proposal
+- Refund/cancellation spike investigation
+- Magento cron/indexer health review
+- Customer-service order summary
+
+Schedules and delivery channels are organization-specific. Install scheduled
+workflows disabled until the admin confirms timezone, cadence, and output
+channel. Manual workflows may be active immediately.
+
+#### Watchers
+
+Install polling watchers for:
+
+- paid order unshipped beyond threshold
+- low/out-of-stock SKU count
+- refund/cancellation spike
+- failed/stuck cron jobs
+- invalid/stale indexers
+- API authentication and analytics freshness
+
+Threshold-dependent watchers start disabled. Each definition includes cadence,
+debounce, severity, dedupe key, cooldown, and linked workflow. Add business-hour
+and test-fire support if not already available; avoid creating notification
+storms during install.
+
+#### Skills
+
+Ship one discoverable skill per recurring operator task:
+
+- `magento-review-performance`: daily/weekly briefing, revenue, orders, AOV,
+  store/SKU mix, and routing to a deeper diagnostic.
+- `magento-investigate-order`: one order's invoice, shipment, credit-memo, and
+  cancellation timeline, with an optional governed private comment.
+- `magento-triage-fulfillment`: backlog, aging, partial shipment, and SLA
+  exception prioritization.
+- `magento-investigate-refunds`: refund-value and cancellation-rate comparison,
+  concentration, and credit-memo reconciliation.
+- `magento-check-inventory`: MSI source quantities, reservations, stockouts,
+  and replenishment handoff with salable-quantity caveats.
+- `magento-diagnose-platform-health`: cron, indexer, data freshness, connection,
+  and pack-readiness diagnosis.
+
+Descriptions must be precise enough for automatic selection and explicitly
+route overlapping requests to the more specific skill. Keep each `SKILL.md`
+focused on its decision procedure; place lifecycle semantics, metric formulas,
+MSI behavior, and runbooks in references read only by the relevant skill.
+
+All skills install unconditionally. If write readiness is blocked, the order
+investigation remains usable and only its optional private-comment step reports
+the readiness reason. No skill contains secrets, local credentials, personal
+customer examples, arbitrary REST instructions, or a path around action
+approval.
+
+Exit criteria: all artifacts install with stable IDs, appear in their existing
+OpenNeko surfaces, carry pack provenance, and survive an idempotent reinstall.
+
+### ON-7 — Governed Magento action adapter
+
+Implement after the GraphJin release has been integrated.
+
+The semantic action definition and approval policy are unconditional pack
+artifacts. Maintain a separate action-readiness state with stable reasons such
+as `disabled_by_admin`, `graphjin_version_unsupported`,
+`integration_token_missing`, `integration_token_invalid`, `acl_missing`, or
+`ready`. Recompute readiness on install, configure, doctor, worker startup,
+token change, GraphJin reload, and a named action's enable/disable control.
+Unavailable actions are visible to admins in plain language and omitted from
+ordinary agent action discovery.
+
+#### Declarative action definition
+
+Expose only this semantic input to the agent:
+
+```json
+{
+  "kind": "magento.add_internal_order_comment",
+  "input": {
+    "order_id": "42",
+    "comment": "Reviewed by operations"
+  }
+}
+```
+
+The pack action definition fixes:
+
+- GraphJin source and OpenAPI operation ID
+- mapping of `order_id` to the path parameter
+- mapping of `comment` to the request body
+- `is_customer_notified = 0`
+- `is_visible_on_front = 0`
+- precondition query
+- post-write reconciliation query
+- redaction rules and receipt fields
+
+The model cannot set source, base URL, method, authentication, operation ID,
+notification flag, visibility flag, or arbitrary body fields.
+
+#### Execution flow
+
+1. Agent proposes the semantic action.
+2. OpenNeko validates input and resolves the installed pack/action version.
+3. Default policy is `ask`, approver role admin, with a human-readable preview.
+4. After approval the worker mints a short-lived, audience-bound GraphJin JWT
+   carrying only `magento_action_executor`; include action request ID as `jti`.
+5. The token is held only in worker memory and is never injected into an agent
+   sandbox.
+6. Worker executes the fixed GraphJin mutation through its internal client.
+7. Worker reads the order/comment endpoint to reconcile the result.
+8. `action_execution` stores source, operation, status, Magento reference,
+   correlation ID, request hash, response hash, and redacted summary.
+9. Ambiguous timeout/network outcomes enter `reconcile_required`; they are not
+   automatically replayed.
+
+Add a generic internal `graphjin_api_operation` adapter, but do not expose that
+generic kind to agents. Packs expose reviewed semantic action kinds backed by a
+restricted mapping DSL with constants, input references, and result paths—no
+templates capable of arbitrary code execution.
+
+#### Guard hardening
+
+- Keep direct GraphQL mutation text blocked in `graphjin-guard.ts`.
+- Resolve saved-query metadata before executing a saved query/workflow and
+  block saved mutations for ordinary agent runs; a mutation must not bypass the
+  guard merely because its text is stored under a name.
+- Ordinary run tokens must fail GraphJin's operation `allowed_roles` check even
+  if the wrapper is bypassed.
+- Raw HTTP access to GraphJin remains blocked from the sandbox.
+
+Exit criteria:
+
+- Installing without a Magento Integration token still installs the action and
+  policy and reports `integration_token_missing`.
+- Supplying a valid token through `pack configure` changes readiness without
+  creating or replacing pack artifacts.
+- No action executes before approval.
+- Exactly one internal comment is created and reconciled.
+- Customer notification and storefront visibility remain false.
+- Denied, expired-token, wrong-role, duplicate approval, timeout, and ambiguous
+  result cases have explicit tests.
+
+### ON-8 — Upgrade OpenNeko's GraphJin version
+
+Start only after the upstream release handoff provides the exact version,
+release commit, Docker digests, and immutable GitHub asset IDs.
+
+Update all active pins together:
+
+- `compose.yml`
+- `compose.adventureworks.yml`
+- `apps/openneko/assets/compose/core.yml`
+- `apps/openneko/assets/compose/demo.yml`
+- both `GRAPHJIN_VERSION` arguments in `Dockerfile`
+- `GRAPHJIN_ASSET_AMD64` and `GRAPHJIN_ASSET_ARM64` in `Dockerfile`
+- `scripts/install-clis.sh`
+- `packages/llm/src/graphjin/version.ts`
+- `packages/records/src/graphjin/config.ts`
+- version assertions/fixtures under `apps/worker/test`,
+  `packages/records/test`, and related tests
+- comments in active example/config files that claim the current version
+
+Do not rewrite historical migration comments solely to make the number look
+current when they describe behavior introduced in 3.18.42.
+
+Add one source of truth or a CI consistency test that scans all runtime pins and
+fails on disagreement. Docker asset IDs and semver are a coupled tuple.
+
+Compatibility test matrix:
+
+| Runtime | Required check |
+|---|---|
+| customer GraphJin | source/agentic config loads, read queries, saved queries, config reload |
+| metadata `neko-graphjin` | migrations, workflow/action tables, watch store, healthcheck |
+| records GraphJin | version gate, schema lifecycle commands, policy projection |
+| CLI in runtime images | `graphjin version` equals the expected pin on amd64 and arm64 |
+| OpenAPI importer | current OAS3 reads plus Magento mutation spec |
+| agent sandbox | existing read commands work; direct mutation remains blocked |
+
+Run a production-mode soak before enabling the pack write action. Keep the
+previous GraphJin semver tag as the rollback pin, but do not roll back after an
+ambiguous Magento action without reconciling it first.
+
+Exit criteria:
+
+- Every pin reports the released version.
+- OpenNeko build/test and prod smoke tests pass.
+- Records, metadata, and customer GraphJin instances are healthy.
+- The Magento pack compatibility check accepts the new release and rejects the
+  old 3.18.42 pin.
+
+### ON-9 — End-to-end fixtures and evaluation
+
+The local sample catalog is useful for exploration but contains too few orders
+for stable metric assertions. Build deterministic fixtures through supported
+Magento service/setup interfaces, not ad hoc writes into Magento application
+tables.
+
+Required fixture scenarios:
+
+- two stores and base/display currency distinction
+- orders spanning timezone boundaries
+- invoiced and partially refunded order
+- cancelled order
+- paid/unshipped and partially shipped order
+- repeat customer represented with minimized test PII
+- MSI source stock plus reservations
+- low-stock/out-of-stock SKU
+- failed cron and invalid/stale indexer state in an isolated test environment
+- designated order for an internal-comment mutation
+
+Test layers:
+
+1. Manifest/schema/canonical hash unit tests.
+2. Planner, drift, rollback, idempotency, and conflict tests.
+3. Artifact adapter integration tests against metadata Postgres/temp GraphJin
+   config.
+4. MariaDB privilege and sensitive-discovery tests.
+5. Saved-query metric golden tests.
+6. Workflow/watcher scheduling, debounce, dedupe, and test-fire tests.
+7. Action policy/approval/JWT/adapter/reconciliation tests.
+8. Full OrbStack/Docker production-stack installation against local Magento.
+9. Upgrade from previous pack version with one unmodified and one user-modified
+   artifact.
+10. Uninstall proving user modifications and Magento data are preserved.
+
+Safety assertions after the write canary:
+
+- one and only one expected order-history entry was created
+- no email/customer notification was requested
+- order status, totals, shipment, invoice, refund, and inventory are unchanged
+- no automatic retry occurred
+- action request, approval, execution, GraphJin correlation, and reconciliation
+  are linked in the audit trail
+
+### ON-10 — Documentation, packaging, and release
+
+Documentation:
+
+- Prerequisites and supported Magento versions/editions
+- Creating a least-privilege analytics DB account
+- Creating/revoking a least-privilege Magento Integration
+- External-network vs host-gateway setup for Docker/OrbStack
+- Multistore/currency/timezone choices
+- Metric definitions and caveats
+- Action approval and audit behavior
+- Doctor output and troubleshooting
+- Upgrade, drift resolution, detach, and safe uninstall
+- Privacy/data declaration
+- Explicit statement that Adobe Marketplace keys are unrelated to pack runtime
+
+Packaging:
+
+- Produce a deterministic pack bundle and SHA-256 digest.
+- Generate an SBOM/license inventory for bundled material.
+- Sign the first-party bundle when a project signing mechanism is available;
+  embedded V1 still records its build digest.
+- Include manifest version and compatibility contract in OpenNeko release notes.
+
+Release gates:
+
+- The exact GraphJin released version is pinned everywhere.
+- The pinned GraphJin release enforces column blocklists on both direct tables
+  and logical table aliases, and the negative Magento customer-email canary
+  passes.
+- Full OpenNeko CI and Magento pack E2E are green.
+- Fresh install, no-op reinstall, upgrade with drift, doctor, rollback simulation,
+  and safe uninstall pass.
+- No credentials, admin tokens, Marketplace keys, customer PII, or full
+  authenticated Magento schema are committed.
+- Operator action defaults to approval-required.
+- Cancel/refund/ship/inventory mutations are absent, not merely hidden in UI.
+
+## 9. Initial pack content inventory
+
+Each item receives a stable artifact key and a definition hash.
+
+### GraphJin
+
+- `source.magento_analytics`
+- `source.magento_operator`
+- `spec.magento_operator_v1`
+- reviewed Magento relationship overlays
+- saved queries for each metric, watcher, precondition, and reconciliation
+- explicit table/column blocklist
+
+### Metrics
+
+- net invoiced revenue
+- orders placed
+- average order value
+- refund rate
+- cancellation rate
+- fulfillment backlog
+- fulfillment age
+- sales by store
+- top products/SKUs
+- low/out-of-stock SKUs, labeled with its inventory semantics
+- cron health
+- indexer health
+- data freshness
+
+### Workflows
+
+- daily commerce briefing
+- fulfillment exceptions
+- low-stock investigation
+- refund/cancellation spike investigation
+- cron/indexer health review
+- customer-service order summary
+
+### Watchers
+
+- aged fulfillment backlog
+- stock threshold
+- refund/cancellation spike
+- cron failure/stall
+- indexer invalid/stale
+- API auth/data freshness
+
+### Actions/policies
+
+- `magento.add_internal_order_comment`
+- default policy `ask`, admin approver
+- fixed notification/visibility safety constants
+- precondition and reconciliation definitions
+
+### Skills
+
+- `magento-review-performance`
+- `magento-investigate-order`
+- `magento-triage-fulfillment`
+- `magento-investigate-refunds`
+- `magento-check-inventory`
+- `magento-diagnose-platform-health`
+
+## 10. Pull-request sequence
+
+Recommended sequence:
+
+1. **PR 1:** manifest/schema/canonicalization and fixture tests (ON-0/ON-1
+   foundation).
+2. **PR 2:** provenance tables, stores, planner, drift, rollback engine.
+3. **PR 3:** worker control plane and Go CLI lifecycle commands.
+4. **PR 4:** Magento DB preflight, connection modes, analytics source, privacy
+   blocklist.
+5. **PR 5:** deterministic metric mode and Magento saved queries/cards.
+6. **PR 6:** workflows, watchers, task-focused skills, and pack artifact bundle.
+7. **PR 7:** curated Swagger 2 -> OAS3 build/verification pipeline.
+8. **PR 8:** GraphJin released-version pin upgrade and compatibility soak
+   (blocked on upstream release).
+9. **PR 9:** generic internal GraphJin API adapter, semantic Magento action,
+   guard hardening, reconciliation.
+10. **PR 10:** full Magento E2E, admin UI, docs, bundle integrity, and release.
+
+PRs 1-7 can progress while GraphJin is being implemented, using a local canary
+only in development. PR 8 is the hard production gate for PR 9.
+
+## 11. Test commands and merge evidence
+
+Use targeted commands during development and the full suite at phase gates:
+
+```sh
+pnpm --filter @neko/packs test
+pnpm --filter @neko/db test
+pnpm --filter @neko/llm test
+pnpm --filter @neko/worker test
+pnpm --filter @neko/worker test:e2e
+pnpm --filter @neko/web test
+pnpm --filter @neko/web typecheck
+(cd apps/openneko && go test ./...)
+pnpm build
+pnpm lint
+```
+
+The production E2E evidence should also capture, with secrets redacted:
+
+- `openneko pack plan/install/status/doctor` output
+- GraphJin version from every runtime image
+- MariaDB grant verification
+- sensitive-table discovery denial
+- metric golden results
+- watcher dedupe behavior
+- action approval and reconciliation receipt
+- upgrade-with-drift and uninstall results
+
+## 12. Rollout
+
+1. **Internal alpha (`0.2.x`):** embedded complete pack; write action installed
+   but blocked by readiness by default.
+2. **Operator canary:** upgraded released GraphJin, one designated Magento test
+   environment, internal-comment readiness enabled for admins only.
+3. **Beta:** selected non-production Magento installations, action still
+   approval-required, doctor telemetry and compatibility failures reviewed.
+4. **V1:** documented compatibility range, signed/digested bundle, stable
+   upgrade/uninstall contract, no high-risk mutations.
+5. **Post-V1:** hold/unhold behind approval after soak. Evaluate shipment and
+   inventory only with operation-specific idempotency/reconciliation. Refund and
+   cancellation require separate risk review.
+6. **WooCommerce:** reuse the pack engine, deterministic metric contract,
+   governed API adapter, provenance, lifecycle, and task-focused operator skill structure;
+   replace only platform-specific sources, queries, actions, and knowledge.
+
+## 13. Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| Pack lifecycle becomes demo-installer v2 | Separate typed pack engine; no exclusivity, Compose requirement, or raw SQL bootstrap. |
+| Magento API schema is huge and ACL-dependent | Curated OAS3 allowlist generated and reviewed per supported version. |
+| DB credential exposes customer/payment data | Dedicated SELECT grants plus GraphJin table/column deny/allowlist and discovery tests. |
+| Agent bypasses action approval | Ordinary role cannot invoke GraphJin operation; executor JWT exists only after approval in worker memory. |
+| Duplicate writes after timeout | No automatic retries; reconcile ambiguous outcomes before any replay. |
+| Pack upgrade overwrites user customization | Hash-based drift detection, preserve/detach default, explicit per-artifact overwrite. |
+| Metadata transaction succeeds but GraphJin reload fails | Durable saga with snapshots, atomic file materialization, health gate, compensation. |
+| Metrics are semantically misleading | Checked-in formulas, currency/timezone/store scope, calculation notes, golden fixtures. |
+| GraphJin pin drift across images/CLI | One inventory/consistency test; bump semver and immutable asset IDs together. |
+| Sample catalog is too sparse | Deterministic Magento fixture scenarios independent of the existing sample orders. |
+| Missing write credentials create a confusing partial install | Always install the full artifact set; expose a separate readiness state and `pack configure` remediation. |
+
+## 14. Definition of done
+
+The OpenNeko work is done only when:
+
+- The reusable solution-pack lifecycle exists with provenance, plan, drift,
+  upgrade, rollback, doctor, and safe uninstall.
+- Magento analytics uses a verified SELECT-only account and exposes no sensitive
+  tables/columns.
+- Shipped metrics are deterministic and documented.
+- Workflows, watchers, skills, actions, and policies install with stable IDs and
+  pack ownership regardless of write readiness.
+- The released GraphJin mutation version is pinned consistently across every
+  OpenNeko runtime and has passed compatibility soak.
+- The internal-comment action requires approval, uses a short-lived executor
+  role, is reconciled, and cannot notify the customer or appear on the
+  storefront.
+- Fresh install without an Integration token succeeds with the action blocked;
+  adding a valid token changes only readiness/configuration, not artifact
+  membership.
+- Fresh install, reinstall, upgrade with drift, failure compensation, doctor,
+  and uninstall pass in the production stack against the Magento fixture.
+- The pack bundle contains no secrets or high-risk Magento mutations.

--- a/OPENSHELL.md
+++ b/OPENSHELL.md
@@ -106,6 +106,17 @@ state dir under `$HOME` automatically (see Deployment); on Linux it uses
 connecting binary all self-derive from your `/settings` model config on first
 boot — the env table below is only for manual / advanced setups.
 
+A full source build uses the checked-in overlay and an absolute state path so
+the host Docker daemon and gateway container resolve the same files:
+
+```sh
+export OPENSHELL_STATE_DIR="$PWD/.openneko/openshell"
+docker compose -f compose.yml -f compose.openshell.yml up -d --build
+```
+
+The overlay builds the matching agent image and does not start web or worker
+until an authenticated gateway readiness call succeeds.
+
 ## Deployment
 
 - **Host-process gateway** (brew on macOS / binary + systemd on Linux) — the

--- a/apps/openneko/assets/compose/core.yml
+++ b/apps/openneko/assets/compose/core.yml
@@ -286,11 +286,16 @@ services:
     restart: "no"
 
   graphjin:
-    image: dosco/graphjin:3.18.42
+    image: ${OPENNEKO_GRAPHJIN_IMAGE:-dosco/graphjin:3.18.42}
     restart: unless-stopped
     depends_on:
       graphjin-config-init:
         condition: service_completed_successfully
+      # The worker reconciles the per-org JWT secret into agentic.yml during
+      # startup. GraphJin 3.18 does not hot-reload auth keys, so start it only
+      # after that reconciliation has completed.
+      worker:
+        condition: service_healthy
     expose:
       - "8080"
     environment:
@@ -333,6 +338,27 @@ services:
       XDG_CONFIG_HOME: /config
     volumes:
       - openneko-config:/config/openneko
+
+  # The migration CLI runs as root and may create the shared config directory
+  # and secret key on first boot. Repair ownership before the non-root worker
+  # mounts the volume so a completely fresh Compose project can start.
+  openneko-config-init:
+    image: ghcr.io/open-neko/neko-worker:${OPENNEKO_VERSION:-latest}
+    user: "0:0"
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        mkdir -p /config/openneko
+        chown -R neko:neko /config/openneko
+        chmod 0700 /config/openneko
+    depends_on:
+      neko-migrate:
+        condition: service_completed_successfully
+    volumes:
+      - openneko-config:/config/openneko
+    restart: "no"
 
   neko-graphjin:
     image: ghcr.io/open-neko/neko-graphjin:${OPENNEKO_VERSION:-latest}
@@ -400,6 +426,8 @@ services:
       # entrypoint no longer runs migrate.
       neko-migrate:
         condition: service_completed_successfully
+      openneko-config-init:
+        condition: service_completed_successfully
       records-db:
         condition: service_healthy
       neko-backup:
@@ -408,8 +436,10 @@ services:
         condition: service_started
       records-watch-graphjin:
         condition: service_started
-      graphjin:
-        condition: service_started
+      # The worker must patch the per-org JWT secret before customer GraphJin
+      # starts; depending on the one-shot seed avoids a startup cycle.
+      graphjin-config-init:
+        condition: service_completed_successfully
     environment:
       <<: *neko-app-env
       OPENNEKO_GRAPHJIN_URL: http://neko-graphjin:8089

--- a/apps/openneko/assets/compose/openshell.yml
+++ b/apps/openneko/assets/compose/openshell.yml
@@ -4,11 +4,11 @@
 #
 #   docker compose -f compose.yml -f compose.openshell.yml up
 #
-# STATUS: VALIDATED end-to-end on the Linux target (neko-vm / GCP, 2026-06-03):
-# containerised gateway boots with mTLS, the Docker driver creates a sandbox,
-# the supervisor fetches policy + reaches Ready, exec runs, and default-deny
-# egress is enforced. On macOS/OrbStack the same compose stalls at JWT delivery
-# (see requirement #4) — run it on Linux.
+# STATUS: VALIDATED end-to-end on Linux and macOS/OrbStack. The containerised
+# gateway boots with mTLS, the Docker driver creates a sandbox, the supervisor
+# fetches policy + reaches Ready, exec runs, and default-deny egress is
+# enforced. On macOS the host-side state path must live under $HOME; the
+# `openneko` supervisor configures that automatically (see requirement #4).
 #
 # Hard requirements proven during bring-up:
 #  1. Docker sandboxes REQUIRE mTLS (JWT + client-cert auth); --disable-tls is a
@@ -135,6 +135,37 @@ services:
       # path the gateway hands the daemon resolves identically on the host.
       - ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}:${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}
 
+  # A running gateway container is not yet a usable gateway: it still has to
+  # finish its database migrations and bind the mTLS control plane. Probe a
+  # real, read-only RPC before either app process is allowed to start. This
+  # closes the fresh-install race where setup completed successfully but the
+  # first profiler sandbox failed with "No active gateway"/connection errors.
+  openshell-ready:
+    image: ghcr.io/open-neko/neko-worker:${OPENNEKO_VERSION:-latest}
+    restart: "no"
+    entrypoint: ["/bin/sh", "-ceu"]
+    command:
+      - |
+        attempt=0
+        until openshell --gateway openneko provider list --names >/dev/null 2>&1; do
+          attempt=$$((attempt + 1))
+          if [ "$$attempt" -ge 60 ]; then
+            echo "OpenShell gateway did not become ready within 120 seconds" >&2
+            openshell --gateway openneko provider list --names
+            exit 1
+          fi
+          sleep 2
+        done
+        echo "OpenShell gateway ready"
+    environment:
+      HOME: /tmp/openneko-home
+      XDG_CONFIG_HOME: /config
+    volumes:
+      - openshell-config:/config/openshell:ro
+    depends_on:
+      openshell-gateway:
+        condition: service_started
+
   # Worker: channel-triggered agent runs + plugins, both in OpenShell sandboxes.
   worker:
     environment:
@@ -155,8 +186,8 @@ services:
     volumes:
       - openshell-config:/config/openshell
     depends_on:
-      openshell-gateway:
-        condition: service_started
+      openshell-ready:
+        condition: service_completed_successfully
 
   # Web: interactive chat launches the agent in a sandbox too (the Next.js server
   # is the control plane; the agent never runs in-process). Same flags; egress
@@ -173,8 +204,8 @@ services:
     volumes:
       - openshell-config:/config/openshell
     depends_on:
-      openshell-gateway:
-        condition: service_started
+      openshell-ready:
+        condition: service_completed_successfully
 
 volumes:
   # Holds the worker/web CLI's gateway registration at /config/openshell (the

--- a/apps/openneko/assets/compose_security_test.go
+++ b/apps/openneko/assets/compose_security_test.go
@@ -197,6 +197,10 @@ func TestPackagedComposeKeepsRuntimeTrafficOnDockerNetwork(t *testing.T) {
 	if gateway.DependsOn["neko-migrate"].Condition != "service_completed_successfully" {
 		t.Fatal("OpenShell gateway must wait for private database preparation")
 	}
+	ready := openshell.Services["openshell-ready"]
+	if ready.DependsOn["openshell-gateway"].Condition != "service_started" {
+		t.Fatal("OpenShell readiness probe must start after the gateway container")
+	}
 	for _, service := range []string{"worker", "web"} {
 		env := openshell.Services[service].Environment
 		if env["OPENNEKO_SANDBOX_SHARED_NETWORK"] != "1" {
@@ -204,6 +208,9 @@ func TestPackagedComposeKeepsRuntimeTrafficOnDockerNetwork(t *testing.T) {
 		}
 		if _, exposed := env["OPENNEKO_BROKER_HOST_ALIAS"]; exposed {
 			t.Fatalf("%s must derive a private container IP instead of a host broker alias", service)
+		}
+		if openshell.Services[service].DependsOn["openshell-ready"].Condition != "service_completed_successfully" {
+			t.Fatalf("%s must wait for a successful OpenShell control-plane probe", service)
 		}
 	}
 	for _, required := range []string{

--- a/apps/openneko/assets/migrations/0059_solution_packs.sql
+++ b/apps/openneko/assets/migrations/0059_solution_packs.sql
@@ -1,0 +1,117 @@
+-- First-class, organization-scoped solution-pack lifecycle and provenance.
+-- Pack application is a durable saga because GraphJin files and metadata
+-- Postgres cannot share one transaction.
+
+create table if not exists pack_install (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null references organization(id) on delete cascade,
+  pack_id text not null,
+  version text not null,
+  status text not null default 'planning'
+    check (status in ('planning', 'installing', 'installed', 'upgrading', 'failed', 'removing', 'removed')),
+  manifest_hash text not null,
+  config jsonb not null default '{}'::jsonb,
+  source text not null default 'embedded'
+    check (source in ('embedded')),
+  installed_by_user_id text references app_user(id) on delete set null,
+  operation_id uuid,
+  last_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  installed_at timestamptz,
+  removed_at timestamptz
+);
+
+create unique index if not exists pack_install_org_pack_active_unique
+  on pack_install (org_id, pack_id)
+  where status <> 'removed';
+create index if not exists pack_install_org_status_idx
+  on pack_install (org_id, status, updated_at desc);
+
+create table if not exists pack_artifact (
+  id uuid primary key default gen_random_uuid(),
+  pack_install_id uuid not null references pack_install(id) on delete cascade,
+  org_id text not null references organization(id) on delete cascade,
+  artifact_kind text not null
+    check (artifact_kind in ('source', 'relationships', 'spec', 'saved_query', 'metric', 'workflow', 'watcher', 'action', 'policy', 'skill')),
+  artifact_key text not null,
+  target_ref text not null,
+  desired_hash text not null,
+  last_applied_hash text not null,
+  ownership text not null default 'managed'
+    check (ownership in ('managed', 'modified', 'detached', 'retired')),
+  readiness text not null default 'not_applicable'
+    check (readiness in ('ready', 'blocked', 'degraded', 'not_applicable')),
+  readiness_reason text,
+  previous_snapshot jsonb,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  detached_at timestamptz,
+  unique (org_id, artifact_kind, target_ref),
+  unique (pack_install_id, artifact_kind, artifact_key)
+);
+
+create index if not exists pack_artifact_install_idx
+  on pack_artifact (pack_install_id, ownership, artifact_kind);
+create index if not exists pack_artifact_org_readiness_idx
+  on pack_artifact (org_id, readiness, updated_at desc);
+
+create table if not exists pack_action_definition (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null references organization(id) on delete cascade,
+  kind text not null,
+  description text not null default '',
+  definition jsonb not null,
+  definition_hash text not null,
+  readiness text not null default 'blocked'
+    check (readiness in ('ready', 'blocked', 'degraded')),
+  readiness_reason text,
+  enabled boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (org_id, kind)
+);
+
+create index if not exists pack_action_definition_discovery_idx
+  on pack_action_definition (org_id, readiness, enabled, updated_at desc);
+
+create table if not exists pack_operation (
+  id uuid primary key default gen_random_uuid(),
+  pack_install_id uuid not null references pack_install(id) on delete cascade,
+  org_id text not null references organization(id) on delete cascade,
+  operation_type text not null
+    check (operation_type in ('install', 'upgrade', 'configure', 'doctor', 'uninstall')),
+  actor_user_id text references app_user(id) on delete set null,
+  status text not null default 'planned'
+    check (status in ('planned', 'running', 'compensating', 'succeeded', 'failed')),
+  requested_version text,
+  idempotency_key text not null,
+  plan jsonb not null default '{}'::jsonb,
+  plan_hash text not null,
+  phase text not null default 'planned',
+  failure_phase text,
+  error text,
+  compensation_status text
+    check (compensation_status is null or compensation_status in ('not_required', 'pending', 'running', 'succeeded', 'failed')),
+  started_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (org_id, idempotency_key)
+);
+
+create index if not exists pack_operation_install_recent_idx
+  on pack_operation (pack_install_id, created_at desc);
+create index if not exists pack_operation_org_status_idx
+  on pack_operation (org_id, status, created_at desc);
+
+alter table pack_install
+  add constraint pack_install_operation_fk
+  foreign key (operation_id) references pack_operation(id) on delete set null;
+
+alter table watcher
+  add column if not exists cooldown_seconds integer not null default 0,
+  add column if not exists dedupe_key text,
+  add column if not exists activation text,
+  add column if not exists variables_json jsonb not null default '{}'::jsonb;

--- a/apps/openneko/assets/migrations/0060_deterministic_metrics.sql
+++ b/apps/openneko/assets/migrations/0060_deterministic_metrics.sql
@@ -1,0 +1,34 @@
+-- Deterministic saved-query metrics. Existing agent-authored metrics retain the
+-- current execution mode; pack metrics opt into a validated declarative query.
+
+alter table metric
+  add column if not exists execution_mode text not null default 'agent',
+  add column if not exists definition_json jsonb,
+  add column if not exists definition_version integer,
+  add column if not exists definition_hash text;
+
+alter table metric
+  add constraint metric_execution_mode_check
+  check (execution_mode in ('agent', 'saved_query'));
+
+alter table metric
+  add constraint metric_saved_query_definition_check
+  check (
+    execution_mode = 'agent'
+    or (
+      definition_json is not null
+      and definition_version is not null
+      and definition_version > 0
+      and definition_hash is not null
+    )
+  );
+
+create index if not exists metric_saved_query_active_idx
+  on metric (org_id, cadence, updated_at)
+  where active = true and execution_mode = 'saved_query';
+
+alter table metric_snapshot
+  add column if not exists definition_hash text,
+  add column if not exists source_freshness_at timestamptz,
+  add column if not exists duration_ms integer,
+  add column if not exists error_class text;

--- a/apps/openneko/internal/cli/cli_test.go
+++ b/apps/openneko/internal/cli/cli_test.go
@@ -23,7 +23,7 @@ func TestExitCodeFor(t *testing.T) {
 
 func TestRootHasAllCommands(t *testing.T) {
 	root := NewRoot()
-	want := []string{"setup", "init", "install", "remove", "list", "doctor", "marketplace", "secrets", "version", "start", "upgrade", "stop", "status", "backup", "restore", "records", "logs", "migrate", "seed", "reset", "eval"}
+	want := []string{"setup", "init", "install", "remove", "list", "doctor", "marketplace", "secrets", "pack", "version", "start", "upgrade", "stop", "status", "backup", "restore", "records", "logs", "migrate", "seed", "reset", "eval"}
 	got := map[string]bool{}
 	for _, c := range root.Commands() {
 		got[c.Name()] = true

--- a/apps/openneko/internal/cli/pack.go
+++ b/apps/openneko/internal/cli/pack.go
@@ -1,0 +1,712 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+
+	"github.com/open-neko/neko/apps/openneko/internal/prompt"
+)
+
+const defaultWorkerAdminURL = "http://127.0.0.1:4100"
+
+type packListEntry struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Version   string `json:"version"`
+	Installed bool   `json:"installed"`
+}
+
+type packStatusResponse struct {
+	PackID    string `json:"packId"`
+	Version   string `json:"version"`
+	Status    string `json:"status"`
+	Readiness map[string]struct {
+		Status string  `json:"status"`
+		Reason *string `json:"reason"`
+	} `json:"readiness"`
+	InstalledAt *string `json:"installedAt"`
+	LastError   *string `json:"lastError"`
+}
+
+type packDoctorResponse struct {
+	PackID string `json:"packId"`
+	Status string `json:"status"`
+	Checks []struct {
+		ID     string `json:"id"`
+		Status string `json:"status"`
+		Detail string `json:"detail"`
+	} `json:"checks"`
+}
+
+type packInstallOptions struct {
+	baseURL          string
+	storeCode        string
+	tablePrefix      string
+	databaseMode     string
+	databaseHost     string
+	databasePort     int
+	databaseName     string
+	analyticsUserRef string
+	analyticsPassRef string
+	integrationRef   string
+	nonInteractive   bool
+	output           string
+}
+
+func newPackCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "pack",
+		Short: "Install and manage application-specific solution packs",
+	}
+	cmd.AddCommand(
+		newPackListCmd(),
+		newPackInspectCmd(),
+		newPackPlanCmd(),
+		newPackInstallCmd(),
+		newPackStatusCmd(),
+		newPackManageCmd(),
+		newPackDoctorCmd(),
+		newPackConfigureCmd(),
+		newPackUpgradeCmd(),
+		newPackUninstallCmd(),
+	)
+	return cmd
+}
+
+func newPackManageCmd() *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:     "manage <pack>",
+		Aliases: []string{"overview"},
+		Short:   "Show pack health and common administration commands",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if code, proxied := MaybeProxyToWorker(cmd); proxied {
+				return WithExit(code, nil)
+			}
+			packID := args[0]
+			var status packStatusResponse
+			statusRaw, err := requestPackAPI(cmd.Context(), http.MethodGet, "/admin/packs/"+url.PathEscape(packID)+"/status", nil, &status)
+			if err != nil {
+				return err
+			}
+			var doctor packDoctorResponse
+			doctorRaw, err := requestPackAPI(cmd.Context(), http.MethodGet, "/admin/packs/"+url.PathEscape(packID)+"/doctor", nil, &doctor)
+			if err != nil {
+				return err
+			}
+			if output == "json" {
+				return json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]json.RawMessage{
+					"status": statusRaw,
+					"doctor": doctorRaw,
+				})
+			}
+			writePackStatus(cmd.OutOrStdout(), status)
+			fmt.Fprintln(cmd.OutOrStdout(), "Health checks:")
+			for _, check := range doctor.Checks {
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s — %s\n", packCapabilityLabel(check.ID), check.Status, check.Detail)
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), "Common tasks:")
+			fmt.Fprintf(cmd.OutOrStdout(), "  Recheck connection: openneko pack doctor %s\n", packID)
+			fmt.Fprintf(cmd.OutOrStdout(), "  Update credentials: openneko pack configure %s\n", packID)
+			fmt.Fprintf(cmd.OutOrStdout(), "  Apply an update:    openneko pack upgrade %s\n", packID)
+			fmt.Fprintf(cmd.OutOrStdout(), "  Remove safely:      openneko pack uninstall %s\n", packID)
+			return nil
+		},
+	}
+	addPackOutputFlag(cmd, &output)
+	return cmd
+}
+
+func newPackDoctorCmd() *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:   "doctor <pack>",
+		Short: "Recheck pack connectivity, permissions, and capability readiness",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if code, proxied := MaybeProxyToWorker(cmd); proxied {
+				return WithExit(code, nil)
+			}
+			var response packDoctorResponse
+			raw, err := requestPackAPI(cmd.Context(), http.MethodGet, "/admin/packs/"+url.PathEscape(args[0])+"/doctor", nil, &response)
+			if err != nil {
+				return err
+			}
+			if output == "json" {
+				_, err = cmd.OutOrStdout().Write(append(raw, '\n'))
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", response.PackID, response.Status)
+			for _, check := range response.Checks {
+				fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s — %s\n", packCapabilityLabel(check.ID), check.Status, check.Detail)
+			}
+			return nil
+		},
+	}
+	addPackOutputFlag(cmd, &output)
+	return cmd
+}
+
+func newPackConfigureCmd() *cobra.Command {
+	var analyticsUserRef string
+	var analyticsPassRef string
+	var integrationRef string
+	var output string
+	cmd := &cobra.Command{
+		Use:   "configure <pack>",
+		Short: "Replace stored pack credential references and re-run readiness checks",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if code, proxied := MaybeProxyToWorker(cmd); proxied {
+				return WithExit(code, nil)
+			}
+			secretRefs := map[string]string{}
+			for key, value := range map[string]string{
+				"database.analytics_username": analyticsUserRef,
+				"database.analytics_password": analyticsPassRef,
+				"magento.integration_token":   integrationRef,
+			} {
+				if value != "" {
+					secretRefs[key] = value
+				}
+			}
+			body := map[string]any{
+				"secretRefs":     secretRefs,
+				"idempotencyKey": uuid.NewString(),
+			}
+			var response packStatusResponse
+			raw, err := requestPackAPI(cmd.Context(), http.MethodPost, "/admin/packs/"+url.PathEscape(args[0])+"/configure", body, &response)
+			if err != nil {
+				return err
+			}
+			if output == "json" {
+				_, err = cmd.OutOrStdout().Write(append(raw, '\n'))
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "configured %s@%s\n", response.PackID, response.Version)
+			writePackReadiness(cmd.OutOrStdout(), response.Readiness)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&analyticsUserRef, "analytics-username-ref", "", "Stored key in the pack.magento secret section")
+	cmd.Flags().StringVar(&analyticsPassRef, "analytics-password-ref", "", "Stored key in the pack.magento secret section")
+	cmd.Flags().StringVar(&integrationRef, "integration-token-ref", "", "Stored Magento integration token key")
+	addPackOutputFlag(cmd, &output)
+	return cmd
+}
+
+func newPackUpgradeCmd() *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:   "upgrade <pack>",
+		Short: "Apply the embedded pack version while preserving owned-artifact drift",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if code, proxied := MaybeProxyToWorker(cmd); proxied {
+				return WithExit(code, nil)
+			}
+			body := map[string]any{"idempotencyKey": uuid.NewString()}
+			var response packStatusResponse
+			raw, err := requestPackAPI(cmd.Context(), http.MethodPost, "/admin/packs/"+url.PathEscape(args[0])+"/upgrade", body, &response)
+			if err != nil {
+				return err
+			}
+			if output == "json" {
+				_, err = cmd.OutOrStdout().Write(append(raw, '\n'))
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "upgraded %s@%s\n", response.PackID, response.Version)
+			writePackReadiness(cmd.OutOrStdout(), response.Readiness)
+			return nil
+		},
+	}
+	addPackOutputFlag(cmd, &output)
+	return cmd
+}
+
+func newPackUninstallCmd() *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:   "uninstall <pack>",
+		Short: "Safely remove unchanged pack configuration while retaining history and data",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if code, proxied := MaybeProxyToWorker(cmd); proxied {
+				return WithExit(code, nil)
+			}
+			body := map[string]any{"idempotencyKey": uuid.NewString()}
+			var response packStatusResponse
+			raw, err := requestPackAPI(cmd.Context(), http.MethodPost, "/admin/packs/"+url.PathEscape(args[0])+"/uninstall", body, &response)
+			if err != nil {
+				return err
+			}
+			if output == "json" {
+				_, err = cmd.OutOrStdout().Write(append(raw, '\n'))
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "uninstalled %s@%s (history and data retained)\n", response.PackID, response.Version)
+			return nil
+		},
+	}
+	addPackOutputFlag(cmd, &output)
+	return cmd
+}
+
+func newPackListCmd() *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List solution packs available in this OpenNeko release",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if code, proxied := MaybeProxyToWorker(cmd); proxied {
+				return WithExit(code, nil)
+			}
+			var response struct {
+				Packs []packListEntry `json:"packs"`
+			}
+			raw, err := requestPackAPI(cmd.Context(), http.MethodGet, "/admin/packs", nil, &response)
+			if err != nil {
+				return err
+			}
+			if output == "json" {
+				_, err = cmd.OutOrStdout().Write(append(raw, '\n'))
+				return err
+			}
+			if len(response.Packs) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "no solution packs are available")
+				return nil
+			}
+			for _, entry := range response.Packs {
+				state := "available"
+				if entry.Installed {
+					state = "installed"
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\t%s\t%s\n", entry.ID, entry.Name, entry.Version, state)
+			}
+			return nil
+		},
+	}
+	addPackOutputFlag(cmd, &output)
+	return cmd
+}
+
+func newPackInspectCmd() *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:   "inspect <pack>",
+		Short: "Show a pack's metadata, requirements, and permissions",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if code, proxied := MaybeProxyToWorker(cmd); proxied {
+				return WithExit(code, nil)
+			}
+			path := "/admin/packs/" + url.PathEscape(args[0])
+			var response struct {
+				Manifest struct {
+					Metadata struct {
+						ID        string `json:"id"`
+						Name      string `json:"name"`
+						Version   string `json:"version"`
+						Publisher string `json:"publisher"`
+						Category  string `json:"category"`
+					} `json:"metadata"`
+					Inputs []struct {
+						Key      string `json:"key"`
+						Type     string `json:"type"`
+						Required bool   `json:"required"`
+						Discover bool   `json:"discover"`
+					} `json:"inputs"`
+				} `json:"manifest"`
+				Permissions map[string]string `json:"permissions"`
+			}
+			raw, err := requestPackAPI(cmd.Context(), http.MethodGet, path, nil, &response)
+			if err != nil {
+				return err
+			}
+			if output == "json" {
+				_, err = cmd.OutOrStdout().Write(append(raw, '\n'))
+				return err
+			}
+			meta := response.Manifest.Metadata
+			fmt.Fprintf(cmd.OutOrStdout(), "%s (%s)\nVersion: %s\nPublisher: %s\nCategory: %s\n", meta.Name, meta.ID, meta.Version, meta.Publisher, meta.Category)
+			if len(response.Permissions) > 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "Permissions:")
+				keys := make([]string, 0, len(response.Permissions))
+				for key := range response.Permissions {
+					keys = append(keys, key)
+				}
+				sort.Strings(keys)
+				for _, key := range keys {
+					fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s\n", key, response.Permissions[key])
+				}
+			}
+			var required []string
+			for _, input := range response.Manifest.Inputs {
+				if input.Required && !input.Discover {
+					required = append(required, input.Key)
+				}
+			}
+			if len(required) > 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "Required configuration: %s\n", strings.Join(required, ", "))
+			}
+			return nil
+		},
+	}
+	addPackOutputFlag(cmd, &output)
+	return cmd
+}
+
+func newPackPlanCmd() *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:   "plan <pack>",
+		Short: "Preview the artifact changes for a pack install or upgrade",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if code, proxied := MaybeProxyToWorker(cmd); proxied {
+				return WithExit(code, nil)
+			}
+			var response struct {
+				PackID  string `json:"packId"`
+				Version string `json:"version"`
+				Hash    string `json:"hash"`
+				Entries []struct {
+					Action    string `json:"action"`
+					Kind      string `json:"kind"`
+					Key       string `json:"key"`
+					TargetRef string `json:"targetRef"`
+					Reason    string `json:"reason"`
+				} `json:"entries"`
+			}
+			raw, err := requestPackAPI(cmd.Context(), http.MethodGet, "/admin/packs/"+url.PathEscape(args[0])+"/plan", nil, &response)
+			if err != nil {
+				return err
+			}
+			if output == "json" {
+				_, err = cmd.OutOrStdout().Write(append(raw, '\n'))
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s %s\n", response.PackID, response.Version)
+			for _, entry := range response.Entries {
+				suffix := ""
+				if entry.Reason != "" {
+					suffix = " (" + entry.Reason + ")"
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "  %-8s %-14s %s%s\n", entry.Action, entry.Kind, entry.TargetRef, suffix)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Plan: %s\n", response.Hash)
+			return nil
+		},
+	}
+	addPackOutputFlag(cmd, &output)
+	return cmd
+}
+
+func newPackStatusCmd() *cobra.Command {
+	var output string
+	cmd := &cobra.Command{
+		Use:   "status <pack>",
+		Short: "Show pack installation and capability readiness",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if code, proxied := MaybeProxyToWorker(cmd); proxied {
+				return WithExit(code, nil)
+			}
+			var response packStatusResponse
+			raw, err := requestPackAPI(cmd.Context(), http.MethodGet, "/admin/packs/"+url.PathEscape(args[0])+"/status", nil, &response)
+			if err != nil {
+				return err
+			}
+			if output == "json" {
+				_, err = cmd.OutOrStdout().Write(append(raw, '\n'))
+				return err
+			}
+			writePackStatus(cmd.OutOrStdout(), response)
+			return nil
+		},
+	}
+	addPackOutputFlag(cmd, &output)
+	return cmd
+}
+
+func newPackInstallCmd() *cobra.Command {
+	opts := packInstallOptions{storeCode: "all", databaseMode: "external_network", databasePort: 3306, output: "text"}
+	cmd := &cobra.Command{
+		Use:   "install <pack>",
+		Short: "Install every artifact in a solution pack",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if code, proxied := MaybeProxyToWorker(cmd); proxied {
+				return WithExit(code, nil)
+			}
+			if args[0] != "magento" {
+				return fmt.Errorf("pack install: unsupported embedded pack %q", args[0])
+			}
+			if err := completeMagentoInstallOptions(&opts); err != nil {
+				return err
+			}
+			secretRefs := map[string]string{}
+			for key, value := range map[string]string{
+				"database.analytics_username": opts.analyticsUserRef,
+				"database.analytics_password": opts.analyticsPassRef,
+				"magento.integration_token":   opts.integrationRef,
+			} {
+				if value != "" {
+					secretRefs[key] = value
+				}
+			}
+			secrets := map[string]string{}
+			if opts.analyticsUserRef == "" || opts.analyticsPassRef == "" {
+				if opts.nonInteractive || !prompt.IsInteractive() {
+					return errors.New("pack install: analytics credentials are required; use --analytics-username-ref and --analytics-password-ref with keys stored under the pack.magento secret section")
+				}
+				if opts.analyticsUserRef == "" {
+					value, err := prompt.Visible("Read-only analytics username: ")
+					if err != nil {
+						return err
+					}
+					secrets["database.analytics_username"] = value
+				}
+				if opts.analyticsPassRef == "" {
+					value, err := prompt.Hidden("Read-only analytics password (hidden): ")
+					if err != nil {
+						return err
+					}
+					secrets["database.analytics_password"] = value
+				}
+			}
+			body := map[string]any{
+				"inputs": map[string]any{
+					"magento.base_url":           opts.baseURL,
+					"magento.store_code":         opts.storeCode,
+					"magento.table_prefix":       opts.tablePrefix,
+					"database.connectivity_mode": opts.databaseMode,
+					"database.host":              opts.databaseHost,
+					"database.port":              opts.databasePort,
+					"database.name":              opts.databaseName,
+				},
+				"secrets":        secrets,
+				"secretRefs":     secretRefs,
+				"idempotencyKey": uuid.NewString(),
+			}
+			var response packStatusResponse
+			raw, err := requestPackAPI(cmd.Context(), http.MethodPost, "/admin/packs/"+url.PathEscape(args[0])+"/install", body, &response)
+			if err != nil {
+				return err
+			}
+			if opts.output == "json" {
+				_, err = cmd.OutOrStdout().Write(append(raw, '\n'))
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "installed %s@%s\n", response.PackID, response.Version)
+			writePackReadiness(cmd.OutOrStdout(), response.Readiness)
+			fmt.Fprintln(cmd.OutOrStdout(), "Credentials were saved in OpenNeko's local secret store.")
+			fmt.Fprintf(cmd.OutOrStdout(), "Manage this pack: openneko pack manage %s\n", response.PackID)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&opts.baseURL, "base-url", "", "Magento base URL (for example https://store.example.com)")
+	cmd.Flags().StringVar(&opts.storeCode, "store-code", opts.storeCode, "Magento REST store code")
+	cmd.Flags().StringVar(&opts.tablePrefix, "table-prefix", "", "Magento database table prefix (discovered when omitted)")
+	cmd.Flags().StringVar(&opts.databaseMode, "database-connectivity", opts.databaseMode, "Database connectivity: external_network, host_gateway, or remote")
+	cmd.Flags().StringVar(&opts.databaseHost, "database-host", "", "MariaDB/MySQL host reachable from OpenNeko")
+	cmd.Flags().IntVar(&opts.databasePort, "database-port", opts.databasePort, "MariaDB/MySQL port")
+	cmd.Flags().StringVar(&opts.databaseName, "database-name", "", "Magento database name")
+	cmd.Flags().StringVar(&opts.analyticsUserRef, "analytics-username-ref", "", "Stored key in the pack.magento secret section")
+	cmd.Flags().StringVar(&opts.analyticsPassRef, "analytics-password-ref", "", "Stored key in the pack.magento secret section")
+	cmd.Flags().StringVar(&opts.integrationRef, "integration-token-ref", "", "Optional stored Magento integration token key")
+	cmd.Flags().BoolVar(&opts.nonInteractive, "non-interactive", false, "Never prompt; fail if required configuration is missing")
+	addPackOutputFlag(cmd, &opts.output)
+	return cmd
+}
+
+func completeMagentoInstallOptions(opts *packInstallOptions) error {
+	if opts.nonInteractive || !prompt.IsInteractive() {
+		missing := make([]string, 0, 3)
+		if strings.TrimSpace(opts.baseURL) == "" {
+			missing = append(missing, "--base-url")
+		}
+		if strings.TrimSpace(opts.databaseHost) == "" {
+			missing = append(missing, "--database-host")
+		}
+		if strings.TrimSpace(opts.databaseName) == "" {
+			missing = append(missing, "--database-name")
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("pack install: required flags missing in non-interactive mode: %s", strings.Join(missing, ", "))
+		}
+	} else {
+		var err error
+		fmt.Fprintln(os.Stdout, "Magento setup")
+		fmt.Fprintln(os.Stdout, "Tip: for separate Docker/OrbStack stacks, publish MariaDB and use host.docker.internal.")
+		if opts.baseURL == "" {
+			opts.baseURL, err = prompt.Visible("Magento base URL: ")
+			if err != nil {
+				return err
+			}
+		}
+		if opts.databaseHost == "" {
+			opts.databaseHost, err = prompt.Visible("MariaDB/MySQL host: ")
+			if err != nil {
+				return err
+			}
+		}
+		if opts.databaseName == "" {
+			opts.databaseName, err = prompt.Visible("Magento database name: ")
+			if err != nil {
+				return err
+			}
+		}
+	}
+	for label, value := range map[string]string{
+		"Magento base URL": opts.baseURL,
+		"database host":    opts.databaseHost,
+		"database name":    opts.databaseName,
+	} {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("pack install: %s must not be empty", label)
+		}
+	}
+	if parsed, err := url.ParseRequestURI(opts.baseURL); err != nil || parsed.Host == "" || (parsed.Scheme != "http" && parsed.Scheme != "https") {
+		return errors.New("pack install: --base-url must be an absolute HTTP or HTTPS URL")
+	}
+	if opts.databasePort < 1 || opts.databasePort > 65535 {
+		return errors.New("pack install: --database-port must be between 1 and 65535")
+	}
+	if opts.databaseMode != "external_network" && opts.databaseMode != "host_gateway" && opts.databaseMode != "remote" {
+		return errors.New("pack install: --database-connectivity must be external_network, host_gateway, or remote")
+	}
+	return nil
+}
+
+func addPackOutputFlag(cmd *cobra.Command, output *string) {
+	cmd.Flags().StringVarP(output, "output", "o", "text", "Output format: text or json")
+	cmd.PreRunE = func(_ *cobra.Command, _ []string) error {
+		if *output != "text" && *output != "json" {
+			return errors.New("--output must be text or json")
+		}
+		return nil
+	}
+}
+
+func writePackStatus(out io.Writer, response packStatusResponse) {
+	fmt.Fprintf(out, "%s@%s: %s\n", response.PackID, response.Version, response.Status)
+	writePackReadiness(out, response.Readiness)
+	if response.LastError != nil && *response.LastError != "" {
+		fmt.Fprintf(out, "Last error: %s\n", *response.LastError)
+	}
+}
+
+func writePackReadiness(out io.Writer, readiness map[string]struct {
+	Status string  `json:"status"`
+	Reason *string `json:"reason"`
+}) {
+	keys := make([]string, 0, len(readiness))
+	for key := range readiness {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		value := readiness[key]
+		status := value.Status
+		if key == "operator" && status == "blocked" {
+			status = "optional"
+		}
+		reason := ""
+		if value.Reason != nil && *value.Reason != "" {
+			reason = " — " + packReadinessReason(*value.Reason)
+		}
+		fmt.Fprintf(out, "  %s: %s%s\n", packCapabilityLabel(key), status, reason)
+	}
+}
+
+func packCapabilityLabel(value string) string {
+	if value == "operator" {
+		return "write actions"
+	}
+	return value
+}
+
+func packReadinessReason(reason string) string {
+	switch reason {
+	case "integration_token_missing":
+		return "add a Magento API token to enable them"
+	case "integration_token_invalid":
+		return "the Magento API token needs attention"
+	case "acl_missing":
+		return "the Magento API token needs more permissions"
+	case "graphjin_version_unsupported":
+		return "available after the required GraphJin update"
+	default:
+		return strings.ReplaceAll(reason, "_", " ")
+	}
+}
+
+func requestPackAPI(ctx context.Context, method, path string, body any, destination any) ([]byte, error) {
+	base := strings.TrimRight(os.Getenv("WORKER_ADMIN_URL"), "/")
+	if base == "" {
+		base = defaultWorkerAdminURL
+	}
+	endpoint := base + path
+	var reader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		reader = bytes.NewReader(encoded)
+	}
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, reader)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("pack service at %s is unreachable: %w", base, err)
+	}
+	defer res.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(res.Body, 2<<20))
+	if err != nil {
+		return nil, err
+	}
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		var errorBody struct {
+			Error string `json:"error"`
+		}
+		_ = json.Unmarshal(raw, &errorBody)
+		if errorBody.Error == "" {
+			errorBody.Error = strings.TrimSpace(string(raw))
+		}
+		if errorBody.Error == "" {
+			errorBody.Error = http.StatusText(res.StatusCode)
+		}
+		return nil, fmt.Errorf("pack service: %s (HTTP %s)", errorBody.Error, strconv.Itoa(res.StatusCode))
+	}
+	if destination != nil {
+		if err := json.Unmarshal(raw, destination); err != nil {
+			return nil, fmt.Errorf("pack service returned invalid JSON: %w", err)
+		}
+	}
+	return raw, nil
+}

--- a/apps/openneko/internal/cli/pack_test.go
+++ b/apps/openneko/internal/cli/pack_test.go
@@ -1,0 +1,206 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func runPackCommand(t *testing.T, handler http.Handler, args ...string) (string, error) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	t.Setenv("WORKER_ADMIN_URL", server.URL)
+	t.Setenv("OPENNEKO_PROXIED", "1")
+	command := newPackCmd()
+	var output bytes.Buffer
+	command.SetOut(&output)
+	command.SetErr(&output)
+	command.SetArgs(args)
+	err := command.Execute()
+	return output.String(), err
+}
+
+func TestPackListText(t *testing.T) {
+	output, err := runPackCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/admin/packs" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"packs":[{"id":"magento","name":"Magento","version":"0.1.0","installed":false}]}`)
+	}), "list")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output != "magento\tMagento\t0.1.0\tavailable\n" {
+		t.Fatalf("unexpected output: %q", output)
+	}
+}
+
+func TestPackInstallUsesSecretRefsAndConciseOutput(t *testing.T) {
+	output, err := runPackCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/admin/packs/magento/install" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		var body struct {
+			Inputs     map[string]any    `json:"inputs"`
+			Secrets    map[string]string `json:"secrets"`
+			SecretRefs map[string]string `json:"secretRefs"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if len(body.Secrets) != 0 {
+			t.Fatalf("plaintext secrets unexpectedly submitted: %#v", body.Secrets)
+		}
+		if body.SecretRefs["database.analytics_username"] != "ANALYTICS_USER" || body.SecretRefs["database.analytics_password"] != "ANALYTICS_PASSWORD" {
+			t.Fatalf("secret refs missing: %#v", body.SecretRefs)
+		}
+		if body.Inputs["database.host"] != "mariadb" {
+			t.Fatalf("database host not submitted: %#v", body.Inputs)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"packId":"magento","version":"0.1.0","status":"installed","readiness":{"analytics":{"status":"ready","reason":null},"operator":{"status":"blocked","reason":"graphjin_version_unsupported"}},"installedAt":"2026-08-20T00:00:00Z","lastError":null}`)
+	}), "install", "magento",
+		"--non-interactive",
+		"--base-url", "https://store.example.com",
+		"--database-host", "mariadb",
+		"--database-name", "magento",
+		"--analytics-username-ref", "ANALYTICS_USER",
+		"--analytics-password-ref", "ANALYTICS_PASSWORD",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"installed magento@0.1.0", "analytics: ready", "write actions: optional — available after the required GraphJin update"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("missing %q in %q", want, output)
+		}
+	}
+	for _, unwanted := range []string{"metric cards", "workflows", "watchers", "Will install"} {
+		if strings.Contains(output, unwanted) {
+			t.Fatalf("normal install output should not contain %q: %q", unwanted, output)
+		}
+	}
+}
+
+func TestPackInstallNonInteractiveRequiresReferences(t *testing.T) {
+	output, err := runPackCommand(t, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Fatal("request should not be sent")
+	}), "install", "magento",
+		"--non-interactive",
+		"--base-url", "https://store.example.com",
+		"--database-host", "mariadb",
+		"--database-name", "magento",
+	)
+	if err == nil || !strings.Contains(err.Error(), "analytics credentials are required") {
+		t.Fatalf("expected credential-reference error, output=%q err=%v", output, err)
+	}
+}
+
+func TestPackAPIErrorIsActionable(t *testing.T) {
+	_, err := runPackCommand(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":"read-only grant check failed"}`)
+	}), "status", "magento")
+	if err == nil || !strings.Contains(err.Error(), "read-only grant check failed (HTTP 400)") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPackDoctorReportsOptionalWriteActionsSeparately(t *testing.T) {
+	output, err := runPackCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/admin/packs/magento/doctor" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"packId":"magento","status":"ready","checks":[{"id":"analytics","status":"ready","detail":"SELECT-only grants verified"},{"id":"operator","status":"optional","detail":"Write actions are not enabled; analytics and automations are healthy."}]}`)
+	}), "doctor", "magento")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"magento: ready", "analytics: ready", "write actions: optional"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("missing %q in %q", want, output)
+		}
+	}
+}
+
+func TestPackManageShowsOnePageOverviewAndCommonTasks(t *testing.T) {
+	output, err := runPackCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/admin/packs/magento/status":
+			_, _ = io.WriteString(w, `{"packId":"magento","version":"0.1.0","status":"installed","readiness":{"analytics":{"status":"ready","reason":null}},"lastError":null}`)
+		case "/admin/packs/magento/doctor":
+			_, _ = io.WriteString(w, `{"packId":"magento","status":"degraded","checks":[{"id":"analytics","status":"ready","detail":"SELECT-only grants verified"}]}`)
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+	}), "manage", "magento")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"magento@0.1.0: installed",
+		"Health checks:",
+		"analytics: ready",
+		"openneko pack configure magento",
+		"openneko pack upgrade magento",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("missing %q in %q", want, output)
+		}
+	}
+}
+
+func TestPackConfigureUsesStoredReferences(t *testing.T) {
+	_, err := runPackCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/admin/packs/magento/configure" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		var body struct {
+			SecretRefs map[string]string `json:"secretRefs"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body.SecretRefs["magento.integration_token"] != "MAGENTO_TOKEN" {
+			t.Fatalf("integration token reference missing: %#v", body.SecretRefs)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"packId":"magento","version":"0.1.0","status":"installed","readiness":{"analytics":{"status":"ready","reason":null},"operator":{"status":"blocked","reason":"graphjin_version_unsupported"}}}`)
+	}), "configure", "magento", "--integration-token-ref", "MAGENTO_TOKEN")
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestPackUninstallRetainsHistoryAndData(t *testing.T) {
+	output, err := runPackCommand(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/admin/packs/magento/uninstall" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		var body struct {
+			IdempotencyKey string `json:"idempotencyKey"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body.IdempotencyKey == "" {
+			t.Fatal("uninstall request omitted idempotency key")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"packId":"magento","version":"0.1.0","status":"removed","readiness":{},"installedAt":"2026-08-20T00:00:00Z","lastError":null}`)
+	}), "uninstall", "magento")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output != "uninstalled magento@0.1.0 (history and data retained)\n" {
+		t.Fatalf("unexpected output: %q", output)
+	}
+}

--- a/apps/openneko/internal/cli/root.go
+++ b/apps/openneko/internal/cli/root.go
@@ -69,6 +69,7 @@ func NewRoot() *cobra.Command {
 
 Getting started: setup (guided install — preflight, bring-up, configure).
 Plugin ops: init, install, list, remove, marketplace, secrets, doctor.
+Solution packs: pack list, pack inspect, pack plan, pack install, pack status.
 Stack ops:  start, upgrade, stop, logs, status, backup, restore, migrate, seed, reset.
 Developer ops: eval.`,
 		Version:       version.Version,
@@ -92,6 +93,7 @@ Developer ops: eval.`,
 		newDoctorCmd(),
 		newMarketplaceCmd(),
 		newSecretsCmd(),
+		newPackCmd(),
 		newVersionCmd(),
 		newStartCmd(),
 		newUpgradeCmd(),

--- a/apps/openneko/internal/cli/status.go
+++ b/apps/openneko/internal/cli/status.go
@@ -49,6 +49,7 @@ var oneShotJobs = map[string]bool{
 	"neko-adventureworks-seed":     true,
 	"openshell-certgen":            true,
 	"openshell-reg":                true,
+	"openshell-ready":              true,
 }
 
 func newStatusCmd() *cobra.Command {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -2,6 +2,18 @@ import path from "node:path";
 import type { NextConfig } from "next";
 import pkg from "./package.json";
 
+const hostWebDev = process.env.OPENNEKO_HOST_WEB_DEV === "1";
+const demoMode =
+  process.env.OPENNEKO_STACK_MODE === "demo" ||
+  process.env.NEXT_PUBLIC_DEMO === "true" ||
+  process.env.DEMO === "true";
+
+if (hostWebDev && (process.env.NODE_ENV !== "development" || demoMode)) {
+  throw new Error(
+    "OPENNEKO_HOST_WEB_DEV is development-only; production and demo modes must run web inside the stack.",
+  );
+}
+
 const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_APP_VERSION: pkg.version,

--- a/apps/web/src/app/(work)/library/page.tsx
+++ b/apps/web/src/app/(work)/library/page.tsx
@@ -4,6 +4,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { FileText, RefreshCw, Share2, Trash2, Upload } from "lucide-react";
 import { confirmDialog } from "@/components/ConfirmModal";
 import PageHeading from "@/components/PageHeading";
+import { ActionGroup } from "@/components/ui/ActionGroup";
+import { Button } from "@/components/ui/Button";
+import { MenuItem, OverflowMenu } from "@/components/ui/OverflowMenu";
+import { Pill, type PillVariant } from "@/components/ui/Pill";
 
 type DocumentRow = {
   id: string;
@@ -55,6 +59,19 @@ async function fetchLibraryData(signal?: AbortSignal): Promise<LibraryData> {
     team: data.team ?? [],
     pending: data.pending ?? [],
   };
+}
+
+function statusVariant(status: string): PillVariant {
+  if (["cataloged", "stable", "approved", "ready"].includes(status)) {
+    return "success";
+  }
+  if (["failed", "declined", "deprecated"].includes(status)) {
+    return "danger";
+  }
+  if (["pending", "processing", "review"].includes(status)) {
+    return "watch";
+  }
+  return "muted";
 }
 
 export default function LibraryPage() {
@@ -360,7 +377,7 @@ export default function LibraryPage() {
           </div>
         ) : null}
       </div>
-      <div className="memory-review-actions">{actions}</div>
+      <ActionGroup className="memory-review-actions">{actions}</ActionGroup>
     </li>
   );
 
@@ -390,9 +407,14 @@ export default function LibraryPage() {
               <strong>Library unavailable</strong>
               <span>{error}</span>
             </div>
-            <button type="button" onClick={() => void refresh()}>
+            <Button
+              variant="danger"
+              size="sm"
+              className="shrink-0"
+              onClick={() => void refresh()}
+            >
               Retry
-            </button>
+            </Button>
           </div>
         ) : null}
 
@@ -411,21 +433,21 @@ export default function LibraryPage() {
                   concept,
                   index,
                   <>
-                    <button
-                      type="button"
-                      className="is-primary"
+                    <Button
+                      variant="primary"
+                      size="sm"
                       disabled={busyId === concept.id}
                       onClick={() => void decide(concept.id, "approve")}
                     >
                       Approve
-                    </button>
-                    <button
-                      type="button"
+                    </Button>
+                    <Button
+                      size="sm"
                       disabled={busyId === concept.id}
                       onClick={() => void decide(concept.id, "decline")}
                     >
                       Decline
-                    </button>
+                    </Button>
                   </>,
                 ),
               )}
@@ -439,7 +461,7 @@ export default function LibraryPage() {
               <span>Uploads</span>
               <h2>Your documents</h2>
             </div>
-            <div className="memory-review-actions">
+            <ActionGroup className="memory-review-actions">
               <input
                 ref={fileInputRef}
                 type="file"
@@ -447,16 +469,15 @@ export default function LibraryPage() {
                 hidden
                 onChange={(event) => void upload(event.target.files)}
               />
-              <button
-                type="button"
-                className="is-primary"
+              <Button
+                variant="primary"
                 disabled={uploading}
                 onClick={() => fileInputRef.current?.click()}
               >
-                <Upload aria-hidden="true" strokeWidth={2} size={12} />{" "}
+                <Upload aria-hidden="true" strokeWidth={2} />
                 {uploading ? "Uploading…" : "Upload"}
-              </button>
-            </div>
+              </Button>
+            </ActionGroup>
           </header>
           {loading ? (
             <div className="library-loading" role="status" aria-label="Loading library">
@@ -495,28 +516,32 @@ export default function LibraryPage() {
                       <small>{doc.error}</small>
                     ) : null}
                   </div>
-                  <div className="memory-review-actions">
-                    <span data-status={doc.status}>{humanize(doc.status)}</span>
+                  <ActionGroup className="memory-review-actions">
+                    <Pill variant={statusVariant(doc.status)}>
+                      {humanize(doc.status)}
+                    </Pill>
                     {doc.status === "failed" || doc.status === "skipped" ? (
-                      <button
-                        type="button"
+                      <Button
+                        size="sm"
                         disabled={busyId === doc.id}
                         onClick={() => void retryDocument(doc.id)}
                         title="Distill this document (bypasses triage)"
                       >
-                        <RefreshCw aria-hidden="true" strokeWidth={2} size={12} />{" "}
+                        <RefreshCw aria-hidden="true" strokeWidth={2} />
                         Retry
-                      </button>
+                      </Button>
                     ) : null}
-                    <button
-                      type="button"
-                      disabled={busyId === doc.id}
-                      onClick={() => void removeDocument(doc.id)}
-                      title="Remove from library"
-                    >
-                      <Trash2 aria-hidden="true" strokeWidth={2} size={12} />
-                    </button>
-                  </div>
+                    <OverflowMenu label={`Actions for ${doc.filename}`}>
+                      <MenuItem
+                        danger
+                        disabled={busyId === doc.id}
+                        onClick={() => void removeDocument(doc.id)}
+                      >
+                        <Trash2 aria-hidden="true" strokeWidth={2} />
+                        Remove from library
+                      </MenuItem>
+                    </OverflowMenu>
+                  </ActionGroup>
                 </li>
               ))}
             </ol>
@@ -546,22 +571,24 @@ export default function LibraryPage() {
                   concept,
                   index,
                   <>
-                    <button
-                      type="button"
+                    <Button
+                      size="sm"
                       disabled={busyId === concept.id}
                       onClick={() => void share(concept.id)}
                     >
-                      <Share2 aria-hidden="true" strokeWidth={2} size={12} /> Share
-                      with team
-                    </button>
-                    <button
-                      type="button"
-                      disabled={busyId === concept.id}
-                      onClick={() => void archiveConcept(concept.id)}
-                      title="Archive concept"
-                    >
-                      <Trash2 aria-hidden="true" strokeWidth={2} size={12} />
-                    </button>
+                      <Share2 aria-hidden="true" strokeWidth={2} />
+                      Share with team
+                    </Button>
+                    <OverflowMenu label={`Actions for ${concept.title}`}>
+                      <MenuItem
+                        danger
+                        disabled={busyId === concept.id}
+                        onClick={() => void archiveConcept(concept.id)}
+                      >
+                        <Trash2 aria-hidden="true" strokeWidth={2} />
+                        Archive concept
+                      </MenuItem>
+                    </OverflowMenu>
                   </>,
                 ),
               )}
@@ -592,16 +619,21 @@ export default function LibraryPage() {
                   concept,
                   index,
                   <>
-                    <span data-status={concept.status}>{humanize(concept.status)}</span>
+                    <Pill variant={statusVariant(concept.status)}>
+                      {humanize(concept.status)}
+                    </Pill>
                     {isAdmin && concept.status === "stable" ? (
-                      <button
-                        type="button"
-                        disabled={busyId === concept.id}
-                        onClick={() => void decide(concept.id, "deprecate")}
-                        title="Retire from the assistant's knowledge"
-                      >
-                        Deprecate
-                      </button>
+                      <OverflowMenu label={`Actions for ${concept.title}`}>
+                        <MenuItem
+                          danger
+                          disabled={busyId === concept.id}
+                          onClick={() => void decide(concept.id, "deprecate")}
+                          title="Retire from the assistant's knowledge"
+                        >
+                          <Trash2 aria-hidden="true" strokeWidth={2} />
+                          Deprecate concept
+                        </MenuItem>
+                      </OverflowMenu>
                     ) : null}
                   </>,
                 ),
@@ -617,10 +649,13 @@ export default function LibraryPage() {
                 <h2>Portability &amp; starter packs</h2>
               </div>
             </header>
-            <div className="memory-review-actions library-portability">
-              <button type="button" onClick={() => void exportBundle()}>
+            <ActionGroup
+              align="start"
+              className="memory-review-actions library-portability"
+            >
+              <Button size="sm" onClick={() => void exportBundle()}>
                 Export OKF bundle
-              </button>
+              </Button>
               <input
                 ref={importInputRef}
                 type="file"
@@ -628,10 +663,13 @@ export default function LibraryPage() {
                 hidden
                 onChange={(event) => void importBundle(event.target.files)}
               />
-              <button type="button" onClick={() => importInputRef.current?.click()}>
+              <Button
+                size="sm"
+                onClick={() => importInputRef.current?.click()}
+              >
                 Import bundle
-              </button>
-            </div>
+              </Button>
+            </ActionGroup>
             {packs.length > 0 ? (
               <ol className="memory-review-list">
                 {packs.map((pack, index) => (
@@ -647,15 +685,16 @@ export default function LibraryPage() {
                       <p>{pack.title}</p>
                       {pack.description ? <small>{pack.description}</small> : null}
                     </div>
-                    <div className="memory-review-actions">
-                      <button
-                        type="button"
+                    <ActionGroup className="memory-review-actions">
+                      <Button
+                        variant="primary"
+                        size="sm"
                         disabled={busyId === pack.id}
                         onClick={() => void installPack(pack.id)}
                       >
                         Install
-                      </button>
-                    </div>
+                      </Button>
+                    </ActionGroup>
                   </li>
                 ))}
               </ol>

--- a/apps/web/src/app/(work)/memory/page.tsx
+++ b/apps/web/src/app/(work)/memory/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { Archive, Pin } from "lucide-react";
 import { confirmDialog } from "@/components/ConfirmModal";
 import PageHeading from "@/components/PageHeading";
+import { Button, IconButton } from "@/components/ui/Button";
 
 type MemoryRow = {
   id: string;
@@ -175,9 +176,14 @@ export default function MemoryPage() {
               <strong>Memory unavailable</strong>
               <span>{error}</span>
             </div>
-            <button type="button" onClick={() => void refresh()}>
+            <Button
+              variant="danger"
+              size="sm"
+              className="shrink-0"
+              onClick={() => void refresh()}
+            >
               Retry
-            </button>
+            </Button>
           </div>
         ) : null}
 
@@ -206,21 +212,21 @@ export default function MemoryPage() {
                     {item.reasoning ? <small>{item.reasoning}</small> : null}
                   </div>
                   <div className="memory-review-actions">
-                    <button
-                      type="button"
-                      className="is-primary"
+                    <Button
+                      variant="primary"
+                      size="sm"
                       disabled={busyId === item.id}
                       onClick={() => void decide(item.id, "accept")}
                     >
                       Save globally
-                    </button>
-                    <button
-                      type="button"
+                    </Button>
+                    <Button
+                      size="sm"
                       disabled={busyId === item.id}
                       onClick={() => void decide(item.id, "decline")}
                     >
                       Decline
-                    </button>
+                    </Button>
                   </div>
                 </li>
               ))}
@@ -291,16 +297,15 @@ export default function MemoryPage() {
                             : "not used"}
                       </small>
                     </div>
-                    <button
-                      type="button"
-                      className="memory-archive"
+                    <IconButton
+                      label="Archive memory"
+                      variant="danger"
+                      className="memory-archive-control"
                       disabled={busyId === memory.id}
                       onClick={() => void archive(memory.id)}
-                      aria-label="Archive memory"
-                      title="Archive memory"
                     >
                       <Archive aria-hidden="true" strokeWidth={1.9} />
-                    </button>
+                    </IconButton>
                   </li>
                 ))}
               </ol>

--- a/apps/web/src/app/(work)/skills/page.tsx
+++ b/apps/web/src/app/(work)/skills/page.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { ArrowUpRight, FileText, Trash2 } from "lucide-react";
 import { confirmDialog } from "@/components/ConfirmModal";
 import PageHeading from "@/components/PageHeading";
+import { Button, IconButton } from "@/components/ui/Button";
 
 type SkillSummary = {
   name: string;
@@ -117,9 +118,14 @@ export default function SkillsPage() {
               <strong>Skills unavailable</strong>
               <span>{error}</span>
             </div>
-            <button type="button" onClick={() => void refresh()}>
+            <Button
+              variant="danger"
+              size="sm"
+              className="shrink-0"
+              onClick={() => void refresh()}
+            >
               Retry
-            </button>
+            </Button>
           </div>
         ) : null}
 
@@ -179,16 +185,15 @@ export default function SkillsPage() {
                         strokeWidth={1.9}
                       />
                     </Link>
-                    <button
-                      type="button"
-                      className="skill-delete"
+                    <IconButton
+                      label={`Delete skill ${skill.name}`}
+                      variant="danger"
+                      className="skill-delete-control"
                       disabled={busyName === skill.name}
                       onClick={() => void remove(skill.name)}
-                      aria-label={`Delete skill ${skill.name}`}
-                      title="Delete skill"
                     >
                       <Trash2 aria-hidden="true" strokeWidth={1.9} />
-                    </button>
+                    </IconButton>
                   </li>
                 ))}
               </ol>

--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -1211,7 +1211,7 @@ export default function WorkScreen() {
               <div key={`${message.id}-${index}`} className="flex flex-col gap-2.5">
                 {briefingCardCtx ? (
                   <div className="flex flex-col gap-2 mb-1">
-                    <div className="inline-flex items-center gap-2.5 font-display text-[10.5px] font-bold tracking-[0.14em] uppercase text-text3">
+                    <div className="inline-flex items-center gap-2.5 font-display text-ui-label font-bold tracking-[0.14em] uppercase text-text3">
                       <span aria-hidden="true" className="w-6 h-px bg-border" />
                       From your briefing
                     </div>
@@ -1298,7 +1298,7 @@ export default function WorkScreen() {
                   type="button"
                   role="option"
                   aria-selected={i === mentionActiveIndex}
-                  className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-[13px] ${
+                  className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-ui-body-sm ${
                     i === mentionActiveIndex
                       ? "bg-neutral-soft text-text"
                       : "text-text2"
@@ -1330,7 +1330,7 @@ export default function WorkScreen() {
                   <span className="max-w-[140px] overflow-hidden text-ellipsis whitespace-nowrap text-text">
                     {file.name}
                   </span>
-                  <span className="text-text3 tabular-nums text-[10.5px] tracking-wide">
+                  <span className="text-text3 tabular-nums text-ui-label tracking-wide">
                     {Math.max(1, Math.round(file.size / 1024))} KB
                   </span>
                   <button
@@ -1564,14 +1564,14 @@ function PendingMemoryPanel({
   if (!item) return null;
   return (
     <div className="flex items-center justify-between gap-3 border border-border bg-white/80 rounded-2xl px-3 py-2.5 shadow-soft max-[560px]:items-stretch max-[560px]:flex-col">
-      <div className="min-w-0 text-[12.5px] leading-[1.45] text-text2">
-        <div className="text-[10.5px] font-bold tracking-[0.13em] uppercase text-text3 mb-0.5">Memory suggestion</div>
+      <div className="min-w-0 text-ui-body-sm leading-[1.45] text-text2">
+        <div className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3 mb-0.5">Memory suggestion</div>
         <div>{item.draftText}</div>
         {pending.length > 1 ? (
-          <div className="mt-1 text-text3 text-[11px]">+{pending.length - 1} more</div>
+          <div className="mt-1 text-text3 text-ui-label">+{pending.length - 1} more</div>
         ) : null}
       </div>
-      <div className="inline-flex min-w-0 gap-[7px] flex-wrap justify-end flex-shrink-0 max-[560px]:justify-start [&_button]:h-[30px] [&_button]:max-w-full [&_button]:rounded-[10px] [&_button]:border [&_button]:border-border [&_button]:bg-card [&_button]:text-text2 [&_button]:inline-flex [&_button]:items-center [&_button]:justify-center [&_button]:gap-1 [&_button]:px-2 [&_button]:text-[11px] [&_button]:cursor-pointer [&_button]:transition-all [&_button]:duration-200 [&_button:hover]:border-accent [&_button:hover]:text-accent">
+      <div className="inline-flex min-w-0 gap-[7px] flex-wrap justify-end flex-shrink-0 max-[560px]:justify-start [&_button]:h-[30px] [&_button]:max-w-full [&_button]:rounded-[10px] [&_button]:border [&_button]:border-border [&_button]:bg-card [&_button]:text-text2 [&_button]:inline-flex [&_button]:items-center [&_button]:justify-center [&_button]:gap-1 [&_button]:px-2 [&_button]:text-ui-label [&_button]:cursor-pointer [&_button]:transition-all [&_button]:duration-200 [&_button:hover]:border-accent [&_button:hover]:text-accent">
         <button type="button" onClick={() => onDecide(item.id, "decline")} title="Dismiss">
           <X size={14} />
         </button>
@@ -2499,7 +2499,7 @@ function RunTimeline({
           );
         }
         return (
-          <div key={`error-${index}`} className="border border-warn/40 bg-warn-soft text-warn-ink rounded-2xl px-3 py-2.5 text-[13px]">
+          <div key={`error-${index}`} className="border border-warn/40 bg-warn-soft text-warn-ink rounded-2xl px-3 py-2.5 text-ui-body-sm">
             {item.message}
           </div>
         );
@@ -2515,7 +2515,7 @@ function RunTimeline({
           <span>{presentation.lastStatus ?? "Running…"}</span>
         </div>
       ) : null}
-      {!pending && run?.error ? <div className="border border-warn/40 bg-warn-soft text-warn-ink rounded-2xl px-3 py-2.5 text-[13px]">{run.error}</div> : null}
+      {!pending && run?.error ? <div className="border border-warn/40 bg-warn-soft text-warn-ink rounded-2xl px-3 py-2.5 text-ui-body-sm">{run.error}</div> : null}
       {!pending && hasContent ? (
         <AnswerRunFooter
           run={run}

--- a/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
+++ b/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
@@ -549,7 +549,7 @@ function WorkflowRow({
             <ArrowUpRight className="workflows-row-arrow" aria-hidden="true" />
           </div>
           {w.description && (
-            <div className="text-[13px] text-text2 mt-1 leading-[1.45]">{w.description}</div>
+            <div className="text-ui-body-sm text-text2 mt-1 leading-[1.45]">{w.description}</div>
           )}
           <div className="workflows-row-meta">
             <span>
@@ -831,7 +831,7 @@ function WorkflowDetail({
       </Section>
 
       <Section title="Schedule">
-        <div className="flex items-center justify-between gap-3 text-[13px]">
+        <div className="flex items-center justify-between gap-3 text-ui-body-sm">
           <span>
             {describeSchedule(
               workflow.cron,
@@ -883,11 +883,11 @@ function WorkflowDetail({
         ) : (
           <ul className="list-none p-0 mt-0 mb-1.5 flex flex-col gap-1.5">
             {policies.map((p) => (
-              <li key={p.id} className="flex min-w-0 items-start gap-2 text-[12.5px]">
-                <span className="min-w-0 flex-1 font-mono text-[11.5px] text-text2 [overflow-wrap:anywhere]">{p.name}</span>
+              <li key={p.id} className="flex min-w-0 items-start gap-2 text-ui-body-sm">
+                <span className="min-w-0 flex-1 font-mono text-ui-caption text-text2 [overflow-wrap:anywhere]">{p.name}</span>
                 <span
                   className={cn(
-                    "shrink-0 whitespace-nowrap text-[9.5px] font-bold tracking-[0.13em] uppercase px-1.5 py-0.5 rounded-full ml-auto",
+                    "shrink-0 whitespace-nowrap text-ui-label font-bold tracking-[0.13em] uppercase px-1.5 py-0.5 rounded-full ml-auto",
                     policyModeClass(p.mode),
                   )}
                 >
@@ -908,7 +908,7 @@ function WorkflowDetail({
         ) : (
           <ul className="list-none p-0 m-0 flex flex-col gap-1.5">
             {recentRuns.map((r) => (
-              <li key={r.id} className="flex items-baseline gap-2 text-[13px]">
+              <li key={r.id} className="flex items-baseline gap-2 text-ui-body-sm">
                 <button
                   type="button"
                   className="workflow-drawer-run-link"
@@ -926,7 +926,7 @@ function WorkflowDetail({
                     {formatRelative(r.createdAt)} · {r.triggerKind} ·{" "}
                     {formatDuration(r.durationMs)}
                   </span>
-                  <span className="workflow-drawer-run-arrow ml-auto text-text3 font-mono text-[11.5px] transition-[color,transform] duration-[0.18s]" aria-hidden="true">
+                  <span className="workflow-drawer-run-arrow ml-auto text-text3 font-mono text-ui-caption transition-[color,transform] duration-[0.18s]" aria-hidden="true">
                     →
                   </span>
                 </button>
@@ -952,7 +952,7 @@ function WorkflowDetail({
                   )}
                   <span
                     className={cn(
-                      "ml-auto shrink-0 whitespace-nowrap text-[10.5px] font-bold tracking-[0.08em] uppercase px-2 py-0.5 rounded-full",
+                      "ml-auto shrink-0 whitespace-nowrap text-ui-label font-bold tracking-[0.08em] uppercase px-2 py-0.5 rounded-full",
                       actionPillClass(a.status),
                     )}
                   >

--- a/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
+++ b/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
@@ -10,6 +10,7 @@ import { describeSchedule } from "@/lib/cron-english";
 import { formatSavedShort } from "@/lib/hours-saved";
 import { Sparkline } from "@/components/Sparkline";
 import PageHeading from "@/components/PageHeading";
+import { Button, IconButton } from "@/components/ui/Button";
 
 type WorkflowListItem = {
   id: string;
@@ -269,9 +270,8 @@ export default function WorkflowsPage() {
               <strong>{String(grouped.broken.length).padStart(2, "0")}</strong>
               <span>attention</span>
             </div>
-            <button
-              type="button"
-              className="workflows-new-btn"
+            <Button
+              variant="primary"
               onClick={() =>
                 router.push(
                   `/work?seed=${encodeURIComponent("Set up a new workflow that ")}`,
@@ -280,7 +280,7 @@ export default function WorkflowsPage() {
             >
               <Plus aria-hidden="true" />
               New workflow
-            </button>
+            </Button>
           </div>
         }
       />
@@ -564,18 +564,19 @@ function WorkflowRow({
           </div>
           </div>
         </button>
-        <button
-          type="button"
+        <IconButton
+          label={`Delete ${w.name}`}
+          size="icon-sm"
+          variant="danger"
           className="workflows-row-delete"
           title="Delete workflow"
-          aria-label={`Delete ${w.name}`}
           onClick={(event) => {
             event.stopPropagation();
             onDelete();
           }}
         >
-          <Trash2 size={14} strokeWidth={2} />
-        </button>
+          <Trash2 aria-hidden="true" strokeWidth={2} />
+        </IconButton>
       </div>
     </li>
   );
@@ -736,9 +737,9 @@ function WorkflowDetail({
   return (
     <div className="workflow-detail">
       <div className="workflow-drawer-actions">
-        <button
-          type="button"
-          className="workflow-drawer-btn is-primary"
+        <Button
+          size="sm"
+          variant="primary"
           onClick={runNow}
           disabled={busy || !workflow.enabled}
           title={
@@ -748,25 +749,23 @@ function WorkflowDetail({
           }
         >
           Run now
-        </button>
-        <button
-          type="button"
-          className="workflow-drawer-btn"
+        </Button>
+        <Button
+          size="sm"
           onClick={togglePause}
           disabled={busy}
         >
           {workflow.enabled ? "Pause" : "Resume"}
-        </button>
+        </Button>
         {workflow.enabled && (
-          <button
-            type="button"
-            className="workflow-drawer-btn"
+          <Button
+            size="sm"
             onClick={pauseForToday}
             disabled={busy}
             title="Pause until midnight UTC; resumes automatically"
           >
             Pause for today
-          </button>
+          </Button>
         )}
       </div>
 

--- a/apps/web/src/app/a/[app]/[object]/[id]/page.tsx
+++ b/apps/web/src/app/a/[app]/[object]/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
   RecordRelatedLists,
 } from "@/components/records/RecordDetailActivity";
 import { PendingChangeMarker } from "@/components/records/PendingChangeMarker";
+import { buttonClassName } from "@/components/ui/Button";
 
 export const dynamic = "force-dynamic";
 
@@ -54,7 +55,13 @@ export default async function RecordDetailPage({
           <PendingChangeMarker actions={result.pendingActions} />
         </div>
         {result.view.permission.canUpdate && (
-          <Link className="records-secondary-action" href={`${base}/${encodeURIComponent(String(result.row.id))}/edit`}>
+          <Link
+            className={buttonClassName({
+              size: "sm",
+              className: "records-secondary-action",
+            })}
+            href={`${base}/${encodeURIComponent(String(result.row.id))}/edit`}
+          >
             <Pencil aria-hidden="true" /> Edit
           </Link>
         )}

--- a/apps/web/src/app/a/[app]/[object]/page.tsx
+++ b/apps/web/src/app/a/[app]/[object]/page.tsx
@@ -14,6 +14,7 @@ import { RecordTable } from "@/components/records/RecordTable";
 import { RecordViewBar } from "@/components/records/RecordViewBar";
 import { RecordsUnavailable } from "@/components/records/RecordsNotice";
 import { SubstrateStrip } from "@/components/records/SubstrateStrip";
+import { buttonClassName } from "@/components/ui/Button";
 import {
   normalizeRecordSavedViewDefinition,
   type RecordFilterExpression,
@@ -230,19 +231,35 @@ export default async function RecordObjectPage({
           {query.view && <input type="hidden" name="view" value={query.view} />}
         </form>
         {result.view.permission.canCreate && (
-          <Link className="records-primary-action" href={`${base}/new`}>
+          <Link
+            className={buttonClassName({
+              variant: "primary",
+              size: "sm",
+              className: "records-primary-action",
+            })}
+            href={`${base}/new`}
+          >
             <Plus aria-hidden="true" /> New {result.view.object.label.toLowerCase()}
           </Link>
         )}
         {actor.role === "admin" && (
           <Link
-            className="records-secondary-action"
+            className={buttonClassName({
+              size: "sm",
+              className: "records-secondary-action",
+            })}
             href={`/a/${result.app.appId}/admin?object=${encodeURIComponent(result.view.object.apiName)}`}
           >
             <Upload aria-hidden="true" /> Import
           </Link>
         )}
-        <Link className="records-secondary-action" href={`${base}/recycle`}>
+        <Link
+          className={buttonClassName({
+            size: "sm",
+            className: "records-secondary-action",
+          })}
+          href={`${base}/recycle`}
+        >
           <Trash2 aria-hidden="true" /> Recycle bin
         </Link>
       </header>

--- a/apps/web/src/app/actions/[actionRequestId]/page.tsx
+++ b/apps/web/src/app/actions/[actionRequestId]/page.tsx
@@ -11,6 +11,7 @@ import {
   parseRecordUpdatePayload,
   RecordActionDiff,
 } from "@/components/records/RecordActionDiff";
+import { Button } from "@/components/ui/Button";
 
 function actionStatusClasses(status: string): string {
   switch (status) {
@@ -257,14 +258,14 @@ export default function ActionPage() {
             .filter(Boolean)
             .join(" · ")}
           actions={
-            <button
-              type="button"
-              className="shrink-0 px-3.5 py-[7px] rounded-full border-[1.5px] border-border bg-white/60 font-body text-ui-body-sm font-semibold text-text2 cursor-pointer transition hover:border-accent hover:text-accent hover:bg-accent-soft"
+            <Button
+              size="sm"
+              className="shrink-0"
               onClick={askFollowUp}
               title="Open an Ask thread pre-loaded with this action's context"
             >
               Ask a follow-up →
-            </button>
+            </Button>
           }
         />
 
@@ -429,17 +430,16 @@ export default function ActionPage() {
                   rows={2}
                 />
                 <div className="flex gap-2 mt-2.5">
-                  <button
-                    type="button"
-                    className="px-3.5 py-[7px] rounded-[10px] border border-danger bg-danger text-white font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:bg-[#c84545] hover:enabled:border-[#c84545] disabled:opacity-55 disabled:cursor-not-allowed"
+                  <Button
+                    variant="danger"
+                    size="sm"
                     disabled={busy}
                     onClick={() => void submitReject()}
                   >
                     Confirm reject
-                  </button>
-                  <button
-                    type="button"
-                    className="px-3.5 py-[7px] rounded-[10px] border border-border bg-card text-text font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:border-text3 disabled:opacity-55 disabled:cursor-not-allowed"
+                  </Button>
+                  <Button
+                    size="sm"
                     disabled={busy}
                     onClick={() => {
                       setRejecting(false);
@@ -447,27 +447,27 @@ export default function ActionPage() {
                     }}
                   >
                     Cancel
-                  </button>
+                  </Button>
                 </div>
               </div>
             ) : (
               <div className="flex gap-2 mt-2.5">
-                <button
-                  type="button"
-                  className="px-3.5 py-[7px] rounded-[10px] border border-accent bg-accent text-white font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:bg-[#5a4cd1] hover:enabled:border-[#5a4cd1] disabled:opacity-55 disabled:cursor-not-allowed"
+                <Button
+                  variant="primary"
+                  size="sm"
                   disabled={busy}
                   onClick={() => void submitDecision("approve")}
                 >
                   Approve
-                </button>
-                <button
-                  type="button"
-                  className="px-3.5 py-[7px] rounded-[10px] border border-border bg-card text-text font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:border-text3 disabled:opacity-55 disabled:cursor-not-allowed"
+                </Button>
+                <Button
+                  variant="danger"
+                  size="sm"
                   disabled={busy}
                   onClick={() => setRejecting(true)}
                 >
                   Reject
-                </button>
+                </Button>
               </div>
             )}
           </Section>

--- a/apps/web/src/app/actions/[actionRequestId]/page.tsx
+++ b/apps/web/src/app/actions/[actionRequestId]/page.tsx
@@ -259,7 +259,7 @@ export default function ActionPage() {
           actions={
             <button
               type="button"
-              className="shrink-0 px-3.5 py-[7px] rounded-full border-[1.5px] border-border bg-white/60 font-body text-[12.5px] font-semibold text-text2 cursor-pointer transition hover:border-accent hover:text-accent hover:bg-accent-soft"
+              className="shrink-0 px-3.5 py-[7px] rounded-full border-[1.5px] border-border bg-white/60 font-body text-ui-body-sm font-semibold text-text2 cursor-pointer transition hover:border-accent hover:text-accent hover:bg-accent-soft"
               onClick={askFollowUp}
               title="Open an Ask thread pre-loaded with this action's context"
             >
@@ -336,7 +336,7 @@ export default function ActionPage() {
                   <span className="font-mono">{latestExecution.executor}</span>
                   <span className="text-text3/70"> · </span>
                   <span className={cn(
-                    "inline-block px-2 py-0.5 rounded-full text-[11.5px] font-semibold tracking-[0.04em] uppercase",
+                    "inline-block px-2 py-0.5 rounded-full text-ui-caption font-semibold tracking-[0.04em] uppercase",
                     actionStatusClasses(latestExecution.status),
                   )}>
                     {latestExecution.status}
@@ -350,7 +350,7 @@ export default function ActionPage() {
                     </>
                   )}
                   {latestExecution.error && (
-                    <div className="mt-1.5 px-2.5 py-2 bg-danger-soft text-danger rounded-lg font-mono text-[12.5px]">{latestExecution.error}</div>
+                    <div className="mt-1.5 px-2.5 py-2 bg-danger-soft text-danger rounded-lg font-mono text-ui-body-sm">{latestExecution.error}</div>
                   )}
                 </>
               ) : (
@@ -367,7 +367,7 @@ export default function ActionPage() {
                 {showPayload ? "hide" : "show"} JSON
               </button>
               {showPayload && (
-                <pre className="mt-2 px-3.5 py-3 bg-card border border-border rounded-[10px] font-mono text-[12.5px] text-text2 whitespace-pre-wrap break-words overflow-x-auto">
+                <pre className="mt-2 px-3.5 py-3 bg-card border border-border rounded-[10px] font-mono text-ui-body-sm text-text2 whitespace-pre-wrap break-words overflow-x-auto">
                   {JSON.stringify(ar.payload, null, 2)}
                 </pre>
               )}
@@ -378,7 +378,7 @@ export default function ActionPage() {
         {(workflow || upstreamOutput) && (
           <Section title="Lineage">
             {workflow && ar.workflowRunId && (
-              <p className="m-0 mb-2 text-[13.5px] text-text2 leading-[1.55]">
+              <p className="m-0 mb-2 text-ui-body text-text2 leading-[1.55]">
                 Proposed by workflow{" "}
                 <button
                   type="button"
@@ -391,7 +391,7 @@ export default function ActionPage() {
               </p>
             )}
             {upstreamOutput && (
-              <p className="m-0 mb-2 text-[13.5px] text-text2 leading-[1.55]">
+              <p className="m-0 mb-2 text-ui-body text-text2 leading-[1.55]">
                 Triggered by finding{" "}
                 <em>{upstreamOutput.title}</em>
                 {upstreamOutput.workflowRunId && (
@@ -417,11 +417,11 @@ export default function ActionPage() {
           <Section title="Decide">
             {rejecting ? (
               <div className="pt-3 border-t border-border mt-2.5 flex flex-col gap-2">
-                <label className="text-[11px] font-bold tracking-[0.13em] uppercase text-text3">
+                <label className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3">
                   Why are you rejecting this? (optional)
                 </label>
                 <textarea
-                  className="border border-border rounded-[10px] px-3 py-2 font-body text-[13px] text-text bg-card resize-y min-h-[50px] outline-none focus:border-accent"
+                  className="border border-border rounded-[10px] px-3 py-2 font-body text-ui-body-sm text-text bg-card resize-y min-h-[50px] outline-none focus:border-accent"
                   value={rejectReason}
                   placeholder="e.g. wrong channel, retry tomorrow…"
                   onChange={(e) => setRejectReason(e.target.value)}
@@ -431,7 +431,7 @@ export default function ActionPage() {
                 <div className="flex gap-2 mt-2.5">
                   <button
                     type="button"
-                    className="px-3.5 py-[7px] rounded-[10px] border border-danger bg-danger text-white font-body text-[13px] font-semibold cursor-pointer hover:enabled:bg-[#c84545] hover:enabled:border-[#c84545] disabled:opacity-55 disabled:cursor-not-allowed"
+                    className="px-3.5 py-[7px] rounded-[10px] border border-danger bg-danger text-white font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:bg-[#c84545] hover:enabled:border-[#c84545] disabled:opacity-55 disabled:cursor-not-allowed"
                     disabled={busy}
                     onClick={() => void submitReject()}
                   >
@@ -439,7 +439,7 @@ export default function ActionPage() {
                   </button>
                   <button
                     type="button"
-                    className="px-3.5 py-[7px] rounded-[10px] border border-border bg-card text-text font-body text-[13px] font-semibold cursor-pointer hover:enabled:border-text3 disabled:opacity-55 disabled:cursor-not-allowed"
+                    className="px-3.5 py-[7px] rounded-[10px] border border-border bg-card text-text font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:border-text3 disabled:opacity-55 disabled:cursor-not-allowed"
                     disabled={busy}
                     onClick={() => {
                       setRejecting(false);
@@ -454,7 +454,7 @@ export default function ActionPage() {
               <div className="flex gap-2 mt-2.5">
                 <button
                   type="button"
-                  className="px-3.5 py-[7px] rounded-[10px] border border-accent bg-accent text-white font-body text-[13px] font-semibold cursor-pointer hover:enabled:bg-[#5a4cd1] hover:enabled:border-[#5a4cd1] disabled:opacity-55 disabled:cursor-not-allowed"
+                  className="px-3.5 py-[7px] rounded-[10px] border border-accent bg-accent text-white font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:bg-[#5a4cd1] hover:enabled:border-[#5a4cd1] disabled:opacity-55 disabled:cursor-not-allowed"
                   disabled={busy}
                   onClick={() => void submitDecision("approve")}
                 >
@@ -462,7 +462,7 @@ export default function ActionPage() {
                 </button>
                 <button
                   type="button"
-                  className="px-3.5 py-[7px] rounded-[10px] border border-border bg-card text-text font-body text-[13px] font-semibold cursor-pointer hover:enabled:border-text3 disabled:opacity-55 disabled:cursor-not-allowed"
+                  className="px-3.5 py-[7px] rounded-[10px] border border-border bg-card text-text font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:border-text3 disabled:opacity-55 disabled:cursor-not-allowed"
                   disabled={busy}
                   onClick={() => setRejecting(true)}
                 >
@@ -488,7 +488,7 @@ function Section({
 }) {
   return (
     <div className="mb-7">
-      <div className="text-[10.5px] font-bold tracking-[0.13em] uppercase text-text3 mb-2.5">{title}</div>
+      <div className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3 mb-2.5">{title}</div>
       {children}
     </div>
   );
@@ -503,8 +503,8 @@ function Field({
 }) {
   return (
     <div className="grid grid-cols-[110px_1fr] gap-x-4 gap-y-2.5 items-baseline">
-      <dt className="text-[11.5px] font-bold tracking-[0.13em] uppercase text-text3 m-0">{label}</dt>
-      <dd className="m-0 text-[13.5px] text-text2 leading-[1.55]">{children}</dd>
+      <dt className="text-ui-caption font-bold tracking-[0.13em] uppercase text-text3 m-0">{label}</dt>
+      <dd className="m-0 text-ui-body text-text2 leading-[1.55]">{children}</dd>
     </div>
   );
 }

--- a/apps/web/src/app/actions/page.tsx
+++ b/apps/web/src/app/actions/page.tsx
@@ -257,7 +257,7 @@ function ActionsPageInner() {
                 key={t.key}
                 type="button"
                 className={cn(
-                  "font-body text-[13px] font-semibold px-3.5 py-2 -mb-px border-b-2 transition-[color,border-color] duration-[120ms] ease-out cursor-pointer",
+                  "font-body text-ui-body-sm font-semibold px-3.5 py-2 -mb-px border-b-2 transition-[color,border-color] duration-[120ms] ease-out cursor-pointer",
                   active
                     ? "text-text border-accent"
                     : "text-text3 border-transparent hover:text-text2",
@@ -271,9 +271,9 @@ function ActionsPageInner() {
         </div>
 
         {error ? (
-          <div className="py-[60px] text-center text-danger text-[14px]">{error}</div>
+          <div className="py-[60px] text-center text-danger text-ui-body">{error}</div>
         ) : data === null ? (
-          <div className="py-[60px] text-center text-text3 text-[14px]">Loading…</div>
+          <div className="py-[60px] text-center text-text3 text-ui-body">Loading…</div>
         ) : data.actions.length === 0 ? (
           <EmptyState filter={filter} onBack={() => router.push("/")} />
         ) : (
@@ -364,7 +364,7 @@ function ActionReadingPane({
   if (!action) {
     return (
       <aside className="triage-pane">
-        <div className="bg-card border border-border rounded-2xl px-5 py-10 text-center text-[13px] text-text3 shadow-soft">
+        <div className="bg-card border border-border rounded-2xl px-5 py-10 text-center text-ui-body-sm text-text3 shadow-soft">
           Select an action to review.
         </div>
       </aside>
@@ -382,23 +382,23 @@ function ActionReadingPane({
     <aside className="triage-pane">
       <div className="bg-card border border-border rounded-2xl px-5 py-[18px] shadow-soft">
         <div className="flex items-center gap-2.5 mb-2.5">
-          <span className={cn("font-display text-[9.5px] font-extrabold tracking-[0.08em] uppercase px-2 py-0.5 rounded-full", RISK_PILL[risk] ?? RISK_PILL.low)}>
+          <span className={cn("font-display text-ui-label font-extrabold tracking-[0.08em] uppercase px-2 py-0.5 rounded-full", RISK_PILL[risk] ?? RISK_PILL.low)}>
             {risk} risk
           </span>
-          <code className="ml-auto font-mono text-[11px] text-text3">{action.kind}</code>
+          <code className="ml-auto font-mono text-ui-label text-text3">{action.kind}</code>
         </div>
-        <h2 className="font-display text-[19px] font-extrabold tracking-[-0.02em] leading-[1.2] text-text">
+        <h2 className="font-display text-ui-section font-extrabold tracking-[-0.02em] leading-[1.2] text-text">
           {action.summary || action.kind}
         </h2>
-        <div className="text-[12.5px] text-text2 mt-2 leading-[1.5]">
+        <div className="text-ui-body-sm text-text2 mt-2 leading-[1.5]">
           Proposed by <span className="text-text font-semibold">{workflowDisplayName(action.workflow)}</span>
           {action.triggeredByObservation ? <> · triggered by “{action.triggeredByObservation.title}”</> : null}
         </div>
 
         {action.target && (
           <div className="mt-4">
-            <div className="text-[10px] font-bold tracking-[0.12em] uppercase text-text3 mb-1.5">Target</div>
-            <code className="font-mono text-[12px] text-text2 break-all">{action.target}</code>
+            <div className="text-ui-label font-bold tracking-[0.12em] uppercase text-text3 mb-1.5">Target</div>
+            <code className="font-mono text-ui-caption text-text2 break-all">{action.target}</code>
           </div>
         )}
 
@@ -414,10 +414,10 @@ function ActionReadingPane({
 
         {payloadEntries.length > 0 && (
           <div className="mt-4">
-            <div className="text-[10px] font-bold tracking-[0.12em] uppercase text-text3 mb-1.5">Payload</div>
+            <div className="text-ui-label font-bold tracking-[0.12em] uppercase text-text3 mb-1.5">Payload</div>
             <div className="bg-bg border border-border rounded-xl px-3 py-2.5 grid gap-1.5">
               {payloadEntries.map(([k, v]) => (
-                <div key={k} className="flex gap-3 text-[12px]">
+                <div key={k} className="flex gap-3 text-ui-caption">
                   <span className="text-text3 min-w-[88px] flex-none">{k}</span>
                   <span className="font-mono text-text break-all">
                     {typeof v === "object" ? JSON.stringify(v) : String(v)}
@@ -429,7 +429,7 @@ function ActionReadingPane({
         )}
 
         {(action.minutesSaved ?? 0) > 0 && (
-          <div className="mt-4 text-[12.5px] text-text2">
+          <div className="mt-4 text-ui-body-sm text-text2">
             Saves <span className="font-mono text-success-ink">{formatSavedShort(action.minutesSaved as number)}</span> of manual effort.
           </div>
         )}
@@ -439,7 +439,7 @@ function ActionReadingPane({
             type="button"
             disabled={busy}
             onClick={onApprove}
-            className="px-[18px] py-2.5 rounded-[11px] bg-accent text-white font-display font-bold text-[13.5px] tracking-[-0.01em] hover:bg-[#5a4cd1] disabled:opacity-50 cursor-pointer"
+            className="px-[18px] py-2.5 rounded-[11px] bg-accent text-white font-display font-bold text-ui-body tracking-[-0.01em] hover:bg-[#5a4cd1] disabled:opacity-50 cursor-pointer"
           >
             Approve
           </button>
@@ -447,7 +447,7 @@ function ActionReadingPane({
             type="button"
             disabled={busy}
             onClick={onReject}
-            className="px-[18px] py-2.5 rounded-[11px] border border-border text-text2 font-semibold text-[13.5px] hover:border-danger hover:text-danger disabled:opacity-50 cursor-pointer"
+            className="px-[18px] py-2.5 rounded-[11px] border border-border text-text2 font-semibold text-ui-body hover:border-danger hover:text-danger disabled:opacity-50 cursor-pointer"
           >
             Reject
           </button>
@@ -481,10 +481,10 @@ function EmptyState({ filter, onBack }: { filter: Filter; onBack: () => void }) 
   return (
     <div className="py-20 px-5 text-center text-text3">
       <p className="font-display text-2xl font-bold text-text tracking-[-0.01em] mb-2">{copy.line}</p>
-      <p className="text-[14px] leading-[1.5] max-w-[400px] mx-auto mb-6">{copy.sub}</p>
+      <p className="text-ui-body leading-[1.5] max-w-[400px] mx-auto mb-6">{copy.sub}</p>
       <button
         type="button"
-        className="bg-transparent border-0 text-accent [font:inherit] text-[13px] cursor-pointer p-0 hover:underline hover:[text-underline-offset:3px]"
+        className="bg-transparent border-0 text-accent [font:inherit] text-ui-body-sm cursor-pointer p-0 hover:underline hover:[text-underline-offset:3px]"
         onClick={onBack}
       >
         ← Back to dashboard

--- a/apps/web/src/app/actions/page.tsx
+++ b/apps/web/src/app/actions/page.tsx
@@ -18,6 +18,9 @@ import {
   parseRecordUpdatePayload,
   RecordActionDiff,
 } from "@/components/records/RecordActionDiff";
+import { Button } from "@/components/ui/Button";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Tab, Tabs } from "@/components/ui/Tabs";
 
 type Filter = "awaiting" | "fired" | "rejected" | "all";
 
@@ -249,33 +252,27 @@ function ActionsPageInner() {
           }
         />
 
-        <div className="flex gap-1 -mt-3 mb-[18px] border-b border-border">
+        <Tabs aria-label="Review queue filter" className="-mt-2 mb-[18px]">
           {TABS.map((t) => {
             const active = filter === t.key;
             return (
-              <button
+              <Tab
                 key={t.key}
-                type="button"
-                className={cn(
-                  "font-body text-ui-body-sm font-semibold px-3.5 py-2 -mb-px border-b-2 transition-[color,border-color] duration-[120ms] ease-out cursor-pointer",
-                  active
-                    ? "text-text border-accent"
-                    : "text-text3 border-transparent hover:text-text2",
-                )}
+                selected={active}
                 onClick={() => switchFilter(t.key)}
               >
                 {t.label}
-              </button>
+              </Tab>
             );
           })}
-        </div>
+        </Tabs>
 
         {error ? (
           <div className="py-[60px] text-center text-danger text-ui-body">{error}</div>
         ) : data === null ? (
           <div className="py-[60px] text-center text-text3 text-ui-body">Loading…</div>
         ) : data.actions.length === 0 ? (
-          <EmptyState filter={filter} onBack={() => router.push("/")} />
+          <ActionsEmptyState filter={filter} onBack={() => router.push("/")} />
         ) : (
           <div className="triage-layout">
             <div className="act-list triage-queue">
@@ -435,29 +432,27 @@ function ActionReadingPane({
         )}
 
         <div className="flex items-center gap-2.5 mt-[18px] pt-4 border-t border-border">
-          <button
-            type="button"
+          <Button
+            variant="primary"
             disabled={busy}
             onClick={onApprove}
-            className="px-[18px] py-2.5 rounded-[11px] bg-accent text-white font-display font-bold text-ui-body tracking-[-0.01em] hover:bg-[#5a4cd1] disabled:opacity-50 cursor-pointer"
           >
             Approve
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            variant="danger"
             disabled={busy}
             onClick={onReject}
-            className="px-[18px] py-2.5 rounded-[11px] border border-border text-text2 font-semibold text-ui-body hover:border-danger hover:text-danger disabled:opacity-50 cursor-pointer"
           >
             Reject
-          </button>
+          </Button>
         </div>
       </div>
     </aside>
   );
 }
 
-function EmptyState({ filter, onBack }: { filter: Filter; onBack: () => void }) {
+function ActionsEmptyState({ filter, onBack }: { filter: Filter; onBack: () => void }) {
   const copy =
     filter === "awaiting"
       ? {
@@ -479,16 +474,15 @@ function EmptyState({ filter, onBack }: { filter: Filter; onBack: () => void }) 
               sub: "Workflows haven't proposed anything yet. Once they do, the receipts live here.",
             };
   return (
-    <div className="py-20 px-5 text-center text-text3">
-      <p className="font-display text-2xl font-bold text-text tracking-[-0.01em] mb-2">{copy.line}</p>
-      <p className="text-ui-body leading-[1.5] max-w-[400px] mx-auto mb-6">{copy.sub}</p>
-      <button
-        type="button"
-        className="bg-transparent border-0 text-accent [font:inherit] text-ui-body-sm cursor-pointer p-0 hover:underline hover:[text-underline-offset:3px]"
-        onClick={onBack}
-      >
-        ← Back to dashboard
-      </button>
-    </div>
+    <EmptyState
+      title={copy.line}
+      body={copy.sub}
+      className="py-20"
+      action={
+        <Button variant="ghost" size="sm" onClick={onBack}>
+          ← Back to dashboard
+        </Button>
+      }
+    />
   );
 }

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -213,7 +213,7 @@ function AdminCardGroup({
 }) {
   return (
     <section className="mt-7">
-      <div className="mb-3 text-[11px] font-bold uppercase tracking-[0.14em] text-text3">
+      <div className="mb-3 text-ui-label font-bold uppercase tracking-[0.14em] text-text3">
         {title}
       </div>
       <div className="grid gap-3 md:grid-cols-2">
@@ -270,7 +270,7 @@ function SummaryStat({
         : "text-text";
   return (
     <div className="rounded-[14px] border border-border bg-card px-4 py-3 shadow-soft">
-      <div className="text-[10px] font-bold uppercase tracking-[0.12em] text-text3">
+      <div className="text-ui-label font-bold uppercase tracking-[0.12em] text-text3">
         {label}
       </div>
       <div className={`mt-2 font-display text-2xl font-bold ${toneClass}`}>

--- a/apps/web/src/app/admin/plugins/page.tsx
+++ b/apps/web/src/app/admin/plugins/page.tsx
@@ -116,7 +116,7 @@ export default async function AdminPluginsPage() {
         ) : (
           <div className="mt-4 border-t border-border">
             <div
-              className="hidden grid-cols-[minmax(0,0.9fr)_120px_minmax(0,1.5fr)] gap-5 border-b border-border py-2 text-[10px] font-bold uppercase tracking-[0.12em] text-text3 md:grid"
+              className="hidden grid-cols-[minmax(0,0.9fr)_120px_minmax(0,1.5fr)] gap-5 border-b border-border py-2 text-ui-label font-bold uppercase tracking-[0.12em] text-text3 md:grid"
               aria-hidden="true"
             >
               <div>Kind</div>
@@ -163,7 +163,7 @@ function Stat({
 }) {
   return (
     <div className="flex min-h-[92px] items-end justify-between gap-4 bg-card px-5 py-4">
-      <div className="text-[10px] font-bold uppercase tracking-[0.12em] text-text3">
+      <div className="text-ui-label font-bold uppercase tracking-[0.12em] text-text3">
         {label}
       </div>
       <div
@@ -190,7 +190,7 @@ function RegistryColumn({
     <div className="border-b border-border py-5 last:border-b-0 md:border-b-0 md:border-l md:px-5 md:first:border-l-0 md:first:pl-0 md:last:pr-0">
       <div className="flex items-center justify-between gap-3">
         <h3
-          className={`text-[10px] font-bold uppercase tracking-[0.12em] ${
+          className={`text-ui-label font-bold uppercase tracking-[0.12em] ${
             warn && values.length > 0 ? "text-danger" : "text-text3"
           }`}
         >
@@ -231,7 +231,7 @@ function Capability({
 }) {
   return (
     <div className="border-b border-border py-4 last:border-b-0 sm:border-b-0 sm:border-l sm:px-5 sm:first:border-l-0 sm:first:pl-0 sm:last:pr-0">
-      <div className="text-[10px] font-bold uppercase tracking-[0.12em] text-text3">
+      <div className="text-ui-label font-bold uppercase tracking-[0.12em] text-text3">
         {label}
       </div>
       <div className="mt-2 text-sm font-semibold leading-6 text-text">
@@ -250,7 +250,7 @@ function DescriptorField({
 }) {
   return (
     <div className="min-w-0">
-      <div className="mb-1 text-[9px] font-bold uppercase tracking-[0.12em] text-text3 md:hidden">
+      <div className="mb-1 text-ui-label font-bold uppercase tracking-[0.12em] text-text3 md:hidden">
         {label}
       </div>
       {children}

--- a/apps/web/src/app/admin/rules/RulesClient.tsx
+++ b/apps/web/src/app/admin/rules/RulesClient.tsx
@@ -275,7 +275,7 @@ function PolicyCard({
       className={cn("px-5 py-4.5", !policy.enabled && "opacity-60")}
     >
       <div className="flex items-center justify-between gap-3 mb-2 max-[560px]:items-start max-[560px]:flex-col">
-        <div className="min-w-0 max-w-full font-display text-[17px] font-bold tracking-[-0.01em] text-text [overflow-wrap:anywhere]">
+        <div className="min-w-0 max-w-full font-display text-ui-subsection font-bold tracking-[-0.01em] text-text [overflow-wrap:anywhere]">
           {policy.name}
         </div>
         <div className="flex max-w-full items-center gap-2 flex-wrap max-[560px]:self-stretch">
@@ -302,12 +302,12 @@ function PolicyCard({
       </div>
 
       {policy.description && (
-        <p className="text-[13.5px] text-text2 mt-0 mb-3 leading-[1.55]">
+        <p className="text-ui-body text-text2 mt-0 mb-3 leading-[1.55]">
           {policy.description}
         </p>
       )}
 
-      <dl className="m-0 flex flex-col gap-1 text-[13px]">
+      <dl className="m-0 flex flex-col gap-1 text-ui-body-sm">
         <Row label="Applies to">
           <span className="font-mono text-xs text-text2">{appliesKinds}</span>
           {appliesScopes && (
@@ -337,7 +337,7 @@ function Row({
 }) {
   return (
     <div className="grid grid-cols-[110px_minmax(0,1fr)] gap-2.5 items-baseline max-[480px]:grid-cols-1 max-[480px]:gap-0.5">
-      <dt className="text-[10.5px] font-bold tracking-[0.13em] uppercase text-text3">
+      <dt className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3">
         {label}
       </dt>
       <dd className="m-0 text-text break-words">{children}</dd>
@@ -394,19 +394,19 @@ function InstalledPluginsSection({
   return (
     <section className="mb-6">
       <div className="flex items-baseline justify-between mb-2.5">
-        <h2 className="font-display text-[18px] font-bold tracking-[-0.01em] text-text">
+        <h2 className="font-display text-ui-section font-bold tracking-[-0.01em] text-text">
           Installed plugins
         </h2>
-        <span className="font-mono text-[11px] text-text3">
+        <span className="font-mono text-ui-label text-text3">
           {descriptors.length} action kind{descriptors.length === 1 ? "" : "s"}
         </span>
       </div>
-      <p className="text-[13px] leading-[1.5] text-text2 mb-3 max-w-[640px]">
+      <p className="text-ui-body-sm leading-[1.5] text-text2 mb-3 max-w-[640px]">
         Plugins contribute action kinds the agent can call from /work. Each
         kind's effective approval mode comes from the rule whose
         <em> applies-to-kinds </em>
         includes it; everything else falls through to{" "}
-        <code className="font-mono text-[12px] bg-neutral px-1 rounded">
+        <code className="font-mono text-ui-caption bg-neutral px-1 rounded">
           external_default
         </code>
         . Click a kind to edit the rule that governs it.
@@ -414,7 +414,7 @@ function InstalledPluginsSection({
       <ul className="list-none p-0 m-0 flex flex-col gap-3">
         {[...groups.entries()].map(([groupName, kinds]) => (
           <Card key={groupName} as="li" className="px-5 py-4">
-            <div className="font-display text-[14px] font-bold uppercase tracking-[0.1em] text-text3 mb-2">
+            <div className="font-display text-ui-label font-bold uppercase tracking-[0.1em] text-text3 mb-2">
               {groupName}
             </div>
             <div className="flex flex-col gap-2">
@@ -429,10 +429,10 @@ function InstalledPluginsSection({
                     className="flex min-w-0 items-center justify-between gap-3 px-3 py-2 rounded-[10px] bg-neutral-soft max-[640px]:items-stretch max-[640px]:flex-col"
                   >
                     <div className="flex flex-col gap-0.5 min-w-0">
-                      <code className="font-mono text-[12px] text-text [overflow-wrap:anywhere]">
+                      <code className="font-mono text-ui-caption text-text [overflow-wrap:anywhere]">
                         {descriptor.kind}
                       </code>
-                      <span className="text-[11px] text-text3 truncate max-[640px]:whitespace-normal max-[640px]:[overflow-wrap:anywhere]">
+                      <span className="text-ui-caption text-text3 truncate max-[640px]:whitespace-normal max-[640px]:[overflow-wrap:anywhere]">
                         {descriptor.description}
                       </span>
                     </div>
@@ -440,14 +440,14 @@ function InstalledPluginsSection({
                       <Pill variant={modePillVariant(mode)}>
                         {describeMode(mode)}
                       </Pill>
-                      <span className="min-w-0 text-[10.5px] text-text3 [overflow-wrap:anywhere]">
+                      <span className="min-w-0 text-ui-label text-text3 [overflow-wrap:anywhere]">
                         {describeDefaultMode(descriptor.default_mode)}
                       </span>
                       {policyId ? (
                         <button
                           type="button"
                           onClick={() => onEditPolicy(policyId)}
-                          className="text-[11px] font-semibold text-text2 hover:text-accent bg-transparent border-0 p-0 cursor-pointer"
+                          className="text-ui-label font-semibold text-text2 hover:text-accent bg-transparent border-0 p-0 cursor-pointer"
                         >
                           edit rule →
                         </button>

--- a/apps/web/src/app/admin/rules/RulesClient.tsx
+++ b/apps/web/src/app/admin/rules/RulesClient.tsx
@@ -2,11 +2,15 @@
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import { Search } from "lucide-react";
 import AppHeader from "@/components/AppHeader";
 import CreatorCredit from "@/components/CreatorCredit";
 import PageHeading from "@/components/PageHeading";
 import SectionNav from "@/components/SectionNav";
-import { Card } from "@/components/ui/Card";
+import { ActionGroup } from "@/components/ui/ActionGroup";
+import { Button } from "@/components/ui/Button";
+import { Disclosure } from "@/components/ui/Disclosure";
+import { Input } from "@/components/ui/Field";
 import { Pill, type PillVariant } from "@/components/ui/Pill";
 import { cn } from "@/lib/cn";
 
@@ -138,6 +142,7 @@ export default function RulesClient() {
     PluginActionDescriptor[]
   >([]);
   const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
 
   useEffect(() => {
     let cancelled = false;
@@ -168,6 +173,17 @@ export default function RulesClient() {
     };
   }, []);
 
+  const normalizedQuery = query.trim().toLowerCase();
+  const filteredPolicies = policies?.filter((policy) =>
+    [
+      policy.name,
+      policy.description,
+      policy.mode,
+      ...policy.appliesToKinds,
+      ...policy.appliesToScopes,
+    ].some((value) => value.toLowerCase().includes(normalizedQuery)),
+  );
+
   return (
     <>
       <div
@@ -183,9 +199,8 @@ export default function RulesClient() {
           title="Rules"
           description="Control what agents may execute automatically, what requires review, and what is never allowed."
           actions={
-          <button
-            type="button"
-            className="px-4 py-2 rounded-full border-[1.5px] border-border bg-white/60 font-body text-sm font-semibold text-text2 cursor-pointer transition-[border-color,color,background,transform] duration-200 hover:border-accent hover:text-accent hover:bg-accent-soft hover:-translate-y-px"
+          <Button
+            variant="primary"
             onClick={() =>
               router.push(
                 `/work?seed=${encodeURIComponent("Add a new rule that ")}`,
@@ -193,9 +208,24 @@ export default function RulesClient() {
             }
           >
             + New rule
-          </button>
+          </Button>
           }
         />
+
+        <label className="relative mb-5 block max-w-[520px]">
+          <span className="sr-only">Search rules and action kinds</span>
+          <Search
+            aria-hidden="true"
+            className="pointer-events-none absolute left-3.5 top-1/2 z-10 size-4 -translate-y-1/2 text-text3"
+          />
+          <Input
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="Search rules and action kinds"
+            className="pl-10"
+          />
+        </label>
 
         {error ? (
           <div className="py-14 text-center text-sm text-danger">{error}</div>
@@ -207,6 +237,7 @@ export default function RulesClient() {
               <InstalledPluginsSection
                 descriptors={pluginDescriptors}
                 policies={policies}
+                query={query}
                 onEditPolicy={(policyId) => {
                   const policy = policies.find((p) => p.id === policyId);
                   const name = policy?.name ?? "this rule";
@@ -222,9 +253,13 @@ export default function RulesClient() {
                 No rules yet. Defaults are seeded automatically the first time a
                 workflow proposes an action that needs gating.
               </div>
+            ) : filteredPolicies?.length === 0 ? (
+              <div className="py-10 text-center text-ui-body-sm text-text2">
+                No rules match “{query}”.
+              </div>
             ) : (
-              <ul className="list-none p-0 m-0 flex flex-col gap-3.5">
-                {policies.map((p) => (
+              <ul className="list-none p-0 m-0 flex flex-col gap-2">
+                {filteredPolicies?.map((p) => (
                   <PolicyCard
                     key={p.id}
                     policy={p}
@@ -270,39 +305,17 @@ function PolicyCard({
   const limits = describeLimits(policy.limits);
 
   return (
-    <Card
-      as="li"
-      className={cn("px-5 py-4.5", !policy.enabled && "opacity-60")}
+    <Disclosure
+      title={policy.name}
+      meta={
+        <Pill variant={modePillVariant(policy.mode)}>
+          {describeMode(policy.mode)}
+        </Pill>
+      }
+      className={cn(!policy.enabled && "opacity-60")}
     >
-      <div className="flex items-center justify-between gap-3 mb-2 max-[560px]:items-start max-[560px]:flex-col">
-        <div className="min-w-0 max-w-full font-display text-ui-subsection font-bold tracking-[-0.01em] text-text [overflow-wrap:anywhere]">
-          {policy.name}
-        </div>
-        <div className="flex max-w-full items-center gap-2 flex-wrap max-[560px]:self-stretch">
-          <Pill variant={modePillVariant(policy.mode)}>
-            {describeMode(policy.mode)}
-          </Pill>
-          <button
-            type="button"
-            className="bg-transparent border-0 text-text3 cursor-pointer font-[inherit] text-xs px-1.5 py-1 hover:text-accent hover:underline underline-offset-2"
-            onClick={onOpen}
-            aria-label={`Open rule ${policy.name}`}
-          >
-            open
-          </button>
-          <button
-            type="button"
-            className="bg-transparent border-0 text-text3 cursor-pointer font-[inherit] text-xs px-1.5 py-1 hover:text-accent hover:underline underline-offset-2"
-            onClick={onEdit}
-            aria-label={`Edit rule ${policy.name}`}
-          >
-            edit
-          </button>
-        </div>
-      </div>
-
       {policy.description && (
-        <p className="text-ui-body text-text2 mt-0 mb-3 leading-[1.55]">
+        <p className="mb-3 text-ui-body text-text2 leading-[1.55]">
           {policy.description}
         </p>
       )}
@@ -324,7 +337,24 @@ function PolicyCard({
         {policy.approverRole && <Row label="Approver">{policy.approverRole}</Row>}
         {!policy.enabled && <Row label="Status">disabled</Row>}
       </dl>
-    </Card>
+      <ActionGroup align="start" className="mt-4">
+        <Button
+          size="sm"
+          onClick={onOpen}
+          aria-label={`Open rule ${policy.name}`}
+        >
+          View details
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onEdit}
+          aria-label={`Edit rule ${policy.name}`}
+        >
+          Edit in Work
+        </Button>
+      </ActionGroup>
+    </Disclosure>
   );
 }
 
@@ -372,10 +402,12 @@ function describeDefaultMode(
 function InstalledPluginsSection({
   descriptors,
   policies,
+  query,
   onEditPolicy,
 }: {
   descriptors: PluginActionDescriptor[];
   policies: Policy[];
+  query: string;
   onEditPolicy: (policyId: string) => void;
 }) {
   // descriptors are flat across plugins; the kind name itself carries
@@ -383,8 +415,13 @@ function InstalledPluginsSection({
   // committed to Option-A namespacing earlier in the design. Group
   // for display by the leading token — close enough until plugins
   // tell us their package name in the descriptor (a small follow-up).
+  const normalizedQuery = query.trim().toLowerCase();
+  const visibleDescriptors = descriptors.filter((descriptor) =>
+    [descriptor.kind, descriptor.description, pluginNameFromKind(descriptor.kind)]
+      .some((value) => value.toLowerCase().includes(normalizedQuery)),
+  );
   const groups = new Map<string, PluginActionDescriptor[]>();
-  for (const d of descriptors) {
+  for (const d of visibleDescriptors) {
     const key = pluginNameFromKind(d.kind);
     const list = groups.get(key) ?? [];
     list.push(d);
@@ -398,12 +435,13 @@ function InstalledPluginsSection({
           Installed plugins
         </h2>
         <span className="font-mono text-ui-label text-text3">
-          {descriptors.length} action kind{descriptors.length === 1 ? "" : "s"}
+          {visibleDescriptors.length} of {descriptors.length} action kind
+          {descriptors.length === 1 ? "" : "s"}
         </span>
       </div>
       <p className="text-ui-body-sm leading-[1.5] text-text2 mb-3 max-w-[640px]">
         Plugins contribute action kinds the agent can call from /work. Each
-        kind's effective approval mode comes from the rule whose
+        kind&apos;s effective approval mode comes from the rule whose
         <em> applies-to-kinds </em>
         includes it; everything else falls through to{" "}
         <code className="font-mono text-ui-caption bg-neutral px-1 rounded">
@@ -411,55 +449,64 @@ function InstalledPluginsSection({
         </code>
         . Click a kind to edit the rule that governs it.
       </p>
-      <ul className="list-none p-0 m-0 flex flex-col gap-3">
-        {[...groups.entries()].map(([groupName, kinds]) => (
-          <Card key={groupName} as="li" className="px-5 py-4">
-            <div className="font-display text-ui-label font-bold uppercase tracking-[0.1em] text-text3 mb-2">
-              {groupName}
-            </div>
-            <div className="flex flex-col gap-2">
-              {kinds.map((descriptor) => {
-                const { mode, policyId } = resolveEffectiveMode(
-                  descriptor.kind,
-                  policies,
-                );
-                return (
-                  <div
-                    key={descriptor.kind}
-                    className="flex min-w-0 items-center justify-between gap-3 px-3 py-2 rounded-[10px] bg-neutral-soft max-[640px]:items-stretch max-[640px]:flex-col"
-                  >
-                    <div className="flex flex-col gap-0.5 min-w-0">
-                      <code className="font-mono text-ui-caption text-text [overflow-wrap:anywhere]">
-                        {descriptor.kind}
-                      </code>
-                      <span className="text-ui-caption text-text3 truncate max-[640px]:whitespace-normal max-[640px]:[overflow-wrap:anywhere]">
-                        {descriptor.description}
-                      </span>
-                    </div>
-                    <div className="flex min-w-0 items-center justify-end gap-2 flex-wrap max-[640px]:justify-start">
-                      <Pill variant={modePillVariant(mode)}>
-                        {describeMode(mode)}
-                      </Pill>
-                      <span className="min-w-0 text-ui-label text-text3 [overflow-wrap:anywhere]">
-                        {describeDefaultMode(descriptor.default_mode)}
-                      </span>
-                      {policyId ? (
-                        <button
-                          type="button"
-                          onClick={() => onEditPolicy(policyId)}
-                          className="text-ui-label font-semibold text-text2 hover:text-accent bg-transparent border-0 p-0 cursor-pointer"
-                        >
-                          edit rule →
-                        </button>
-                      ) : null}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </Card>
-        ))}
-      </ul>
+      {groups.size === 0 ? (
+        <div className="border-y border-border py-8 text-center text-ui-body-sm text-text2">
+          No plugin action kinds match “{query}”.
+        </div>
+      ) : (
+        <ul className="list-none p-0 m-0 flex flex-col gap-2">
+          {[...groups.entries()].map(([groupName, kinds]) => (
+            <li key={groupName}>
+              <Disclosure
+                title={groupName}
+                meta={`${kinds.length} kind${kinds.length === 1 ? "" : "s"}`}
+                open={normalizedQuery ? true : undefined}
+              >
+                <div className="flex flex-col gap-2">
+                  {kinds.map((descriptor) => {
+                    const { mode, policyId } = resolveEffectiveMode(
+                      descriptor.kind,
+                      policies,
+                    );
+                    return (
+                      <div
+                        key={descriptor.kind}
+                        className="flex min-w-0 items-center justify-between gap-3 border-b border-border px-1 py-2.5 last:border-0 max-[640px]:items-stretch max-[640px]:flex-col"
+                      >
+                        <div className="flex flex-col gap-0.5 min-w-0">
+                          <code className="font-mono text-ui-caption text-text [overflow-wrap:anywhere]">
+                            {descriptor.kind}
+                          </code>
+                          <span className="text-ui-caption text-text3 max-[640px]:whitespace-normal [overflow-wrap:anywhere]">
+                            {descriptor.description}
+                          </span>
+                        </div>
+                        <div className="flex min-w-0 items-center justify-end gap-2 flex-wrap max-[640px]:justify-start">
+                          <Pill variant={modePillVariant(mode)}>
+                            {describeMode(mode)}
+                          </Pill>
+                          <span className="min-w-0 text-ui-label text-text3 [overflow-wrap:anywhere]">
+                            {describeDefaultMode(descriptor.default_mode)}
+                          </span>
+                          {policyId ? (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => onEditPolicy(policyId)}
+                            >
+                              edit rule →
+                            </Button>
+                          ) : null}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </Disclosure>
+            </li>
+          ))}
+        </ul>
+      )}
     </section>
   );
 }

--- a/apps/web/src/app/admin/rules/[policyId]/PolicyDetailClient.tsx
+++ b/apps/web/src/app/admin/rules/[policyId]/PolicyDetailClient.tsx
@@ -87,18 +87,18 @@ export default function PolicyDetailClient({ policyId }: { policyId: string }) {
         ) : (
           <article className="bg-card border border-border rounded-2xl p-6">
             <Field label="Mode">
-              <code className="font-mono text-[13px] text-text2">{policy.mode}</code>
+              <code className="font-mono text-ui-body-sm text-text2">{policy.mode}</code>
             </Field>
 
             <Field label="Applies to">
-              <div className="text-[13px] text-text">
+              <div className="text-ui-body-sm text-text">
                 {policy.appliesToKinds.length === 0 ? (
                   <span className="italic text-text3">any action kind</span>
                 ) : (
                   policy.appliesToKinds.map((k) => (
                     <code
                       key={k}
-                      className="font-mono text-[12px] bg-neutral-soft text-text2 px-1.5 py-0.5 rounded mr-1.5"
+                      className="font-mono text-ui-caption bg-neutral-soft text-text2 px-1.5 py-0.5 rounded mr-1.5"
                     >
                       {k}
                     </code>
@@ -112,9 +112,9 @@ export default function PolicyDetailClient({ policyId }: { policyId: string }) {
 
             {policy.riskThresholdAutoApprove && (
               <Field label="Auto-approve">
-                <span className="text-[13px]">
+                <span className="text-ui-body-sm">
                   risk ≤{" "}
-                  <code className="font-mono text-[12px] text-text2">
+                  <code className="font-mono text-ui-caption text-text2">
                     {policy.riskThresholdAutoApprove}
                   </code>
                 </span>
@@ -123,7 +123,7 @@ export default function PolicyDetailClient({ policyId }: { policyId: string }) {
 
             {Object.keys(policy.limits).length > 0 && (
               <Field label="Limits">
-                <code className="font-mono text-[12px] text-text2">
+                <code className="font-mono text-ui-caption text-text2">
                   {Object.entries(policy.limits)
                     .map(([k, v]) => `${k}: ${String(v)}`)
                     .join(" · ")}
@@ -133,16 +133,16 @@ export default function PolicyDetailClient({ policyId }: { policyId: string }) {
 
             {policy.approverRole && (
               <Field label="Approver role">
-                <span className="text-[13px]">{policy.approverRole}</span>
+                <span className="text-ui-body-sm">{policy.approverRole}</span>
               </Field>
             )}
 
             <Field label="Priority">
-              <span className="text-[13px]">{policy.priority}</span>
+              <span className="text-ui-body-sm">{policy.priority}</span>
             </Field>
 
             <Field label="Updated">
-              <span className="text-[13px] text-text2">
+              <span className="text-ui-body-sm text-text2">
                 {new Date(policy.updatedAt).toLocaleString()}
               </span>
             </Field>
@@ -163,7 +163,7 @@ export default function PolicyDetailClient({ policyId }: { policyId: string }) {
               )}
               <button
                 type="button"
-                className="px-3 py-2 rounded-lg border border-accent bg-accent text-white font-body text-[13px] font-semibold cursor-pointer hover:bg-[#5a4cd1] hover:border-[#5a4cd1]"
+                className="px-3 py-2 rounded-lg border border-accent bg-accent text-white font-body text-ui-body-sm font-semibold cursor-pointer hover:bg-[#5a4cd1] hover:border-[#5a4cd1]"
                 onClick={editInWork}
               >
                 edit in /work
@@ -181,7 +181,7 @@ export default function PolicyDetailClient({ policyId }: { policyId: string }) {
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="mb-4 last:mb-0">
-      <div className="text-[10.5px] font-bold tracking-[0.13em] uppercase text-text3 mb-1">
+      <div className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3 mb-1">
         {label}
       </div>
       <div className="text-text">{children}</div>

--- a/apps/web/src/app/admin/rules/[policyId]/PolicyDetailClient.tsx
+++ b/apps/web/src/app/admin/rules/[policyId]/PolicyDetailClient.tsx
@@ -6,6 +6,7 @@ import AppHeader from "@/components/AppHeader";
 import CreatorCredit from "@/components/CreatorCredit";
 import PageHeading from "@/components/PageHeading";
 import SectionNav from "@/components/SectionNav";
+import { Button } from "@/components/ui/Button";
 
 type PolicyDetail = {
   policy: {
@@ -149,25 +150,25 @@ export default function PolicyDetailClient({ policyId }: { policyId: string }) {
 
             <div className="mt-6 pt-4 border-t border-border flex items-center justify-between gap-3">
               {policy.createdByThreadId ? (
-                <button
-                  type="button"
-                  className="bg-transparent border-0 text-text3 cursor-pointer text-xs font-semibold py-1 px-0 hover:text-accent hover:underline hover:underline-offset-[3px]"
+                <Button
+                  variant="ghost"
+                  size="sm"
                   onClick={() =>
                     router.push(`/work/${policy.createdByThreadId}`)
                   }
                 >
                   view conversation
-                </button>
+                </Button>
               ) : (
                 <span />
               )}
-              <button
-                type="button"
-                className="px-3 py-2 rounded-lg border border-accent bg-accent text-white font-body text-ui-body-sm font-semibold cursor-pointer hover:bg-[#5a4cd1] hover:border-[#5a4cd1]"
+              <Button
+                variant="primary"
+                size="sm"
                 onClick={editInWork}
               >
                 edit in /work
-              </button>
+              </Button>
             </div>
           </article>
         )}

--- a/apps/web/src/app/admin/settings/SetupWizard.tsx
+++ b/apps/web/src/app/admin/settings/SetupWizard.tsx
@@ -7,7 +7,7 @@ import Select from "@/components/Select";
 import { Button } from "@/components/ui/Button";
 
 const INPUT_CLS =
-  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-[15px] font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
+  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
 
 type ProviderOption = { value: string; label: string; description: string };
 type Field = {
@@ -444,7 +444,7 @@ export default function SetupWizard({ initial }: { initial: Initial }) {
               onChange={(e) => setConfirmPassword(e.target.value)}
             />
             {confirmPassword.length > 0 && confirmPassword !== newPassword && (
-              <span className="text-[13px] text-[#c33] leading-[1.45]">
+              <span className="text-ui-body-sm text-[#c33] leading-[1.45]">
                 Passwords don&apos;t match.
               </span>
             )}
@@ -480,7 +480,7 @@ export default function SetupWizard({ initial }: { initial: Initial }) {
                 setData((p) => ({ ...p, rootUrl: e.target.value }));
               }}
             />
-            <span className="text-[13px] text-text3 leading-[1.45]">
+            <span className="text-ui-body-sm text-text3 leading-[1.45]">
               Just the base URL — OpenNeko handles the GraphQL and MCP endpoints automatically.
             </span>
           </Field>
@@ -523,7 +523,7 @@ export default function SetupWizard({ initial }: { initial: Initial }) {
               options={initial.agent.options}
               ariaLabel="Agent backend"
             />
-            <span className="text-[13px] text-text3 leading-[1.45]">
+            <span className="text-ui-body-sm text-text3 leading-[1.45]">
               {initial.agent.options.find((o) => o.value === backend)?.description}
             </span>
           </Field>
@@ -538,7 +538,7 @@ export default function SetupWizard({ initial }: { initial: Initial }) {
                 ariaLabel="Primary provider"
               />
               {backend === "claude-agent" && (
-                <span className="text-[13px] text-text3 leading-[1.45]">Locked because Agent backend = Claude Agent.</span>
+                <span className="text-ui-body-sm text-text3 leading-[1.45]">Locked because Agent backend = Claude Agent.</span>
               )}
             </Field>
             <Field label="Model">
@@ -578,7 +578,7 @@ export default function SetupWizard({ initial }: { initial: Initial }) {
               value={concurrentJobs}
               onChange={(e) => setConcurrentJobs(e.target.value)}
             />
-            <span className="text-[13px] text-text3 leading-[1.45]">
+            <span className="text-ui-body-sm text-text3 leading-[1.45]">
               How many metric jobs the worker runs in parallel. Worker restart applies changes.
             </span>
           </Field>
@@ -605,7 +605,7 @@ export default function SetupWizard({ initial }: { initial: Initial }) {
           title="Research (optional)"
           description="Lets the system pull industry context from Perplexity once your business team submits the onboarding profile. Leave the toggle off to set this up later."
         >
-          <label className="inline-flex items-center gap-2.5 mt-[18px] text-text2 text-[15px]">
+          <label className="inline-flex items-center gap-2.5 mt-[18px] text-text2 text-ui-body-lg">
             <input
               type="checkbox"
               checked={researchEnabled}
@@ -715,7 +715,7 @@ function Step({
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <label className="flex flex-col gap-2">
-      <span className="text-[14px] font-semibold text-text">{label}</span>
+      <span className="text-ui-body font-semibold text-text">{label}</span>
       {children}
     </label>
   );
@@ -726,7 +726,7 @@ function InlineError({ message }: { message: string | null }) {
   return (
     <div
       role="alert"
-      className="rounded-2xl px-4 py-3.5 mt-3.5 text-[14px] leading-[1.5] bg-[#fff0ee] border border-[#f2c9c3] text-[#9a4035]"
+      className="rounded-2xl px-4 py-3.5 mt-3.5 text-ui-body leading-[1.5] bg-[#fff0ee] border border-[#f2c9c3] text-[#9a4035]"
     >
       {message}
     </div>
@@ -744,7 +744,7 @@ function ProviderFieldInput({
 }) {
   return (
     <label className="flex flex-col gap-2">
-      <span className="text-[14px] font-semibold text-text">
+      <span className="text-ui-body font-semibold text-text">
         {field.label}
         {field.required ? " *" : ""}
       </span>
@@ -755,7 +755,7 @@ function ProviderFieldInput({
         placeholder={field.placeholder}
         onChange={(e) => onChange(e.target.value)}
       />
-      {field.help && <span className="text-[13px] text-text3 leading-[1.45]">{field.help}</span>}
+      {field.help && <span className="text-ui-body-sm text-text3 leading-[1.45]">{field.help}</span>}
     </label>
   );
 }

--- a/apps/web/src/app/admin/settings/agent/AgentForm.tsx
+++ b/apps/web/src/app/admin/settings/agent/AgentForm.tsx
@@ -33,10 +33,10 @@ type SettingsPayload = {
   fields: { primary: Record<string, Field[]>; research: Record<string, Field[]> };
 };
 const INPUT_CLS =
-  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-[15px] font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
+  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
 const FIELD_CLS = "flex flex-col gap-2";
-const LABEL_CLS = "text-[14px] font-semibold text-text";
-const HELP_CLS = "text-[13px] text-text3 leading-[1.45]";
+const LABEL_CLS = "text-ui-body font-semibold text-text";
+const HELP_CLS = "text-ui-body-sm text-text3 leading-[1.45]";
 
 type AgentBackendOption = { value: "hermes" | "claude-agent"; label: string; description: string };
 type AgentSettingsPayload = {
@@ -248,10 +248,10 @@ export default function AgentForm({
                 {field.help && <span className={HELP_CLS}>{field.help}</span>}
                 {isSecret && masked && !primary.clearedSecrets[field.key] && (
                   <div className="flex items-center justify-between gap-3">
-                    <span className="text-text3 text-[13px]">Saved: {masked}</span>
+                    <span className="text-text3 text-ui-body-sm">Saved: {masked}</span>
                     <button
                       type="button"
-                      className="border-0 bg-transparent text-[#b05555] cursor-pointer text-[13px] font-semibold"
+                      className="border-0 bg-transparent text-[#b05555] cursor-pointer text-ui-body-sm font-semibold"
                       onClick={() =>
                         setPrimary((p) => ({
                           ...p,

--- a/apps/web/src/app/admin/settings/data/DataSourceForm.tsx
+++ b/apps/web/src/app/admin/settings/data/DataSourceForm.tsx
@@ -15,10 +15,10 @@ type DataSourcePayload = {
 };
 
 const INPUT_CLS =
-  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-[15px] font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
+  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
 const FIELD_CLS = "flex flex-col gap-2";
-const LABEL_CLS = "text-[14px] font-semibold text-text";
-const HELP_CLS = "text-[13px] text-text3 leading-[1.45]";
+const LABEL_CLS = "text-ui-body font-semibold text-text";
+const HELP_CLS = "text-ui-body-sm text-text3 leading-[1.45]";
 
 const GRAPHQL_SUFFIX = "/api/v1/graphql";
 const MCP_SUFFIX = "/api/v1/mcp";

--- a/apps/web/src/app/admin/settings/graphjin/SourceSecretsPanel.tsx
+++ b/apps/web/src/app/admin/settings/graphjin/SourceSecretsPanel.tsx
@@ -11,9 +11,9 @@ type SourceSecretSummary = {
 };
 
 const INPUT_CLS =
-  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-[15px] font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
+  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
 const FIELD_CLS = "flex flex-col gap-2";
-const LABEL_CLS = "text-[14px] font-semibold text-text";
+const LABEL_CLS = "text-ui-body font-semibold text-text";
 
 export default function SourceSecretsPanel({
   initialSecrets,

--- a/apps/web/src/app/admin/settings/graphjin/page.tsx
+++ b/apps/web/src/app/admin/settings/graphjin/page.tsx
@@ -139,7 +139,7 @@ export default async function AdminGraphjinPage() {
               className="w-full border-collapse text-left text-sm"
               style={{ minWidth: 1040 }}
             >
-              <thead className="text-[10px] uppercase tracking-[0.12em] text-text3">
+              <thead className="text-ui-label uppercase tracking-[0.12em] text-text3">
                 <tr>
                   <th className="whitespace-nowrap border-b border-border px-3 py-2 font-bold">Source</th>
                   <th className="whitespace-nowrap border-b border-border px-3 py-2 font-bold">Auth</th>
@@ -288,7 +288,7 @@ function Stat({
 }) {
   return (
     <div className="rounded-[14px] border border-border bg-card px-4 py-3 shadow-soft">
-      <div className="text-[10px] font-bold uppercase tracking-[0.12em] text-text3">
+      <div className="text-ui-label font-bold uppercase tracking-[0.12em] text-text3">
         {label}
       </div>
       <div
@@ -311,7 +311,7 @@ function Badge({
 }) {
   return (
     <span
-      className={`whitespace-nowrap rounded-md border px-2 py-0.5 text-[11px] font-semibold ${
+      className={`whitespace-nowrap rounded-md border px-2 py-0.5 text-ui-label font-semibold ${
         tone === "ok"
           ? "border-success-soft bg-bg text-text2"
           : "border-danger-soft bg-bg text-danger"

--- a/apps/web/src/app/admin/settings/packs/MagentoPackAdmin.tsx
+++ b/apps/web/src/app/admin/settings/packs/MagentoPackAdmin.tsx
@@ -122,7 +122,8 @@ export default function MagentoPackAdmin() {
   }, []);
 
   useEffect(() => {
-    void refresh(true);
+    const initial = window.setTimeout(() => void refresh(true), 0);
+    return () => window.clearTimeout(initial);
   }, [refresh]);
 
   function update<K extends keyof FormState>(key: K, value: FormState[K]) {
@@ -347,7 +348,7 @@ export default function MagentoPackAdmin() {
                 <h2 className="settings-card-title">Remove pack</h2>
                 <p className="settings-card-copy">Disables its live configuration and automations. Historical metrics and audit records stay available.</p>
               </div>
-              <Button type="button" variant="secondary" disabled={busy !== null} onClick={() => void runAction("uninstall")}>{busy === "uninstall" ? "Removing…" : "Remove"}</Button>
+              <Button type="button" variant="danger" disabled={busy !== null} onClick={() => void runAction("uninstall")}>{busy === "uninstall" ? "Removing…" : "Remove"}</Button>
             </div>
           </section>
         </div>

--- a/apps/web/src/app/admin/settings/packs/MagentoPackAdmin.tsx
+++ b/apps/web/src/app/admin/settings/packs/MagentoPackAdmin.tsx
@@ -1,0 +1,455 @@
+"use client";
+
+import { FormEvent, useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { toast } from "sonner";
+import AppHeader from "@/components/AppHeader";
+import PageHeading from "@/components/PageHeading";
+import SectionNav from "@/components/SectionNav";
+import { Button } from "@/components/ui/Button";
+
+type PackStatus = {
+  packId: string;
+  version: string;
+  status: string;
+  readiness: Record<string, { status: string; reason: string | null }>;
+  installedAt: string | null;
+  lastError: string | null;
+};
+
+type DoctorResult = {
+  packId: string;
+  status: string;
+  checks: Array<{ id: string; status: string; detail: string }>;
+};
+
+type FormState = {
+  baseUrl: string;
+  databaseHost: string;
+  databasePort: string;
+  databaseName: string;
+  analyticsUsername: string;
+  analyticsPassword: string;
+  storeCode: string;
+  tablePrefix: string;
+  integrationToken: string;
+};
+
+const initialForm: FormState = {
+  baseUrl: "http://host.docker.internal:8080",
+  databaseHost: "host.docker.internal",
+  databasePort: "3306",
+  databaseName: "magento",
+  analyticsUsername: "magento_analytics",
+  analyticsPassword: "",
+  storeCode: "all",
+  tablePrefix: "",
+  integrationToken: "",
+};
+
+const FIELD = "flex flex-col gap-2";
+const LABEL = "text-[14px] font-semibold text-text";
+const HELP = "text-[13px] leading-[1.45] text-text3";
+const INPUT = "rounded-xl border-[1.5px] border-border bg-bg px-3.5 py-3 text-[15px] text-text outline-none transition focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
+const REPORTING_LOGIN_REQUEST = `Please create a dedicated read-only MariaDB/MySQL login for OpenNeko analytics on our Magento database.
+
+Grant only SELECT and SHOW VIEW on the Magento database. Do not grant INSERT, UPDATE, DELETE, CREATE, ALTER, DROP, ALL PRIVILEGES, or GRANT OPTION.
+
+Please send me the database hostname, port, database name, username, and password, and allow connections from the server running OpenNeko.`;
+
+async function api<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(path, { ...init, cache: "no-store" });
+  const body = (await response.json().catch(() => null)) as (T & { error?: string }) | null;
+  if (!response.ok) throw new Error(body?.error ?? `Request failed (HTTP ${response.status})`);
+  return body as T;
+}
+
+function healthLabel(status: string): string {
+  if (status === "ready" || status === "installed") return "Healthy";
+  if (status === "degraded") return "Needs attention";
+  if (status === "removed") return "Not installed";
+  return status.replaceAll("_", " ");
+}
+
+function checkLabel(id: string): string {
+  if (id === "operator") return "Magento access";
+  if (id === "analytics-query") return "Reporting query";
+  return id.replaceAll("-", " ");
+}
+
+function checkStatusLabel(id: string, status: string): string {
+  if (id === "operator") return status === "ready" ? "Changes available" : "View only";
+  if (status === "ready") return "Healthy";
+  if (status === "optional") return "Optional";
+  if (status === "blocked") return "Needs attention";
+  return status.replaceAll("_", " ");
+}
+
+function checkTone(status: string): string {
+  if (status === "ready") return "text-success-ink";
+  if (status === "optional") return "text-text3";
+  return "text-danger";
+}
+
+export default function MagentoPackAdmin() {
+  const [status, setStatus] = useState<PackStatus | null>(null);
+  const [doctor, setDoctor] = useState<DoctorResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [advanced, setAdvanced] = useState(false);
+  const [rotateCredentials, setRotateCredentials] = useState(false);
+  const [clearIntegrationToken, setClearIntegrationToken] = useState(false);
+  const [form, setForm] = useState<FormState>(initialForm);
+
+  const refresh = useCallback(async (runDoctor = false) => {
+    setLoading(true);
+    try {
+      const nextStatus = await api<PackStatus>("/api/admin/packs/magento/status").catch((error) => {
+        if (error instanceof Error && error.message.includes("not installed")) return null;
+        throw error;
+      });
+      setStatus(nextStatus);
+      if (nextStatus && nextStatus.status !== "removed" && runDoctor) {
+        setDoctor(await api<DoctorResult>("/api/admin/packs/magento/doctor"));
+      } else if (!nextStatus || nextStatus.status === "removed") {
+        setDoctor(null);
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh(true);
+  }, [refresh]);
+
+  function update<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((current) => ({ ...current, [key]: value }));
+  }
+
+  async function install(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setBusy("install");
+    try {
+      await api<PackStatus>("/api/admin/packs/magento/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          inputs: {
+            "magento.base_url": form.baseUrl,
+            "magento.store_code": form.storeCode || "all",
+            "magento.table_prefix": form.tablePrefix,
+            "database.connectivity_mode": form.databaseHost === "host.docker.internal" ? "host_gateway" : "remote",
+            "database.host": form.databaseHost,
+            "database.port": Number(form.databasePort),
+            "database.name": form.databaseName,
+          },
+          secrets: {
+            "database.analytics_username": form.analyticsUsername,
+            "database.analytics_password": form.analyticsPassword,
+            ...(form.integrationToken ? { "magento.integration_token": form.integrationToken } : {}),
+          },
+        }),
+      });
+      setForm((current) => ({ ...current, analyticsPassword: "", integrationToken: "" }));
+      toast.success("Magento is connected. Metrics are refreshing now.");
+      await refresh(true);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function copyReportingLoginRequest() {
+    try {
+      await navigator.clipboard.writeText(REPORTING_LOGIN_REQUEST);
+      toast.success("Request copied. Send it to your Magento host or database administrator.");
+    } catch {
+      toast.error("Could not copy automatically. Select and copy the request manually.");
+    }
+  }
+
+  async function runAction(action: "doctor" | "upgrade" | "uninstall") {
+    if (action === "uninstall" && !window.confirm("Remove the Magento pack? Historical metrics and operation records will be kept.")) return;
+    setBusy(action);
+    try {
+      if (action === "doctor") {
+        setDoctor(await api<DoctorResult>("/api/admin/packs/magento/doctor"));
+        toast.success("Connection and permissions checked.");
+      } else {
+        await api<PackStatus>(`/api/admin/packs/magento/${action}`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "{}",
+        });
+        toast.success(action === "upgrade" ? "Magento pack updated." : "Magento pack removed safely.");
+        await refresh(action === "upgrade");
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function saveCredentials(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (form.analyticsPassword && !form.analyticsUsername) {
+      toast.error("Enter the reporting username that belongs to this password.");
+      return;
+    }
+    if (!form.analyticsPassword && !form.integrationToken && !clearIntegrationToken) {
+      toast.error("Enter a new reporting password, an API token, or choose to remove the API token.");
+      return;
+    }
+    setBusy("configure");
+    try {
+      const secrets = {
+        ...(form.analyticsPassword
+          ? {
+              "database.analytics_username": form.analyticsUsername,
+              "database.analytics_password": form.analyticsPassword,
+            }
+          : {}),
+        ...(form.integrationToken
+          ? { "magento.integration_token": form.integrationToken }
+          : clearIntegrationToken
+            ? { "magento.integration_token": "" }
+            : {}),
+      };
+      await api<PackStatus>("/api/admin/packs/magento/configure", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ secrets }),
+      });
+      setForm((current) => ({ ...current, analyticsPassword: "", integrationToken: "" }));
+      setRotateCredentials(false);
+      setClearIntegrationToken(false);
+      toast.success("Credentials updated and verified.");
+      await refresh(true);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : String(error));
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  const installed = status && status.status !== "removed";
+
+  return (
+    <div className="root" style={{ "--page-width": "min(1000px, 100%)" } as React.CSSProperties}>
+      <AppHeader back={{ href: "/admin/settings", label: "All settings" }}>
+        <SectionNav current="admin" />
+      </AppHeader>
+      <PageHeading
+        eyebrow="Settings · Packs"
+        title="Magento"
+        description="Connect the store once, then keep its health, metrics, automations, and credentials in one place."
+      />
+
+      {loading && !status ? (
+        <section className="settings-card"><p className="settings-card-copy">Checking Magento…</p></section>
+      ) : installed ? (
+        <div className="flex flex-col gap-4">
+          <section className="settings-card">
+            <div className="settings-card-head">
+              <div>
+                <h2 className="settings-card-title">Magento pack</h2>
+                <p className="settings-card-copy">Version {status.version} · installed {status.installedAt ? new Date(status.installedAt).toLocaleString() : "recently"}</p>
+              </div>
+              <div className="settings-source">
+                <strong className={doctor?.status === "blocked" ? "is-warn" : "is-ok"}>{healthLabel(doctor?.status ?? status.status)}</strong>
+              </div>
+            </div>
+            {status.lastError ? <p className="mt-3 text-sm text-danger">{status.lastError}</p> : null}
+            <div className="mt-5 flex flex-wrap gap-2">
+              <Button type="button" disabled={busy !== null} onClick={() => void runAction("doctor")}>{busy === "doctor" ? "Checking…" : "Check health"}</Button>
+              <Button type="button" variant="secondary" disabled={busy !== null} onClick={() => void runAction("upgrade")}>{busy === "upgrade" ? "Updating…" : "Update pack"}</Button>
+              <Button type="button" variant="secondary" disabled={busy !== null} onClick={() => setRotateCredentials((value) => !value)}>Change credentials</Button>
+            </div>
+          </section>
+
+          <section className="settings-card">
+            <div className="settings-card-head">
+              <div>
+                <h2 className="settings-card-title">Use your Magento pack</h2>
+                <p className="settings-card-copy">Everything is installed already. These are the everyday places your team will use.</p>
+              </div>
+            </div>
+            <div className="mt-4 grid gap-3 sm:grid-cols-2">
+              {[
+                { href: "/", title: "View Magento metrics", copy: "See current store performance and findings." },
+                { href: "/workflows", title: "Run automations", copy: "Start or review Magento workflows." },
+                { href: "/actions", title: "Review proposed changes", copy: "Approve or reject a specific Magento change prepared by OpenNeko." },
+                { href: "/skills", title: "Magento operator skills", copy: "Choose a focused skill for orders, fulfillment, refunds, inventory, performance, or platform health." },
+              ].map((item) => (
+                <Link key={item.href} href={item.href} className="rounded-xl border border-border px-4 py-3 transition hover:border-accent">
+                  <strong className="text-sm text-text">{item.title}</strong>
+                  <p className="mt-1 text-[13px] leading-[1.45] text-text3">{item.copy}</p>
+                </Link>
+              ))}
+            </div>
+          </section>
+
+          {doctor ? (
+            <section className="settings-card">
+              <div className="settings-card-head">
+                <div>
+                  <h2 className="settings-card-title">Health</h2>
+                  <p className="settings-card-copy">Plain-language checks for Magento, the reporting connection, and OpenNeko.</p>
+                </div>
+              </div>
+              <ul className="mt-4 flex flex-col gap-3">
+                {doctor.checks.map((check) => (
+                  <li key={check.id} className="flex flex-col gap-1 rounded-xl border border-border px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                      <strong className="text-sm capitalize text-text">{checkLabel(check.id)}</strong>
+                      <p className="mt-1 text-[13px] leading-[1.45] text-text3">{check.detail}</p>
+                    </div>
+                    <span className={`mt-1 text-xs font-semibold uppercase tracking-wide ${checkTone(check.status)}`}>{checkStatusLabel(check.id, check.status)}</span>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ) : null}
+
+          {rotateCredentials ? (
+            <form className="settings-card" onSubmit={saveCredentials}>
+              <div className="settings-card-head">
+                <div>
+                  <h2 className="settings-card-title">Change credentials</h2>
+                  <p className="settings-card-copy">Only enter credentials you want to change. New values are tested before replacing the saved ones.</p>
+                </div>
+              </div>
+              <CredentialFields form={form} update={update} includeToken required={false} />
+              <label className="mt-4 flex items-center gap-2 text-sm text-text2">
+                <input
+                  type="checkbox"
+                  checked={clearIntegrationToken}
+                  disabled={Boolean(form.integrationToken)}
+                  onChange={(event) => setClearIntegrationToken(event.target.checked)}
+                />
+                Remove the saved Magento API token
+              </label>
+              <div className="mt-5 flex gap-2">
+                <Button type="submit" disabled={busy !== null}>{busy === "configure" ? "Testing and saving…" : "Save credentials"}</Button>
+                <Button type="button" variant="secondary" disabled={busy !== null} onClick={() => setRotateCredentials(false)}>Cancel</Button>
+              </div>
+            </form>
+          ) : null}
+
+          <section className="settings-card">
+            <div className="settings-card-head">
+              <div>
+                <h2 className="settings-card-title">Remove pack</h2>
+                <p className="settings-card-copy">Disables its live configuration and automations. Historical metrics and audit records stay available.</p>
+              </div>
+              <Button type="button" variant="secondary" disabled={busy !== null} onClick={() => void runAction("uninstall")}>{busy === "uninstall" ? "Removing…" : "Remove"}</Button>
+            </div>
+          </section>
+        </div>
+      ) : (
+        <form className="settings-card" onSubmit={install}>
+          <div className="settings-card-head">
+            <div>
+              <h2 className="settings-card-title">Connect Magento</h2>
+              <p className="settings-card-copy">Use a read-only reporting login. OpenNeko discovers the store settings and installs the complete pack automatically.</p>
+            </div>
+            <div className="settings-source"><strong>About 2 minutes</strong></div>
+          </div>
+
+          <details className="mt-5 rounded-xl border border-border bg-bg2 px-4 py-3 text-sm text-text2">
+            <summary className="cursor-pointer font-semibold text-text">I do not have a read-only reporting login</summary>
+            <p className="mt-3 leading-[1.5]">Send this request to your Magento hosting provider or database administrator. OpenNeko never needs your Magento administrator password or Adobe Marketplace keys.</p>
+            <pre className="mt-3 whitespace-pre-wrap rounded-lg bg-bg px-3 py-3 text-xs leading-[1.5] text-text2">{REPORTING_LOGIN_REQUEST}</pre>
+            <Button type="button" variant="secondary" className="mt-3" onClick={() => void copyReportingLoginRequest()}>Copy request</Button>
+          </details>
+
+          <div className="mt-5 grid gap-4 sm:grid-cols-2">
+            <label className={`${FIELD} sm:col-span-2`}>
+              <span className={LABEL}>Magento address</span>
+              <input required type="url" className={INPUT} value={form.baseUrl} onChange={(event) => update("baseUrl", event.target.value)} />
+              <span className={HELP}>The storefront URL as seen from OpenNeko. The default works when Magento is another local Docker or OrbStack stack.</span>
+            </label>
+            <label className={FIELD}>
+              <span className={LABEL}>Database address</span>
+              <input required className={INPUT} value={form.databaseHost} onChange={(event) => update("databaseHost", event.target.value)} />
+            </label>
+            <label className={FIELD}>
+              <span className={LABEL}>Database name</span>
+              <input required className={INPUT} value={form.databaseName} onChange={(event) => update("databaseName", event.target.value)} />
+            </label>
+          </div>
+
+          <CredentialFields form={form} update={update} required />
+
+          <button type="button" className="mt-5 text-sm font-semibold text-text2 underline" onClick={() => setAdvanced((value) => !value)}>{advanced ? "Hide advanced settings" : "Advanced settings"}</button>
+          {advanced ? (
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              <label className={FIELD}>
+                <span className={LABEL}>Database port</span>
+                <input required type="number" min="1" max="65535" className={INPUT} value={form.databasePort} onChange={(event) => update("databasePort", event.target.value)} />
+              </label>
+              <label className={FIELD}>
+                <span className={LABEL}>Store code</span>
+                <input className={INPUT} value={form.storeCode} onChange={(event) => update("storeCode", event.target.value)} />
+              </label>
+              <label className={FIELD}>
+                <span className={LABEL}>Table prefix</span>
+                <input className={INPUT} value={form.tablePrefix} onChange={(event) => update("tablePrefix", event.target.value)} />
+              </label>
+              <label className={FIELD}>
+                <span className={LABEL}>Magento API token (optional)</span>
+                <input type="password" autoComplete="off" className={INPUT} value={form.integrationToken} onChange={(event) => update("integrationToken", event.target.value)} />
+                <span className={HELP}>This token is only for specific Magento changes that OpenNeko supports. Each change must be enabled by an administrator and still requires approval.</span>
+              </label>
+            </div>
+          ) : null}
+
+          <div className="mt-6 rounded-xl border border-border bg-bg2 px-4 py-3 text-[13px] leading-[1.5] text-text2">
+            OpenNeko starts in view-only mode: it can analyze the store but cannot change Magento data. Any supported change is enabled separately by an administrator and requires approval.
+          </div>
+          <div className="mt-5">
+            <Button type="submit" disabled={busy !== null || !form.analyticsPassword}>{busy === "install" ? "Connecting and installing…" : "Connect and install"}</Button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}
+
+function CredentialFields({
+  form,
+  update,
+  includeToken = false,
+  required,
+}: {
+  form: FormState;
+  update: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+  includeToken?: boolean;
+  required: boolean;
+}) {
+  return (
+    <div className="mt-4 grid gap-4 sm:grid-cols-2">
+      <label className={FIELD}>
+        <span className={LABEL}>Read-only reporting username</span>
+        <input required={required} autoComplete="username" className={INPUT} value={form.analyticsUsername} onChange={(event) => update("analyticsUsername", event.target.value)} />
+      </label>
+      <label className={FIELD}>
+        <span className={LABEL}>Read-only reporting password</span>
+        <input required={required} type="password" autoComplete="new-password" className={INPUT} value={form.analyticsPassword} onChange={(event) => update("analyticsPassword", event.target.value)} />
+        {!required ? <span className={HELP}>Leave blank to keep the saved reporting login.</span> : null}
+      </label>
+      {includeToken ? (
+        <label className={`${FIELD} sm:col-span-2`}>
+          <span className={LABEL}>Magento API token (optional)</span>
+          <input type="password" autoComplete="off" className={INPUT} value={form.integrationToken} onChange={(event) => update("integrationToken", event.target.value)} />
+          <span className={HELP}>Leave blank to keep the saved token. A token alone does not allow OpenNeko to change Magento.</span>
+        </label>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/settings/packs/MagentoPackAdmin.tsx
+++ b/apps/web/src/app/admin/settings/packs/MagentoPackAdmin.tsx
@@ -48,9 +48,9 @@ const initialForm: FormState = {
 };
 
 const FIELD = "flex flex-col gap-2";
-const LABEL = "text-[14px] font-semibold text-text";
-const HELP = "text-[13px] leading-[1.45] text-text3";
-const INPUT = "rounded-xl border-[1.5px] border-border bg-bg px-3.5 py-3 text-[15px] text-text outline-none transition focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
+const LABEL = "text-ui-body font-semibold text-text";
+const HELP = "text-ui-body-sm leading-[1.45] text-text3";
+const INPUT = "rounded-xl border-[1.5px] border-border bg-bg px-3.5 py-3 text-ui-body-lg text-text outline-none transition focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
 const REPORTING_LOGIN_REQUEST = `Please create a dedicated read-only MariaDB/MySQL login for OpenNeko analytics on our Magento database.
 
 Grant only SELECT and SHOW VIEW on the Magento database. Do not grant INSERT, UPDATE, DELETE, CREATE, ALTER, DROP, ALL PRIVILEGES, or GRANT OPTION.
@@ -288,7 +288,7 @@ export default function MagentoPackAdmin() {
               ].map((item) => (
                 <Link key={item.href} href={item.href} className="rounded-xl border border-border px-4 py-3 transition hover:border-accent">
                   <strong className="text-sm text-text">{item.title}</strong>
-                  <p className="mt-1 text-[13px] leading-[1.45] text-text3">{item.copy}</p>
+                  <p className="mt-1 text-ui-body-sm leading-[1.45] text-text3">{item.copy}</p>
                 </Link>
               ))}
             </div>
@@ -307,7 +307,7 @@ export default function MagentoPackAdmin() {
                   <li key={check.id} className="flex flex-col gap-1 rounded-xl border border-border px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
                     <div>
                       <strong className="text-sm capitalize text-text">{checkLabel(check.id)}</strong>
-                      <p className="mt-1 text-[13px] leading-[1.45] text-text3">{check.detail}</p>
+                      <p className="mt-1 text-ui-body-sm leading-[1.45] text-text3">{check.detail}</p>
                     </div>
                     <span className={`mt-1 text-xs font-semibold uppercase tracking-wide ${checkTone(check.status)}`}>{checkStatusLabel(check.id, check.status)}</span>
                   </li>
@@ -409,7 +409,7 @@ export default function MagentoPackAdmin() {
             </div>
           ) : null}
 
-          <div className="mt-6 rounded-xl border border-border bg-bg2 px-4 py-3 text-[13px] leading-[1.5] text-text2">
+          <div className="mt-6 rounded-xl border border-border bg-bg2 px-4 py-3 text-ui-body-sm leading-[1.5] text-text2">
             OpenNeko starts in view-only mode: it can analyze the store but cannot change Magento data. Any supported change is enabled separately by an administrator and requires approval.
           </div>
           <div className="mt-5">

--- a/apps/web/src/app/admin/settings/packs/page.tsx
+++ b/apps/web/src/app/admin/settings/packs/page.tsx
@@ -1,0 +1,11 @@
+import { connection } from "next/server";
+import { AdminDenied } from "@/app/admin/AdminShell";
+import { getCurrentActor } from "@/lib/actor";
+import MagentoPackAdmin from "./MagentoPackAdmin";
+
+export default async function SettingsPacksPage() {
+  await connection();
+  const actor = await getCurrentActor();
+  if (actor.role !== "admin") return <AdminDenied />;
+  return <MagentoPackAdmin />;
+}

--- a/apps/web/src/app/admin/settings/page.tsx
+++ b/apps/web/src/app/admin/settings/page.tsx
@@ -130,6 +130,13 @@ export default async function SettingsPage() {
         jwtSources === enabledSources.length,
     },
     {
+      href: "/admin/settings/packs",
+      title: "Solution packs",
+      copy: "Connect and administer Magento and future application packs without using the terminal.",
+      status: "Magento available",
+      statusOk: true,
+    },
+    {
       href: "/admin/settings/research",
       title: "Research",
       copy: "Optional industry research run during onboarding.",

--- a/apps/web/src/app/admin/settings/page.tsx
+++ b/apps/web/src/app/admin/settings/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { connection } from "next/server";
 import { data_source, db, eq, hasCustomPassword } from "@neko/db";
+import { ArrowUpRight } from "lucide-react";
 import AppHeader from "@/components/AppHeader";
 import PageHeading from "@/components/PageHeading";
 import SectionNav from "@/components/SectionNav";
@@ -95,14 +96,14 @@ export default async function SettingsPage() {
     title: string;
     copy: string;
     status?: string;
-    statusOk?: boolean;
+    statusTone?: "success" | "watch" | "neutral";
   }[] = [
     {
       href: "/admin/settings/data",
       title: "Data source",
       copy: "Graphjin server endpoint OpenNeko should connect to.",
       status: dataReady ? "Configured" : "Not set",
-      statusOk: dataReady,
+      statusTone: dataReady ? "success" : "watch",
     },
     {
       href: "/admin/settings/agent",
@@ -111,8 +112,12 @@ export default async function SettingsPage() {
         agent.backend === "claude-agent"
           ? "Claude Agent — locked to Anthropic primary provider."
           : "Hermes — works with any primary provider.",
-      status: primaryReady ? `Backend: ${agent.backend}` : "Primary provider not set",
-      statusOk: primaryReady,
+      status: primaryReady
+        ? agent.backend === "claude-agent"
+          ? "Claude Agent backend"
+          : "Hermes backend"
+        : "Primary provider not set",
+      statusTone: primaryReady ? "success" : "watch",
     },
     {
       href: "/admin/settings/graphjin",
@@ -124,24 +129,25 @@ export default async function SettingsPage() {
             ? "MCP on · no source"
             : `MCP on · ${jwtSources}/${enabledSources.length} JWT`
           : "MCP config off",
-      statusOk:
-        graphjinConfig.settings.sourceConfigEnabled &&
-        enabledSources.length > 0 &&
-        jwtSources === enabledSources.length,
+      statusTone: !graphjinConfig.settings.sourceConfigEnabled
+        ? "neutral"
+        : enabledSources.length > 0 && jwtSources === enabledSources.length
+          ? "success"
+          : "watch",
     },
     {
       href: "/admin/settings/packs",
       title: "Solution packs",
       copy: "Connect and administer Magento and future application packs without using the terminal.",
-      status: "Magento available",
-      statusOk: true,
+      status: "Magento ready",
+      statusTone: "success",
     },
     {
       href: "/admin/settings/research",
       title: "Research",
       copy: "Optional industry research run during onboarding.",
       status: researchStatus === "enabled" ? "Enabled" : "Disabled",
-      statusOk: true,
+      statusTone: researchStatus === "enabled" ? "success" : "neutral",
     },
   ];
   cards.push({
@@ -171,20 +177,28 @@ export default async function SettingsPage() {
         description="Configure the agent runtime, data access, research, and trust policy."
       />
 
-      <div className="flex flex-col gap-4">
+      <div className="settings-index-grid">
         {cards.map((card) => (
-          <Link key={card.href} href={card.href} className="settings-card block no-underline">
-            <div className="settings-card-head">
-              <div>
-                <h2 className="settings-card-title">{card.title}</h2>
-                <p className="settings-card-copy">{card.copy}</p>
-              </div>
-              {card.status ? (
-                <div className="settings-source">
-                  <strong className={card.statusOk ? "is-ok" : "is-warn"}>{card.status}</strong>
-                </div>
-              ) : null}
+          <Link
+            key={card.href}
+            href={card.href}
+            className="settings-card settings-index-card no-underline"
+          >
+            <div className="settings-index-card-top">
+              <h2 className="settings-card-title">{card.title}</h2>
+              <ArrowUpRight className="settings-index-card-arrow" aria-hidden="true" />
             </div>
+            <p className="settings-card-copy">{card.copy}</p>
+            {card.status ? (
+              <div className="settings-index-card-foot">
+                <span
+                  className="settings-index-status"
+                  data-tone={card.statusTone ?? "neutral"}
+                >
+                  {card.status}
+                </span>
+              </div>
+            ) : null}
           </Link>
         ))}
       </div>

--- a/apps/web/src/app/admin/settings/research/ResearchForm.tsx
+++ b/apps/web/src/app/admin/settings/research/ResearchForm.tsx
@@ -26,10 +26,10 @@ type ProviderConfig = {
   secretStatus: Record<string, string>;
 };
 const INPUT_CLS =
-  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-[15px] font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
+  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
 const FIELD_CLS = "flex flex-col gap-2";
-const LABEL_CLS = "text-[14px] font-semibold text-text";
-const HELP_CLS = "text-[13px] text-text3 leading-[1.45]";
+const LABEL_CLS = "text-ui-body font-semibold text-text";
+const HELP_CLS = "text-ui-body-sm text-text3 leading-[1.45]";
 
 type SettingsPayload = {
   primary: ProviderConfig;
@@ -120,7 +120,7 @@ export default function ResearchForm({ initial }: { initial: SettingsPayload }) 
       />
 
       <section className="settings-card">
-        <label className="inline-flex items-center gap-2.5 mt-[18px] text-text2 text-[15px]">
+        <label className="inline-flex items-center gap-2.5 mt-[18px] text-text2 text-ui-body-lg">
           <input
             type="checkbox"
             checked={enabled}
@@ -196,10 +196,10 @@ export default function ResearchForm({ initial }: { initial: SettingsPayload }) 
                   {field.help && <span className={HELP_CLS}>{field.help}</span>}
                   {isSecret && masked && !research.clearedSecrets[field.key] && (
                     <div className="flex items-center justify-between gap-3">
-                      <span className="text-text3 text-[13px]">Saved: {masked}</span>
+                      <span className="text-text3 text-ui-body-sm">Saved: {masked}</span>
                       <button
                         type="button"
-                        className="border-0 bg-transparent text-[#b05555] cursor-pointer text-[13px] font-semibold"
+                        className="border-0 bg-transparent text-[#b05555] cursor-pointer text-ui-body-sm font-semibold"
                         onClick={() =>
                           setResearch((p) => ({
                             ...p,

--- a/apps/web/src/app/admin/settings/security/SecurityForm.tsx
+++ b/apps/web/src/app/admin/settings/security/SecurityForm.tsx
@@ -23,10 +23,10 @@ const OFFICIAL_MARKETPLACE_URL =
   "https://open-neko.github.io/plugins/marketplace.json";
 
 const FIELD_CLS = "flex flex-col gap-2";
-const LABEL_CLS = "text-[14px] font-semibold text-text";
-const HELP_CLS = "text-[13px] text-text3 leading-[1.45]";
+const LABEL_CLS = "text-ui-body font-semibold text-text";
+const HELP_CLS = "text-ui-body-sm text-text3 leading-[1.45]";
 const INPUT_CLS =
-  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-[15px] font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
+  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
 
 export default function SecurityForm({ initial }: { initial: InstallPolicyPayload }) {
   const [policy, setPolicy] = useState<InstallPolicy>(initial.policy);
@@ -136,13 +136,13 @@ export default function SecurityForm({ initial }: { initial: InstallPolicyPayloa
                   key={url}
                   className="flex items-center gap-2 px-3 py-2 rounded-lg border border-border bg-bg"
                 >
-                  <code className="flex-1 truncate text-[13px] text-text2">{url}</code>
+                  <code className="flex-1 truncate text-ui-body-sm text-text2">{url}</code>
                   {url === OFFICIAL_MARKETPLACE_URL ? (
-                    <span className="text-[12px] text-text3">official</span>
+                    <span className="text-ui-caption text-text3">official</span>
                   ) : (
                     <button
                       type="button"
-                      className="text-[12px] text-text2 underline"
+                      className="text-ui-caption text-text2 underline"
                       onClick={() => removeMarketplace(url)}
                     >
                       remove

--- a/apps/web/src/app/admin/settings/signin/SignInSetupCard.tsx
+++ b/apps/web/src/app/admin/settings/signin/SignInSetupCard.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { Button } from "@/components/ui/Button";
 
 const MAGIC_LINK_PLUGIN = "@open-neko/plugin-magic-link";
 
@@ -54,7 +55,8 @@ export default function SignInSetupCard() {
   }, []);
 
   useEffect(() => {
-    void reload();
+    const initial = window.setTimeout(() => void reload(), 0);
+    return () => window.clearTimeout(initial);
   }, [reload]);
 
   if (loadError) {
@@ -301,13 +303,13 @@ function DeliverySection({
             className="w-72 rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text"
           />
         </label>
-        <button
+        <Button
           type="submit"
+          variant="primary"
           disabled={busy}
-          className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-ink disabled:opacity-50"
         >
           {busy ? "Saving…" : "Save delivery settings"}
-        </button>
+        </Button>
       </form>
       <p className="mt-2 text-xs text-text3">
         The From address must be a sender verified with the provider you
@@ -416,13 +418,13 @@ function UsersSection({
             <option value="member">member</option>
           </select>
         </label>
-        <button
+        <Button
           type="submit"
+          variant="primary"
           disabled={busy}
-          className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-ink disabled:opacity-50"
         >
           {busy ? "Adding…" : "Add user"}
-        </button>
+        </Button>
       </form>
     </section>
   );
@@ -500,13 +502,12 @@ function TestSection({ status }: { status: Status }) {
             className="w-72 rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text"
           />
         </label>
-        <button
+        <Button
           type="submit"
           disabled={busy}
-          className="rounded-md border border-border px-4 py-2 text-sm font-semibold text-text2 hover:text-text disabled:opacity-50"
         >
           {busy ? "Sending…" : "Send test email"}
-        </button>
+        </Button>
       </form>
     </section>
   );

--- a/apps/web/src/app/admin/settings/sso/SsoSetupForm.tsx
+++ b/apps/web/src/app/admin/settings/sso/SsoSetupForm.tsx
@@ -6,21 +6,13 @@ import AppHeader from "@/components/AppHeader";
 import CreatorCredit from "@/components/CreatorCredit";
 import PageHeading from "@/components/PageHeading";
 import SectionNav from "@/components/SectionNav";
-import { Button } from "@/components/ui/Button";
+import { Button, ButtonLink } from "@/components/ui/Button";
 import type {
   SsoEnvironmentRow,
   SsoOrganizationRow,
   SsoSetupStatus,
   SsoSetupStatusResult,
 } from "@/lib/sso-setup";
-
-const STATUS_LABEL: Record<SsoSetupStatus, string> = {
-  not_started: "Not started",
-  awaiting_portal: "Waiting for the IdP",
-  polling: "Checking the connection",
-  connected: "Connected",
-  failed: "Failed",
-};
 
 const HELP_CLS = "text-ui-body-sm text-text3 leading-[1.45]";
 const INPUT_CLS =
@@ -174,7 +166,11 @@ export default function SsoSetupForm({
   // When the environment picker changes, refresh the organization list.
   useEffect(() => {
     if (envOptions.length > 0 && environmentId) {
-      void loadOrganizations(environmentId);
+      const initial = window.setTimeout(
+        () => void loadOrganizations(environmentId),
+        0,
+      );
+      return () => window.clearTimeout(initial);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [environmentId, envOptions.length]);
@@ -370,12 +366,11 @@ export default function SsoSetupForm({
                   Opens Scalekit in your browser. Sign in or create the account
                   there; the consent screen names the scopes and endpoint.
                 </p>
-                <a
+                <ButtonLink
                   href="/api/integrations/connect/%40open-neko%2Fplugin-scalekit/start?returnTo=%2Fadmin%2Fsettings%2Fsso"
-                  className="inline-flex"
                 >
-                  <Button type="button">Connect Scalekit workspace</Button>
-                </a>
+                  Connect Scalekit workspace
+                </ButtonLink>
               </>
             )}
           </div>
@@ -527,7 +522,7 @@ export default function SsoSetupForm({
                   >
                     {autofilling ? "Fetching…" : "Auto-fill from Scalekit"}
                   </Button>
-                  <a
+                  <ButtonLink
                     href={
                       environmentId
                         ? `https://app.scalekit.com/ws/environments/${encodeURIComponent(environmentId)}/settings/api-credentials`
@@ -535,12 +530,9 @@ export default function SsoSetupForm({
                     }
                     target="_blank"
                     rel="noreferrer"
-                    className="inline-flex"
                   >
-                    <Button type="button" variant="secondary">
-                      Find the secret in Scalekit ↗
-                    </Button>
-                  </a>
+                    Find the secret in Scalekit ↗
+                  </ButtonLink>
                   <input
                     className={`${INPUT_CLS} flex-1 min-w-[220px]`}
                     placeholder="https://your-app.scalekit.com"
@@ -594,9 +586,9 @@ export default function SsoSetupForm({
               <>
                 <p className={HELP_CLS}>
                   Optional for the trial — sign-in already works through
-                  Scalekit's hosted login. Generate a portal link to connect
-                  your company's own IdP (Okta, Entra ID…): open it, follow the
-                  guided setup, and the agent polls the connection until it's
+                  Scalekit’s hosted login. Generate a portal link to connect
+                  your company’s own IdP (Okta, Entra ID…): open it, follow the
+                  guided setup, and the agent polls the connection until it’s
                   live.
                 </p>
                 {status?.portalLink ? (
@@ -612,9 +604,13 @@ export default function SsoSetupForm({
                       <Button type="button" variant="secondary" onClick={copyLink}>
                         Copy
                       </Button>
-                      <a href={status.portalLink} target="_blank" rel="noreferrer">
-                        <Button type="button">Open</Button>
-                      </a>
+                      <ButtonLink
+                        href={status.portalLink}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Open
+                      </ButtonLink>
                     </div>
                   </div>
                 ) : null}

--- a/apps/web/src/app/admin/settings/sso/SsoSetupForm.tsx
+++ b/apps/web/src/app/admin/settings/sso/SsoSetupForm.tsx
@@ -22,9 +22,9 @@ const STATUS_LABEL: Record<SsoSetupStatus, string> = {
   failed: "Failed",
 };
 
-const HELP_CLS = "text-[13px] text-text3 leading-[1.45]";
+const HELP_CLS = "text-ui-body-sm text-text3 leading-[1.45]";
 const INPUT_CLS =
-  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-[15px] font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
+  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
 
 function StepHeader({
   step,
@@ -39,19 +39,19 @@ function StepHeader({
     <div className="flex items-center gap-2">
       {done ? (
         <span
-          className="flex items-center justify-center w-5 h-5 rounded-full bg-accent text-bg text-[11px] font-bold"
+          className="flex items-center justify-center w-5 h-5 rounded-full bg-accent text-bg text-ui-label font-bold"
           aria-label="done"
         >
           ✓
         </span>
       ) : (
-        <span className="flex items-center justify-center w-5 h-5 rounded-full border-[1.5px] border-border text-text3 text-[11px] font-semibold">
+        <span className="flex items-center justify-center w-5 h-5 rounded-full border-[1.5px] border-border text-text3 text-ui-label font-semibold">
           {step}
         </span>
       )}
-      <span className="text-[14px] font-semibold text-text">{title}</span>
+      <span className="text-ui-body font-semibold text-text">{title}</span>
       {done ? (
-        <span className="text-[11px] font-semibold text-accent">Done</span>
+        <span className="text-ui-label font-semibold text-accent">Done</span>
       ) : null}
     </div>
   );
@@ -399,7 +399,7 @@ export default function SsoSetupForm({
                 <div>
                   <button
                     type="button"
-                    className="text-[12px] text-text2 underline"
+                    className="text-ui-caption text-text2 underline"
                     onClick={() => setEditingStep(2)}
                   >
                     Change
@@ -419,7 +419,7 @@ export default function SsoSetupForm({
                 </p>
                 <div className="flex gap-2 flex-wrap items-center">
                   {pickerBusy ? (
-                    <span className="flex items-center gap-2 text-[13px] text-text2">
+                    <span className="flex items-center gap-2 text-ui-body-sm text-text2">
                       <span
                         className="inline-block w-4 h-4 border-2 border-border border-t-accent rounded-full animate-spin"
                         aria-hidden="true"
@@ -502,7 +502,7 @@ export default function SsoSetupForm({
                 <div>
                   <button
                     type="button"
-                    className="text-[12px] text-text2 underline"
+                    className="text-ui-caption text-text2 underline"
                     onClick={() => setEditingStep(3)}
                   >
                     Replace
@@ -606,7 +606,7 @@ export default function SsoSetupForm({
                       once opened it stays valid for the session.
                     </p>
                     <div className="flex items-center gap-2">
-                      <code className="flex-1 truncate text-[13px] text-text2">
+                      <code className="flex-1 truncate text-ui-body-sm text-text2">
                         {status.portalLink}
                       </code>
                       <Button type="button" variant="secondary" onClick={copyLink}>

--- a/apps/web/src/app/admin/users/UsersClient.tsx
+++ b/apps/web/src/app/admin/users/UsersClient.tsx
@@ -143,7 +143,7 @@ export function UsersClient({ users }: { users: AdminUserRow[] }) {
       ) : (
         <div className="overflow-x-auto">
           <table className="w-full border-collapse text-left text-sm">
-            <thead className="text-[10px] uppercase tracking-[0.12em] text-text3">
+            <thead className="text-ui-label uppercase tracking-[0.12em] text-text3">
               <tr>
                 <th className="border-b border-border px-3 py-2 font-bold">User</th>
                 <th className="border-b border-border px-3 py-2 font-bold">Role</th>

--- a/apps/web/src/app/admin/users/UsersClient.tsx
+++ b/apps/web/src/app/admin/users/UsersClient.tsx
@@ -2,6 +2,10 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import { ActionGroup } from "@/components/ui/ActionGroup";
+import { Button } from "@/components/ui/Button";
+import { Field, Input, NativeSelect } from "@/components/ui/Field";
+import { Pill } from "@/components/ui/Pill";
 
 export interface AdminUserRow {
   id: string;
@@ -84,56 +88,53 @@ export function UsersClient({ users }: { users: AdminUserRow[] }) {
   return (
     <>
       {error ? (
-        <div className="mb-4 rounded-md bg-danger-soft px-3 py-2 text-sm text-danger" role="alert">
+        <div className="mb-4 rounded-control bg-danger-soft px-3 py-2 text-sm text-danger" role="alert">
           {error}
         </div>
       ) : null}
 
       <form
         onSubmit={createUser}
-        className="mb-6 flex flex-wrap items-end gap-3"
+        className="mb-6 grid grid-cols-[minmax(220px,1.4fr)_minmax(180px,1fr)_minmax(130px,0.6fr)_auto] items-end gap-3 max-[820px]:grid-cols-2 max-[520px]:grid-cols-1"
       >
-        <label className="flex flex-col gap-1 text-xs font-semibold text-text2">
-          Email
-          <input
+        <Field label="Email" htmlFor="new-user-email">
+          <Input
+            id="new-user-email"
             type="email"
             required
             value={email}
             onChange={(event) => setEmail(event.target.value)}
             placeholder="person@company.com"
-            className="rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text"
           />
-        </label>
-        <label className="flex flex-col gap-1 text-xs font-semibold text-text2">
-          Name (optional)
-          <input
+        </Field>
+        <Field label="Name (optional)" htmlFor="new-user-name">
+          <Input
+            id="new-user-name"
             type="text"
             value={name}
             onChange={(event) => setName(event.target.value)}
             placeholder="Display name"
-            className="rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text"
           />
-        </label>
-        <label className="flex flex-col gap-1 text-xs font-semibold text-text2">
-          Role
-          <select
+        </Field>
+        <Field label="Role" htmlFor="new-user-role">
+          <NativeSelect
+            id="new-user-role"
             value={role}
             onChange={(event) =>
               setRole(event.target.value === "admin" ? "admin" : "member")
             }
-            className="rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text"
           >
             <option value="member">member</option>
             <option value="admin">admin</option>
-          </select>
-        </label>
-        <button
+          </NativeSelect>
+        </Field>
+        <Button
           type="submit"
+          variant="primary"
           disabled={busy === "create"}
-          className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-accent-ink disabled:opacity-50"
         >
           {busy === "create" ? "Adding…" : "Add user"}
-        </button>
+        </Button>
       </form>
 
       {users.length === 0 ? (
@@ -176,30 +177,29 @@ export function UsersClient({ users }: { users: AdminUserRow[] }) {
                     {formatDate(user.createdAt)}
                   </td>
                   <td className="px-3 py-3">
-                    <div className="flex gap-2">
-                      <button
-                        type="button"
+                    <ActionGroup align="start" className="flex-nowrap">
+                      <Button
+                        size="sm"
                         disabled={busy === user.id}
                         onClick={() =>
                           patchUser(user.id, {
                             role: user.role === "admin" ? "member" : "admin",
                           })
                         }
-                        className="rounded-md border border-border px-2 py-1 text-xs font-semibold text-text2 hover:text-text disabled:opacity-50"
                       >
                         {user.role === "admin" ? "Make member" : "Make admin"}
-                      </button>
-                      <button
-                        type="button"
+                      </Button>
+                      <Button
+                        variant={user.disabled ? "primary" : "danger"}
+                        size="sm"
                         disabled={busy === user.id}
                         onClick={() =>
                           patchUser(user.id, { disabled: !user.disabled })
                         }
-                        className="rounded-md border border-border px-2 py-1 text-xs font-semibold text-text2 hover:text-text disabled:opacity-50"
                       >
                         {user.disabled ? "Enable" : "Disable"}
-                      </button>
-                    </div>
+                      </Button>
+                    </ActionGroup>
                   </td>
                 </tr>
               ))}
@@ -214,25 +214,17 @@ export function UsersClient({ users }: { users: AdminUserRow[] }) {
 function RoleBadge({ role }: { role: string }) {
   const isAdmin = role === "admin";
   return (
-    <span
-      className={`rounded-full px-3 py-1 text-xs font-semibold ${
-        isAdmin ? "bg-success-soft text-success-ink" : "bg-neutral text-text2"
-      }`}
-    >
+    <Pill variant={isAdmin ? "success" : "muted"}>
       {role}
-    </span>
+    </Pill>
   );
 }
 
 function StatusBadge({ disabled }: { disabled: boolean }) {
   return (
-    <span
-      className={`rounded-full px-3 py-1 text-xs font-semibold ${
-        disabled ? "bg-danger-soft text-danger" : "bg-success-soft text-success-ink"
-      }`}
-    >
+    <Pill variant={disabled ? "danger" : "success"}>
       {disabled ? "Disabled" : "Active"}
-    </span>
+    </Pill>
   );
 }
 

--- a/apps/web/src/app/api/admin/packs/[packId]/[action]/route.ts
+++ b/apps/web/src/app/api/admin/packs/[packId]/[action]/route.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { isDenied, requireAdminActor } from "@/lib/admin-auth";
+import {
+  isPackReadAction,
+  isPackWriteAction,
+  requestPackWorker,
+  validPackId,
+} from "@/lib/solution-packs";
+
+type RouteContext = {
+  params: Promise<{ packId: string; action: string }>;
+};
+
+const MAX_BODY_BYTES = 64 * 1024;
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  const allowed = await requireAdminActor();
+  if (isDenied(allowed)) return allowed;
+  const { packId, action } = await context.params;
+  if (!validPackId(packId) || !isPackReadAction(action)) {
+    return NextResponse.json({ error: "unknown pack operation" }, { status: 404 });
+  }
+  try {
+    const result = await requestPackWorker(
+      `/admin/packs/${encodeURIComponent(packId)}/${action}`,
+    );
+    return NextResponse.json(result.body, { status: result.status });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 502 },
+    );
+  }
+}
+
+export async function POST(request: NextRequest, context: RouteContext) {
+  const allowed = await requireAdminActor();
+  if (isDenied(allowed)) return allowed;
+  const { packId, action } = await context.params;
+  if (!validPackId(packId) || !isPackWriteAction(action)) {
+    return NextResponse.json({ error: "unknown pack operation" }, { status: 404 });
+  }
+  const declaredLength = Number(request.headers.get("content-length") ?? "0");
+  if (Number.isFinite(declaredLength) && declaredLength > MAX_BODY_BYTES) {
+    return NextResponse.json({ error: "request is too large" }, { status: 413 });
+  }
+  let parsed: unknown;
+  try {
+    const raw = await request.text();
+    if (Buffer.byteLength(raw, "utf8") > MAX_BODY_BYTES) {
+      return NextResponse.json({ error: "request is too large" }, { status: 413 });
+    }
+    parsed = raw ? JSON.parse(raw) as unknown : {};
+  } catch {
+    return NextResponse.json({ error: "request body must be valid JSON" }, { status: 400 });
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return NextResponse.json({ error: "request body must be an object" }, { status: 400 });
+  }
+  try {
+    const body = {
+      ...(parsed as Record<string, unknown>),
+      actorUserId: allowed.userId,
+      idempotencyKey:
+        typeof (parsed as Record<string, unknown>).idempotencyKey === "string"
+          ? (parsed as Record<string, unknown>).idempotencyKey
+          : randomUUID(),
+    };
+    const result = await requestPackWorker(
+      `/admin/packs/${encodeURIComponent(packId)}/${action}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      },
+    );
+    return NextResponse.json(result.body, { status: result.status });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/web/src/app/api/admin/packs/route.ts
+++ b/apps/web/src/app/api/admin/packs/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { isDenied, requireAdminActor } from "@/lib/admin-auth";
+import { requestPackWorker } from "@/lib/solution-packs";
+
+export async function GET() {
+  const allowed = await requireAdminActor();
+  if (isDenied(allowed)) return allowed;
+  try {
+    const result = await requestPackWorker("/admin/packs");
+    return NextResponse.json(result.body, { status: result.status });
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : String(error) },
+      { status: 502 },
+    );
+  }
+}

--- a/apps/web/src/app/api/briefing/route.ts
+++ b/apps/web/src/app/api/briefing/route.ts
@@ -7,7 +7,9 @@ import {
   eq,
   metric,
   metric_snapshot,
+  or,
   processing_job,
+  sql,
 } from "@neko/db";
 import { enqueue, QUEUE } from "@neko/db/jobs";
 import {
@@ -236,7 +238,7 @@ export async function GET(request: NextRequest) {
               )
             : and(
                 eq(metric.org_id, (await getOrgId())),
-                eq(metric.role, role),
+                or(eq(metric.role, role), sql`${metric.source} like 'pack:%'`),
                 eq(metric.active, true),
               ),
           orderBy: asc(metric.slug),
@@ -249,7 +251,7 @@ export async function GET(request: NextRequest) {
         })
         .catch(() => [] as Array<never>);
 
-  const dbInsights = cards.slice(0, isOverview ? 12 : undefined).map((m) => {
+  const dbInsights = cards.map((m) => {
     const snap = m.snapshots?.[0];
     const p = snap?.payload as SnapshotPayload;
     const hasData = !!p;

--- a/apps/web/src/app/api/onboarding/status/route.ts
+++ b/apps/web/src/app/api/onboarding/status/route.ts
@@ -29,7 +29,7 @@ const STAGE_KINDS: StageKind[] = [
 ];
 
 const PROFILE_BUILD_FAILED_MESSAGE =
-  "Setup could not finish because the profiler agent failed. Check the agent provider configuration, then try again.";
+  "Setup could not finish because the agent became unavailable. Confirm `openneko status` shows serving, re-test the model in Admin → Settings → Agent, then try again.";
 
 function isStageKind(s: string): s is StageKind {
   return (STAGE_KINDS as string[]).includes(s);

--- a/apps/web/src/app/api/onboarding/submit/route.ts
+++ b/apps/web/src/app/api/onboarding/submit/route.ts
@@ -8,6 +8,12 @@ import {
 } from "@neko/db";
 import { enqueue, QUEUE } from "@neko/db/jobs";
 import { getOrgId } from "@/lib/db";
+import {
+  AGENT_RUNTIME_UNAVAILABLE_CODE,
+  AgentRuntimeUnavailableError,
+  requireAgentRuntimeReady,
+} from "@/lib/agent-runtime-readiness";
+import { hasPrimaryProviderSetup } from "@/lib/provider-settings";
 
 export async function POST(request: NextRequest) {
   const body = await request.json();
@@ -34,6 +40,29 @@ export async function POST(request: NextRequest) {
   }
 
   const orgId = await getOrgId();
+
+  if (!(await hasPrimaryProviderSetup(orgId))) {
+    return NextResponse.json(
+      {
+        error:
+          "The primary model provider is not configured. Open Agent settings, save a provider, then try again.",
+        code: "primary_provider_unavailable",
+      },
+      { status: 409 },
+    );
+  }
+
+  try {
+    await requireAgentRuntimeReady(orgId);
+  } catch (error) {
+    if (error instanceof AgentRuntimeUnavailableError) {
+      return NextResponse.json(
+        { error: error.message, code: AGENT_RUNTIME_UNAVAILABLE_CODE },
+        { status: 503 },
+      );
+    }
+    throw error;
+  }
 
   await db()
     .update(organization)

--- a/apps/web/src/app/api/workflow-runs/[workflowRunId]/route.ts
+++ b/apps/web/src/app/api/workflow-runs/[workflowRunId]/route.ts
@@ -87,7 +87,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
   // Lineage: if subscription-triggered, surface the upstream output's title
   // and originating workflow so the operator can walk backwards.
-  let lineage: {
+  const lineage: {
     triggeredBySubscriptionId: string | null;
     triggeredByOutputId: string | null;
     triggeredByObservationId: string | null;

--- a/apps/web/src/app/api/workflows/[workflowId]/subscriptions/dry-run/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/subscriptions/dry-run/route.ts
@@ -10,10 +10,6 @@ import { getOrgId } from "@/lib/db";
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
-type RouteContext = {
-  params: Promise<{ workflowId: string }>;
-};
-
 const DRY_RUN_LIMIT = 5;
 
 /**
@@ -23,7 +19,7 @@ const DRY_RUN_LIMIT = 5;
  *
  * Body: { sourceKind: "source_change", filter: { table, where, primary_key, ... } }
  */
-export async function POST(req: NextRequest, _context: RouteContext) {
+export async function POST(req: NextRequest) {
   const body = await req.json().catch(() => ({}));
   const sourceKind = body.sourceKind as string | undefined;
 

--- a/apps/web/src/app/business-profile/page.tsx
+++ b/apps/web/src/app/business-profile/page.tsx
@@ -7,6 +7,7 @@ import PageHeading from "@/components/PageHeading";
 import SectionNav from "@/components/SectionNav";
 import EditableMarkdown from "@/components/EditableMarkdown";
 import { Button } from "@/components/ui/Button";
+import { Segment, SegmentedControl } from "@/components/ui/Tabs";
 import { useDebouncedSave } from "@/hooks/useDebouncedSave";
 import type { StageKind } from "@/lib/db";
 
@@ -272,21 +273,22 @@ export default function ProcessingPage() {
         meta={insightsPending ? "research running" : "ready"}
       />
 
-      <div
-        className="pills"
+      <SegmentedControl
+        aria-label="Business context section"
+        className="mb-6"
         style={{ animation: "fadeUp 0.5s ease 0.12s both" }}
       >
-        <button
-          className={`pill${tab === "profile" ? " on" : ""}`}
+        <Segment
+          selected={tab === "profile"}
           onClick={async () => {
             await flushAll();
             setTab("profile");
           }}
         >
           Business Profile
-        </button>
-        <button
-          className={`pill${tab === "insights" ? " on" : ""}`}
+        </Segment>
+        <Segment
+          selected={tab === "insights"}
           onClick={async () => {
             await flushAll();
             setTab("insights");
@@ -304,8 +306,8 @@ export default function ProcessingPage() {
               · running
             </span>
           )}
-        </button>
-      </div>
+        </Segment>
+      </SegmentedControl>
 
       <div className="profile-card" style={{ animation: "fadeUp 0.6s ease 0.3s both" }}>
         {tab === "profile" ? (

--- a/apps/web/src/app/business-profile/page.tsx
+++ b/apps/web/src/app/business-profile/page.tsx
@@ -297,7 +297,7 @@ export default function ProcessingPage() {
             <span
               style={{
                 marginLeft: 8,
-                fontSize: 12,
+                fontSize: "var(--type-caption)",
                 opacity: 0.75,
               }}
             >
@@ -335,7 +335,7 @@ export default function ProcessingPage() {
         <div
           style={{
             marginTop: 8,
-            fontSize: 12,
+            fontSize: "var(--type-caption)",
             color: "var(--text3)",
             textAlign: "right",
           }}
@@ -357,7 +357,7 @@ export default function ProcessingPage() {
       >
         <Button
           variant="primary"
-          className="px-8 py-3.5 text-[15px]"
+          className="px-8 py-3.5 text-ui-body-lg"
           onClick={async () => {
             await flushAll();
             router.replace(needsPersona ? "/onboarding" : "/");
@@ -417,13 +417,13 @@ function StageStrip({ current }: { current: StageKind | null }) {
               border: "1px solid var(--border)",
               background: state === "active" ? "var(--accent-soft)" : "transparent",
               color: state === "done" ? "var(--text2)" : state === "active" ? "var(--accent)" : "var(--text3)",
-              fontSize: 13,
+              fontSize: "var(--type-body-sm)",
               display: "inline-flex",
               alignItems: "center",
               gap: 6,
             }}
           >
-            <span aria-hidden style={{ fontSize: 11 }}>{dot}</span>
+            <span aria-hidden style={{ fontSize: "var(--type-label)" }}>{dot}</span>
             <span>{STAGE_LABELS[kind]}</span>
           </div>
         );
@@ -432,11 +432,11 @@ function StageStrip({ current }: { current: StageKind | null }) {
   );
 }
 
-const PM_H2_CLS = "font-display text-[22px] font-bold leading-[1.3] tracking-[-0.3px] mb-4 text-text";
-const PM_H3_CLS = "font-display text-[13px] font-semibold uppercase tracking-[0.8px] text-text3 mt-6 mb-2 first:mt-0";
-const PM_P_CLS = "text-base leading-[1.65] text-text2 mb-1.5";
+const PM_H2_CLS = "font-display text-ui-section font-bold leading-[1.3] tracking-[-0.3px] mb-4 text-text";
+const PM_H3_CLS = "font-display text-ui-label font-semibold uppercase tracking-[0.8px] text-text3 mt-6 mb-2 first:mt-0";
+const PM_P_CLS = "text-ui-body leading-[1.65] text-text2 mb-1.5";
 const PM_CITE_CLS =
-  "text-[11px] font-semibold text-accent no-underline bg-accent-soft rounded-[4px] px-[5px] py-px mx-px align-super leading-none transition-all duration-150 hover:bg-accent hover:text-white";
+  "text-ui-label font-semibold text-accent no-underline bg-accent-soft rounded-[4px] px-[5px] py-px mx-px align-super leading-none transition-all duration-150 hover:bg-accent hover:text-white";
 
 function InsightsLoading() {
   return (

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -55,6 +55,17 @@
   --shadow-soft: 0 1px 3px rgba(20,18,12,0.04), 0 4px 16px rgba(20,18,12,0.03);
   --shadow-hover: 0 2px 8px rgba(20,18,12,0.06), 0 12px 36px -8px rgba(20,18,12,0.07);
   --shadow-lift: 0 1px 2px rgba(20,18,12,0.04), 0 18px 48px -16px rgba(20,18,12,0.16);
+
+  /* Semantic utilities for component-local Tailwind. These mirror the
+     product scale in _tokens.css instead of exposing one-off pixel values. */
+  --text-ui-page: var(--type-page);
+  --text-ui-section: var(--type-section);
+  --text-ui-subsection: var(--type-subsection);
+  --text-ui-body-lg: var(--type-body-lg);
+  --text-ui-body: var(--type-body);
+  --text-ui-body-sm: var(--type-body-sm);
+  --text-ui-caption: var(--type-caption);
+  --text-ui-label: var(--type-label);
 }
 
 /* font-display / font-body utilities use the bundled Fontsource variable
@@ -74,7 +85,7 @@ html[data-density="compact"] {
   /* Cap at TWO cards side by side — charts need the width to stay legible. */
   --d-brief-cols: repeat(2, minmax(0, 1fr));
   --d-brief-gap: 12px;
-  --d-greet: 30px;
+  --d-greet: 32px;
   --d-section-gap: 22px;
   --d-icard-pad: 15px 16px 15px 20px;
   /* Sticky offset for the side panels — set to their resting top (sticky
@@ -86,7 +97,7 @@ html[data-density="comfortable"] {
   --d-dash-width: 760px;
   --d-brief-cols: 1fr;
   --d-brief-gap: 12px;
-  --d-greet: 46px;
+  --d-greet: 48px;
   --d-section-gap: 32px;
   --d-icard-pad: 22px 24px 22px 28px;
 }
@@ -96,7 +107,7 @@ html[data-density="comfortable"] {
   border-radius: 999px; padding: 3px; gap: 2px; flex: 0 0 auto;
 }
 .density-seg button {
-  font-family: var(--font-body), 'Manrope', sans-serif; font-weight: 600; font-size: 12.5px;
+  font-family: var(--font-body), 'Manrope', sans-serif; font-weight: 600; font-size: var(--type-body-sm);
   color: var(--text2); border: 0; background: transparent; padding: 6px 14px; border-radius: 999px;
   cursor: pointer; display: inline-flex; align-items: center; gap: 6px; line-height: 1; transition: color 0.18s;
 }
@@ -147,7 +158,7 @@ html[data-density="compact"] .triage-pane {
   padding: 13px 14px 14px; box-shadow: var(--shadow);
 }
 .wcr-h {
-  font-family: var(--font-display), 'Archivo', sans-serif; font-size: 10px; font-weight: 700;
+  font-family: var(--font-display), 'Archivo', sans-serif; font-size: var(--type-label); font-weight: 700;
   text-transform: uppercase; letter-spacing: 0.13em; color: var(--text3);
   margin: 0 0 9px; display: flex; align-items: center; gap: 8px;
 }
@@ -167,23 +178,23 @@ html[data-density="compact"] .triage-pane {
   display: flex; align-items: flex-start; gap: 8px; padding: 9px 11px;
   border: 1px solid var(--border); border-radius: 11px; background: var(--bg);
   text-align: left; width: 100%; cursor: pointer;
-  font-family: var(--font-body), 'Manrope', sans-serif; font-size: 12.5px; line-height: 1.4;
+  font-family: var(--font-body), 'Manrope', sans-serif; font-size: var(--type-body-sm); line-height: var(--leading-compact);
   color: var(--text2);
   transition: border-color 0.15s, background 0.15s, color 0.15s, transform 0.15s;
 }
 .wcr-chip:hover { border-color: var(--accent); background: var(--accent-soft); color: var(--accent); transform: translateY(-1px); }
-.wcr-source { display: flex; align-items: center; gap: 8px; padding: 6px 2px; font-size: 12.5px; color: var(--text2); }
+.wcr-source { display: flex; align-items: center; gap: 8px; padding: 6px 2px; font-size: var(--type-body-sm); color: var(--text2); }
 .wcr-source-dot { width: 6px; height: 6px; border-radius: 2px; background: var(--accent); opacity: 0.7; flex: none; }
-.wcr-memo { background: var(--bg); border: 1px solid var(--border); border-left: 2px solid var(--accent); border-radius: 11px; padding: 9px 11px; font-size: 12px; line-height: 1.45; color: var(--text2); }
-.wcr-empty-text { margin: 0; font-size: 12px; line-height: 1.5; color: var(--text3); }
+.wcr-memo { background: var(--bg); border: 1px solid var(--border); border-left: 2px solid var(--accent); border-radius: 11px; padding: 9px 11px; font-size: var(--type-caption); line-height: var(--leading-compact); color: var(--text2); }
+.wcr-empty-text { margin: 0; font-size: var(--type-caption); line-height: var(--leading-body); color: var(--text3); }
 .wcr-vitals { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
 .wcr-vital { background: var(--bg); border: 1px solid var(--border); border-radius: 12px; padding: 9px 10px; }
-.wcr-vital-k { font-size: 9.5px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text3); margin-bottom: 5px; }
+.wcr-vital-k { font-size: var(--type-label); font-weight: 700; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text3); margin-bottom: 5px; }
 .wcr-vital-v {
-  font-family: var(--font-display), 'Archivo', sans-serif; font-weight: 800; font-size: 18px;
+  font-family: var(--font-display), 'Archivo', sans-serif; font-weight: 800; font-size: var(--type-section);
   line-height: 1; letter-spacing: -0.02em; font-variant-numeric: tabular-nums; color: var(--text);
 }
-.wcr-vital-s { margin-top: 4px; font-size: 10.5px; font-weight: 600; color: var(--success-ink); }
+.wcr-vital-s { margin-top: 4px; font-size: var(--type-label); font-weight: 600; color: var(--success-ink); }
 
 @media (min-width: 1100px) {
   html[data-density="compact"] .work-layout.has-rail {
@@ -205,9 +216,9 @@ html[data-density="compact"] .triage-pane {
 .topbar-brand { display: inline-flex; align-items: center; gap: 9px; text-decoration: none; color: var(--text); flex: 0 0 auto; transition: opacity 0.18s; }
 .topbar-brand:hover { opacity: 0.85; }
 .topbar-logo { width: 22px; height: auto; object-fit: contain; display: block; flex: none; }
-.topbar-name { font-family: var(--font-display), 'Archivo', sans-serif; font-weight: 800; font-size: 17px; letter-spacing: -0.02em; line-height: 1; }
+.topbar-name { font-family: var(--font-display), 'Archivo', sans-serif; font-weight: 800; font-size: var(--type-subsection); letter-spacing: -0.02em; line-height: 1; }
 .topbar-ver {
-  font-family: var(--font-body), 'Manrope', sans-serif; font-weight: 600; font-size: 10.5px;
+  font-family: var(--font-body), 'Manrope', sans-serif; font-weight: 600; font-size: var(--type-label);
   color: var(--text2); background: var(--neutral); padding: 2px 6px; border-radius: 999px;
   border: 0; line-height: 1.4; letter-spacing: 0; white-space: nowrap; flex: 0 0 auto;
 }
@@ -220,7 +231,7 @@ html[data-density="compact"] .triage-pane {
 .topbar-ver-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--success-mid); }
 .topbar-nav { display: flex; align-items: center; gap: 2px; margin-left: 6px; flex-wrap: nowrap; }
 .topbar-nav-link {
-  font-size: 13.5px; font-weight: 500; color: var(--text2); padding: 7px 12px; border-radius: 999px;
+  font-size: var(--type-body); font-weight: 500; color: var(--text2); padding: 7px 12px; border-radius: 999px;
   border: 1px solid transparent; text-decoration: none; white-space: nowrap; display: inline-flex; align-items: center;
   transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
@@ -231,11 +242,11 @@ html[data-density="compact"] .triage-pane {
   background: var(--accent); margin-right: 7px;
 }
 .topbar-spacer { flex: 1; }
-.topbar-signout { background: transparent; border: 0; cursor: pointer; color: var(--text2); font-size: 12px; font-weight: 500; padding: 0; flex: 0 0 auto; white-space: nowrap; }
+.topbar-signout { background: transparent; border: 0; cursor: pointer; color: var(--text2); font-size: var(--type-caption); font-weight: 500; padding: 0; flex: 0 0 auto; white-space: nowrap; }
 .topbar-signout:hover { color: var(--text); }
 .topbar-credit {
   display: inline-flex; align-items: center; flex: 0 0 auto;
-  font-family: var(--font-body), 'Manrope', sans-serif; font-size: 11.5px; font-weight: 500;
+  font-family: var(--font-body), 'Manrope', sans-serif; font-size: var(--type-caption); font-weight: 500;
   color: var(--text3); text-decoration: none; line-height: 1; white-space: nowrap;
   padding-left: 14px; margin-left: 2px; border-left: 1px solid var(--border);
   transition: color 0.18s;
@@ -249,8 +260,5 @@ html[data-density="compact"] .triage-pane {
   .topbar-spacer { display: none; }
   .topbar-nav { order: 3; width: 100%; overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; }
 }
-
-
-
 
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 @import "./styles/_tokens.css";
+@import "./styles/_ui.css";
 @import "./styles/_rail.css";
 @import "./styles/_chrome.css";
 @import "./styles/_dashboard.css";
@@ -28,8 +29,8 @@
   --color-bg: #FAFAF7;
   --color-card: #FFFFFF;
   --color-text: #2D2A24;
-  --color-text2: #7A756A;
-  --color-text3: #B0AA9F;
+  --color-text2: #6F6A60;
+  --color-text3: #756F65;
   --color-border: #EEEBE4;
   --color-neutral: #F2EFE8;
   --color-neutral-soft: #F7F4ED;
@@ -38,13 +39,13 @@
   --color-success: #6CFF7F;
   --color-success-ink: #113719;
   --color-success-soft: #E2FBE6;
-  --color-success-mid: #4CAF82;
+  --color-success-mid: #357A57;
   --color-watch: #E9A23B;
   --color-watch-soft: #FFF1D8;
   --color-warn: #F0D97A;
   --color-warn-soft: #FFF4CC;
   --color-warn-ink: #8A6D00;
-  --color-danger: #E05656;
+  --color-danger: #A53535;
   --color-danger-soft: #FEECEC;
 
   --radius-card: 20px;
@@ -260,5 +261,4 @@ html[data-density="compact"] .triage-pane {
   .topbar-spacer { display: none; }
   .topbar-nav { order: 3; width: 100%; overflow-x: auto; flex-wrap: nowrap; -webkit-overflow-scrolling: touch; }
 }
-
 

--- a/apps/web/src/app/integrations/IntegrationsList.tsx
+++ b/apps/web/src/app/integrations/IntegrationsList.tsx
@@ -73,15 +73,15 @@ export default function IntegrationsList({ initial }: { initial: InitialState })
         className="flex items-center gap-4 p-4 rounded-xl border border-border bg-bg max-[480px]:items-stretch max-[480px]:flex-col"
       >
         <div className="flex-1 min-w-0">
-          <div className="font-semibold text-text">{row.providerLabel}</div>
-          <div className="text-[12px] text-text3 truncate">
+          <div className="font-display text-ui-subsection font-bold text-text">{row.providerLabel}</div>
+          <div className="text-ui-caption text-text3 truncate">
             {row.pluginName}
           </div>
-          <div className="text-[12px] text-text3 mt-1 truncate">
+          <div className="text-ui-caption text-text3 mt-1 truncate">
             Scopes: {row.scopes.join(", ")}
           </div>
           {row.connected && row.connectedAt && (
-            <div className="text-[12px] text-text2 mt-1">
+            <div className="text-ui-caption text-text2 mt-1">
               Connected {new Date(row.connectedAt).toLocaleString()}
             </div>
           )}
@@ -117,10 +117,10 @@ export default function IntegrationsList({ initial }: { initial: InitialState })
 
       {workspace.length > 0 && (
         <>
-          <h2 className="mt-6 mb-2 text-[15px] font-semibold text-text">
+          <h2 className="mt-6 mb-2 font-display text-ui-section font-bold text-text">
             Workspace connections
           </h2>
-          <p className="text-[13px] text-text3 mb-2">
+          <p className="text-ui-body-sm text-text3 mb-2">
             One org-wide authorization, consented once by an admin and shared
             by every operator. Authorizing opens a browser consent screen that
             names the scopes and the endpoint.
@@ -135,10 +135,10 @@ export default function IntegrationsList({ initial }: { initial: InitialState })
 
       {connectors.length > 0 && (
         <>
-          <h2 className="mt-6 mb-2 text-[15px] font-semibold text-text">
+          <h2 className="mt-6 mb-2 font-display text-ui-section font-bold text-text">
             Per-operator connectors
           </h2>
-          <p className="text-[13px] text-text3 mb-2">
+          <p className="text-ui-body-sm text-text3 mb-2">
             Each operator authorizes independently with their own account.
           </p>
           <ul className="flex flex-col gap-3">
@@ -150,7 +150,7 @@ export default function IntegrationsList({ initial }: { initial: InitialState })
       )}
 
       {workspace.length === 0 && connectors.length === 0 && (
-        <p className="text-[14px] text-text3 mt-4">
+        <p className="text-ui-body text-text3 mt-4">
           No connect-capable plugins installed. Install one with{" "}
           <code>openneko install &lt;name&gt;</code>.
         </p>

--- a/apps/web/src/app/integrations/IntegrationsList.tsx
+++ b/apps/web/src/app/integrations/IntegrationsList.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import AppHeader from "@/components/AppHeader";
 import PageHeading from "@/components/PageHeading";
-import { Button } from "@/components/ui/Button";
+import { Button, ButtonLink } from "@/components/ui/Button";
 
 type Row = {
   pluginId: string;
@@ -95,12 +95,11 @@ export default function IntegrationsList({ initial }: { initial: InitialState })
             {busy === row.pluginName ? "…" : "Disconnect"}
           </Button>
         ) : (
-          <a
+          <ButtonLink
             href={`/api/integrations/connect/${encodeURIComponent(row.pluginName)}/start`}
-            className="inline-flex"
           >
-            <Button>Connect</Button>
-          </a>
+            Connect
+          </ButtonLink>
         )}
       </li>
     );

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -64,7 +64,7 @@ export default function RootLayout({
               boxShadow:
                 "0 1px 2px rgba(20,18,12,0.04), 0 12px 40px -8px rgba(20,18,12,0.12), 0 24px 60px -16px rgba(20,18,12,0.08)",
               fontFamily: "var(--font-body), 'Manrope', sans-serif",
-              fontSize: 13,
+              fontSize: "var(--type-body-sm)",
               fontWeight: 400,
               lineHeight: 1.5,
               boxSizing: "border-box",

--- a/apps/web/src/app/onboarding/OnboardingUnavailable.tsx
+++ b/apps/web/src/app/onboarding/OnboardingUnavailable.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import EntryShell from "@/components/EntryShell";
+import { ButtonLink } from "@/components/ui/Button";
 
 type OnboardingUnavailableProps = {
   retryAction?: ReactNode;
@@ -26,9 +27,9 @@ export default function OnboardingUnavailable({
           </p>
         </div>
         <div className="entry-actions is-end">
-          <a href="/onboarding" className="entry-button is-primary">
+          <ButtonLink href="/onboarding" variant="primary" size="lg">
             Check again
-          </a>
+          </ButtonLink>
         </div>
       </EntryShell>
     );
@@ -53,16 +54,13 @@ export default function OnboardingUnavailable({
         been changed.
       </div>
       <div className="entry-actions">
-        <a href="/admin/settings" className="entry-button">
+        <ButtonLink href="/admin/settings" size="lg">
           Admin settings
-        </a>
+        </ButtonLink>
         {retryAction ?? (
-          <a
-            href="/onboarding"
-            className="entry-button is-primary"
-          >
+          <ButtonLink href="/onboarding" variant="primary" size="lg">
             Retry
-          </a>
+          </ButtonLink>
         )}
       </div>
     </EntryShell>

--- a/apps/web/src/app/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/app/onboarding/OnboardingWizard.tsx
@@ -5,6 +5,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import EntryShell from "@/components/EntryShell";
 import { toast } from "sonner";
 import Select from "@/components/Select";
+import { Button } from "@/components/ui/Button";
 
 // Quick-pick suggestions only — seats are free text (CV3 personas). A
 // custom role flows through metrics, briefing tabs, and the persona
@@ -194,14 +195,14 @@ export default function OnboardingWizard({
             </Field>
           </div>
           <div className="entry-actions is-end">
-            <button
-              type="button"
-              className="entry-button is-primary"
+            <Button
+              variant="primary"
+              size="lg"
               disabled={!companyName.trim() || !companyNote.trim()}
               onClick={() => setStep(1)}
             >
               Continue
-            </button>
+            </Button>
           </div>
         </>
       ) : null}
@@ -245,28 +246,27 @@ export default function OnboardingWizard({
                 }}
                 aria-label="Add a custom decision-maker seat"
               />
-              <button
-                type="button"
+              <Button
+                size="lg"
                 onClick={addCustomSeat}
                 disabled={!customSeat.trim()}
-                className="entry-button"
               >
                 Add role
-              </button>
+              </Button>
             </div>
           </fieldset>
           <div className="entry-actions">
-            <button type="button" className="entry-button" onClick={() => setStep(0)}>
+            <Button size="lg" onClick={() => setStep(0)}>
               Back
-            </button>
-            <button
-              type="button"
-              className="entry-button is-primary"
+            </Button>
+            <Button
+              variant="primary"
+              size="lg"
               disabled={seats.length === 0}
               onClick={() => setStep(2)}
             >
               Continue
-            </button>
+            </Button>
           </div>
         </>
       ) : null}
@@ -302,22 +302,21 @@ export default function OnboardingWizard({
             ) : null}
           </div>
           <div className="entry-actions">
-            <button
-              type="button"
-              className="entry-button"
+            <Button
+              size="lg"
               disabled={submitting}
               onClick={() => setStep(teamMode ? 0 : 1)}
             >
               Back
-            </button>
-            <button
-              type="button"
-              className="entry-button is-primary"
+            </Button>
+            <Button
+              variant="primary"
+              size="lg"
               disabled={!canSubmit}
               onClick={() => void submit()}
             >
               {submitting ? "Building workspace…" : "Build workspace"}
-            </button>
+            </Button>
           </div>
         </>
       ) : null}

--- a/apps/web/src/app/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/app/onboarding/OnboardingWizard.tsx
@@ -116,7 +116,14 @@ export default function OnboardingWizard({
           priorities,
         }),
       });
-      if (!res.ok) throw new Error(await res.text());
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(
+          typeof body.error === "string"
+            ? body.error
+            : "Workspace setup could not start. Please try again.",
+        );
+      }
       router.push("/business-profile");
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));

--- a/apps/web/src/app/onboarding/PersonaStep.tsx
+++ b/apps/web/src/app/onboarding/PersonaStep.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import EntryShell from "@/components/EntryShell";
+import { Button } from "@/components/ui/Button";
 
 /**
  * Per-user onboarding (CV3): every SSO identity describes its own role and
@@ -88,14 +89,14 @@ export default function PersonaStep({
         ) : null}
       </div>
       <div className="entry-actions is-end">
-        <button
-          type="button"
+        <Button
+          variant="primary"
+          size="lg"
           onClick={() => void submit()}
           disabled={submitting || !roleTemplate.trim()}
-          className="entry-button is-primary"
         >
           {submitting ? "Saving…" : "Open my workspace"}
-        </button>
+        </Button>
       </div>
     </EntryShell>
   );

--- a/apps/web/src/app/onboarding/error.tsx
+++ b/apps/web/src/app/onboarding/error.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
+import { Button } from "@/components/ui/Button";
 import OnboardingUnavailable from "./OnboardingUnavailable";
 
 export default function OnboardingError({
@@ -17,13 +18,13 @@ export default function OnboardingError({
   return (
     <OnboardingUnavailable
       retryAction={
-        <button
-          type="button"
+        <Button
+          variant="primary"
+          size="lg"
           onClick={reset}
-          className="entry-button is-primary"
         >
           Retry
-        </button>
+        </Button>
       }
     />
   );

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -569,7 +569,7 @@ export default function Dashboard() {
                 style={{ animation: "fadeUp 0.5s ease 0.15s both" }}
               >
                 <p className="m-0">{findings.summary.summaryMd}</p>
-                <div className="mt-2 font-mono text-[11.5px] text-text3 italic">
+                <div className="mt-2 font-mono text-ui-caption text-text3 italic">
                   as of {new Date(findings.summary.createdAt).toLocaleTimeString("en-IN", {
                     hour: "numeric",
                     minute: "2-digit",
@@ -623,7 +623,7 @@ export default function Dashboard() {
                 className="mb-7"
                 style={{ animation: "fadeUp 0.5s ease 0.21s both" }}
               >
-                <div className="text-[11px] font-bold tracking-[0.13em] uppercase text-text3 mb-3">
+                <div className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3 mb-3">
                   Worth your read
                 </div>
                 <div className="flex flex-col gap-3">
@@ -644,7 +644,7 @@ export default function Dashboard() {
                 className="mb-7"
                 style={{ animation: "fadeUp 0.5s ease 0.22s both" }}
               >
-                <div className="text-[11px] font-bold tracking-[0.13em] uppercase text-text3 mb-3">
+                <div className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3 mb-3">
                   Pinned
                 </div>
                 <div className="flex flex-col gap-3">
@@ -670,7 +670,7 @@ export default function Dashboard() {
                 className="mb-7"
                 style={{ animation: "fadeUp 0.5s ease 0.25s both" }}
               >
-                <div className="text-[11px] font-bold tracking-[0.13em] uppercase text-text3 mb-3">
+                <div className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3 mb-3">
                   Worth knowing
                 </div>
                 <div className="flex flex-col gap-3">
@@ -691,7 +691,7 @@ export default function Dashboard() {
                 className="mb-7"
                 style={{ animation: "fadeUp 0.5s ease 0.27s both" }}
               >
-                <div className="text-[11px] font-bold tracking-[0.13em] uppercase text-text3 mb-3">
+                <div className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3 mb-3">
                   Elevated
                 </div>
                 <div className="flex flex-col gap-3">
@@ -717,7 +717,7 @@ export default function Dashboard() {
 
             {findings && findings.quiet.goodOutputs > 0 && (
               <div
-                className="-mt-1.5 mb-7 text-[13px] text-text3 italic"
+                className="-mt-1.5 mb-7 text-ui-body-sm text-text3 italic"
                 style={{ animation: "fadeUp 0.5s ease 0.3s both" }}
               >
                 {findings.quiet.goodOutputs} healthy run
@@ -730,7 +730,7 @@ export default function Dashboard() {
               metricsProgress.completed + metricsProgress.failed < metricsProgress.total && (
                 <div
                   role="status"
-                  className="mt-4 px-3.5 py-2.5 rounded-[10px] border border-border bg-accent-soft text-accent text-[13px] inline-block"
+                  className="mt-4 px-3.5 py-2.5 rounded-[10px] border border-border bg-accent-soft text-accent text-ui-body-sm inline-block"
                 >
                   Building your briefing — {metricsProgress.completed + metricsProgress.failed} of {metricsProgress.total} cards complete
                 </div>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import Link from "next/link";
-import { useState, useEffect, useCallback, useMemo } from "react";
+import {
+  useState,
+  useEffect,
+  useCallback,
+  useMemo,
+  type ReactNode,
+} from "react";
 import { useRouter } from "next/navigation";
 import { applyMessage, getResolvedComponents } from "@/a2ui/surface";
 import type { SurfaceState, A2UIComponent } from "@/a2ui/types";
@@ -23,6 +29,8 @@ import HoursSavedHero, {
   type HoursSavedValue,
 } from "@/components/HoursSavedHero";
 import AgentLauncher from "@/components/AgentLauncher";
+import { Button } from "@/components/ui/Button";
+import { Segment, SegmentedControl } from "@/components/ui/Tabs";
 import { formatSavedShort } from "@/lib/hours-saved";
 import { cn } from "@/lib/cn";
 import {
@@ -78,6 +86,46 @@ type ReceiptRow = {
   trigger: string | null;
   payload: unknown;
 };
+
+function ProgressiveList({
+  count,
+  label,
+  className,
+  children,
+}: {
+  count: number;
+  label: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const remaining = Math.max(0, count - 3);
+
+  return (
+    <>
+      <div
+        className={cn(
+          "mobile-progressive-list",
+          expanded && "is-expanded",
+          className,
+        )}
+      >
+        {children}
+      </div>
+      {remaining > 0 ? (
+        <Button
+          size="sm"
+          variant="ghost"
+          className="mobile-progressive-toggle"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((current) => !current)}
+        >
+          {expanded ? "Show fewer" : `View ${remaining} more ${label}`}
+        </Button>
+      ) : null}
+    </>
+  );
+}
 
 type RecentActionsPayload = {
   receipts: ReceiptRow[];
@@ -483,12 +531,13 @@ export default function Dashboard() {
                 the connection is back.
               </p>
             </div>
-            <button
+            <Button
+              variant="danger"
+              size="sm"
               onClick={() => { setGateError(null); setGateChecked(false); setLoading(true); window.location.reload(); }}
-              type="button"
             >
               Retry
-            </button>
+            </Button>
           </div>
         ) : loading ? (
           <div className="dash-system-state is-loading" role="status">
@@ -521,19 +570,17 @@ export default function Dashboard() {
                 !personalMode && roles.length > 0 ? (
                   <div className="dash-role-control" aria-label="Briefing role">
                     <span>Briefing view</span>
-                    <div className="dash-role-list">
+                    <SegmentedControl className="dash-role-list">
                       {roles.map((kind) => (
-                        <button
+                        <Segment
                           key={kind}
-                          type="button"
-                          className={cn(role === kind && "is-active")}
-                          aria-pressed={role === kind}
+                          selected={role === kind}
                           onClick={() => setRole(kind)}
                         >
                           {kind}
-                        </button>
+                        </Segment>
                       ))}
-                    </div>
+                    </SegmentedControl>
                   </div>
                 ) : null
               }
@@ -626,7 +673,11 @@ export default function Dashboard() {
                 <div className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3 mb-3">
                   Worth your read
                 </div>
-                <div className="flex flex-col gap-3">
+                <ProgressiveList
+                  count={findings.awaitingYou.actFindings.length}
+                  label="findings"
+                  className="flex flex-col gap-3"
+                >
                   {findings.awaitingYou.actFindings.map((f, i) => (
                     <FindingCard
                       key={f.id}
@@ -635,7 +686,7 @@ export default function Dashboard() {
                       onMuted={fetchFindings}
                     />
                   ))}
-                </div>
+                </ProgressiveList>
               </section>
             )}
 
@@ -647,7 +698,11 @@ export default function Dashboard() {
                 <div className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3 mb-3">
                   Pinned
                 </div>
-                <div className="flex flex-col gap-3">
+                <ProgressiveList
+                  count={findings.pinned.length}
+                  label="findings"
+                  className="flex flex-col gap-3"
+                >
                   {findings.pinned.map((f, i) => (
                     <FindingCard
                       key={f.pinId ?? f.id}
@@ -661,7 +716,7 @@ export default function Dashboard() {
                       }}
                     />
                   ))}
-                </div>
+                </ProgressiveList>
               </section>
             )}
 
@@ -673,7 +728,11 @@ export default function Dashboard() {
                 <div className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3 mb-3">
                   Worth knowing
                 </div>
-                <div className="flex flex-col gap-3">
+                <ProgressiveList
+                  count={findings.worthKnowing.length}
+                  label="findings"
+                  className="flex flex-col gap-3"
+                >
                   {findings.worthKnowing.map((f, i) => (
                     <FindingCard
                       key={f.id}
@@ -682,7 +741,7 @@ export default function Dashboard() {
                       onMuted={fetchFindings}
                     />
                   ))}
-                </div>
+                </ProgressiveList>
               </section>
             )}
 
@@ -694,7 +753,11 @@ export default function Dashboard() {
                 <div className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3 mb-3">
                   Elevated
                 </div>
-                <div className="flex flex-col gap-3">
+                <ProgressiveList
+                  count={findings.elevated.length}
+                  label="findings"
+                  className="flex flex-col gap-3"
+                >
                   {findings.elevated.map((c, i) => (
                     <FindingCard
                       key={c.id}
@@ -711,7 +774,7 @@ export default function Dashboard() {
                       index={i}
                     />
                   ))}
-                </div>
+                </ProgressiveList>
               </section>
             )}
 
@@ -738,7 +801,11 @@ export default function Dashboard() {
 
             <div className="mb-6">
               <div className="label">Today&apos;s Briefing</div>
-              <div className="brief-grid">
+              <ProgressiveList
+                count={briefingCards.length}
+                label="cards"
+                className="brief-grid"
+              >
                 {briefingCards.map((ins, i) => (
                   <BriefingCard
                     key={ins.id}
@@ -749,7 +816,7 @@ export default function Dashboard() {
                     onDeepDive={deepDiveCard}
                   />
                 ))}
-              </div>
+              </ProgressiveList>
             </div>
 
             {recentActions && recentActions.receipts.length > 0 && (

--- a/apps/web/src/app/runs/[workflowRunId]/page.tsx
+++ b/apps/web/src/app/runs/[workflowRunId]/page.tsx
@@ -9,6 +9,7 @@ import AppHeader from "@/components/AppHeader";
 import CreatorCredit from "@/components/CreatorCredit";
 import PageHeading from "@/components/PageHeading";
 import SectionNav from "@/components/SectionNav";
+import { Button } from "@/components/ui/Button";
 import { cn } from "@/lib/cn";
 
 type RunDetailPayload = {
@@ -359,15 +360,15 @@ export default function RunPage() {
           meta={run.status.replace(/_/g, " ")}
           description={`${formatRunTimestamp(run.startedAt ?? run.createdAt)} · ${formatTrigger(run.triggerKind)} · ${formatDuration(durationMs)}`}
           actions={
-            <button
-              type="button"
-              className="run-followup-btn"
+            <Button
+              size="sm"
+              className="run-followup-control"
               onClick={askFollowUp}
               title="Open an Ask thread pre-loaded with this run's context"
             >
               <MessageCircle aria-hidden="true" />
               <span>Ask about this run</span>
-            </button>
+            </Button>
           }
         />
 
@@ -433,9 +434,14 @@ export default function RunPage() {
                         <span>{formatTaxonomy(o.topic)}</span>
                       )}
                     </div>
-                    <button
-                      type="button"
-                      className="run-finding-pin"
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className={cn(
+                        "run-finding-pin-control",
+                        pinnedOutputIds.has(o.id) &&
+                          "disabled:text-success-mid disabled:opacity-100",
+                      )}
                       disabled={
                         pinningOutputId === o.id || pinnedOutputIds.has(o.id)
                       }
@@ -454,7 +460,7 @@ export default function RunPage() {
                             ? "Pinning…"
                             : "Pin to briefing"}
                       </span>
-                    </button>
+                    </Button>
                   </footer>
                 </li>
               ))}
@@ -522,42 +528,41 @@ export default function RunPage() {
                         rows={2}
                       />
                       <div className="flex gap-2 mt-2.5">
-                        <button
-                          type="button"
-                          className="px-3.5 py-[7px] rounded-control border border-danger bg-danger text-white font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:bg-[var(--danger-hover)] hover:enabled:border-[var(--danger-hover)] disabled:opacity-55 disabled:cursor-not-allowed"
+                        <Button
+                          variant="danger"
+                          size="sm"
                           disabled={actionBusyId === a.id}
                           onClick={() => void submitReject()}
                         >
                           Confirm reject
-                        </button>
-                        <button
-                          type="button"
-                          className="px-3.5 py-[7px] rounded-[10px] border border-border bg-card text-text font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:border-text3 disabled:opacity-55 disabled:cursor-not-allowed"
+                        </Button>
+                        <Button
+                          size="sm"
                           disabled={actionBusyId === a.id}
                           onClick={cancelReject}
                         >
                           Cancel
-                        </button>
+                        </Button>
                       </div>
                     </div>
                   ) : a.status === "pending_approval" ? (
                     <div className="flex gap-2 mt-2.5">
-                      <button
-                        type="button"
-                        className="px-3.5 py-[7px] rounded-control border border-accent bg-accent text-white font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:bg-[var(--accent-hover)] hover:enabled:border-[var(--accent-hover)] disabled:opacity-55 disabled:cursor-not-allowed"
+                      <Button
+                        variant="primary"
+                        size="sm"
                         disabled={actionBusyId === a.id}
                         onClick={() => void actOnRequest(a.id, "approve")}
                       >
                         Approve
-                      </button>
-                      <button
-                        type="button"
-                        className="px-3.5 py-[7px] rounded-[10px] border border-border bg-card text-text font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:border-text3 disabled:opacity-55 disabled:cursor-not-allowed"
+                      </Button>
+                      <Button
+                        variant="danger"
+                        size="sm"
                         disabled={actionBusyId === a.id}
                         onClick={() => setRejectingId(a.id)}
                       >
                         Reject
-                      </button>
+                      </Button>
                     </div>
                   ) : null}
                   {a.status === "rejected" && a.rejectionReason && (
@@ -640,15 +645,16 @@ export default function RunPage() {
                     </span>
                   </p>
                   {lineage.upstream.workflowRunId && (
-                    <button
-                      type="button"
-                      className="mt-2 bg-transparent border-0 text-accent cursor-pointer font-inherit text-ui-body-sm p-0 hover:underline hover:underline-offset-[3px]"
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="mt-2"
                       onClick={() =>
                         router.push(`/runs/${lineage.upstream!.workflowRunId}`)
                       }
                     >
                       open upstream run →
-                    </button>
+                    </Button>
                   )}
                 </div>
               )}

--- a/apps/web/src/app/runs/[workflowRunId]/page.tsx
+++ b/apps/web/src/app/runs/[workflowRunId]/page.tsx
@@ -484,7 +484,7 @@ export default function RunPage() {
                     </button>
                     <span
                       className={cn(
-                        "text-[10.5px] font-bold tracking-[0.12em] uppercase px-[9px] py-[3px] rounded-full shrink-0",
+                        "text-ui-label font-bold tracking-[0.12em] uppercase px-[9px] py-[3px] rounded-full shrink-0",
                         actionPillClasses(a.status),
                       )}
                     >
@@ -510,11 +510,11 @@ export default function RunPage() {
                   </div>
                   {a.status === "pending_approval" && rejectingId === a.id ? (
                     <div className="pt-3 border-t border-border mt-2.5 flex flex-col gap-2">
-                      <label className="text-[11px] font-bold tracking-[0.13em] uppercase text-text3">
+                      <label className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3">
                         Why are you rejecting this? (optional)
                       </label>
                       <textarea
-                        className="border border-border rounded-[10px] px-3 py-2 font-body text-[13px] text-text bg-card resize-y min-h-[50px] outline-none focus:border-accent"
+                        className="border border-border rounded-[10px] px-3 py-2 font-body text-ui-body-sm text-text bg-card resize-y min-h-[50px] outline-none focus:border-accent"
                         value={rejectReason}
                         placeholder="e.g. wrong channel, retry tomorrow…"
                         onChange={(e) => setRejectReason(e.target.value)}
@@ -524,7 +524,7 @@ export default function RunPage() {
                       <div className="flex gap-2 mt-2.5">
                         <button
                           type="button"
-                          className="px-3.5 py-[7px] rounded-control border border-danger bg-danger text-white font-body text-[13px] font-semibold cursor-pointer hover:enabled:bg-[var(--danger-hover)] hover:enabled:border-[var(--danger-hover)] disabled:opacity-55 disabled:cursor-not-allowed"
+                          className="px-3.5 py-[7px] rounded-control border border-danger bg-danger text-white font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:bg-[var(--danger-hover)] hover:enabled:border-[var(--danger-hover)] disabled:opacity-55 disabled:cursor-not-allowed"
                           disabled={actionBusyId === a.id}
                           onClick={() => void submitReject()}
                         >
@@ -532,7 +532,7 @@ export default function RunPage() {
                         </button>
                         <button
                           type="button"
-                          className="px-3.5 py-[7px] rounded-[10px] border border-border bg-card text-text font-body text-[13px] font-semibold cursor-pointer hover:enabled:border-text3 disabled:opacity-55 disabled:cursor-not-allowed"
+                          className="px-3.5 py-[7px] rounded-[10px] border border-border bg-card text-text font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:border-text3 disabled:opacity-55 disabled:cursor-not-allowed"
                           disabled={actionBusyId === a.id}
                           onClick={cancelReject}
                         >
@@ -544,7 +544,7 @@ export default function RunPage() {
                     <div className="flex gap-2 mt-2.5">
                       <button
                         type="button"
-                        className="px-3.5 py-[7px] rounded-control border border-accent bg-accent text-white font-body text-[13px] font-semibold cursor-pointer hover:enabled:bg-[var(--accent-hover)] hover:enabled:border-[var(--accent-hover)] disabled:opacity-55 disabled:cursor-not-allowed"
+                        className="px-3.5 py-[7px] rounded-control border border-accent bg-accent text-white font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:bg-[var(--accent-hover)] hover:enabled:border-[var(--accent-hover)] disabled:opacity-55 disabled:cursor-not-allowed"
                         disabled={actionBusyId === a.id}
                         onClick={() => void actOnRequest(a.id, "approve")}
                       >
@@ -552,7 +552,7 @@ export default function RunPage() {
                       </button>
                       <button
                         type="button"
-                        className="px-3.5 py-[7px] rounded-[10px] border border-border bg-card text-text font-body text-[13px] font-semibold cursor-pointer hover:enabled:border-text3 disabled:opacity-55 disabled:cursor-not-allowed"
+                        className="px-3.5 py-[7px] rounded-[10px] border border-border bg-card text-text font-body text-ui-body-sm font-semibold cursor-pointer hover:enabled:border-text3 disabled:opacity-55 disabled:cursor-not-allowed"
                         disabled={actionBusyId === a.id}
                         onClick={() => setRejectingId(a.id)}
                       >
@@ -561,7 +561,7 @@ export default function RunPage() {
                     </div>
                   ) : null}
                   {a.status === "rejected" && a.rejectionReason && (
-                    <p className="mt-2 text-[12.5px] text-text2 italic">
+                    <p className="mt-2 text-ui-body-sm text-text2 italic">
                       Rejected: {a.rejectionReason}
                     </p>
                   )}
@@ -623,7 +623,7 @@ export default function RunPage() {
                 </p>
               )}
               {lineage.upstream && (
-                <div className="text-[13.5px] leading-[1.55] text-text">
+                <div className="text-ui-body leading-[1.55] text-text">
                   <p>
                     Triggered by{" "}
                     {lineage.upstream.workflow ? (
@@ -642,7 +642,7 @@ export default function RunPage() {
                   {lineage.upstream.workflowRunId && (
                     <button
                       type="button"
-                      className="mt-2 bg-transparent border-0 text-accent cursor-pointer font-inherit text-[12.5px] p-0 hover:underline hover:underline-offset-[3px]"
+                      className="mt-2 bg-transparent border-0 text-accent cursor-pointer font-inherit text-ui-body-sm p-0 hover:underline hover:underline-offset-[3px]"
                       onClick={() =>
                         router.push(`/runs/${lineage.upstream!.workflowRunId}`)
                       }
@@ -701,7 +701,7 @@ function coalesceEvents(events: EventRow[]): RenderedItem[] {
 function EventStream({ events }: { events: EventRow[] }) {
   const items = coalesceEvents(events);
   return (
-    <ul className="list-none p-0 m-0 flex flex-col gap-1.5 text-[13.5px] border-l-2 border-border pl-3">
+    <ul className="list-none p-0 m-0 flex flex-col gap-1.5 text-ui-body border-l-2 border-border pl-3">
       {items.map((item) => {
         if (item.type === "message-block") {
           return (
@@ -716,7 +716,7 @@ function EventStream({ events }: { events: EventRow[] }) {
         if (ev.type === "status") {
           const message = (ev.event as { message?: string } | null)?.message;
           return (
-            <li key={ev.seq} className="text-text3 text-[12.5px] italic">
+            <li key={ev.seq} className="text-text3 text-ui-body-sm italic">
               · {message}
             </li>
           );
@@ -724,7 +724,7 @@ function EventStream({ events }: { events: EventRow[] }) {
         if (ev.type === "output_emit") {
           const e = ev.event as { kind?: string } | null;
           return (
-            <li key={ev.seq} className="text-text2 text-[12.5px]">
+            <li key={ev.seq} className="text-text2 text-ui-body-sm">
               emitted output ({e?.kind ?? "unknown kind"})
             </li>
           );
@@ -734,7 +734,7 @@ function EventStream({ events }: { events: EventRow[] }) {
             | { kind?: string; risk_level?: string }
             | null;
           return (
-            <li key={ev.seq} className="text-text2 text-[12.5px]">
+            <li key={ev.seq} className="text-text2 text-ui-body-sm">
               proposed action: {e?.kind ?? "unknown"}
               {e?.risk_level ? ` (risk ${e.risk_level})` : ""}
             </li>
@@ -743,7 +743,7 @@ function EventStream({ events }: { events: EventRow[] }) {
         if (ev.type === "needs_input") {
           const e = ev.event as { question?: string } | null;
           return (
-            <li key={ev.seq} className="text-warn-ink text-[12.5px]">
+            <li key={ev.seq} className="text-warn-ink text-ui-body-sm">
               paused for input: {e?.question}
             </li>
           );
@@ -751,14 +751,14 @@ function EventStream({ events }: { events: EventRow[] }) {
         if (ev.type === "error") {
           const e = ev.event as { message?: string } | null;
           return (
-            <li key={ev.seq} className="text-danger text-[12.5px]">
+            <li key={ev.seq} className="text-danger text-ui-body-sm">
               error: {e?.message}
             </li>
           );
         }
         if (ev.type === "done") {
           return (
-            <li key={ev.seq} className="text-text3 text-[11.5px] font-mono">
+            <li key={ev.seq} className="text-text3 text-ui-caption font-mono">
               — done
             </li>
           );

--- a/apps/web/src/app/runs/page.tsx
+++ b/apps/web/src/app/runs/page.tsx
@@ -7,6 +7,7 @@ import CreatorCredit from "@/components/CreatorCredit";
 import PageHeading from "@/components/PageHeading";
 import SectionNav from "@/components/SectionNav";
 import { cn } from "@/lib/cn";
+import { Segment, SegmentedControl } from "@/components/ui/Tabs";
 
 type StatusFilter = "active" | "completed" | "failed" | "all";
 
@@ -75,7 +76,7 @@ function statusLabel(status: string): string {
 function statusClass(status: string): string {
   switch (status) {
     case "completed":
-      return "bg-success-soft text-success-mid";
+      return "bg-success-soft text-success-ink";
     case "failed":
     case "cancelled":
       return "bg-danger-soft text-danger";
@@ -145,7 +146,8 @@ function RunsPageInner() {
   }, [filter]);
 
   useEffect(() => {
-    void load();
+    const initialLoadId = window.setTimeout(() => void load(), 0);
+    return () => window.clearTimeout(initialLoadId);
   }, [load]);
 
   useEffect(() => {
@@ -181,23 +183,17 @@ function RunsPageInner() {
           meta={data ? `${data.runs.length} shown` : undefined}
         />
 
-        <div className="flex gap-1.5 flex-wrap mb-5">
+        <SegmentedControl aria-label="Run status filter" className="mb-5">
           {TABS.map((tab) => (
-            <button
+            <Segment
               key={tab.key}
-              type="button"
+              selected={filter === tab.key}
               onClick={() => switchFilter(tab.key)}
-              className={cn(
-                "px-3.5 py-1.5 rounded-full border font-body text-ui-body-sm font-semibold cursor-pointer transition",
-                filter === tab.key
-                  ? "bg-text text-bg border-text"
-                  : "bg-white/60 text-text2 border-border hover:border-accent hover:text-accent hover:bg-accent-soft",
-              )}
             >
               {tab.label}
-            </button>
+            </Segment>
           ))}
-        </div>
+        </SegmentedControl>
 
         {error ? (
           <div className="py-[50px] text-center text-sm text-danger">

--- a/apps/web/src/app/runs/page.tsx
+++ b/apps/web/src/app/runs/page.tsx
@@ -188,7 +188,7 @@ function RunsPageInner() {
               type="button"
               onClick={() => switchFilter(tab.key)}
               className={cn(
-                "px-3.5 py-1.5 rounded-full border font-body text-[12.5px] font-semibold cursor-pointer transition",
+                "px-3.5 py-1.5 rounded-full border font-body text-ui-body-sm font-semibold cursor-pointer transition",
                 filter === tab.key
                   ? "bg-text text-bg border-text"
                   : "bg-white/60 text-text2 border-border hover:border-accent hover:text-accent hover:bg-accent-soft",
@@ -226,27 +226,27 @@ function RunsPageInner() {
                         <span className="font-semibold text-text">
                           {run.workflow.name}
                         </span>
-                        <span className="font-mono text-[11.5px] text-text3">
+                        <span className="font-mono text-ui-caption text-text3">
                           {run.triggerKind}
                           {run.chainDepth > 0
                             ? ` · chain ${run.chainDepth}`
                             : ""}
                         </span>
                       </div>
-                      <p className="mt-1.5 mb-0 text-[13px] leading-[1.45] text-text2 line-clamp-2">
+                      <p className="mt-1.5 mb-0 text-ui-body-sm leading-[1.45] text-text2 line-clamp-2">
                         {describeRun(run)}
                       </p>
                     </div>
                     <span
                       className={cn(
-                        "shrink-0 uppercase text-[10.5px] tracking-[0.12em] font-bold px-2 py-0.5 rounded-full",
+                        "shrink-0 uppercase text-ui-label tracking-[0.12em] font-bold px-2 py-0.5 rounded-full",
                         statusClass(run.status),
                       )}
                     >
                       {statusLabel(run.status)}
                     </span>
                   </div>
-                  <div className="mt-3 flex flex-wrap items-center gap-1.5 text-[11.5px] text-text3">
+                  <div className="mt-3 flex flex-wrap items-center gap-1.5 text-ui-caption text-text3">
                     <span className="font-mono">
                       {formatRelative(run.createdAt)}
                     </span>
@@ -272,7 +272,7 @@ function RunsPageInner() {
                         </span>
                       </>
                     )}
-                    <span className="ml-auto font-mono text-[11.5px] text-text3">
+                    <span className="ml-auto font-mono text-ui-caption text-text3">
                       →
                     </span>
                   </div>

--- a/apps/web/src/app/settings/finish/route.ts
+++ b/apps/web/src/app/settings/finish/route.ts
@@ -5,12 +5,17 @@ import { isDenied, requireAdminActor } from "@/lib/admin-auth";
 import { getOrgId } from "@/lib/db";
 import { hasDataSourceSetup } from "@/lib/data-source-settings";
 import { hasPrimaryProviderSetup } from "@/lib/provider-settings";
+import {
+  AGENT_RUNTIME_UNAVAILABLE_CODE,
+  AgentRuntimeUnavailableError,
+  requireAgentRuntimeReady,
+} from "@/lib/agent-runtime-readiness";
 
 /**
- * Marks admin setup complete on the org. Gated on the same prerequisites
- * the wizard's "Finish" button enforces in the UI — re-checked server-side
- * so a direct API call can't bypass them. Research is intentionally NOT
- * required: it's optional and admins can skip it.
+ * Marks admin setup complete on the org. Data, provider configuration, and a
+ * live OpenShell control-plane call are re-checked server-side so neither a
+ * direct API call nor a fresh-install race can send users into onboarding with
+ * an unusable agent. Research remains optional.
  */
 export async function POST() {
   const allowed = await requireAdminActor();
@@ -32,6 +37,18 @@ export async function POST() {
       { error: "Primary model provider not configured." },
       { status: 400 },
     );
+  }
+
+  try {
+    await requireAgentRuntimeReady(orgId);
+  } catch (error) {
+    if (error instanceof AgentRuntimeUnavailableError) {
+      return NextResponse.json(
+        { error: error.message, code: AGENT_RUNTIME_UNAVAILABLE_CODE },
+        { status: 503 },
+      );
+    }
+    throw error;
   }
 
   await db()

--- a/apps/web/src/app/signin/page.tsx
+++ b/apps/web/src/app/signin/page.tsx
@@ -3,6 +3,7 @@
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import EntryShell from "@/components/EntryShell";
+import { Button } from "@/components/ui/Button";
 
 interface ProviderInfo {
   pluginName: string;
@@ -101,11 +102,11 @@ function SignInBody() {
                 : `Helps ${provider.providerLabel} route you to the correct identity provider.`}
             </span>
           </label>
-          <button type="submit" className="entry-button is-primary is-wide">
+          <Button type="submit" variant="primary" size="lg" className="w-full">
             {provider.loginHintRequired
               ? "Email me a sign-in link"
               : `Sign in with ${provider.providerLabel}`}
-          </button>
+          </Button>
           <p className="entry-provider-note">
             Provided by <code>{provider.pluginName}</code>
           </p>

--- a/apps/web/src/app/skills/[name]/page.tsx
+++ b/apps/web/src/app/skills/[name]/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { ArrowLeft, FileText } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import PageHeading from "@/components/PageHeading";
+import { Button, buttonClassName } from "@/components/ui/Button";
 
 function stripFrontmatter(markdown: string): string {
   return markdown.replace(/^---\n[\s\S]*?\n---\n?/, "").trimStart();
@@ -106,11 +107,18 @@ export default function SkillDetailPage({ params }: PageProps) {
                 </span>
               </div>
               {state === "error" ? (
-                <button type="button" onClick={() => void load()}>
+                <Button
+                  variant="danger"
+                  size="sm"
+                  className="shrink-0"
+                  onClick={() => void load()}
+                >
                   Retry
-                </button>
+                </Button>
               ) : (
-                <Link href="/skills">All skills</Link>
+                <Link href="/skills" className={buttonClassName({ size: "sm" })}>
+                  All skills
+                </Link>
               )}
             </div>
           )}

--- a/apps/web/src/app/styles/_act-card.css
+++ b/apps/web/src/app/styles/_act-card.css
@@ -26,7 +26,7 @@
   border-radius: 100px;
   background: var(--danger);
   color: #fff;
-  font-size: 10.5px;
+  font-size: var(--type-label);
   font-weight: 700;
   line-height: 1;
 }

--- a/apps/web/src/app/styles/_agentic.css
+++ b/apps/web/src/app/styles/_agentic.css
@@ -38,8 +38,8 @@
   gap: 8px;
   color: var(--text2);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 9px;
-  font-weight: 850;
+  font-size: var(--type-label);
+  font-weight: 800;
   letter-spacing: 0.14em;
   line-height: 1;
   text-transform: uppercase;
@@ -62,8 +62,8 @@
   border-radius: 999px;
   background: var(--neutral);
   color: var(--text3);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 9px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
   letter-spacing: 0;
   text-transform: none;
 }
@@ -78,7 +78,7 @@
   font-size: var(--page-head-title-size);
   font-weight: 800;
   letter-spacing: -0.025em;
-  line-height: 1.2;
+  line-height: var(--leading-page);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -90,8 +90,8 @@
   margin: 0;
   overflow: hidden;
   color: var(--text2);
-  font-size: 11.5px;
-  line-height: 1.35;
+  font-size: var(--type-body-sm);
+  line-height: var(--leading-compact);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -157,10 +157,6 @@
     display: none;
   }
 
-  .page-heading-eyebrow {
-    font-size: 8px;
-  }
-
   .page-heading-meta {
     max-width: 78px;
     overflow: hidden;
@@ -189,14 +185,14 @@
 
 .dash-system-state p {
   margin: 4px 0 0;
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   line-height: 1.5;
 }
 
 .dash-system-label {
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 14px;
+  font-size: var(--type-body);
   font-weight: 800;
   letter-spacing: -0.01em;
 }
@@ -240,7 +236,7 @@
   background: var(--danger);
   color: var(--on-accent);
   font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: 12px;
+  font-size: var(--type-caption);
   font-weight: 750;
   cursor: pointer;
   transition:
@@ -288,7 +284,7 @@
 .dash-role-control > span {
   color: var(--text3);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.13em;
   text-transform: uppercase;
@@ -309,7 +305,7 @@
   background: transparent;
   color: var(--text2);
   font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: 11.5px;
+  font-size: var(--type-caption);
   font-weight: 700;
   cursor: pointer;
   transition:
@@ -364,7 +360,7 @@
   margin: 0;
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 19px;
+  font-size: var(--type-section);
   font-weight: 800;
   letter-spacing: -0.025em;
   line-height: 1.2;
@@ -374,8 +370,8 @@
   max-width: 58ch;
   margin: 5px 0 0;
   color: var(--text2);
-  font-size: 12.5px;
-  line-height: 1.55;
+  font-size: var(--type-body-sm);
+  line-height: var(--leading-body);
 }
 
 .agent-launcher-form {
@@ -410,7 +406,7 @@
   background: transparent;
   color: var(--text);
   font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: 14.5px;
+  font-size: var(--type-body-lg);
   line-height: 1.5;
   padding: 7px 0;
 }
@@ -470,7 +466,7 @@
   gap: 10px;
   margin-top: 11px;
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-label);
 }
 
 .agent-starters {
@@ -487,7 +483,7 @@
   background: transparent;
   color: var(--text2);
   font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: 10.5px;
+  font-size: var(--type-caption);
   font-weight: 650;
   cursor: pointer;
   transition:
@@ -506,7 +502,7 @@
   border-left: 2px solid var(--danger);
   background: var(--danger-soft);
   color: var(--danger);
-  font-size: 11.5px;
+  font-size: var(--type-caption);
   line-height: 1.45;
 }
 

--- a/apps/web/src/app/styles/_agentic.css
+++ b/apps/web/src/app/styles/_agentic.css
@@ -72,15 +72,16 @@
   grid-area: title;
   min-width: 0;
   margin: 0;
-  overflow: hidden;
+  overflow: visible;
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
   font-size: var(--page-head-title-size);
   font-weight: 800;
   letter-spacing: -0.025em;
   line-height: var(--leading-page);
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  white-space: normal;
 }
 
 .page-heading p {
@@ -141,16 +142,30 @@
   }
 }
 
-@media (max-width: 600px) {
+@media (max-width: 680px) {
   .page-heading {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
     min-height: 62px;
-    gap: 10px;
+    gap: 8px;
     margin-bottom: 18px;
     padding-block: 8px;
   }
 
   .page-heading-copy {
-    column-gap: 9px;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-areas:
+      "title"
+      "eyebrow";
+    row-gap: 5px;
+  }
+
+  .page-heading-eyebrow {
+    min-width: 0;
+    flex-wrap: wrap;
+    gap: 6px;
+    line-height: 1.25;
+    white-space: normal;
   }
 
   .page-heading p {
@@ -158,14 +173,21 @@
   }
 
   .page-heading-meta {
-    max-width: 78px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    max-width: min(100%, 220px);
   }
 
   .page-heading-actions {
+    width: 100%;
+    min-height: 0;
+    justify-content: flex-start;
     gap: 4px;
+    overflow-x: auto;
+    padding: 1px 2px 3px;
+    scrollbar-width: none;
+  }
+
+  .page-heading-actions::-webkit-scrollbar {
+    display: none;
   }
 }
 
@@ -228,32 +250,6 @@
   animation: agent-breathe 1.4s ease-in-out infinite;
 }
 
-.dash-system-state button {
-  min-height: 40px;
-  padding: 8px 14px;
-  border: 1px solid var(--danger);
-  border-radius: 10px;
-  background: var(--danger);
-  color: var(--on-accent);
-  font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: var(--type-caption);
-  font-weight: 750;
-  cursor: pointer;
-  transition:
-    background 0.15s ease,
-    transform 0.15s ease;
-}
-
-.dash-system-state button:hover {
-  background: var(--danger-hover);
-  transform: translateY(-1px);
-}
-
-.dash-system-state button:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
 .dash-role-control {
   display: grid;
   flex: 0 1 auto;
@@ -295,36 +291,6 @@
   flex-wrap: wrap;
   justify-content: flex-end;
   gap: 5px;
-}
-
-.dash-role-list button {
-  min-height: 34px;
-  padding: 6px 11px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: transparent;
-  color: var(--text2);
-  font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: var(--type-caption);
-  font-weight: 700;
-  cursor: pointer;
-  transition:
-    color 0.16s ease,
-    border-color 0.16s ease,
-    background 0.16s ease,
-    transform 0.16s ease;
-}
-
-.dash-role-list button:hover {
-  border-color: var(--text3);
-  color: var(--text);
-  transform: translateY(-1px);
-}
-
-.dash-role-list button.is-active {
-  border-color: var(--text);
-  background: var(--text);
-  color: var(--bg);
 }
 
 .agent-launcher {
@@ -506,8 +472,7 @@
   line-height: 1.45;
 }
 
-.agent-launcher :where(button, textarea):focus-visible,
-.dash-role-list button:focus-visible {
+.agent-launcher :where(button, textarea):focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
 }
@@ -550,11 +515,6 @@
     justify-content: flex-start;
   }
 
-  .dash-role-list button {
-    min-height: 44px;
-    padding-inline: 14px;
-  }
-
   .agent-launcher {
     padding: 18px;
   }
@@ -578,6 +538,18 @@
   .agent-starters button {
     min-height: 44px;
     text-align: left;
+  }
+}
+
+@media (pointer: coarse) {
+  .agent-launcher-submit,
+  .agent-starters button {
+    min-height: var(--control-touch);
+  }
+
+  .agent-launcher-submit {
+    width: var(--control-touch);
+    height: var(--control-touch);
   }
 }
 

--- a/apps/web/src/app/styles/_chrome.css
+++ b/apps/web/src/app/styles/_chrome.css
@@ -59,7 +59,7 @@ html {
   bottom: 100px;
   right: 16px;
   font-family: var(--font-body), 'Manrope', sans-serif;
-  font-size: 11px;
+  font-size: var(--type-label);
   font-weight: 600;
   color: var(--success-ink);
   background: var(--success);
@@ -101,7 +101,7 @@ html {
 .settings-backlink {
   text-decoration: none;
   color: var(--text2);
-  font-size: 13.5px;
+  font-size: var(--type-body);
   font-weight: 500;
   border: 1px solid transparent;
   border-radius: 999px;
@@ -175,7 +175,7 @@ html {
   overflow: hidden;
   text-overflow: ellipsis;
   font-family: var(--font-body), 'Manrope', sans-serif;
-  font-size: 13.5px;
+  font-size: var(--type-body);
   font-weight: 600;
   color: var(--text2);
   background: var(--card);

--- a/apps/web/src/app/styles/_composer.css
+++ b/apps/web/src/app/styles/_composer.css
@@ -92,7 +92,7 @@
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  font-size: 11.5px;
+  font-size: var(--type-caption);
   color: var(--text2);
   background: color-mix(in srgb, var(--neutral-soft) 70%, var(--card));
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
@@ -132,7 +132,7 @@
   outline: none;
   background: transparent;
   font: inherit;
-  font-size: 14.5px;
+  font-size: var(--type-body-lg);
   line-height: 1.55;
   color: var(--text);
   padding: 14px 12px 6px;
@@ -141,7 +141,7 @@
 .work-input:disabled { color: var(--text2); cursor: progress; }
 
 .work-composer-hint {
-  font-size: 11.5px;
+  font-size: var(--type-caption);
   color: var(--text3);
   letter-spacing: 0.01em;
   display: inline-flex;
@@ -164,7 +164,7 @@
   background: color-mix(in srgb, var(--neutral-soft) 50%, var(--card));
   color: var(--text2);
   font-family: var(--font-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
+  font-size: var(--type-label);
   line-height: 1;
 }
 .work-composer-hint-sep {
@@ -223,7 +223,7 @@
     var(--success) 100%
   );
   color: var(--success-ink);
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   font-weight: 600;
   letter-spacing: 0.01em;
   cursor: pointer;
@@ -285,8 +285,8 @@
   }
   /* 36px is the practical touch-target floor with surrounding padding. */
   .work-icon-btn { width: 38px; height: 38px; border-radius: 12px; }
-  .work-send-btn { height: 38px; padding: 0 14px 0 16px; font-size: 13.5px; }
-  .work-file-chip { padding: 5px 5px 5px 9px; font-size: 12px; }
+  .work-send-btn { height: 38px; padding: 0 14px 0 16px; font-size: var(--type-body); }
+  .work-file-chip { padding: 5px 5px 5px 9px; font-size: var(--type-caption); }
   .work-file-chip button { width: 22px; height: 22px; }
 }
 /* Hide the keyboard hint text entirely on small phones so the file
@@ -295,7 +295,7 @@
 @media (max-width: 480px) {
   .work-composer-hint kbd,
   .work-composer-hint-sep { display: none; }
-  .work-composer-hint { font-size: 11px; }
+  .work-composer-hint { font-size: var(--type-label); }
 }
 /* Touch devices: hover styles are misleading (sticky tap = sticky hover).
    Strip the lift/glow on hover for anything that can't truly hover. */
@@ -359,7 +359,7 @@
   width: 30px; height: 30px;
   border-radius: 9px; border: 1px solid transparent; background: transparent; cursor: pointer;
   display: inline-flex; align-items: center; justify-content: center;
-  font-size: 13px; color: var(--text3);
+  font-size: var(--type-body-sm); color: var(--text3);
   transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 .ipin.on { color: var(--accent); background: var(--accent-soft); }
@@ -381,7 +381,7 @@
 .idetail { position: relative; z-index: 1; }
 .idetail.open { max-height: 480px; opacity: 1; margin-top: 16px; }
 .dtext {
-  font-size: 14.5px;
+  font-size: var(--type-body-lg);
   color: var(--text2);
   line-height: 1.6;
   margin-bottom: 14px;
@@ -394,4 +394,3 @@
   padding: 14px 12px 8px 12px;
   margin-left: 54px;
 }
-

--- a/apps/web/src/app/styles/_dashboard.css
+++ b/apps/web/src/app/styles/_dashboard.css
@@ -4,7 +4,7 @@
   align-items: center;
   gap: 8px;
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 11px; font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
+  font-size: var(--type-label); font-weight: 700; letter-spacing: 0.14em; text-transform: uppercase;
   color: var(--warn-ink); text-decoration: none;
   background: var(--warn-soft); border: 1px solid var(--warn); border-radius: 999px;
   padding: 6px 14px 6px 12px; margin-bottom: 16px;
@@ -31,7 +31,7 @@
   align-items: center;
   gap: 10px;
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 11px;
+  font-size: var(--type-label);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.14em;
@@ -49,7 +49,7 @@
 }
 .greet {
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 52px; font-weight: 800; line-height: 1.02; letter-spacing: -0.035em;
+  font-size: var(--type-display); font-weight: 800; line-height: var(--leading-display); letter-spacing: -0.035em;
   margin-bottom: 12px;
   color: var(--text);
 }
@@ -59,7 +59,7 @@
   color: var(--accent);
 }
 .greet-sub {
-  font-size: 17px;
+  font-size: var(--type-body-lg);
   color: var(--text2);
   margin-bottom: 36px;
   line-height: 1.45;
@@ -69,7 +69,7 @@
   font-family: var(--font-display), 'Archivo', sans-serif;
   font-style: italic;
   font-weight: 500;
-  font-size: 19px;
+  font-size: var(--type-section);
   letter-spacing: -0.01em;
   line-height: 1.4;
   color: var(--text2);
@@ -78,11 +78,11 @@
   border-left: 2px solid var(--accent);
   max-width: 56ch;
 }
-.date-note { font-size: 15px; color: var(--text3); }
+.date-note { font-size: var(--type-body); color: var(--text3); }
 
 @media (max-width: 600px) {
-  .greet { font-size: 38px; }
-  .greet-sub { font-size: 16px; }
+  .greet { font-size: var(--type-display); }
+  .greet-sub { font-size: var(--type-body); }
 }
 
 /* ─── SECTION LABEL ─── */
@@ -91,7 +91,7 @@
   align-items: baseline;
   gap: 10px;
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.16em;
+  font-size: var(--type-label); font-weight: 700; text-transform: uppercase; letter-spacing: 0.14em;
   color: var(--text3); margin-bottom: 16px; padding-left: 2px;
 }
 .label::after {
@@ -150,7 +150,7 @@
 }
 .icontent { flex: 1; min-width: 0; }
 .itext {
-  font-size: 16.5px;
+  font-size: var(--type-subsection);
   font-weight: 500;
   line-height: 1.42;
   color: var(--text);
@@ -161,7 +161,7 @@
   align-items: center;
   gap: 6px;
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 10px;
+  font-size: var(--type-label);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.14em;
@@ -196,14 +196,14 @@
 .kpi-chat { margin-top: 0; margin-bottom: 10px; }
 .kpi-chat .kpi-metric { font-size: 38px; }
 .kpi-label {
-  font-size: 11.5px;
+  font-size: var(--type-caption);
   color: var(--text3);
   text-transform: uppercase;
   letter-spacing: 0.1em;
   font-weight: 600;
 }
 .kpi-delta {
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   font-weight: 600;
   padding: 3px 10px;
   border-radius: 999px;
@@ -245,7 +245,7 @@
   gap: 10px;
   margin: 0 0 12px;
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 11px;
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -270,7 +270,7 @@
   border-radius: 999px;
   background: var(--watch);
   color: var(--on-accent);
-  font-size: 11px;
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: 0;
   line-height: 1.4;
@@ -278,7 +278,7 @@
 .dash-call-skim {
   margin-left: auto;
   font-family: var(--font-body), 'Manrope', sans-serif;
-  font-size: 12px;
+  font-size: var(--type-caption);
   font-weight: 600;
   letter-spacing: 0;
   text-transform: none;
@@ -313,7 +313,7 @@
   cursor: pointer;
   padding: 10px 2px;
   font-family: var(--font-body), 'Manrope', sans-serif;
-  font-size: 16px;
+  font-size: var(--type-subsection);
   color: var(--text2);
   transition: color 0.15s;
 }
@@ -335,12 +335,12 @@
 }
 .dash-proof-label {
   color: var(--text2);
-  font-size: 16px;
+  font-size: var(--type-subsection);
 }
 .dash-proof-caret {
   margin-left: auto;
   color: var(--text3);
-  font-size: 13px;
+  font-size: var(--type-body-sm);
   transition: transform 0.18s ease;
   align-self: center;
 }

--- a/apps/web/src/app/styles/_dashboard.css
+++ b/apps/web/src/app/styles/_dashboard.css
@@ -118,6 +118,7 @@
   width: 4px;
   background: var(--mood-color, var(--accent));
   opacity: 0.85;
+  border-radius: inherit;
 }
 .icard::after {
   content: "";
@@ -126,7 +127,9 @@
   pointer-events: none;
   background: linear-gradient(135deg, var(--mood-tint, transparent) 0%, transparent 45%);
   opacity: 0.55;
+  border-radius: inherit;
 }
+.icard:has([data-ui-menu-trigger][aria-expanded="true"]) { overflow: visible; }
 .icard:hover { box-shadow: var(--shadow-h); transform: translateY(-1px); border-color: var(--mood-color, var(--accent)); }
 .icard.exp { border-color: var(--border); }
 .itop { display: flex; align-items: flex-start; gap: 14px; position: relative; z-index: 1; }
@@ -174,6 +177,56 @@
   border-radius: 50%;
   background: currentColor;
   box-shadow: 0 0 0 3px var(--mood-tint, transparent);
+}
+
+.icard-toggle,
+.mobile-progressive-toggle {
+  display: none;
+}
+
+@media (max-width: 700px) {
+  .mobile-progressive-list:not(.is-expanded) > :nth-child(n + 4) {
+    display: none;
+  }
+
+  .mobile-progressive-toggle {
+    display: inline-flex;
+    margin-top: 10px;
+  }
+
+  .icard-toggle {
+    position: relative;
+    z-index: 2;
+    width: 100%;
+    min-height: var(--control-touch);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-top: 10px;
+    padding: 8px 0 0;
+    border: 0;
+    border-top: 1px solid var(--border);
+    background: transparent;
+    color: var(--text2);
+    font: 700 var(--type-body-sm)/1.2 var(--font-body), "Manrope", sans-serif;
+    cursor: pointer;
+  }
+
+  .icard-toggle svg {
+    width: 16px;
+    height: 16px;
+    transition: transform 0.18s ease;
+  }
+
+  .icard-toggle svg.is-open {
+    transform: rotate(180deg);
+  }
+
+  .idetail.open[data-mobile-open="false"] {
+    max-height: 0;
+    margin-top: 0;
+    opacity: 0;
+  }
 }
 
 .icard[data-mood="good"] { --mood-color: var(--success-mid); --mood-tint: var(--success-soft); }

--- a/apps/web/src/app/styles/_dock.css
+++ b/apps/web/src/app/styles/_dock.css
@@ -75,7 +75,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     font-family: var(--font-body), "Manrope", sans-serif;
-    font-size: 9.5px;
+    font-size: var(--type-label);
     font-weight: 600;
     letter-spacing: 0;
     line-height: 1;
@@ -127,7 +127,7 @@
     border-radius: 999px;
     background: var(--danger);
     color: #fff;
-    font-size: 9px;
+    font-size: var(--type-label);
     font-weight: 800;
     line-height: 1;
   }
@@ -185,7 +185,7 @@
   .cdock-sheet-head h2 {
     margin: 0;
     font-family: var(--font-display), "Archivo", sans-serif;
-    font-size: 20px;
+    font-size: var(--type-section);
     font-weight: 800;
     letter-spacing: -0.025em;
     color: var(--text);
@@ -193,8 +193,8 @@
 
   .cdock-sheet-head p {
     margin: 3px 0 0;
-    font-size: 11.5px;
-    line-height: 1.45;
+    font-size: var(--type-body-sm);
+    line-height: var(--leading-compact);
     color: var(--text3);
   }
 
@@ -273,7 +273,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     font-family: var(--font-display), "Archivo", sans-serif;
-    font-size: 14px;
+    font-size: var(--type-body);
     font-weight: 700;
     letter-spacing: -0.01em;
     white-space: nowrap;
@@ -283,7 +283,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     color: var(--text3);
-    font-size: 11px;
+    font-size: var(--type-body-sm);
     white-space: nowrap;
   }
 
@@ -304,7 +304,7 @@
     gap: 12px;
     border-top: 1px solid var(--border);
     color: var(--text2);
-    font-size: 11px;
+    font-size: var(--type-label);
     font-weight: 700;
   }
 
@@ -337,13 +337,13 @@
   }
 
   .cdock-persona-link strong {
-    font-size: 13px;
+    font-size: var(--type-body-sm);
     line-height: 1.2;
   }
 
   .cdock-persona-link small {
     color: var(--text3);
-    font-size: 10.5px;
+    font-size: var(--type-caption);
   }
 
   .cdock-persona-link > svg:last-child {
@@ -384,7 +384,7 @@
     background: var(--danger-soft);
     color: var(--danger);
     font-family: var(--font-display), "Archivo", sans-serif;
-    font-size: 13.5px;
+    font-size: var(--type-body);
     font-weight: 700;
     cursor: pointer;
   }

--- a/apps/web/src/app/styles/_entry.css
+++ b/apps/web/src/app/styles/_entry.css
@@ -22,7 +22,7 @@
   border-radius: 9px;
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 17px;
+  font-size: var(--type-subsection);
   font-weight: 850;
   letter-spacing: -0.025em;
   line-height: 1;
@@ -50,7 +50,7 @@
   border-radius: 999px;
   background: var(--neutral);
   color: var(--text3);
-  font-size: 10px;
+  font-size: var(--type-label);
   font-weight: 700;
 }
 
@@ -93,7 +93,7 @@
   margin: 0 0 16px;
   color: var(--success);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 10px;
+  font-size: var(--type-label);
   font-weight: 850;
   letter-spacing: 0.15em;
   text-transform: uppercase;
@@ -115,8 +115,8 @@
   max-width: 36ch;
   margin: 22px 0 0;
   color: color-mix(in srgb, var(--bg) 72%, transparent);
-  font-size: 13px;
-  line-height: 1.65;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
 }
 
 .entry-steps {
@@ -136,7 +136,7 @@
   padding: 8px 10px;
   border-radius: 10px;
   color: color-mix(in srgb, var(--bg) 45%, transparent);
-  font-size: 12px;
+  font-size: var(--type-caption);
   font-weight: 650;
 }
 
@@ -162,7 +162,7 @@
 .entry-step-number {
   width: 23px;
   color: inherit;
-  font-size: 10px;
+  font-size: var(--type-label);
   text-align: center;
 }
 
@@ -186,7 +186,7 @@
   margin: 0 0 8px;
   color: var(--accent);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 10px;
+  font-size: var(--type-label);
   font-weight: 850;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -196,18 +196,18 @@
   margin: 0;
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: clamp(26px, 3vw, 36px);
+  font-size: var(--type-page);
   font-weight: 900;
   letter-spacing: -0.04em;
-  line-height: 1;
+  line-height: var(--leading-page);
 }
 
 .entry-section-head p {
   max-width: 58ch;
   margin: 10px 0 0;
   color: var(--text2);
-  font-size: 13px;
-  line-height: 1.55;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
 }
 
 .entry-fields {
@@ -222,14 +222,14 @@
 
 .entry-field > span:first-child {
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--type-body);
   font-weight: 750;
 }
 
 .entry-field-help {
   color: var(--text3);
-  font-size: 11.5px;
-  line-height: 1.5;
+  font-size: var(--type-caption);
+  line-height: var(--leading-compact);
 }
 
 .entry-control {
@@ -242,7 +242,7 @@
   background: var(--bg);
   color: var(--text);
   font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: 14px;
+  font-size: var(--type-body);
   line-height: 1.45;
   transition:
     border-color 0.16s ease,
@@ -279,7 +279,7 @@ textarea.entry-control {
   background: var(--card);
   color: var(--text2);
   font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: 13px;
+  font-size: var(--type-body-sm);
   font-weight: 700;
   cursor: pointer;
   transition:
@@ -334,7 +334,7 @@ textarea.entry-control {
   background: var(--card);
   color: var(--text2);
   font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: 13px;
+  font-size: var(--type-body-sm);
   font-weight: 750;
   text-decoration: none;
   cursor: pointer;
@@ -383,7 +383,7 @@ textarea.entry-control {
   border-radius: 10px;
   background: var(--danger-soft);
   color: var(--danger);
-  font-size: 12px;
+  font-size: var(--type-caption);
   line-height: 1.5;
 }
 
@@ -397,7 +397,7 @@ textarea.entry-control {
   border-radius: 12px;
   background: var(--neutral-soft);
   color: var(--text2);
-  font-size: 12px;
+  font-size: var(--type-caption);
   font-weight: 700;
 }
 
@@ -418,13 +418,13 @@ textarea.entry-control {
 .entry-provider-note {
   margin: -6px 0 0;
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-label);
   text-align: center;
 }
 
 .entry-provider-note code {
   color: var(--text2);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
 }
 
 .entry-empty {
@@ -439,7 +439,7 @@ textarea.entry-control {
   margin: 0;
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 19px;
+  font-size: var(--type-section);
   font-weight: 850;
   letter-spacing: -0.02em;
 }
@@ -447,8 +447,8 @@ textarea.entry-control {
 .entry-empty > p:not(.entry-section-kicker) {
   margin: 8px 0 14px;
   color: var(--text2);
-  font-size: 12.5px;
-  line-height: 1.6;
+  font-size: var(--type-body-sm);
+  line-height: var(--leading-body);
 }
 
 .entry-empty code {
@@ -458,8 +458,8 @@ textarea.entry-control {
   border-radius: 8px;
   background: var(--card);
   color: var(--text);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
+  font-family: var(--font-mono);
+  font-size: var(--type-caption);
 }
 
 .entry-shell .settings-card {
@@ -478,7 +478,7 @@ textarea.entry-control {
 }
 
 .entry-shell .settings-card-title {
-  font-size: clamp(26px, 3vw, 36px);
+  font-size: var(--type-page);
   font-weight: 900;
   letter-spacing: -0.04em;
 }
@@ -486,7 +486,7 @@ textarea.entry-control {
 .entry-shell .settings-card-copy {
   max-width: 58ch;
   margin-top: 9px;
-  font-size: 13px;
+  font-size: var(--type-body);
 }
 
 body:has(.setup-entry-shell) {

--- a/apps/web/src/app/styles/_entry.css
+++ b/apps/web/src/app/styles/_entry.css
@@ -323,59 +323,6 @@ textarea.entry-control {
   justify-content: flex-end;
 }
 
-.entry-button {
-  min-height: 44px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px 17px;
-  border: 1px solid var(--border);
-  border-radius: 11px;
-  background: var(--card);
-  color: var(--text2);
-  font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: var(--type-body-sm);
-  font-weight: 750;
-  text-decoration: none;
-  cursor: pointer;
-  transition:
-    color 0.15s ease,
-    border-color 0.15s ease,
-    background 0.15s ease,
-    transform 0.15s ease;
-}
-
-.entry-button:hover:not(:disabled) {
-  border-color: var(--text3);
-  color: var(--text);
-  transform: translateY(-1px);
-}
-
-.entry-button.is-primary {
-  border-color: var(--accent);
-  background: var(--accent);
-  color: var(--on-accent);
-}
-
-.entry-button.is-primary:hover:not(:disabled) {
-  border-color: var(--accent-hover);
-  background: var(--accent-hover);
-  color: var(--on-accent);
-}
-
-.entry-button.is-wide {
-  width: 100%;
-}
-
-.entry-button:active:not(:disabled) {
-  transform: translateY(1px);
-}
-
-.entry-button:disabled {
-  cursor: not-allowed;
-  opacity: 0.42;
-}
-
 .entry-error {
   padding: 12px 14px;
   border: 1px solid color-mix(in srgb, var(--danger) 32%, var(--border));
@@ -609,7 +556,7 @@ body:has(.setup-entry-shell) .cdock-wrap {
     flex-wrap: wrap;
   }
 
-  .entry-actions .entry-button {
+  .entry-actions [data-ui-button] {
     flex: 1 1 auto;
   }
 }
@@ -631,7 +578,7 @@ body:has(.setup-entry-shell) .cdock-wrap {
   }
 
   .entry-chip,
-  .entry-button {
+  [data-ui-button] {
     transition: none;
   }
 }

--- a/apps/web/src/app/styles/_library.css
+++ b/apps/web/src/app/styles/_library.css
@@ -43,7 +43,7 @@
 .library-head-title > p {
   margin: 0;
   color: color-mix(in srgb, var(--bg) 58%, var(--text));
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.15em;
   line-height: 1.35;
@@ -95,7 +95,7 @@
 .library-head-stats span {
   margin-top: 7px;
   color: color-mix(in srgb, var(--bg) 56%, var(--text));
-  font-size: 8px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.14em;
   line-height: 1;
@@ -143,7 +143,7 @@
 .skill-instructions > header > span {
   display: block;
   color: var(--text3);
-  font-size: 8px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.16em;
   line-height: 1.2;
@@ -155,7 +155,7 @@
   margin: 3px 0 0;
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 19px;
+  font-size: var(--type-section);
   font-weight: 800;
   letter-spacing: -0.035em;
   line-height: 1.1;
@@ -163,8 +163,8 @@
 
 .library-section-head > strong {
   color: var(--text3);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
+  font-family: var(--font-mono);
+  font-size: var(--type-caption);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.1em;
@@ -172,8 +172,8 @@
 
 .library-index {
   color: var(--text3);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
   font-weight: 700;
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.04em;
@@ -203,14 +203,14 @@
 
 .library-error strong {
   color: var(--danger);
-  font-size: 12px;
+  font-size: var(--type-body-sm);
   font-weight: 800;
 }
 
 .library-error span {
   color: var(--text2);
-  font-size: 11px;
-  line-height: 1.45;
+  font-size: var(--type-caption);
+  line-height: var(--leading-compact);
 }
 
 .library-error :where(button, a) {
@@ -225,7 +225,7 @@
   background: transparent;
   color: var(--danger);
   font: inherit;
-  font-size: 10px;
+  font-size: var(--type-caption);
   font-weight: 800;
   text-decoration: none;
   cursor: pointer;
@@ -281,7 +281,7 @@
 .library-empty strong {
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 18px;
+  font-size: var(--type-section);
   font-weight: 800;
   letter-spacing: -0.03em;
 }
@@ -289,8 +289,8 @@
 .library-empty span {
   max-width: 62ch;
   color: var(--text2);
-  font-size: 12px;
-  line-height: 1.55;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
 }
 
 /* ─── Memory review queue ─── */
@@ -338,8 +338,8 @@
 
 .memory-review-meta span {
   color: var(--watch);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 8px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -348,17 +348,17 @@
 .memory-review-copy p {
   margin: 0;
   color: var(--text);
-  font-size: 13px;
-  font-weight: 600;
-  line-height: 1.5;
+  font-size: var(--type-subsection);
+  font-weight: 700;
+  line-height: var(--leading-heading);
 }
 
 .memory-review-copy small {
   display: block;
   margin-top: 6px;
   color: var(--text2);
-  font-size: 10px;
-  line-height: 1.5;
+  font-size: var(--type-body-sm);
+  line-height: var(--leading-compact);
 }
 
 .memory-review-actions {
@@ -375,7 +375,7 @@
   background: transparent;
   color: var(--text2);
   font: inherit;
-  font-size: 10px;
+  font-size: var(--type-body-sm);
   font-weight: 800;
   cursor: pointer;
 }
@@ -422,7 +422,7 @@
 .memory-table-head span,
 .skills-table-head span {
   color: var(--text3);
-  font-size: 7px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -481,7 +481,7 @@
 .memory-usage > span {
   overflow: hidden;
   color: var(--text);
-  font-size: 10px;
+  font-size: var(--type-body-sm);
   font-weight: 800;
   text-overflow: ellipsis;
   text-transform: capitalize;
@@ -497,7 +497,7 @@
   gap: 4px;
   overflow: hidden;
   color: var(--text3);
-  font-size: 8px;
+  font-size: var(--type-caption);
   font-weight: 700;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -517,7 +517,7 @@
   min-width: 0;
   margin: 0;
   color: var(--text);
-  font-size: 12px;
+  font-size: var(--type-body);
   font-weight: 600;
   line-height: 1.52;
 }
@@ -590,7 +590,7 @@
   overflow: hidden;
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 14px;
+  font-size: var(--type-subsection);
   font-weight: 800;
   letter-spacing: -0.025em;
   text-overflow: ellipsis;
@@ -603,8 +603,8 @@
   overflow: hidden;
   margin: 0;
   color: var(--text2);
-  font-size: 11px;
-  line-height: 1.5;
+  font-size: var(--type-body-sm);
+  line-height: var(--leading-compact);
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
 }
@@ -614,8 +614,8 @@
   align-items: center;
   gap: 6px;
   color: var(--text2);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
+  font-family: var(--font-mono);
+  font-size: var(--type-caption);
   font-variant-numeric: tabular-nums;
 }
 
@@ -626,8 +626,8 @@
 
 .skill-updated {
   color: var(--text3);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 9px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.03em;
   text-transform: uppercase;
@@ -670,7 +670,7 @@
   overflow: visible;
   color: color-mix(in srgb, var(--bg) 76%, var(--text));
   font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: clamp(12px, 1vw, 14px);
+  font-size: var(--type-body);
   font-weight: 550;
   letter-spacing: 0;
   line-height: 1.52;
@@ -687,7 +687,7 @@
   gap: 7px;
   margin-bottom: 5px;
   color: var(--success);
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.13em;
   text-decoration: none;
@@ -745,7 +745,7 @@
   min-width: 0;
   overflow: hidden;
   color: var(--text);
-  font-size: 9px;
+  font-size: var(--type-caption);
   font-weight: 700;
   line-height: 1.35;
   text-overflow: ellipsis;
@@ -754,8 +754,8 @@
 
 .skill-manifest li small {
   color: var(--text3);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 8px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
   font-variant-numeric: tabular-nums;
 }
 
@@ -768,7 +768,7 @@
   max-width: 76ch;
   margin: 0 0 24px;
   color: var(--text2);
-  font-size: 14px;
+  font-size: var(--type-body);
   font-weight: 550;
   line-height: 1.58;
 }
@@ -781,7 +781,7 @@
 
 .skill-instructions > header h2 {
   margin-top: 5px;
-  font-size: 25px;
+  font-size: var(--type-page);
 }
 
 .library-markdown {
@@ -791,8 +791,8 @@
   border-radius: 0;
   background: transparent;
   color: var(--text);
-  font-size: 13px;
-  line-height: 1.68;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
 }
 
 .library-markdown > :first-child {
@@ -811,17 +811,17 @@
 }
 
 .library-markdown h1 {
-  font-size: 27px;
+  font-size: var(--type-page);
 }
 
 .library-markdown h2 {
   padding-bottom: 7px;
   border-bottom: 1px solid var(--border);
-  font-size: 20px;
+  font-size: var(--type-section);
 }
 
 .library-markdown h3 {
-  font-size: 15px;
+  font-size: var(--type-subsection);
 }
 
 .library-markdown p {
@@ -857,7 +857,7 @@
   border-left: 3px solid var(--accent);
   background: var(--text);
   color: var(--bg);
-  font-size: 11px;
+  font-size: var(--type-caption);
   line-height: 1.62;
 }
 
@@ -900,7 +900,7 @@
 
 .library-markdown th {
   color: var(--text2);
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -1145,7 +1145,7 @@
   }
 
   .library-markdown {
-    font-size: 12px;
+    font-size: var(--type-body);
   }
 }
 
@@ -1157,7 +1157,7 @@
   }
 
   .library-head-title > span {
-    font-size: 8px;
+    font-size: var(--type-label);
   }
 
   .library-head-stats {
@@ -1259,7 +1259,7 @@
 .library-page .library-head-stats strong {
   overflow: hidden;
   color: var(--text);
-  font-size: 16px;
+  font-size: var(--type-subsection);
   font-weight: 850;
   letter-spacing: -0.035em;
   line-height: 1;
@@ -1270,7 +1270,7 @@
 .library-page .library-head-stats span {
   margin: 0;
   color: var(--text3);
-  font-size: 7.5px;
+  font-size: var(--type-label);
 }
 
 .library-page .library-head-stats [data-state="clear"] strong {
@@ -1305,8 +1305,8 @@
 
   .skill-detail-summary {
     margin-bottom: 20px;
-    font-size: 13px;
-    line-height: 1.55;
+    font-size: var(--type-body);
+    line-height: var(--leading-body);
   }
 }
 
@@ -1332,12 +1332,12 @@
   }
 
   .library-page .library-head-stats strong {
-    font-size: 14px;
+    font-size: var(--type-body);
   }
 
   .library-page .library-head-stats span {
     display: block;
-    font-size: 7px;
+    font-size: var(--type-label);
   }
 
   .skill-detail-page .skill-manifest {
@@ -1364,7 +1364,7 @@
 .document-library .memory-review-actions span[data-status] {
   padding: 6px 10px;
   border: 1px solid var(--border);
-  font-size: 10px;
+  font-size: var(--type-label);
   font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.06em;
@@ -1413,7 +1413,7 @@
   margin: 0;
   white-space: pre-wrap;
   word-break: break-word;
-  font-size: 11px;
+  font-size: var(--type-caption);
   line-height: 1.6;
 }
 

--- a/apps/web/src/app/styles/_library.css
+++ b/apps/web/src/app/styles/_library.css
@@ -213,29 +213,6 @@
   line-height: var(--leading-compact);
 }
 
-.library-error :where(button, a) {
-  min-width: 72px;
-  min-height: 40px;
-  display: inline-grid;
-  place-items: center;
-  flex: none;
-  padding: 8px 14px;
-  border: 1px solid var(--danger);
-  border-radius: 0;
-  background: transparent;
-  color: var(--danger);
-  font: inherit;
-  font-size: var(--type-caption);
-  font-weight: 800;
-  text-decoration: none;
-  cursor: pointer;
-}
-
-.library-error :where(button, a):hover {
-  background: var(--danger);
-  color: white;
-}
-
 .library-loading {
   min-height: 174px;
   display: grid;
@@ -367,36 +344,6 @@
   gap: 8px;
 }
 
-.memory-review-actions button {
-  min-height: 44px;
-  padding: 9px 14px;
-  border: 1px solid var(--border);
-  border-radius: 0;
-  background: transparent;
-  color: var(--text2);
-  font: inherit;
-  font-size: var(--type-body-sm);
-  font-weight: 800;
-  cursor: pointer;
-}
-
-.memory-review-actions button:hover:not(:disabled) {
-  border-color: var(--text);
-  color: var(--text);
-}
-
-.memory-review-actions button.is-primary {
-  border-color: var(--text);
-  background: var(--text);
-  color: var(--bg);
-}
-
-.memory-review-actions button.is-primary:hover:not(:disabled) {
-  border-color: var(--accent);
-  background: var(--accent);
-  color: white;
-}
-
 /* ─── Saved-memory index ─── */
 
 .memory-table-head,
@@ -522,33 +469,6 @@
   line-height: 1.52;
 }
 
-.memory-archive,
-.skill-delete {
-  width: 44px;
-  height: 44px;
-  display: grid;
-  place-items: center;
-  border: 1px solid transparent;
-  border-radius: 0;
-  background: transparent;
-  color: var(--text3);
-  cursor: pointer;
-  transition: border-color 0.15s, background 0.15s, color 0.15s;
-}
-
-.memory-archive svg,
-.skill-delete svg {
-  width: 16px;
-  height: 16px;
-}
-
-.memory-archive:hover:not(:disabled),
-.skill-delete:hover:not(:disabled) {
-  border-color: var(--danger);
-  background: var(--danger-soft);
-  color: var(--danger);
-}
-
 /* ─── Skill inventory ─── */
 
 .skills-table-head,
@@ -645,7 +565,7 @@
   color: var(--accent);
 }
 
-.skill-delete {
+.skill-delete-control {
   position: absolute;
   top: 50%;
   right: 4px;
@@ -907,12 +827,12 @@
   white-space: nowrap;
 }
 
-.library-page :where(button, a):focus-visible {
+.library-page :where(a:not([data-ui-button]), .library-concept-title):focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 3px;
 }
 
-.library-page :where(button:disabled) {
+.library-page button:not([data-ui-button]):disabled {
   opacity: 0.42;
   cursor: wait;
 }
@@ -971,7 +891,7 @@
     grid-area: usage;
   }
 
-  .memory-archive {
+  .memory-archive-control {
     grid-area: action;
   }
 }
@@ -1111,7 +1031,7 @@
     justify-self: end;
   }
 
-  .skill-delete {
+  .skill-delete-control {
     right: 0;
   }
 
@@ -1136,12 +1056,9 @@
   }
 
   .memory-review-actions {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-  }
-
-  .memory-review-actions button {
-    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-start;
   }
 
   .library-markdown {
@@ -1176,10 +1093,6 @@
       ". memory memory"
       ". scope scope"
       ". usage usage";
-  }
-
-  .memory-review-actions {
-    grid-template-columns: 1fr;
   }
 
   .skill-manifest li {
@@ -1325,10 +1238,11 @@
   }
 
   .library-page .library-head-stats > div {
-    min-width: 58px;
-    flex-direction: column;
-    gap: 3px;
-    padding-inline: 8px;
+    min-width: 0;
+    flex: 1;
+    flex-direction: row;
+    gap: 6px;
+    padding: 7px 10px;
   }
 
   .library-page .library-head-stats strong {
@@ -1361,28 +1275,6 @@
 
 /* ─── Document library (/library) ─── */
 
-.document-library .memory-review-actions span[data-status] {
-  padding: 6px 10px;
-  border: 1px solid var(--border);
-  font-size: var(--type-label);
-  font-weight: 800;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--text2);
-}
-
-.document-library .memory-review-actions span[data-status="cataloged"],
-.document-library .memory-review-actions span[data-status="stable"] {
-  border-color: var(--text);
-  color: var(--text);
-}
-
-.document-library .memory-review-actions span[data-status="failed"] {
-  border-color: var(--accent);
-  color: var(--accent);
-}
-
-.document-library .memory-review-actions button svg,
 .document-library .memory-review-meta svg {
   vertical-align: -2px;
   margin-right: 4px;

--- a/apps/web/src/app/styles/_operations.css
+++ b/apps/web/src/app/styles/_operations.css
@@ -787,7 +787,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   height: 36px;
   padding-inline: 15px 13px;
   border: 1px solid var(--text);
-  border-radius: 2px 12px 2px 12px;
+  border-radius: var(--radius-control);
   background: var(--success);
   color: var(--success-ink);
   box-shadow: none;
@@ -801,7 +801,7 @@ html[data-density="compact"] .operations-root .operations-layout {
 
 .work-command-surface .work-send-btn:disabled {
   border-color: var(--border);
-  border-radius: 2px 12px 2px 12px;
+  border-radius: var(--radius-control);
   background: var(--neutral);
 }
 
@@ -2149,14 +2149,15 @@ html[data-density="compact"] .operations-root .operations-layout {
 
 .work-command-head h1 {
   max-width: none;
-  overflow: hidden;
+  overflow: visible;
   color: var(--text);
   font-size: var(--type-page);
   font-weight: 800;
   letter-spacing: -0.025em;
   line-height: var(--leading-page);
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  white-space: normal;
 }
 
 .work-command-head p {
@@ -2188,7 +2189,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   gap: 7px;
   padding: 8px 12px;
   border: 1px solid var(--border);
-  border-radius: 3px 11px 3px 11px;
+  border-radius: var(--radius-control);
   background: var(--card);
   color: var(--text2);
   font: inherit;
@@ -2469,6 +2470,12 @@ html[data-density="compact"] .operations-root .operations-layout {
 }
 
 @media (max-width: 680px) {
+  .work-command-surface {
+    min-height: calc(
+      100svh - var(--phone-dock-offset) - env(safe-area-inset-bottom, 0px)
+    );
+  }
+
   .work-command-head {
     min-height: 62px;
     grid-template-columns: minmax(0, 1fr) auto;
@@ -2494,7 +2501,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   }
 
   .work-command-action {
-    min-height: 40px;
+    min-height: var(--control-touch);
     padding-inline: 10px;
   }
 
@@ -2504,10 +2511,11 @@ html[data-density="compact"] .operations-root .operations-layout {
   }
 
   .work-transcript {
-    padding: 25px 0 28px;
+    padding: 25px 0 14px;
   }
 
   .work-empty {
+    grid-template-columns: minmax(0, 1fr);
     gap: 26px;
   }
 
@@ -2523,6 +2531,23 @@ html[data-density="compact"] .operations-root .operations-layout {
     min-height: 70px;
   }
 
+  .work-command-surface > .work-composer {
+    bottom: calc(
+      var(--phone-dock-offset) + env(safe-area-inset-bottom, 0px)
+    );
+  }
+
+  .work-command-surface .work-icon-btn,
+  .work-command-surface .work-send-btn {
+    min-width: var(--control-touch);
+    height: var(--control-touch);
+    min-height: var(--control-touch);
+  }
+
+  .work-command-surface .work-icon-btn {
+    width: var(--control-touch);
+  }
+
   .work-history-scrim {
     left: 0;
   }
@@ -2530,6 +2555,33 @@ html[data-density="compact"] .operations-root .operations-layout {
   .work-history-drawer {
     width: 100%;
     border-left: 0;
+  }
+}
+
+@media (max-width: 1024px) and (min-width: 681px) {
+  .operations-root.is-workflows .page-heading {
+    grid-template-columns: minmax(0, 1fr);
+    align-items: start;
+    gap: 8px;
+  }
+
+  .operations-root.is-workflows .page-heading-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}
+
+@media (pointer: coarse) {
+  .work-command-action,
+  .work-command-surface .work-icon-btn,
+  .work-command-surface .work-send-btn {
+    min-height: var(--control-touch);
+  }
+
+  .work-command-surface .work-icon-btn {
+    width: var(--control-touch);
+    min-width: var(--control-touch);
+    height: var(--control-touch);
   }
 }
 

--- a/apps/web/src/app/styles/_operations.css
+++ b/apps/web/src/app/styles/_operations.css
@@ -76,8 +76,8 @@ html[data-density="compact"] .operations-root .operations-layout {
 .work-gate-state p {
   max-width: 48ch;
   color: var(--text2);
-  font-size: 13px;
-  line-height: 1.55;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
 }
 
 .work-gate-state button {
@@ -89,7 +89,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   background: var(--text);
   color: var(--bg);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--type-caption);
   font-weight: 800;
   cursor: pointer;
 }
@@ -122,8 +122,8 @@ html[data-density="compact"] .operations-root .operations-layout {
   top: 20px;
   right: 28px;
   color: var(--text3);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 9px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: 0.17em;
 }
@@ -139,7 +139,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   margin-bottom: 15px;
   color: var(--text2);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 10px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -199,8 +199,8 @@ html[data-density="compact"] .operations-root .operations-layout {
   max-width: 54ch;
   margin: 17px 0 0;
   color: var(--text2);
-  font-size: 13px;
-  line-height: 1.55;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
 }
 
 .work-phase-rail {
@@ -248,7 +248,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   gap: 10px;
   color: var(--text3);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -309,7 +309,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   gap: 12px;
   padding: 42px 0;
   color: var(--text2);
-  font-size: 12px;
+  font-size: var(--type-caption);
 }
 
 .work-loading-state > span {
@@ -333,7 +333,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   border-left: 3px solid var(--danger);
   background: linear-gradient(90deg, var(--danger-soft), transparent 74%);
   color: var(--danger);
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   line-height: 1.5;
 }
 
@@ -355,8 +355,8 @@ html[data-density="compact"] .operations-root .operations-layout {
   display: block;
   margin-bottom: 15px;
   color: var(--accent);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.12em;
 }
@@ -376,8 +376,8 @@ html[data-density="compact"] .operations-root .operations-layout {
   max-width: 38ch;
   margin: 20px 0 0;
   color: var(--text2);
-  font-size: 13px;
-  line-height: 1.62;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
 }
 
 .work-empty-prompts {
@@ -422,8 +422,8 @@ html[data-density="compact"] .operations-root .operations-layout {
   align-self: start;
   padding-top: 2px;
   color: var(--text3);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
   font-weight: 700;
 }
 
@@ -440,15 +440,15 @@ html[data-density="compact"] .operations-root .operations-layout {
 .work-empty-prompt-copy strong {
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 14px;
+  font-size: var(--type-subsection);
   font-weight: 800;
   letter-spacing: -0.015em;
 }
 
 .work-empty-prompt-copy > span {
   color: var(--text2);
-  font-size: 12.5px;
-  line-height: 1.5;
+  font-size: var(--type-body-sm);
+  line-height: var(--leading-compact);
 }
 
 .work-empty-prompt:hover .work-empty-prompt-copy strong,
@@ -539,7 +539,7 @@ html[data-density="compact"] .operations-root .operations-layout {
 
 .work-surface-title {
   max-width: 22ch;
-  font-size: clamp(22px, 3vw, 32px);
+  font-size: var(--type-page);
   letter-spacing: -0.04em;
   line-height: 1.05;
 }
@@ -621,7 +621,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   align-self: center;
   color: var(--text3);
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 10px;
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -656,7 +656,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   color: var(--text2);
   cursor: pointer;
   font: inherit;
-  font-size: 11.5px;
+  font-size: var(--type-caption);
   font-weight: 700;
   padding: 7px 11px;
   transition: background 0.14s ease, border-color 0.14s ease, color 0.14s ease;
@@ -697,7 +697,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   border: 0;
   background: transparent;
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-label);
   padding: 4px 2px;
 }
 
@@ -720,7 +720,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   background: var(--card);
   color: var(--text);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--type-body-sm);
   padding: 8px 10px;
 }
 
@@ -732,7 +732,7 @@ html[data-density="compact"] .operations-root .operations-layout {
 .work-action-row-error {
   padding: 0 14px 11px 44px;
   color: var(--danger);
-  font-size: 11.5px;
+  font-size: var(--type-caption);
 }
 
 .work-confirm {
@@ -780,7 +780,7 @@ html[data-density="compact"] .operations-root .operations-layout {
 .work-command-surface .work-input {
   min-height: 68px;
   padding: 16px 14px 8px;
-  font-size: 15px;
+  font-size: var(--type-body-lg);
 }
 
 .work-command-surface .work-send-btn {
@@ -847,7 +847,7 @@ html[data-density="compact"] .operations-root .operations-layout {
 .operations-root .wcr-h {
   margin-bottom: 15px;
   color: var(--text);
-  font-size: 9px;
+  font-size: var(--type-label);
 }
 
 .operations-root .wcr-h::after {
@@ -1021,7 +1021,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   margin-bottom: 17px;
   color: var(--text3);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 9.5px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.15em;
   text-transform: uppercase;
@@ -1063,7 +1063,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   z-index: 1;
   margin: 24px 0 0;
   color: var(--text3);
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
 }
 
 .workflows-ops-status {
@@ -1107,7 +1107,7 @@ html[data-density="compact"] .operations-root .operations-layout {
 .workflows-ops-status > div span {
   color: var(--text3);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 8.5px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.13em;
   text-transform: uppercase;
@@ -1124,7 +1124,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   border-radius: 0;
   background: var(--success);
   color: var(--success-ink);
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   font-weight: 800;
 }
 
@@ -1172,7 +1172,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   min-height: 30px;
   margin-left: 52px;
   color: var(--text2);
-  font-size: 9px;
+  font-size: var(--type-label);
 }
 
 .operations-root.is-workflows .workflow-group-head::after {
@@ -1283,7 +1283,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   padding-top: 2px;
   color: var(--text3);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10px;
+  font-size: var(--type-caption);
   font-weight: 700;
 }
 
@@ -1297,22 +1297,22 @@ html[data-density="compact"] .operations-root .operations-layout {
 
 .operations-root.is-workflows .workflows-row-title {
   padding-right: 18px;
-  font-size: 17px;
-  font-weight: 850;
+  font-size: var(--type-subsection);
+  font-weight: 800;
   letter-spacing: -0.03em;
 }
 
 .operations-root.is-workflows .workflows-row-main .text-text2 {
   max-width: 48ch;
   margin-top: 7px;
-  font-size: 12px;
-  line-height: 1.5;
+  font-size: var(--type-body-sm);
+  line-height: var(--leading-compact);
 }
 
 .operations-root.is-workflows .workflows-row-meta {
   margin-top: 13px;
   color: var(--text3);
-  font-size: 9.5px;
+  font-size: var(--type-label);
   letter-spacing: 0.02em;
 }
 
@@ -1359,7 +1359,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   padding-top: 3px;
   color: var(--success);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.08em;
 }
@@ -1466,7 +1466,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   border-right: 1px solid var(--border);
   border-radius: 0;
   background: var(--card);
-  font-size: 11.5px;
+  font-size: var(--type-body-sm);
   font-weight: 800;
 }
 
@@ -1509,8 +1509,8 @@ html[data-density="compact"] .operations-root .operations-layout {
   padding-left: 28px;
   color: var(--text2);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 9px;
-  font-weight: 850;
+  font-size: var(--type-label);
+  font-weight: 800;
   letter-spacing: 0.13em;
   line-height: 1.45;
   text-transform: uppercase;
@@ -1522,15 +1522,15 @@ html[data-density="compact"] .operations-root .operations-layout {
   top: 0;
   left: 0;
   color: var(--accent);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 8px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
 }
 
 .workflow-detail-section-body {
   min-width: 0;
   color: var(--text);
-  font-size: 13px;
-  line-height: 1.58;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
 }
 
 .workflow-impact {
@@ -1609,7 +1609,7 @@ html[data-density="compact"] .operations-root .operations-layout {
 .workflow-budget-copy strong {
   color: var(--text2);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11px;
+  font-size: var(--type-caption);
 }
 
 .workflow-budget-copy strong[data-state="watch"] {
@@ -1648,7 +1648,7 @@ html[data-density="compact"] .operations-root .operations-layout {
 .workflow-action-kind {
   min-width: 0;
   color: var(--text);
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   font-weight: 750;
   overflow-wrap: anywhere;
 }
@@ -1657,14 +1657,14 @@ html[data-density="compact"] .operations-root .operations-layout {
   min-width: 0;
   color: var(--text2);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10.5px;
+  font-size: var(--type-caption);
   overflow-wrap: anywhere;
 }
 
 .workflow-action-meta {
   margin-top: 5px;
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-caption);
 }
 
 .workflow-detail-foot {
@@ -1977,11 +1977,11 @@ html[data-density="compact"] .operations-root .operations-layout {
   }
 
   .work-command-head p {
-    font-size: 12px;
+    font-size: var(--type-body);
   }
 
   .work-phase-rail li {
-    font-size: 8px;
+    font-size: var(--type-label);
   }
 
   .work-empty h2 {
@@ -2151,10 +2151,10 @@ html[data-density="compact"] .operations-root .operations-layout {
   max-width: none;
   overflow: hidden;
   color: var(--text);
-  font-size: 17px;
+  font-size: var(--type-page);
   font-weight: 800;
   letter-spacing: -0.025em;
-  line-height: 1.2;
+  line-height: var(--leading-page);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -2171,7 +2171,7 @@ html[data-density="compact"] .operations-root .operations-layout {
 
 .work-phase-rail li {
   gap: 6px;
-  font-size: 8px;
+  font-size: var(--type-label);
 }
 
 .work-command-actions {
@@ -2192,7 +2192,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   background: var(--card);
   color: var(--text2);
   font: inherit;
-  font-size: 11px;
+  font-size: var(--type-caption);
   font-weight: 750;
   white-space: nowrap;
   cursor: pointer;
@@ -2267,8 +2267,8 @@ html[data-density="compact"] .operations-root .operations-layout {
 
 .work-empty h2 {
   max-width: 8ch;
-  font-size: clamp(36px, 4vw, 48px);
-  line-height: 0.94;
+  font-size: var(--type-display);
+  line-height: var(--leading-display);
 }
 
 .work-empty-statement p {
@@ -2337,8 +2337,8 @@ html[data-density="compact"] .operations-root .operations-layout {
 
 .work-history-drawer-head span {
   color: var(--accent);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 9px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -2348,16 +2348,16 @@ html[data-density="compact"] .operations-root .operations-layout {
   margin: 8px 0 0;
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 31px;
+  font-size: var(--type-page);
   font-weight: 900;
   letter-spacing: -0.05em;
-  line-height: 1;
+  line-height: var(--leading-page);
 }
 
 .work-history-drawer-head p {
   margin: 7px 0 0;
   color: var(--text2);
-  font-size: 11px;
+  font-size: var(--type-body-sm);
 }
 
 .work-history-close {
@@ -2398,7 +2398,7 @@ html[data-density="compact"] .operations-root .operations-layout {
 
 .work-history-panel .ask-history-title {
   color: var(--text);
-  font-size: 10px;
+  font-size: var(--type-label);
 }
 
 .work-history-panel .ask-history-new {
@@ -2437,12 +2437,12 @@ html[data-density="compact"] .operations-root .operations-layout {
 }
 
 .work-history-panel .ask-history-row-title {
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
 }
 
 .work-history-panel .ask-history-row-time {
   margin-top: 2px;
-  font-size: 9px;
+  font-size: var(--type-label);
 }
 
 .work-history-panel .ask-history-delete {
@@ -2486,7 +2486,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   }
 
   .work-command-head h1 {
-    font-size: 15px;
+    font-size: var(--type-page);
   }
 
   .work-command-actions {
@@ -2512,7 +2512,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   }
 
   .work-empty h2 {
-    font-size: 36px;
+    font-size: var(--type-display);
   }
 
   .work-empty-statement p {
@@ -2535,7 +2535,7 @@ html[data-density="compact"] .operations-root .operations-layout {
 
 @media (max-width: 440px) {
   .work-command-head h1 {
-    font-size: 14px;
+    font-size: var(--type-page);
   }
 
   .work-command-action.is-primary span {
@@ -2659,7 +2659,7 @@ html[data-density="compact"] .operations-root .operations-layout {
 }
 
 .workflows-ops-status > div span {
-  font-size: 7.5px;
+  font-size: var(--type-label);
 }
 
 .workflows-ops-status .workflows-new-btn {
@@ -2671,7 +2671,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   padding: 0 22px;
   border-top: 0;
   border-left: 1px solid var(--text);
-  font-size: 11.5px;
+  font-size: var(--type-body-sm);
 }
 
 .operations-root.is-workflows .workflows-workspace {
@@ -2719,20 +2719,20 @@ html[data-density="compact"] .operations-root .operations-layout {
 
 .workflow-inspector-index {
   padding-top: 1px;
-  font-size: 9px;
+  font-size: var(--type-label);
 }
 
 .operations-root.is-workflows .workflow-inspector-head h2 {
   max-width: none;
   margin-top: 7px;
-  font-size: clamp(24px, 2.5vw, 32px);
+  font-size: var(--type-section);
   letter-spacing: -0.045em;
   line-height: 1;
 }
 
 .operations-root.is-workflows .workflow-inspector-head p {
   margin-top: 7px;
-  font-size: 11px;
+  font-size: var(--type-body-sm);
 }
 
 .operations-root.is-workflows .workflow-inspector-close {
@@ -2988,7 +2988,7 @@ html[data-density="compact"] .operations-root .operations-layout {
 
 .operations-root.is-workflows .page-heading .workflows-ops-status strong {
   color: var(--text);
-  font-size: 16px;
+  font-size: var(--type-subsection);
   font-weight: 850;
   letter-spacing: -0.035em;
   line-height: 1;
@@ -3008,7 +3008,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   > div
   span {
   color: var(--text3);
-  font-size: 7.5px;
+  font-size: var(--type-label);
 }
 
 .operations-root.is-workflows
@@ -3028,7 +3028,7 @@ html[data-density="compact"] .operations-root .operations-layout {
   border-radius: 10px;
   background: var(--success);
   color: var(--success-ink);
-  font-size: 11px;
+  font-size: var(--type-body-sm);
 }
 
 .operations-root.is-workflows
@@ -3077,11 +3077,11 @@ html[data-density="compact"] .operations-root .operations-layout {
     > div
     span {
     display: block;
-    font-size: 6.5px;
+    font-size: var(--type-label);
   }
 
   .operations-root.is-workflows .page-heading .workflows-ops-status strong {
-    font-size: 14px;
+    font-size: var(--type-body);
   }
 
   .operations-root.is-workflows

--- a/apps/web/src/app/styles/_profile-review.css
+++ b/apps/web/src/app/styles/_profile-review.css
@@ -19,19 +19,20 @@
 }
 .settings-card-title {
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 22px;
-  font-weight: 700;
-  line-height: 1.2;
+  font-size: var(--type-section);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  line-height: var(--leading-heading);
 }
 .settings-card-copy {
   margin-top: 6px;
   color: var(--text2);
-  line-height: 1.55;
-  font-size: 15px;
+  line-height: var(--leading-body);
+  font-size: var(--type-body);
 }
 .settings-source {
   color: var(--text3);
-  font-size: 11px;
+  font-size: var(--type-label);
   text-transform: uppercase;
   letter-spacing: 0.12em;
   font-weight: 600;
@@ -83,7 +84,7 @@
   list-style: none; padding: 0; margin: 0 0 6px;
 }
 .pm-ul li {
-  font-size: 15px; line-height: 1.6; color: var(--text2);
+  font-size: var(--type-body); line-height: var(--leading-body); color: var(--text2);
   padding: 3px 0 3px 20px; position: relative;
 }
 .pm-ul li::before {

--- a/apps/web/src/app/styles/_profile-review.css
+++ b/apps/web/src/app/styles/_profile-review.css
@@ -32,42 +32,150 @@
 }
 .settings-source {
   color: var(--text3);
-  font-size: var(--type-label);
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-weight: 600;
+  font-size: var(--type-caption);
+  letter-spacing: 0.01em;
+  font-weight: 750;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  flex: none;
+  max-width: 100%;
 }
 .settings-source strong {
-  font-weight: 600;
+  min-height: 26px;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 0;
-  border-radius: 0;
-  background: transparent;
+  padding: 5px 9px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--neutral-soft);
   color: var(--text2);
-}
-.settings-source strong::before {
-  content: "";
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: currentColor;
-  opacity: 0.55;
+  font-weight: 750;
+  line-height: 1.2;
+  white-space: nowrap;
 }
 .settings-source strong.is-ok {
+  border-color: color-mix(in srgb, var(--success-mid) 20%, var(--border));
+  background: var(--success-soft);
   color: var(--success-ink);
 }
 .settings-source strong.is-warn {
-  color: var(--danger);
+  border-color: color-mix(in srgb, var(--watch) 24%, var(--border));
+  background: var(--watch-soft);
+  color: var(--warn-ink);
 }
 .settings-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 16px;
+}
+
+.settings-index-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: stretch;
+  gap: 16px;
+}
+
+.settings-index-grid .settings-card {
+  min-height: 100%;
+  margin-top: 0;
+}
+
+.settings-index-card {
+  min-height: 172px;
+  display: flex;
+  flex-direction: column;
+  padding: 23px 24px 21px;
+  border-radius: 18px;
+  background: var(--card);
+  box-shadow: var(--shadow);
+  transition:
+    border-color 0.18s ease,
+    box-shadow 0.22s ease,
+    transform 0.22s ease;
+}
+
+.settings-index-card:hover {
+  border-color: color-mix(in srgb, var(--accent) 34%, var(--border));
+  box-shadow: var(--shadow-h);
+  transform: translateY(-2px);
+}
+
+.settings-index-card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+.settings-index-card-top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.settings-index-card .settings-card-title {
+  font-size: var(--type-section);
+  letter-spacing: -0.025em;
+}
+
+.settings-index-card .settings-card-copy {
+  max-width: 38ch;
+  margin-top: 8px;
+  color: var(--text2);
+  font-size: var(--type-body);
+  line-height: 1.52;
+}
+
+.settings-index-card-arrow {
+  width: 19px;
+  height: 19px;
+  flex: none;
+  color: var(--text3);
+  transition:
+    color 0.18s ease,
+    transform 0.18s ease;
+}
+
+.settings-index-card:hover .settings-index-card-arrow {
+  color: var(--accent);
+  transform: translate(2px, -2px);
+}
+
+.settings-index-card-foot {
+  display: flex;
+  align-items: center;
+  margin-top: auto;
+  padding-top: 16px;
+}
+
+.settings-index-status {
+  min-width: 0;
+  min-height: 26px;
+  max-width: 100%;
+  display: inline-flex;
+  align-items: center;
+  padding: 5px 9px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--neutral-soft);
+  color: var(--text2);
+  font-size: var(--type-caption);
+  font-weight: 750;
+  letter-spacing: 0.01em;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.settings-index-status[data-tone="success"] {
+  border-color: color-mix(in srgb, var(--success-mid) 20%, var(--border));
+  background: var(--success-soft);
+  color: var(--success-ink);
+}
+
+.settings-index-status[data-tone="watch"] {
+  border-color: color-mix(in srgb, var(--watch) 24%, var(--border));
+  background: var(--watch-soft);
+  color: var(--warn-ink);
 }
 .select-panel {
   box-shadow:
@@ -126,5 +234,15 @@
   }
   .settings-grid {
     grid-template-columns: 1fr;
+  }
+
+  .settings-index-grid {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 12px;
+  }
+
+  .settings-index-card {
+    min-height: 0;
+    padding: 20px 18px;
   }
 }

--- a/apps/web/src/app/styles/_rail.css
+++ b/apps/web/src/app/styles/_rail.css
@@ -29,7 +29,7 @@ body {
 .ask-history-title {
   color: var(--text2);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 9.5px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -44,7 +44,7 @@ body {
   border-radius: 999px;
   background: var(--neutral);
   color: var(--text2);
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 700;
 }
 
@@ -61,7 +61,7 @@ body {
   background: var(--card);
   color: var(--accent);
   font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: 10px;
+  font-size: var(--type-caption);
   font-weight: 750;
   cursor: pointer;
 }
@@ -75,7 +75,7 @@ body {
 .ask-history-empty {
   padding: 16px 10px;
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-caption);
   line-height: 1.45;
   text-align: center;
 }
@@ -128,7 +128,7 @@ body {
 .ask-history-row-title {
   overflow: hidden;
   color: var(--text2);
-  font-size: 11.5px;
+  font-size: var(--type-body-sm);
   font-weight: 650;
   line-height: 1.25;
   text-overflow: ellipsis;
@@ -142,7 +142,7 @@ body {
 
 .ask-history-row-time {
   color: var(--text3);
-  font-size: 8.5px;
+  font-size: var(--type-label);
   line-height: 1.2;
 }
 
@@ -354,7 +354,7 @@ body {
   }
 
   .app-rail-short {
-    font-size: 9px;
+    font-size: var(--type-label);
     font-weight: 700;
     line-height: 1;
     color: currentColor;
@@ -401,7 +401,7 @@ body {
     background: var(--danger);
     color: #fff;
     border: 1.5px solid var(--card);
-    font-size: 9px;
+    font-size: var(--type-label);
     font-weight: 700;
     line-height: 1;
   }
@@ -445,7 +445,7 @@ body {
     background: var(--accent);
     color: var(--on-accent);
     font-family: var(--font-display), "Archivo", sans-serif;
-    font-size: 13px;
+    font-size: var(--type-body-sm);
     font-weight: 800;
     letter-spacing: 0;
   }
@@ -533,7 +533,7 @@ body {
   .app-rail-name {
     display: grid;
     font-family: var(--font-display), "Archivo", sans-serif;
-    font-size: 18px;
+    font-size: var(--type-section);
     font-weight: 800;
     letter-spacing: -0.02em;
     line-height: 1;
@@ -550,7 +550,7 @@ body {
     color: var(--text2);
     padding: 2px 7px;
     font-family: var(--font-body), "Manrope", sans-serif;
-    font-size: 10.5px;
+    font-size: var(--type-label);
     font-weight: 700;
     line-height: 1.4;
     white-space: nowrap;
@@ -567,7 +567,7 @@ body {
     display: block;
     margin: 12px 10px 2px;
     font-family: var(--font-display), "Archivo", sans-serif;
-    font-size: 9.5px;
+    font-size: var(--type-label);
     font-weight: 800;
     letter-spacing: 0.12em;
     text-transform: uppercase;
@@ -587,7 +587,7 @@ body {
     display: block;
     padding: 2px 9px 0;
     color: var(--danger);
-    font-size: 9px;
+    font-size: var(--type-label);
     line-height: 1.4;
   }
 
@@ -626,7 +626,7 @@ body {
     outline: 0;
     background: transparent;
     color: var(--text);
-    font: 700 12px/1.2 var(--font-body), "Manrope", sans-serif;
+    font: 700 var(--type-body-sm)/1.2 var(--font-body), "Manrope", sans-serif;
     cursor: pointer;
   }
 
@@ -667,7 +667,7 @@ body {
     outline: 0;
     background: transparent;
     color: var(--text);
-    font: 600 11.5px/1.2 var(--font-body), "Manrope", sans-serif;
+    font: 600 var(--type-body-sm)/1.2 var(--font-body), "Manrope", sans-serif;
   }
 
   .app-rail-record-search input::placeholder {
@@ -696,7 +696,7 @@ body {
     display: block;
     padding: 2px 8px 4px;
     color: var(--text3);
-    font: 800 8.5px/1.2 var(--font-display), "Archivo", sans-serif;
+    font: 800 var(--type-label)/1.2 var(--font-display), "Archivo", sans-serif;
     letter-spacing: 0.1em;
     text-transform: uppercase;
   }
@@ -732,7 +732,7 @@ body {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-size: 12px;
+    font-size: var(--type-body-sm);
     font-weight: 600;
   }
 
@@ -740,8 +740,8 @@ body {
     display: inline;
     margin-left: auto;
     color: var(--text3);
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 8px;
+    font-family: var(--font-mono);
+    font-size: var(--type-label);
     font-weight: 700;
   }
 
@@ -749,7 +749,7 @@ body {
     display: inline;
     min-width: 18px;
     color: var(--text3);
-    font-size: 9px;
+    font-size: var(--type-label);
     font-variant-numeric: tabular-nums;
     text-align: right;
   }
@@ -798,7 +798,7 @@ body {
     border-radius: 8px;
     background: transparent;
     color: var(--accent);
-    font: 750 10px/1.2 var(--font-body), "Manrope", sans-serif;
+    font: 750 var(--type-caption)/1.2 var(--font-body), "Manrope", sans-serif;
     cursor: pointer;
   }
 
@@ -810,7 +810,7 @@ body {
     display: block;
     padding: 12px 8px;
     color: var(--text3);
-    font-size: 10.5px;
+    font-size: var(--type-caption);
     line-height: 1.4;
     text-align: center;
   }
@@ -846,7 +846,7 @@ body {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-size: 13.5px;
+    font-size: var(--type-body);
     font-weight: 600;
   }
 
@@ -869,7 +869,7 @@ body {
     transform: none;
     min-width: 18px;
     height: 18px;
-    font-size: 10px;
+    font-size: var(--type-label);
   }
 
   .ask-history-panel {
@@ -889,7 +889,7 @@ body {
   .ask-history-title {
     color: var(--text2);
     font-family: var(--font-display), "Archivo", sans-serif;
-    font-size: 9.5px;
+    font-size: var(--type-label);
     font-weight: 800;
     letter-spacing: 0.12em;
     text-transform: uppercase;
@@ -904,7 +904,7 @@ body {
     border-radius: 999px;
     background: var(--neutral);
     color: var(--text2);
-    font-size: 9px;
+    font-size: var(--type-label);
     font-weight: 700;
   }
 
@@ -921,7 +921,7 @@ body {
     background: var(--card);
     color: var(--accent);
     font-family: var(--font-body), "Manrope", sans-serif;
-    font-size: 10px;
+    font-size: var(--type-caption);
     font-weight: 750;
     cursor: pointer;
   }
@@ -935,7 +935,7 @@ body {
   .ask-history-empty {
     padding: 16px 10px;
     color: var(--text3);
-    font-size: 10.5px;
+    font-size: var(--type-caption);
     line-height: 1.45;
     text-align: center;
   }
@@ -988,7 +988,7 @@ body {
   .ask-history-row-title {
     overflow: hidden;
     color: var(--text2);
-    font-size: 11.5px;
+    font-size: var(--type-body-sm);
     font-weight: 650;
     line-height: 1.25;
     text-overflow: ellipsis;
@@ -1002,7 +1002,7 @@ body {
 
   .ask-history-row-time {
     color: var(--text3);
-    font-size: 8.5px;
+    font-size: var(--type-label);
     line-height: 1.2;
   }
 
@@ -1048,7 +1048,7 @@ body {
 
   .app-rail-foot-label {
     font-family: var(--font-display), "Archivo", sans-serif;
-    font-size: 9.5px;
+    font-size: var(--type-label);
     font-weight: 800;
     letter-spacing: 0.12em;
     text-transform: uppercase;
@@ -1088,7 +1088,7 @@ body {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-size: 12.5px;
+    font-size: var(--type-body-sm);
     font-weight: 700;
     color: var(--text);
     line-height: 1.2;
@@ -1098,7 +1098,7 @@ body {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    font-size: 10.5px;
+    font-size: var(--type-caption);
     color: var(--text3);
     line-height: 1.35;
   }

--- a/apps/web/src/app/styles/_rail.css
+++ b/apps/web/src/app/styles/_rail.css
@@ -505,6 +505,52 @@ body {
   }
 }
 
+/* The compact tablet rail must remain discoverable on a 768px viewport.
+   Tighter rhythm keeps common destinations visible, while the slim
+   scrollbar signals that record apps may add more navigation. */
+@media (min-width: 721px) and (max-width: 1024px) {
+  .app-rail-wrap {
+    gap: 10px;
+    padding-block: 12px 10px;
+  }
+
+  .app-rail-nav {
+    gap: 4px;
+    padding-right: 2px;
+    scrollbar-width: thin;
+    scrollbar-color: var(--border) transparent;
+    scroll-padding-block: 6px;
+  }
+
+  .app-rail-nav::-webkit-scrollbar {
+    display: block;
+    width: 3px;
+  }
+
+  .app-rail-nav::-webkit-scrollbar-thumb {
+    border-radius: 999px;
+    background: var(--border);
+  }
+
+  .app-rail-group {
+    gap: 2px;
+  }
+
+  .app-rail-link {
+    min-height: 54px;
+    gap: 3px;
+  }
+
+  .app-rail-link svg {
+    width: 19px;
+    height: 19px;
+  }
+
+  .app-rail-foot {
+    gap: 6px;
+  }
+}
+
 @media (min-width: 1025px) {
   body:has(> .app-rail-wrap) {
     --rail-w: 232px;

--- a/apps/web/src/app/styles/_records.css
+++ b/apps/web/src/app/styles/_records.css
@@ -51,29 +51,6 @@
   line-height: var(--leading-body);
 }
 
-.apps-overview-create {
-  min-height: 38px;
-  padding: 9px 13px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
-  flex: none;
-  border: 1px solid var(--accent);
-  border-radius: var(--radius-control);
-  background: var(--accent);
-  color: var(--on-accent);
-  font-size: var(--type-body-sm);
-  font-weight: 700;
-  text-decoration: none;
-  transition: background 150ms ease, transform 150ms ease;
-}
-
-.apps-overview-create:hover {
-  background: var(--accent-hover);
-  transform: translateY(-1px);
-}
-
 .apps-overview-create svg {
   width: 14px;
   height: 14px;
@@ -243,13 +220,6 @@
   color: var(--text2);
   font-size: var(--type-body);
   line-height: var(--leading-body);
-}
-
-.apps-overview-empty > a:not(.apps-overview-create) {
-  margin-top: 18px;
-  color: var(--accent);
-  font-size: var(--type-body-sm);
-  font-weight: 750;
 }
 
 .apps-overview-empty > .apps-overview-create {
@@ -801,36 +771,6 @@
   font-size: var(--type-body);
 }
 
-.records-primary-action,
-.records-secondary-action,
-.records-page-button {
-  min-height: 36px;
-  padding: 7px 12px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
-  border: 1px solid var(--accent);
-  border-radius: var(--radius-control);
-  background: var(--accent);
-  color: var(--on-accent);
-  font-size: var(--type-body-sm);
-  font-weight: 750;
-  line-height: 1;
-  text-decoration: none;
-  white-space: nowrap;
-}
-
-.records-primary-action:hover {
-  background: var(--accent-hover);
-}
-
-.records-primary-action svg,
-.records-secondary-action svg {
-  width: 14px;
-  height: 14px;
-}
-
 .records-viewbar {
   min-height: 58px;
   padding: 11px 0 9px;
@@ -874,7 +814,6 @@
 }
 
 .records-view-picker select,
-.records-view-picker button,
 .records-view-save > summary {
   min-height: 30px;
   padding: 5px 9px;
@@ -888,7 +827,6 @@
   font-weight: 750;
 }
 
-.records-view-picker button,
 .records-view-save > summary {
   cursor: pointer;
 }
@@ -994,20 +932,6 @@
   background: var(--bg);
   color: var(--text);
   font: inherit;
-}
-
-.records-filter-builder button,
-.records-view-save button,
-.records-view-delete {
-  min-height: 30px;
-  padding: 5px 10px;
-  border: 1px solid var(--accent);
-  border-radius: var(--radius-control);
-  background: var(--accent);
-  color: white;
-  cursor: pointer;
-  font-size: var(--type-body-sm);
-  font-weight: 750;
 }
 
 .records-home-header {
@@ -1602,16 +1526,7 @@
 }
 
 .records-page-button {
-  min-height: 30px;
   margin-left: auto;
-  border-color: var(--border);
-  background: var(--card);
-  color: var(--text2);
-}
-
-.records-page-button:hover {
-  border-color: var(--text3);
-  color: var(--text);
 }
 
 .records-empty {
@@ -1767,9 +1682,6 @@
 
 .records-secondary-action {
   margin-left: auto;
-  border-color: var(--border);
-  background: var(--card);
-  color: var(--text);
 }
 
 .records-object-header .records-secondary-action {
@@ -2505,19 +2417,6 @@
   color: var(--success-mid);
 }
 
-.records-form-cancel {
-  padding: 8px 10px;
-  color: var(--text2);
-  font-size: var(--type-body-sm);
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.records-primary-action:disabled {
-  cursor: wait;
-  opacity: 0.65;
-}
-
 .records-admin-nav {
   margin-left: auto;
   padding: 3px;
@@ -2681,8 +2580,7 @@
   gap: 6px;
 }
 
-.records-identity-backfill select,
-.records-identity-backfill button {
+.records-identity-backfill select {
   min-height: 32px;
   border: 1px solid var(--border);
   border-radius: var(--radius-control);
@@ -2695,29 +2593,6 @@
   outline: 0;
   background: var(--card);
   color: var(--text2);
-}
-
-.records-identity-backfill button {
-  padding: 6px 9px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  background: var(--card);
-  color: var(--text);
-  font-weight: 750;
-  white-space: nowrap;
-  cursor: pointer;
-}
-
-.records-identity-backfill button:disabled {
-  cursor: not-allowed;
-  opacity: 0.55;
-}
-
-.records-identity-backfill button svg {
-  width: 12px;
-  height: 12px;
 }
 
 .records-identity-backfill > span {
@@ -2895,8 +2770,7 @@
   gap: 6px;
 }
 
-.records-identity-control select,
-.records-identity-control button {
+.records-identity-control select {
   min-height: 32px;
   border: 1px solid var(--border);
   border-radius: var(--radius-control);
@@ -2918,32 +2792,6 @@
 .records-identity-control select:focus {
   border-color: color-mix(in srgb, var(--accent) 55%, var(--border));
   box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent-soft) 80%, transparent);
-}
-
-.records-identity-control button {
-  padding: 6px 8px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 5px;
-  background: var(--accent);
-  color: var(--on-accent);
-  cursor: pointer;
-}
-
-.records-identity-control button.is-quiet {
-  background: var(--card);
-  color: var(--text2);
-}
-
-.records-identity-control button:disabled {
-  cursor: not-allowed;
-  opacity: 0.55;
-}
-
-.records-identity-control button svg {
-  width: 11px;
-  height: 11px;
 }
 
 .records-identity-control > span {
@@ -3328,26 +3176,6 @@
   color: var(--danger);
   font-size: var(--type-caption);
   line-height: 1.4;
-}
-
-.records-import-cancel {
-  min-height: 34px;
-  margin-top: 5px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-control);
-  background: var(--card);
-  color: var(--text2);
-  font-size: var(--type-body-sm);
-  font-weight: 750;
-}
-
-.records-import-cancel svg {
-  width: 13px;
-  height: 13px;
 }
 
 .records-import-principles > svg {

--- a/apps/web/src/app/styles/_records.css
+++ b/apps/web/src/app/styles/_records.css
@@ -28,7 +28,7 @@
   margin-bottom: 8px;
   color: var(--accent);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.13em;
   text-transform: uppercase;
@@ -37,18 +37,18 @@
 .apps-overview-header h1 {
   margin: 0;
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: clamp(28px, 4vw, 42px);
+  font-size: var(--type-page);
   font-weight: 800;
   letter-spacing: -0.045em;
-  line-height: 1.05;
+  line-height: var(--leading-page);
 }
 
 .apps-overview-header p {
   max-width: 560px;
   margin: 11px 0 0;
   color: var(--text2);
-  font-size: 12px;
-  line-height: 1.6;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
 }
 
 .apps-overview-create {
@@ -63,8 +63,8 @@
   border-radius: var(--radius-control);
   background: var(--accent);
   color: var(--on-accent);
-  font-size: 11px;
-  font-weight: 750;
+  font-size: var(--type-body-sm);
+  font-weight: 700;
   text-decoration: none;
   transition: background 150ms ease, transform 150ms ease;
 }
@@ -95,7 +95,7 @@
   margin: 0;
   color: var(--text2);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 10px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -103,7 +103,7 @@
 
 .apps-overview-section-heading span {
   color: var(--text3);
-  font-size: 10px;
+  font-size: var(--type-caption);
   font-variant-numeric: tabular-nums;
 }
 
@@ -159,7 +159,7 @@
 
 .apps-overview-app-copy strong {
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 14px;
+  font-size: var(--type-subsection);
   font-weight: 800;
   letter-spacing: -0.015em;
 }
@@ -168,8 +168,8 @@
   max-width: 620px;
   overflow: hidden;
   color: var(--text2);
-  font-size: 11px;
-  line-height: 1.45;
+  font-size: var(--type-body);
+  line-height: var(--leading-compact);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -177,7 +177,7 @@
 .apps-overview-app-copy small {
   overflow: hidden;
   color: var(--text3);
-  font-size: 9.5px;
+  font-size: var(--type-caption);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -187,7 +187,7 @@
   align-items: center;
   gap: 7px;
   color: var(--text3);
-  font-size: 10px;
+  font-size: var(--type-body-sm);
   font-weight: 700;
   white-space: nowrap;
 }
@@ -232,7 +232,7 @@
 .apps-overview-empty h2 {
   margin: 0;
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 20px;
+  font-size: var(--type-section);
   font-weight: 800;
   letter-spacing: -0.025em;
 }
@@ -241,14 +241,14 @@
   max-width: 510px;
   margin: 10px 0 0;
   color: var(--text2);
-  font-size: 11px;
-  line-height: 1.6;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
 }
 
 .apps-overview-empty > a:not(.apps-overview-create) {
   margin-top: 18px;
   color: var(--accent);
-  font-size: 11px;
+  font-size: var(--type-body-sm);
   font-weight: 750;
 }
 
@@ -287,18 +287,18 @@
   border-radius: 999px;
   background: var(--neutral);
   color: var(--text2);
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 800;
 }
 
 .apps-overview-steps strong {
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
 }
 
 .apps-overview-steps small {
   color: var(--text3);
-  font-size: 9px;
-  line-height: 1.45;
+  font-size: var(--type-caption);
+  line-height: var(--leading-compact);
 }
 
 .apps-overview-member-note {
@@ -306,7 +306,7 @@
   padding-top: 17px;
   border-top: 1px solid var(--border);
   color: var(--text3);
-  font-size: 10px;
+  font-size: var(--type-caption);
 }
 
 .records-app-shell {
@@ -397,7 +397,7 @@
   border-radius: 999px;
   background: var(--neutral);
   color: var(--text3);
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 750;
   text-align: center;
 }
@@ -436,7 +436,7 @@
   overflow: hidden;
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 11.5px;
+  font-size: var(--type-body-sm);
   font-weight: 800;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -444,7 +444,7 @@
 
 .app-chat-heading small {
   color: var(--text3);
-  font-size: 8.5px;
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -492,8 +492,8 @@
 }
 
 .app-chat-empty svg { width: 18px; height: 18px; }
-.app-chat-empty strong { color: var(--text); font-size: 12px; }
-.app-chat-empty p { margin: 0; font-size: 10.5px; line-height: 1.55; }
+.app-chat-empty strong { color: var(--text); font-size: var(--type-subsection); }
+.app-chat-empty p { margin: 0; font-size: var(--type-body-sm); line-height: var(--leading-body); }
 
 .app-chat-state {
   margin: auto;
@@ -501,7 +501,7 @@
   align-items: center;
   gap: 7px;
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-caption);
 }
 
 .app-chat-state svg { width: 14px; height: 14px; }
@@ -511,8 +511,8 @@
   display: grid;
   gap: 7px;
   color: var(--text2);
-  font-size: 11.5px;
-  line-height: 1.55;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
 }
 
 .app-chat-message.is-user {
@@ -525,7 +525,7 @@
 .app-chat-message p { margin: 0 0 8px; }
 .app-chat-message ul,
 .app-chat-message ol { margin: 7px 0; padding-left: 18px; }
-.app-chat-message pre { max-width: 100%; padding: 9px; overflow-x: auto; border-radius: 8px; background: var(--neutral-soft); font-size: 10px; }
+.app-chat-message pre { max-width: 100%; padding: 9px; overflow-x: auto; border-radius: 8px; background: var(--neutral-soft); font-size: var(--type-caption); }
 .app-chat-message code { overflow-wrap: anywhere; font-size: 0.92em; }
 
 .app-chat-message.is-user > div {
@@ -543,13 +543,13 @@
   border-radius: var(--radius-inner);
   background: var(--card);
   color: var(--text);
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
   text-decoration: none;
 }
 
 .app-chat-action-link span {
   color: var(--warning-ink, var(--accent));
-  font-size: 8.5px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.09em;
   text-transform: uppercase;
@@ -568,7 +568,7 @@
   align-items: center;
   justify-content: space-between;
   color: var(--text3);
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.09em;
   text-transform: uppercase;
@@ -583,14 +583,14 @@
   border-radius: var(--radius-control);
   background: var(--card);
   color: var(--text2);
-  font-size: 9px;
+  font-size: var(--type-caption);
   font-weight: 750;
   letter-spacing: 0;
   text-transform: none;
 }
 
 .app-chat-history-title svg { width: 11px; height: 11px; }
-.app-chat-history > p { color: var(--text3); font-size: 10.5px; }
+.app-chat-history > p { color: var(--text3); font-size: var(--type-caption); }
 
 .app-chat-history-row {
   display: flex;
@@ -616,13 +616,13 @@
 .app-chat-history-row strong {
   overflow: hidden;
   color: var(--text);
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
   font-weight: 700;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-.app-chat-history-row small { color: var(--text3); font-size: 8.5px; }
+.app-chat-history-row small { color: var(--text3); font-size: var(--type-label); }
 
 .app-chat-history-delete {
   width: 28px;
@@ -654,7 +654,7 @@
   display: block;
   overflow: hidden;
   color: var(--text3);
-  font-size: 8.5px;
+  font-size: var(--type-label);
   font-weight: 650;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -687,7 +687,7 @@
   background: transparent;
   color: var(--text);
   font: inherit;
-  font-size: 11px;
+  font-size: var(--type-body);
   line-height: 1.45;
 }
 
@@ -705,7 +705,7 @@
 
 .app-chat-composer button:disabled { cursor: default; opacity: 0.4; }
 .app-chat-composer button svg { width: 13px; height: 13px; }
-.app-chat-error { margin: 6px 2px 0; color: var(--danger); font-size: 9.5px; }
+.app-chat-error { margin: 6px 2px 0; color: var(--danger); font-size: var(--type-caption); }
 
 @keyframes app-chat-pulse {
   0%, 100% { opacity: 0.35; transform: translateY(1px); }
@@ -746,22 +746,22 @@
   margin: 0;
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 17px;
+  font-size: var(--type-page);
   font-weight: 800;
   letter-spacing: -0.02em;
-  line-height: 1.2;
+  line-height: var(--leading-page);
 }
 
 .records-breadcrumb,
 .records-object-title > span[aria-hidden] {
   color: var(--text3);
-  font-size: 11px;
+  font-size: var(--type-label);
   font-weight: 650;
 }
 
 .records-total {
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-caption);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
@@ -798,7 +798,7 @@
   background: transparent;
   color: var(--text);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--type-body);
 }
 
 .records-primary-action,
@@ -814,7 +814,7 @@
   border-radius: var(--radius-control);
   background: var(--accent);
   color: var(--on-accent);
-  font-size: 11.5px;
+  font-size: var(--type-body-sm);
   font-weight: 750;
   line-height: 1;
   text-decoration: none;
@@ -863,7 +863,7 @@
   box-shadow: var(--shadow);
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 12px;
+  font-size: var(--type-body);
   font-weight: 800;
 }
 
@@ -884,7 +884,7 @@
   box-shadow: var(--shadow);
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 11px;
+  font-size: var(--type-body-sm);
   font-weight: 750;
 }
 
@@ -904,7 +904,7 @@
   border-radius: 999px;
   background: var(--card);
   color: var(--text2);
-  font-size: 10.5px;
+  font-size: var(--type-caption);
   font-weight: 600;
 }
 
@@ -914,7 +914,7 @@
 
 .records-filter-chip a {
   color: var(--text3);
-  font-size: 15px;
+  font-size: var(--type-body-lg);
   line-height: 1;
   text-decoration: none;
 }
@@ -926,7 +926,7 @@
   place-items: center;
   border-radius: 999px;
   color: var(--text3);
-  font-size: 15px;
+  font-size: var(--type-body-lg);
   line-height: 1;
   text-decoration: none;
 }
@@ -978,7 +978,7 @@
   display: grid;
   gap: 5px;
   color: var(--text2);
-  font-size: 10px;
+  font-size: var(--type-caption);
   font-weight: 750;
 }
 
@@ -1006,7 +1006,7 @@
   background: var(--accent);
   color: white;
   cursor: pointer;
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
   font-weight: 750;
 }
 
@@ -1020,15 +1020,17 @@
 .records-home-header h1 {
   margin: 3px 0 0;
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: clamp(28px, 4vw, 44px);
-  letter-spacing: -0.04em;
+  font-size: var(--type-page);
+  letter-spacing: -0.025em;
+  line-height: var(--leading-page);
 }
 
 .records-home-header p {
   max-width: 680px;
   margin: 7px 0 0;
   color: var(--text2);
-  font-size: 13px;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
 }
 
 .records-page-grid {
@@ -1060,15 +1062,14 @@
 .records-page-block h2 {
   margin: 0;
   color: var(--text2);
-  font-size: 11px;
+  font-size: var(--type-subsection);
   font-weight: 800;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  letter-spacing: -0.01em;
 }
 
 .records-page-block > header a {
   color: var(--accent);
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
   font-weight: 750;
   text-decoration: none;
 }
@@ -1076,7 +1077,7 @@
 .records-page-metric {
   display: block;
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: clamp(30px, 4vw, 48px);
+  font-size: var(--type-display);
   letter-spacing: -0.05em;
   line-height: 1;
 }
@@ -1088,7 +1089,7 @@
 .records-page-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 11px;
+  font-size: var(--type-caption);
 }
 
 .records-page-table th,
@@ -1101,7 +1102,7 @@
 
 .records-page-table th {
   color: var(--text3);
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -1143,7 +1144,7 @@
   display: flex;
   gap: 12px;
   color: var(--text2);
-  font-size: 10px;
+  font-size: var(--type-caption);
 }
 
 .records-page-timeline li > div b {
@@ -1155,7 +1156,7 @@
   margin: 0;
   padding: 20px 0;
   color: var(--text3);
-  font-size: 12px;
+  font-size: var(--type-body);
 }
 
 .records-object-grid {
@@ -1191,7 +1192,7 @@
 
 .records-object-grid small {
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-caption);
 }
 
 @container records-content (max-width: 900px) {
@@ -1205,7 +1206,7 @@
   }
 
   .records-page-metric {
-    font-size: clamp(30px, 7cqw, 42px);
+    font-size: var(--type-display);
   }
 }
 
@@ -1232,7 +1233,7 @@
   align-items: center;
   gap: 8px;
   color: var(--text2);
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
   font-weight: 700;
   text-decoration: none;
 }
@@ -1288,7 +1289,7 @@
   border-bottom: 1px solid var(--border);
   color: var(--text3);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.11em;
   text-align: left;
@@ -1311,7 +1312,7 @@
   overflow: hidden;
   border-bottom: 1px solid var(--border);
   color: var(--text2);
-  font-size: 12px;
+  font-size: var(--type-body-sm);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1352,7 +1353,7 @@
   border-radius: 999px;
   background: var(--watch-soft);
   color: var(--warn-ink) !important;
-  font-size: 8.5px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.04em;
   line-height: 1;
@@ -1389,7 +1390,7 @@
 .record-action-diff-target > span,
 .record-action-diff dt {
   color: var(--text3);
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.09em;
   text-transform: uppercase;
@@ -1398,7 +1399,7 @@
 .record-action-diff-target code {
   overflow-wrap: anywhere;
   color: var(--text2);
-  font-size: 10.5px;
+  font-size: var(--type-caption);
 }
 
 .record-action-diff dl {
@@ -1428,7 +1429,7 @@
   overflow-wrap: anywhere;
   color: var(--text2);
   font-family: var(--font-mono), monospace;
-  font-size: 11.5px;
+  font-size: var(--type-body-sm);
 }
 
 .record-action-diff-old {
@@ -1452,7 +1453,7 @@
   padding-top: 9px;
   border-top: 1px dashed var(--border);
   color: var(--text3);
-  font-size: 10px;
+  font-size: var(--type-caption);
   line-height: 1.45;
 }
 
@@ -1479,18 +1480,18 @@
 }
 
 .record-action-diff.is-compact dt {
-  font-size: 8.5px;
+  font-size: var(--type-label);
 }
 
 .record-action-diff.is-compact dd {
   gap: 6px;
-  font-size: 10.5px;
+  font-size: var(--type-caption);
 }
 
 .record-action-diff.is-compact .record-action-diff-freshness {
   margin-top: 7px;
   padding-top: 6px;
-  font-size: 9.5px;
+  font-size: var(--type-caption);
 }
 
 .records-table .is-number {
@@ -1538,7 +1539,7 @@
   padding: 3px 8px;
   display: inline-flex;
   border-radius: 999px;
-  font-size: 10px;
+  font-size: var(--type-caption);
   font-weight: 750;
   line-height: 1.35;
 }
@@ -1556,7 +1557,7 @@
 
 .records-pill-more {
   color: var(--text3);
-  font-size: 10px;
+  font-size: var(--type-caption);
   font-weight: 700;
 }
 
@@ -1570,7 +1571,7 @@
   background: var(--neutral);
   color: var(--text2);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 7.5px;
+  font-size: var(--type-label);
   font-weight: 800;
 }
 
@@ -1585,7 +1586,7 @@
   border-radius: 999px;
   background: var(--watch-soft);
   color: var(--warn-ink);
-  font-size: 8.5px;
+  font-size: var(--type-label);
   font-weight: 750;
 }
 
@@ -1597,7 +1598,7 @@
   gap: 10px;
   border-top: 1px solid var(--border);
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
 }
 
 .records-page-button {
@@ -1626,11 +1627,11 @@
 .records-empty strong {
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 14px;
+  font-size: var(--type-subsection);
 }
 
 .records-empty span {
-  font-size: 11.5px;
+  font-size: var(--type-body-sm);
 }
 
 .records-substrate {
@@ -1661,13 +1662,13 @@
 .records-substrate-item > span {
   display: grid;
   gap: 1px;
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
 }
 
 .records-substrate-item b {
   color: var(--text3);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 8px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -1683,7 +1684,7 @@
   border-bottom: 1px solid color-mix(in srgb, var(--danger) 25%, var(--border));
   background: var(--danger-soft);
   color: var(--text2);
-  font-size: 11.5px;
+  font-size: var(--type-body);
 }
 
 .records-degraded svg {
@@ -1718,7 +1719,7 @@
 .records-eyebrow {
   color: var(--danger);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -1726,13 +1727,16 @@
 
 .records-unavailable-panel h1 {
   margin: 7px 0;
-  font: 800 24px/1.15 var(--font-display), "Archivo", sans-serif;
+  font-family: var(--font-display), "Archivo", sans-serif;
+  font-size: var(--type-page);
+  font-weight: 800;
+  line-height: var(--leading-page);
 }
 
 .records-unavailable-panel p {
   max-width: 48ch;
   color: var(--text2);
-  font-size: 12.5px;
+  font-size: var(--type-body);
   line-height: 1.6;
 }
 
@@ -1779,12 +1783,15 @@
   align-items: baseline;
   gap: 8px;
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
 }
 
 .records-recycle-note strong {
   color: var(--text);
-  font: 800 12px/1.2 var(--font-display), "Archivo", sans-serif;
+  font-family: var(--font-display), "Archivo", sans-serif;
+  font-size: var(--type-body);
+  font-weight: 800;
+  line-height: var(--leading-heading);
 }
 
 .records-recycle-table td:first-child {
@@ -1796,7 +1803,7 @@
   display: block;
   overflow: hidden;
   color: var(--text3);
-  font-size: 8.5px;
+  font-size: var(--type-label);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -1811,7 +1818,7 @@
 .records-restore-control > span {
   max-width: 240px;
   color: var(--text3);
-  font-size: 9.5px;
+  font-size: var(--type-caption);
 }
 
 .records-recycle-warning {
@@ -1822,7 +1829,7 @@
   border-radius: var(--radius-control);
   background: var(--watch-soft);
   color: var(--text2);
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
 }
 
 .records-detail-card {
@@ -1838,7 +1845,7 @@
   margin: 0;
   padding: 13px 20px 0;
   color: var(--text2);
-  font-size: 11px;
+  font-size: var(--type-subsection);
   font-weight: 800;
 }
 
@@ -1862,7 +1869,7 @@
   margin-bottom: 6px;
   color: var(--text3);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -1871,7 +1878,7 @@
 .records-detail-field dd {
   overflow-wrap: anywhere;
   color: var(--text);
-  font-size: 13px;
+  font-size: var(--type-body);
   line-height: 1.5;
 }
 
@@ -1882,7 +1889,7 @@
   gap: 10px;
   background: var(--neutral-soft);
   color: var(--text3);
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 750;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -1891,7 +1898,7 @@
 .records-detail-id code {
   overflow: hidden;
   color: var(--text2);
-  font-size: 10px;
+  font-size: var(--type-caption);
   text-overflow: ellipsis;
   text-transform: none;
   white-space: nowrap;
@@ -1930,13 +1937,13 @@
 .records-related h2,
 .records-history h2 {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--type-subsection);
   font-weight: 800;
 }
 
 .records-related header a {
   color: var(--accent);
-  font-size: 10px;
+  font-size: var(--type-body-sm);
   font-weight: 750;
   text-decoration: none;
 }
@@ -1946,7 +1953,7 @@
   margin: 0;
   padding: 20px 15px;
   color: var(--text3);
-  font-size: 11px;
+  font-size: var(--type-body-sm);
 }
 
 .records-related-scroll { overflow-x: auto; }
@@ -1955,7 +1962,7 @@
   width: 100%;
   min-width: 620px;
   border-collapse: collapse;
-  font-size: 11px;
+  font-size: var(--type-caption);
 }
 
 .records-related th,
@@ -1967,7 +1974,7 @@
 
 .records-related th {
   color: var(--text3);
-  font-size: 9px;
+  font-size: var(--type-label);
   letter-spacing: 0.06em;
   text-transform: uppercase;
 }
@@ -1976,7 +1983,7 @@
 
 .records-history > header span {
   color: var(--text3);
-  font-size: 9.5px;
+  font-size: var(--type-label);
 }
 
 .records-history ol {
@@ -1996,7 +2003,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  font-size: 10.5px;
+  font-size: var(--type-caption);
 }
 
 .records-history-event strong {
@@ -2020,7 +2027,7 @@
   display: grid;
   grid-template-columns: minmax(100px, 0.28fr) 1fr;
   gap: 10px;
-  font-size: 10.5px;
+  font-size: var(--type-caption);
 }
 
 .records-history dt { color: var(--text2); font-weight: 750; }
@@ -2067,13 +2074,13 @@
 .records-ask-label strong {
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 11.5px;
+  font-size: var(--type-body-sm);
   font-weight: 800;
 }
 
 .records-ask-label small {
   color: var(--text3);
-  font-size: 9.5px;
+  font-size: var(--type-caption);
   line-height: 1.35;
 }
 
@@ -2103,7 +2110,7 @@
   background: transparent;
   color: var(--text);
   font: inherit;
-  font-size: 11.5px;
+  font-size: var(--type-body);
 }
 
 .records-ask button {
@@ -2131,7 +2138,7 @@
 .records-ask-error {
   grid-column: 2;
   color: var(--danger);
-  font-size: 10px;
+  font-size: var(--type-caption);
 }
 
 .records-ask.is-list-panel {
@@ -2163,7 +2170,7 @@
 }
 
 .records-ask.is-list-panel .records-ask-label strong {
-  font-size: 9.5px;
+  font-size: var(--type-label);
   letter-spacing: 0.11em;
   text-transform: uppercase;
 }
@@ -2188,7 +2195,7 @@
 
 .records-ask-message {
   margin: 0;
-  font-size: 12px;
+  font-size: var(--type-body);
   line-height: 1.55;
 }
 
@@ -2226,7 +2233,7 @@
 .records-ask-action > header span {
   color: var(--text2);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 8.5px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -2238,7 +2245,7 @@
   border-radius: 6px;
   background: var(--card);
   color: var(--text2);
-  font-size: 9.5px;
+  font-size: var(--type-caption);
 }
 
 .records-ask-action > div {
@@ -2252,14 +2259,14 @@
 
 .records-ask-action > div > strong {
   color: var(--text);
-  font-size: 11.5px;
+  font-size: var(--type-body-sm);
 }
 
 .records-ask-action > div > small {
   margin-top: 2px;
   overflow: hidden;
   color: var(--text3);
-  font-size: 9.5px;
+  font-size: var(--type-caption);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -2273,7 +2280,7 @@
   border-radius: var(--radius-control);
   background: var(--text);
   color: var(--card);
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
   font-weight: 750;
   text-decoration: none;
 }
@@ -2282,7 +2289,7 @@
 .records-ask-empty {
   margin: 0;
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
   line-height: 1.55;
 }
 
@@ -2317,14 +2324,17 @@
 .records-form-intro h2 {
   margin: 5px 0 2px;
   color: var(--text);
-  font: 800 19px/1.2 var(--font-display), "Archivo", sans-serif;
+  font-family: var(--font-display), "Archivo", sans-serif;
+  font-size: var(--type-section);
+  font-weight: 800;
+  line-height: var(--leading-heading);
   letter-spacing: -0.02em;
 }
 
 .records-form-intro p {
   margin: 0;
   color: var(--text3);
-  font-size: 11.5px;
+  font-size: var(--type-body-sm);
 }
 
 .records-form-card {
@@ -2360,7 +2370,7 @@
   display: block;
   color: var(--text2);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 9.5px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.055em;
   text-transform: uppercase;
@@ -2382,7 +2392,7 @@
   background: var(--neutral-soft);
   color: var(--text);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--type-body);
 }
 
 .records-form-field textarea {
@@ -2422,7 +2432,7 @@
   margin-top: 5px;
   display: block;
   color: var(--text3);
-  font-size: 9.5px;
+  font-size: var(--type-caption);
 }
 
 .records-checkbox {
@@ -2431,7 +2441,7 @@
   align-items: center;
   gap: 8px;
   color: var(--text2);
-  font-size: 12px;
+  font-size: var(--type-body-sm);
 }
 
 .records-checkbox input {
@@ -2443,7 +2453,7 @@
 .records-form-empty {
   padding: 34px 18px;
   color: var(--text3);
-  font-size: 12px;
+  font-size: var(--type-body-sm);
   text-align: center;
 }
 
@@ -2457,7 +2467,7 @@
   border-radius: var(--radius-control);
   background: var(--watch-soft);
   color: var(--text2);
-  font-size: 11px;
+  font-size: var(--type-body-sm);
   line-height: 1.45;
 }
 
@@ -2484,7 +2494,7 @@
   align-items: center;
   gap: 7px;
   color: var(--text3);
-  font-size: 9.5px;
+  font-size: var(--type-caption);
   line-height: 1.4;
 }
 
@@ -2498,7 +2508,7 @@
 .records-form-cancel {
   padding: 8px 10px;
   color: var(--text2);
-  font-size: 11px;
+  font-size: var(--type-body-sm);
   font-weight: 700;
   text-decoration: none;
 }
@@ -2527,7 +2537,7 @@
   gap: 6px;
   border-radius: calc(var(--radius-control) - 2px);
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
   font-weight: 750;
   text-decoration: none;
 }
@@ -2561,13 +2571,13 @@
 
 .records-admin-panel h2 {
   margin: 0;
-  font-size: 15px;
+  font-size: var(--type-section);
 }
 
 .records-admin-panel header p {
   margin: 4px 0 0;
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
 }
 
 .records-admin-table-scroll { overflow-x: auto; }
@@ -2576,7 +2586,7 @@
   width: 100%;
   min-width: 740px;
   border-collapse: collapse;
-  font-size: 11px;
+  font-size: var(--type-caption);
 }
 
 .records-admin-table th,
@@ -2588,7 +2598,7 @@
 
 .records-admin-table th {
   color: var(--text3);
-  font-size: 8.5px;
+  font-size: var(--type-label);
   letter-spacing: 0.07em;
   text-transform: uppercase;
 }
@@ -2597,13 +2607,13 @@
   margin-top: 2px;
   display: block;
   color: var(--text3);
-  font-size: 8.5px;
+  font-size: var(--type-label);
 }
 
 .records-permission-grant {
   padding: 3px 7px;
   border-radius: 999px;
-  font-size: 8.5px;
+  font-size: var(--type-label);
   font-weight: 750;
 }
 
@@ -2614,7 +2624,7 @@
   padding: 12px 14px;
   background: var(--neutral-soft);
   color: var(--text2);
-  font-size: 10px;
+  font-size: var(--type-caption);
 }
 
 .records-schema-history > ol {
@@ -2634,15 +2644,15 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  font-size: 10px;
+  font-size: var(--type-caption);
 }
 
 .records-schema-history strong { text-transform: capitalize; }
 .records-schema-history time,
 .records-schema-history span { color: var(--text3); }
-.records-schema-history ul { margin: 0; padding-left: 18px; color: var(--text2); font-size: 10.5px; }
-.records-schema-history code { color: var(--text3); font-size: 9px; }
-.records-admin-empty { margin: 0; padding: 28px 18px; color: var(--text3); font-size: 11px; }
+.records-schema-history ul { margin: 0; padding-left: 18px; color: var(--text2); font-size: var(--type-caption); }
+.records-schema-history code { color: var(--text3); font-size: var(--type-label); }
+.records-admin-empty { margin: 0; padding: 28px 18px; color: var(--text3); font-size: var(--type-body-sm); }
 
 .records-identity-layout {
   width: min(1240px, 100%);
@@ -2676,7 +2686,7 @@
   min-height: 32px;
   border: 1px solid var(--border);
   border-radius: var(--radius-control);
-  font-size: 9.5px;
+  font-size: var(--type-caption);
 }
 
 .records-identity-backfill select {
@@ -2713,7 +2723,7 @@
 .records-identity-backfill > span {
   grid-column: 1 / -1;
   color: var(--text3);
-  font-size: 9px;
+  font-size: var(--type-label);
   text-align: right;
 }
 
@@ -2727,7 +2737,7 @@
   border-radius: var(--radius-control);
   background: var(--card);
   color: var(--text2);
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
   font-weight: 700;
   text-decoration: none;
   white-space: nowrap;
@@ -2745,7 +2755,7 @@
   border-radius: 999px;
   background: var(--neutral);
   color: var(--text3);
-  font-size: 8.5px;
+  font-size: var(--type-label);
   font-variant-numeric: tabular-nums;
   text-align: center;
 }
@@ -2770,20 +2780,23 @@
 .records-identity-card h2 {
   margin: 0 0 3px;
   color: var(--text);
-  font: 800 15px/1.25 var(--font-display), "Archivo", sans-serif;
+  font-family: var(--font-display), "Archivo", sans-serif;
+  font-size: var(--type-section);
+  font-weight: 800;
+  line-height: var(--leading-heading);
 }
 
 .records-identity-card header p {
   max-width: 68ch;
   margin: 0;
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
   line-height: 1.45;
 }
 
 .records-identity-card > header > span {
   color: var(--text3);
-  font-size: 10px;
+  font-size: var(--type-caption);
   white-space: nowrap;
 }
 
@@ -2803,7 +2816,7 @@
   background: var(--neutral-soft);
   color: var(--text3);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 8.5px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.09em;
   text-align: left;
@@ -2814,7 +2827,7 @@
   padding: 11px 12px;
   border-bottom: 1px solid var(--border);
   color: var(--text2);
-  font-size: 10.5px;
+  font-size: var(--type-caption);
   line-height: 1.35;
   vertical-align: top;
 }
@@ -2836,7 +2849,7 @@
 .records-identity-table td > small {
   margin-top: 2px;
   color: var(--text3);
-  font-size: 9px;
+  font-size: var(--type-label);
 }
 
 .records-identity-table code {
@@ -2844,7 +2857,7 @@
   border-radius: 4px;
   background: var(--neutral-soft);
   color: var(--text2);
-  font-size: 9px;
+  font-size: var(--type-label);
 }
 
 .records-identity-status {
@@ -2855,7 +2868,7 @@
   border-radius: 999px;
   background: var(--neutral);
   color: var(--text2);
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 750;
   text-transform: capitalize;
 }
@@ -2887,7 +2900,10 @@
   min-height: 32px;
   border: 1px solid var(--border);
   border-radius: var(--radius-control);
-  font: 700 9.5px/1 var(--font-body), sans-serif;
+  font-family: var(--font-body), sans-serif;
+  font-size: var(--type-caption);
+  font-weight: 700;
+  line-height: 1;
 }
 
 .records-identity-control select {
@@ -2933,7 +2949,7 @@
 .records-identity-control > span {
   grid-column: 1 / -1;
   color: var(--danger);
-  font-size: 9px;
+  font-size: var(--type-label);
 }
 
 .records-import-layout {
@@ -2983,7 +2999,10 @@
 .records-import-principles h2 {
   margin: 4px 0 3px;
   color: var(--text);
-  font: 800 16px/1.25 var(--font-display), "Archivo", sans-serif;
+  font-family: var(--font-display), "Archivo", sans-serif;
+  font-size: var(--type-section);
+  font-weight: 800;
+  line-height: var(--leading-heading);
   letter-spacing: -0.015em;
 }
 
@@ -2992,7 +3011,7 @@
 .records-import-principles p {
   margin: 0;
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
   line-height: 1.5;
 }
 
@@ -3002,7 +3021,7 @@
   gap: 6px;
   color: var(--text2);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.055em;
   text-transform: uppercase;
@@ -3020,7 +3039,10 @@
   outline: 0;
   background: var(--neutral-soft);
   color: var(--text);
-  font: 500 11px/1.2 var(--font-body), sans-serif;
+  font-family: var(--font-body), sans-serif;
+  font-size: var(--type-body-sm);
+  font-weight: 500;
+  line-height: var(--leading-compact);
   text-transform: none;
 }
 
@@ -3080,7 +3102,7 @@
   background: var(--neutral-soft);
   color: var(--text3);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 8.5px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.09em;
   text-align: left;
@@ -3092,7 +3114,7 @@
   padding: 10px 12px;
   border-bottom: 1px solid var(--border);
   color: var(--text2);
-  font-size: 11px;
+  font-size: var(--type-caption);
   line-height: 1.4;
   vertical-align: top;
 }
@@ -3114,7 +3136,7 @@
   margin-top: 5px;
   display: block;
   color: var(--text3);
-  font-size: 9px;
+  font-size: var(--type-label);
 }
 
 .records-import-kind {
@@ -3123,7 +3145,7 @@
   border-radius: 999px;
   background: var(--neutral);
   color: var(--text2);
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 750;
 }
 
@@ -3147,7 +3169,7 @@
   align-items: center;
   gap: 6px;
   color: var(--text3);
-  font-size: 9.5px;
+  font-size: var(--type-caption);
   line-height: 1.4;
 }
 
@@ -3190,7 +3212,7 @@
 .records-import-artifact-report > p {
   margin: 0;
   color: var(--text3);
-  font-size: 9px;
+  font-size: var(--type-caption);
   line-height: 1.5;
 }
 
@@ -3212,14 +3234,14 @@
   margin-top: 4px;
   overflow: hidden;
   color: var(--text);
-  font-size: 11.5px;
+  font-size: var(--type-body-sm);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .records-import-status > span:not(.records-import-status-dot) {
   color: var(--text3);
-  font-size: 9.5px;
+  font-size: var(--type-caption);
 }
 
 .records-import-status-dot {
@@ -3258,7 +3280,7 @@
 
 .records-import-progress small {
   color: var(--text3);
-  font-size: 9px;
+  font-size: var(--type-label);
   font-variant-numeric: tabular-nums;
 }
 
@@ -3283,7 +3305,7 @@
 
 .records-import-report dt {
   color: var(--text3);
-  font-size: 8px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.07em;
   text-transform: uppercase;
@@ -3291,7 +3313,10 @@
 
 .records-import-report dd {
   color: var(--text);
-  font: 800 14px/1 var(--font-display), "Archivo", sans-serif;
+  font-family: var(--font-display), "Archivo", sans-serif;
+  font-size: var(--type-body);
+  font-weight: 800;
+  line-height: 1;
   font-variant-numeric: tabular-nums;
 }
 
@@ -3301,7 +3326,7 @@
   border-radius: var(--radius-inner);
   background: var(--danger-soft);
   color: var(--danger);
-  font-size: 9.5px;
+  font-size: var(--type-caption);
   line-height: 1.4;
 }
 
@@ -3316,7 +3341,7 @@
   border-radius: var(--radius-control);
   background: var(--card);
   color: var(--text2);
-  font-size: 10px;
+  font-size: var(--type-body-sm);
   font-weight: 750;
 }
 
@@ -3362,7 +3387,7 @@
 
 .records-import-recent span {
   overflow: hidden;
-  font-size: 10.5px;
+  font-size: var(--type-body-sm);
   font-weight: 750;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -3370,7 +3395,7 @@
 
 .records-import-recent small {
   color: var(--text3);
-  font-size: 8.5px;
+  font-size: var(--type-label);
 }
 
 .records-spin {

--- a/apps/web/src/app/styles/_responsive.css
+++ b/apps/web/src/app/styles/_responsive.css
@@ -62,10 +62,10 @@ body { overflow-x: hidden; }
   .builder-card { position: static; }
 
   /* Roomier touch targets across nav, pills, and primary buttons. */
-  .settings-link, .settings-backlink { padding: 9px 14px; font-size: 14px; }
-  .pill { padding: 10px 16px; font-size: 14px; }
-  .workflows-new-btn, .run-followup-btn { padding: 10px 16px; font-size: 14px; }
-  .act-row-btn, .workflow-drawer-btn { padding: 10px 16px; font-size: 14px; }
+  .settings-link, .settings-backlink { padding: 9px 14px; font-size: var(--type-body); }
+  .pill { padding: 10px 16px; font-size: var(--type-body); }
+  .workflows-new-btn, .run-followup-btn { padding: 10px 16px; font-size: var(--type-body); }
+  .act-row-btn, .workflow-drawer-btn { padding: 10px 16px; font-size: var(--type-body); }
   .act-row-btn, .workflow-drawer-btn, .modal-btn {
     max-width: 100%;
     white-space: normal;
@@ -94,22 +94,22 @@ body { overflow-x: hidden; }
   /* Dashboard role pills — comfortable wrap, no overflow. */
   .dash-meta { gap: 8px; margin-bottom: 24px; }
   .pills { gap: 6px; }
-  .pill { padding: 9px 14px; font-size: 14px; }
+  .pill { padding: 9px 14px; font-size: var(--type-body); }
 
   /* Greeting / eyebrow scale down so the headline doesn't crush. */
   .greet { font-size: 34px; margin-bottom: 6px; }
-  .greet-sub { font-size: 15px; margin-bottom: 26px; }
-  .greet-sub-quote { font-size: 17px; margin-bottom: 26px; padding-left: 12px; }
-  .greet-eyebrow { font-size: 11px; gap: 10px; }
+  .greet-sub { font-size: var(--type-body-lg); margin-bottom: 26px; }
+  .greet-sub-quote { font-size: var(--type-subsection); margin-bottom: 26px; padding-left: 12px; }
+  .greet-eyebrow { font-size: var(--type-label); gap: 10px; }
   .greet-eyebrow-rule { width: 28px; }
 
-  .briefing-summary { font-size: 15px; }
-  .briefing-tributary-title { font-size: 11px; }
+  .briefing-summary { font-size: var(--type-body-lg); }
+  .briefing-tributary-title { font-size: var(--type-label); }
 
   /* Insight card — keep the left mood-bar but reclaim horizontal room. */
   .icard { padding: 18px 18px 18px 22px; border-radius: 16px; }
   .inum { font-size: 22px; min-width: 32px; }
-  .itext { font-size: 15px; }
+  .itext { font-size: var(--type-body-lg); }
   .dtext, .dchart { padding-left: 0; margin-left: 0; }
   .iactions { top: 10px; right: 10px; }
   .ipin { width: 34px; height: 34px; }
@@ -118,8 +118,8 @@ body { overflow-x: hidden; }
   .profile-card { padding: 22px 20px; border-radius: 18px; }
   .settings-card { padding: 20px 18px; border-radius: 18px; }
   .settings-card-head { flex-direction: column; align-items: stretch; gap: 10px; }
-  .settings-card-title { font-size: 19px; }
-  .settings-card-copy { font-size: 14.5px; }
+  .settings-card-title { font-size: var(--type-section); }
+  .settings-card-copy { font-size: var(--type-body); }
   .settings-grid { grid-template-columns: minmax(0, 1fr) !important; gap: 12px; }
 
   /* Workflows + runs page header rows — title above action button. */
@@ -127,9 +127,9 @@ body { overflow-x: hidden; }
   .workflows-row-meta { flex-wrap: wrap; row-gap: 4px; }
 
   .run-header-row { flex-direction: column; align-items: stretch; gap: 10px; }
-  .run-title { font-size: 22px; }
+  .run-title { font-size: var(--type-page); }
   .run-followup-btn { align-self: flex-start; }
-  .run-header-meta { font-size: 12.5px; }
+  .run-header-meta { font-size: var(--type-body-sm); }
   .run-phase-strip { flex-wrap: wrap; gap: 6px; }
   .run-output-card, .run-action-card { padding: 16px 16px; border-radius: 14px; }
 
@@ -141,7 +141,7 @@ body { overflow-x: hidden; }
   .act-row-btn { flex: 1 1 auto; min-width: 0; text-align: center; }
 
   /* Work transcript / composer bubbles. */
-  .work-bubble { padding: 14px 16px; font-size: 15px; }
+  .work-bubble { padding: 14px 16px; font-size: var(--type-body-lg); }
   .work-bubble.is-user { padding: 10px 14px; }
 
   /* Builder chat min-height was 520px — too tall to be useful on a phone. */
@@ -164,9 +164,9 @@ body { overflow-x: hidden; }
 @media (max-width: 380px) {
   .root { padding-left: 14px; padding-right: 14px; }
   .greet { font-size: 30px; }
-  .pill { padding: 8px 12px; font-size: 13.5px; }
+  .pill { padding: 8px 12px; font-size: var(--type-body); }
   .icard { padding: 16px 14px 16px 18px; }
-  .act-row-btn { font-size: 13px; padding: 10px 12px; }
+  .act-row-btn { font-size: var(--type-body-sm); padding: 10px 12px; }
 }
 
 /* ── TOUCH-ONLY: always reveal hover-only chrome ── */

--- a/apps/web/src/app/styles/_run-replay.css
+++ b/apps/web/src/app/styles/_run-replay.css
@@ -2,43 +2,6 @@
   --page-width: 1000px;
 }
 
-.run-followup-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 7px;
-  min-height: 40px;
-  padding: 8px 14px;
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--card) 72%, transparent);
-  color: var(--text2);
-  font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: var(--type-body-sm);
-  font-weight: 650;
-  cursor: pointer;
-  transition:
-    color 160ms ease,
-    border-color 160ms ease,
-    background 160ms ease;
-}
-
-.run-followup-btn svg {
-  width: 14px;
-  height: 14px;
-  transition: transform 180ms ease;
-}
-
-.run-followup-btn:hover {
-  border-color: color-mix(in srgb, var(--accent) 42%, var(--border));
-  background: var(--accent-soft);
-  color: var(--accent);
-}
-
-.run-followup-btn:hover svg {
-  transform: translateX(2px);
-}
-
 .run-empty-summary {
   margin: 8px 0 24px;
   padding: 14px 16px;
@@ -252,45 +215,6 @@
   content: "/";
 }
 
-.run-finding-pin {
-  display: inline-flex;
-  flex: 0 0 auto;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 9px;
-  border: 0;
-  border-radius: 8px;
-  background: transparent;
-  color: var(--text2);
-  font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: var(--type-caption);
-  font-weight: 650;
-  cursor: pointer;
-  transition:
-    color 160ms ease,
-    background 160ms ease;
-}
-
-.run-finding-pin svg {
-  width: 13px;
-  height: 13px;
-  transition: transform 180ms ease;
-}
-
-.run-finding-pin:hover:not(:disabled) {
-  background: var(--accent-soft);
-  color: var(--accent);
-}
-
-.run-finding-pin:hover:not(:disabled) svg {
-  transform: translateY(-1px) rotate(-6deg);
-}
-
-.run-finding-pin:disabled {
-  color: var(--success-mid);
-  cursor: default;
-}
-
 .run-empty-state {
   margin: 0;
   color: var(--text3);
@@ -439,13 +363,13 @@
 }
 
 @media (max-width: 600px) {
-  .run-followup-btn {
-    width: 42px;
-    min-height: 42px;
+  .run-followup-control {
+    width: var(--control-touch);
+    min-height: var(--control-touch);
     padding: 0;
   }
 
-  .run-followup-btn span {
+  .run-followup-control span {
     position: absolute;
     width: 1px;
     height: 1px;
@@ -454,7 +378,7 @@
     white-space: nowrap;
   }
 
-  .run-followup-btn svg {
+  .run-followup-control svg {
     width: 16px;
     height: 16px;
   }
@@ -496,7 +420,7 @@
     gap: 7px;
   }
 
-  .run-finding-pin {
+  .run-finding-pin-control {
     align-self: flex-end;
     margin-right: -7px;
   }
@@ -523,8 +447,8 @@
   }
 
   .run-finding-card,
-  .run-followup-btn svg,
-  .run-finding-pin svg {
+  .run-followup-control svg,
+  .run-finding-pin-control svg {
     transition: none;
   }
 }

--- a/apps/web/src/app/styles/_run-replay.css
+++ b/apps/web/src/app/styles/_run-replay.css
@@ -14,7 +14,7 @@
   background: color-mix(in srgb, var(--card) 72%, transparent);
   color: var(--text2);
   font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   font-weight: 650;
   cursor: pointer;
   transition:
@@ -46,7 +46,7 @@
   border-radius: 14px;
   background: var(--card);
   color: var(--text2);
-  font-size: 13.5px;
+  font-size: var(--type-body);
   font-style: italic;
   line-height: 1.55;
 }
@@ -69,17 +69,16 @@
   margin: 0;
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 12px;
+  font-size: var(--type-section);
   font-weight: 800;
-  letter-spacing: 0.08em;
-  line-height: 1.2;
-  text-transform: uppercase;
+  letter-spacing: -0.02em;
+  line-height: var(--leading-heading);
 }
 
 .run-section-head > span {
   color: var(--text3);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10.5px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
 }
 
 .run-finding-list {
@@ -146,8 +145,8 @@
   gap: 7px;
   min-width: 0;
   color: var(--text3);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10.5px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
@@ -162,7 +161,7 @@
   border-radius: 999px;
   background: var(--neutral);
   color: var(--text2);
-  font-size: 10px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.08em;
   line-height: 1;
@@ -194,10 +193,10 @@
   margin: 0 0 10px;
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: clamp(21px, 2.6vw, 28px);
+  font-size: var(--type-page);
   font-weight: 800;
   letter-spacing: -0.035em;
-  line-height: 1.12;
+  line-height: var(--leading-page);
   overflow-wrap: anywhere;
 }
 
@@ -205,8 +204,8 @@
   max-width: 76ch;
   margin-bottom: 16px;
   color: var(--text2);
-  font-size: 13.5px;
-  line-height: 1.62;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
 }
 
 .run-finding-body p {
@@ -243,7 +242,7 @@
 
 .run-finding-tags span {
   color: var(--text3);
-  font-size: 10.5px;
+  font-size: var(--type-label);
   line-height: 1.3;
 }
 
@@ -264,7 +263,7 @@
   background: transparent;
   color: var(--text2);
   font-family: var(--font-body), "Manrope", sans-serif;
-  font-size: 11.5px;
+  font-size: var(--type-caption);
   font-weight: 650;
   cursor: pointer;
   transition:
@@ -295,7 +294,7 @@
 .run-empty-state {
   margin: 0;
   color: var(--text3);
-  font-size: 13px;
+  font-size: var(--type-body-sm);
   font-style: italic;
   line-height: 1.55;
 }
@@ -306,7 +305,7 @@
   gap: 9px;
   margin: -15px 0 30px;
   color: var(--text3);
-  font-size: 12px;
+  font-size: var(--type-caption);
   line-height: 1.45;
 }
 
@@ -332,7 +331,7 @@
 .run-trace-head p {
   margin: 4px 0 0;
   color: var(--text3);
-  font-size: 11.5px;
+  font-size: var(--type-caption);
   line-height: 1.4;
 }
 
@@ -345,7 +344,7 @@
   min-height: 46px;
   padding: 11px 2px;
   color: var(--text2);
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   font-weight: 600;
   list-style: none;
   display: flex;
@@ -356,8 +355,8 @@
 .run-expander-summary > span {
   margin-left: auto;
   color: var(--text3);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10.5px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
   font-weight: 500;
 }
 
@@ -365,7 +364,7 @@
 .run-expander-summary::before {
   content: "▸";
   color: var(--text3);
-  font-size: 11px;
+  font-size: var(--type-label);
   display: inline-block;
   transition: transform 0.18s;
 }
@@ -377,8 +376,8 @@
 .run-expander-content {
   padding: 3px 4px 16px 22px;
   color: var(--text);
-  font-size: 13px;
-  line-height: 1.55;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
 }
 
 .run-evt-message p { margin: 0 0 6px; }
@@ -389,8 +388,8 @@
   background: var(--neutral);
   border-radius: 4px;
   padding: 0 4px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 12.5px;
+  font-family: var(--font-mono);
+  font-size: var(--type-body-sm);
 }
 .run-evt-message strong { font-weight: 700; }
 .run-evt-message em { font-style: italic; }
@@ -400,7 +399,7 @@
   border-radius: var(--radius-control);
   padding: 10px 12px;
   overflow-x: auto;
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   line-height: 1.5;
 }
 .run-evt-message pre code { background: transparent; padding: 0; }
@@ -475,20 +474,20 @@
 
   .run-finding-context {
     padding-top: 5px;
-    font-size: 9.5px;
+    font-size: var(--type-label);
   }
 
   .run-finding-status {
-    font-size: 9px;
+    font-size: var(--type-label);
   }
 
   .run-finding-title {
     margin-bottom: 9px;
-    font-size: 22px;
+    font-size: var(--type-page);
   }
 
   .run-finding-body {
-    font-size: 13px;
+    font-size: var(--type-body);
   }
 
   .run-finding-footer {

--- a/apps/web/src/app/styles/_toasts.css
+++ b/apps/web/src/app/styles/_toasts.css
@@ -26,7 +26,7 @@
     0 12px 40px -8px rgba(20, 18, 12, 0.12),
     0 24px 60px -16px rgba(20, 18, 12, 0.08);
   font-family: var(--font-body), 'Manrope', sans-serif;
-  font-size: 13px;
+  font-size: var(--type-body-sm);
   font-weight: 400;
   line-height: 1.5;
   box-sizing: border-box;
@@ -92,7 +92,7 @@
 
 .app-toast .app-toast-title {
   font-family: var(--font-body), 'Manrope', sans-serif;
-  font-size: 14px;
+  font-size: var(--type-body);
   font-weight: 500;
   line-height: 1.4;
   letter-spacing: -0.1px;
@@ -100,7 +100,7 @@
 }
 
 .app-toast .app-toast-desc {
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   font-weight: 400;
   line-height: 1.5;
   color: var(--text2);
@@ -151,7 +151,7 @@
   background: var(--text);
   color: var(--card);
   font-family: inherit;
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   font-weight: 500;
   cursor: pointer;
   transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
@@ -170,7 +170,7 @@
   background: transparent;
   color: var(--text2);
   font-family: inherit;
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   font-weight: 500;
   cursor: pointer;
   transition: color 160ms ease, border-color 160ms ease, background 160ms ease;
@@ -180,4 +180,3 @@
   color: var(--text);
   border-color: var(--text3);
 }
-

--- a/apps/web/src/app/styles/_tokens.css
+++ b/apps/web/src/app/styles/_tokens.css
@@ -32,8 +32,28 @@
   --shadow: 0 1px 3px rgba(20,18,12,0.04), 0 4px 16px rgba(20,18,12,0.03);
   --shadow-h: 0 2px 8px rgba(20,18,12,0.06), 0 12px 36px -8px rgba(20,18,12,0.07);
   --shadow-lift: 0 1px 2px rgba(20,18,12,0.04), 0 18px 48px -16px rgba(20,18,12,0.16);
+
+  /* Canonical product type scale. Page families may change composition,
+     never the semantic size assigned to a role. Display is reserved for
+     entry/empty-state statements; operational page titles use --type-page. */
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  --type-display: clamp(32px, 4vw, 48px);
+  --type-page: clamp(22px, 1.8vw, 24px);
+  --type-section: 18px;
+  --type-subsection: 16px;
+  --type-body-lg: 15px;
+  --type-body: 14px;
+  --type-body-sm: 13px;
+  --type-caption: 12px;
+  --type-label: 11px;
+  --leading-display: 1.02;
+  --leading-page: 1.15;
+  --leading-heading: 1.25;
+  --leading-body: 1.55;
+  --leading-compact: 1.4;
+
   --page-head-height: 68px;
-  --page-head-title-size: 17px;
+  --page-head-title-size: var(--type-page);
   --page-head-z: 45;
   --page-head-bg: color-mix(in srgb, var(--bg) 96%, var(--card));
 }
@@ -46,8 +66,36 @@
 
   body {
     font-family: var(--font-body), 'Manrope', sans-serif;
+    font-size: var(--type-body);
+    line-height: var(--leading-body);
     background: var(--bg);
     color: var(--text);
     -webkit-font-smoothing: antialiased;
+  }
+
+  :where(h1, h2, h3, h4) {
+    color: var(--text);
+    font-family: var(--font-display), 'Archivo', sans-serif;
+  }
+
+  h1 {
+    font-size: var(--type-page);
+    font-weight: 800;
+    letter-spacing: -0.025em;
+    line-height: var(--leading-page);
+  }
+
+  h2 {
+    font-size: var(--type-section);
+    font-weight: 800;
+    letter-spacing: -0.02em;
+    line-height: var(--leading-heading);
+  }
+
+  h3 {
+    font-size: var(--type-subsection);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    line-height: var(--leading-heading);
   }
 }

--- a/apps/web/src/app/styles/_tokens.css
+++ b/apps/web/src/app/styles/_tokens.css
@@ -3,8 +3,10 @@
   --bg: #FAFAF7;
   --card: #FFFFFF;
   --text: #2D2A24;
-  --text2: #7A756A;
-  --text3: #B0AA9F;
+  /* Both muted text roles meet WCAG AA against --bg. Disabled content
+     gets reduced opacity instead of an unreadably pale base color. */
+  --text2: #6F6A60;
+  --text3: #756F65;
   --border: #EEEBE4;
   --neutral: #F2EFE8;
   --neutral-soft: #F7F4ED;
@@ -13,22 +15,26 @@
   --success: #6CFF7F;
   --success-ink: #113719;
   --success-soft: #E2FBE6;
-  --success-mid: #4CAF82;
+  --success-mid: #357A57;
   --watch: #E9A23B;
   --watch-soft: #FFF1D8;
   --warn: #F0D97A;
   --warn-soft: #FFF4CC;
   --warn-ink: #8A6D00;
-  --danger: #E05656;
+  --danger: #A53535;
   --danger-soft: #FEECEC;
   --accent-hover: #5A4CD1;
-  --danger-hover: #C0392B;
+  --danger-hover: #852626;
   --on-accent: #FFFFFF;
   --hover-wash: rgba(20,18,12,0.04);
   --backdrop: rgba(20,18,12,0.45);
   --radius: 20px;
   --radius-inner: 12px;
   --radius-control: 10px;
+  --control-sm: 32px;
+  --control-md: 40px;
+  --control-touch: 44px;
+  --phone-dock-offset: 86px;
   --shadow: 0 1px 3px rgba(20,18,12,0.04), 0 4px 16px rgba(20,18,12,0.03);
   --shadow-h: 0 2px 8px rgba(20,18,12,0.06), 0 12px 36px -8px rgba(20,18,12,0.07);
   --shadow-lift: 0 1px 2px rgba(20,18,12,0.04), 0 18px 48px -16px rgba(20,18,12,0.16);

--- a/apps/web/src/app/styles/_ui.css
+++ b/apps/web/src/app/styles/_ui.css
@@ -1,0 +1,39 @@
+/* Shared interaction contracts. Visual composition stays with components;
+   this file owns only cross-page behavior that must not drift. */
+
+[data-ui-field-control] {
+  min-height: var(--control-md);
+}
+
+[data-ui-action-group] {
+  min-width: 0;
+}
+
+@media (max-width: 720px), (pointer: coarse) {
+  :where([data-ui-button], .ui-button),
+  [data-ui-tab],
+  [data-ui-segment],
+  [data-ui-menu-trigger],
+  [data-ui-menu-item],
+  [data-ui-disclosure],
+  [data-ui-field-control],
+  [data-ui-stat-link] {
+    min-height: var(--control-touch);
+  }
+
+  :where([data-ui-button], .ui-button)[data-size="icon-sm"],
+  :where([data-ui-button], .ui-button)[data-size="icon"] {
+    width: var(--control-touch);
+    min-width: var(--control-touch);
+    height: var(--control-touch);
+  }
+
+  [data-ui-action-group][data-mobile="stack"] {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  [data-ui-action-group][data-mobile="stack"] > :where([data-ui-button], .ui-button) {
+    width: 100%;
+  }
+}

--- a/apps/web/src/app/styles/_work.css
+++ b/apps/web/src/app/styles/_work.css
@@ -59,15 +59,15 @@
   background: transparent;
   color: inherit;
   font: inherit;
-  font-size: 14.5px;
-  line-height: 1.55;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
   outline: none;
 }
 .work-bubble-edit-hint {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-size: 11px;
+  font-size: var(--type-caption);
   color: var(--text3);
 }
 .work-bubble-edit-hint button {
@@ -110,8 +110,8 @@
   border-radius: 16px;
 }
 .work-markdown {
-  font-size: 14.5px;
-  line-height: 1.6;
+  font-size: var(--type-body);
+  line-height: var(--leading-body);
 }
 .work-markdown > * + * {
   margin-top: 10px;
@@ -230,7 +230,7 @@
   align-items: center;
   gap: 8px;
   color: var(--text3);
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   padding-left: 4px;
 }
 .work-status-row::before {
@@ -258,7 +258,7 @@
   padding: 10px 14px 8px;
   color: var(--warn-ink);
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 9.5px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.15em;
   text-transform: uppercase;
@@ -279,7 +279,7 @@
   margin: 0;
   color: var(--text);
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 19px;
+  font-size: var(--type-section);
   font-weight: 800;
   letter-spacing: -0.025em;
   line-height: 1.15;
@@ -287,21 +287,21 @@
 .work-capability-denied p {
   margin: 8px 0 0;
   color: var(--text2);
-  font-size: 12.5px;
-  line-height: 1.55;
+  font-size: var(--type-body-sm);
+  line-height: var(--leading-body);
 }
 .work-capability-denied code {
   display: block;
   margin-top: 13px;
   color: var(--warn-ink);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10.5px;
+  font-family: var(--font-mono);
+  font-size: var(--type-caption);
   overflow-wrap: anywhere;
 }
 .work-capability-recovery > span {
   color: var(--text3);
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 9px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.13em;
   text-transform: uppercase;
@@ -315,7 +315,7 @@
   margin-top: 12px;
   padding: 8px 11px;
   color: var(--text);
-  font-size: 11.5px;
+  font-size: var(--type-caption);
   font-weight: 700;
   text-decoration: none;
 }
@@ -370,7 +370,7 @@
   display: block;
   color: var(--text3);
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 8.5px;
+  font-size: var(--type-label);
   font-weight: 800;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -379,9 +379,9 @@
   display: block;
   margin-top: 4px;
   color: var(--text2);
-  font-size: 11px;
+  font-size: var(--type-body-sm);
   font-weight: 600;
-  line-height: 1.45;
+  line-height: var(--leading-compact);
   overflow-wrap: anywhere;
 }
 .work-answer-evidence a:hover strong {
@@ -408,7 +408,7 @@
   color: var(--text2);
   cursor: pointer;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--type-body-sm);
   text-align: left;
 }
 .work-answer-followups button:hover {
@@ -442,8 +442,8 @@
   border-radius: 999px;
   cursor: pointer;
   padding: 4px 12px 4px 9px;
-  font-size: 11.5px;
-  line-height: 1.4;
+  font-size: var(--type-caption);
+  line-height: var(--leading-compact);
   color: var(--text3);
   text-align: left;
   transition: background 0.15s, border-color 0.15s, color 0.15s;
@@ -455,7 +455,7 @@
   width: 100%;
   padding: 9px 14px;
   align-self: stretch;
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
 }
 .work-tool-group-head:hover {
   border-color: color-mix(in srgb, var(--text3) 35%, var(--border));
@@ -467,7 +467,7 @@
 }
 .work-tool-group-toggle {
   color: var(--text3);
-  font-size: 11px;
+  font-size: var(--type-label);
   width: 10px;
   text-align: center;
   flex-shrink: 0;
@@ -482,7 +482,7 @@
   gap: 5px;
   padding: 2px 9px;
   border-radius: 999px;
-  font-size: 11px;
+  font-size: var(--type-label);
   font-weight: 500;
   background: var(--accent-soft);
   color: var(--accent);
@@ -557,14 +557,14 @@
 }
 .work-tool-row-name {
   font-weight: 600;
-  font-size: 13px;
+  font-size: var(--type-body-sm);
   color: var(--text);
   flex-shrink: 0;
 }
 .work-tool-row-subtitle {
   color: var(--text3);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11.5px;
+  font-family: var(--font-mono);
+  font-size: var(--type-caption);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -583,7 +583,7 @@
   border-top: 1px solid var(--border);
 }
 .work-tool-row-section-label {
-  font-size: 10.5px;
+  font-size: var(--type-label);
   font-weight: 600;
   letter-spacing: 0.06em;
   text-transform: uppercase;
@@ -594,22 +594,22 @@
   margin-top: 4px;
 }
 .work-tool-delta {
-  font-size: 11.5px;
+  font-size: var(--type-caption);
   color: var(--text2);
   font-style: italic;
 }
 .work-tool-row-pre {
   margin: 0;
   padding: 10px 12px;
-  font-size: 11.5px;
-  line-height: 1.55;
+  font-size: var(--type-caption);
+  line-height: var(--leading-body);
   color: var(--text);
   background: var(--card);
   border: 1px solid var(--border);
   border-radius: 10px;
   white-space: pre-wrap;
   word-break: break-word;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
   max-height: 320px;
   overflow: auto;
 }
@@ -676,14 +676,14 @@
 }
 .work-confirm-label {
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 10.5px;
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: 0.13em;
   text-transform: uppercase;
   color: var(--success-mid);
 }
 .work-confirm-title {
-  font-size: 16px;
+  font-size: var(--type-subsection);
   font-weight: 600;
   line-height: 1.3;
   letter-spacing: -0.012em;
@@ -703,7 +703,7 @@
   align-items: center;
   gap: 8px;
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 10.5px;
+  font-size: var(--type-label);
   font-weight: 700;
   text-transform: uppercase;
   letter-spacing: 0.14em;
@@ -718,15 +718,15 @@
 }
 .work-surface-title {
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 19px;
+  font-size: var(--type-section);
   font-weight: 800;
   letter-spacing: -0.025em;
   line-height: 1.18;
   color: var(--text);
 }
 .work-surface-sub {
-  font-size: 13px;
-  line-height: 1.5;
+  font-size: var(--type-body-sm);
+  line-height: var(--leading-compact);
   color: var(--text2);
   margin-top: 4px;
 }
@@ -754,7 +754,7 @@
   padding: 9px 0 8px;
   color: var(--text3);
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 9.5px;
+  font-size: var(--type-label);
   font-weight: 750;
   letter-spacing: 0.14em;
   text-transform: uppercase;
@@ -775,7 +775,7 @@
 }
 .work-key-figure dt {
   color: var(--text3);
-  font-size: 10px;
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: 0.08em;
   line-height: 1.35;
@@ -795,14 +795,14 @@
 .work-key-figure-sub {
   margin-top: 7px;
   color: var(--text2);
-  font-size: 11.5px;
-  line-height: 1.4;
+  font-size: var(--type-caption);
+  line-height: var(--leading-compact);
 }
 .work-key-figure-proof {
   margin-top: 8px;
   color: var(--text3);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 9.5px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
   letter-spacing: 0.02em;
   line-height: 1.4;
   text-transform: uppercase;
@@ -843,19 +843,19 @@
   overflow-x: auto;
 }
 .work-table-caption {
-  font-size: 12px;
+  font-size: var(--type-caption);
   color: var(--text3);
   margin-bottom: 6px;
 }
 .work-table {
   width: 100%;
   border-collapse: collapse;
-  font-size: 13px;
+  font-size: var(--type-body-sm);
 }
 .work-table thead th {
   text-align: left;
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 10.5px;
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -882,7 +882,7 @@
 .work-section-title,
 .work-section-summary {
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 11px;
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: 0.1em;
   text-transform: uppercase;
@@ -939,7 +939,7 @@
 }
 .work-callout-title {
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 10.5px;
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: 0.13em;
   text-transform: uppercase;
@@ -961,7 +961,7 @@
   align-items: center;
   gap: 8px;
   padding: 8px 13px;
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   font-weight: 500;
   color: var(--text);
   background: var(--card);
@@ -980,7 +980,7 @@
 .work-choice-arrow {
   color: var(--accent);
   opacity: 0.7;
-  font-size: 13px;
+  font-size: var(--type-body-sm);
 }
 .work-choice-btn[data-mood="good"] {
   border-color: color-mix(in srgb, var(--success-mid) 40%, var(--border));
@@ -1005,7 +1005,7 @@
   border: none;
   color: var(--text3);
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 10px;
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -1078,13 +1078,13 @@
 .work-surface > .work-a2ui-button { margin-top: 14px; }
 .work-a2ui-text {
   color: var(--text2);
-  font-size: 13px;
-  line-height: 1.55;
+  font-size: var(--type-body-sm);
+  line-height: var(--leading-body);
 }
 .work-a2ui-text > * { margin: 0; }
 .work-a2ui-text.is-caption {
   color: var(--text3);
-  font-size: 11.5px;
+  font-size: var(--type-caption);
 }
 .work-a2ui-field {
   display: flex;
@@ -1095,7 +1095,7 @@
 .work-a2ui-label {
   color: var(--text3);
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 10.5px;
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: 0.07em;
   text-transform: uppercase;
@@ -1110,7 +1110,7 @@
   border-radius: 9px;
   outline: none;
   font: inherit;
-  font-size: 13px;
+  font-size: var(--type-body);
   line-height: 1.35;
   transition: border-color 0.14s ease, box-shadow 0.14s ease;
 }
@@ -1127,7 +1127,7 @@ textarea.work-a2ui-input { resize: vertical; }
   align-items: center;
   gap: 8px;
   color: var(--text2);
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   cursor: pointer;
 }
 .work-a2ui-checkbox input,
@@ -1162,7 +1162,7 @@ textarea.work-a2ui-input { resize: vertical; }
   background: transparent;
   border: 0;
   cursor: pointer;
-  font-size: 12px;
+  font-size: var(--type-caption);
   font-weight: 600;
 }
 .work-a2ui-tab[aria-selected="true"] { color: var(--text); }
@@ -1188,7 +1188,7 @@ textarea.work-a2ui-input { resize: vertical; }
   border: 1px solid var(--border);
   border-radius: 9px;
   cursor: pointer;
-  font-size: 12.5px;
+  font-size: var(--type-body-sm);
   font-weight: 600;
   max-width: 100%;
   overflow-wrap: anywhere;
@@ -1222,7 +1222,7 @@ textarea.work-a2ui-input { resize: vertical; }
   border-radius: 999px;
   cursor: pointer;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--type-caption);
 }
 .work-openapi-mode button[aria-selected="true"] {
   color: var(--text);
@@ -1230,7 +1230,7 @@ textarea.work-a2ui-input { resize: vertical; }
   border-color: color-mix(in srgb, var(--accent) 40%, var(--border));
 }
 .work-openapi-file { padding-block: 6px; }
-.work-openapi-error { color: var(--danger, #b42318); font-size: 12px; }
+.work-openapi-error { color: var(--danger, #b42318); font-size: var(--type-caption); }
 .work-openapi-summary {
   padding: 12px;
   background: var(--card);
@@ -1239,18 +1239,18 @@ textarea.work-a2ui-input { resize: vertical; }
 }
 .work-openapi-summary-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
 .work-openapi-summary-head > div { min-width: 0; }
-.work-openapi-summary-head strong { display: block; color: var(--text); font-size: 13px; overflow-wrap: anywhere; }
-.work-openapi-summary-head span { color: var(--text3); font-size: 11px; }
+.work-openapi-summary-head strong { display: block; color: var(--text); font-size: var(--type-body-sm); overflow-wrap: anywhere; }
+.work-openapi-summary-head span { color: var(--text3); font-size: var(--type-label); }
 .work-openapi-summary-head .work-openapi-ready { color: var(--good, #067647); font-weight: 700; }
 .work-openapi-summary dl { display: grid; gap: 7px; margin: 12px 0 0; }
 .work-openapi-summary dl > div { display: grid; grid-template-columns: minmax(90px, 0.3fr) 1fr; gap: 10px; }
-.work-openapi-summary dt { color: var(--text3); font-size: 11px; }
-.work-openapi-summary dd { min-width: 0; margin: 0; overflow-wrap: anywhere; color: var(--text2); font-size: 11.5px; }
-.work-openapi-checksum { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
-.work-openapi-summary ul { margin: 10px 0 0; padding-left: 18px; color: var(--text3); font-size: 11.5px; }
+.work-openapi-summary dt { color: var(--text3); font-size: var(--type-label); }
+.work-openapi-summary dd { min-width: 0; margin: 0; overflow-wrap: anywhere; color: var(--text2); font-size: var(--type-caption); }
+.work-openapi-checksum { font-family: var(--font-mono); }
+.work-openapi-summary ul { margin: 10px 0 0; padding-left: 18px; color: var(--text3); font-size: var(--type-caption); }
 .work-managed-files-note {
   color: var(--text3);
-  font-size: 11.5px;
+  font-size: var(--type-caption);
   line-height: 1.55;
 }
 .work-managed-files-list { display: grid; gap: 5px; }
@@ -1259,8 +1259,8 @@ textarea.work-a2ui-input { resize: vertical; }
   min-width: 0;
   overflow-wrap: anywhere;
   color: var(--text3);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 10.5px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
 }
 
 @media (max-width: 520px) {

--- a/apps/web/src/app/styles/_workflows.css
+++ b/apps/web/src/app/styles/_workflows.css
@@ -10,7 +10,7 @@
   border: 1.5px solid var(--border);
   background: rgba(255,255,255,0.6);
   font-family: var(--font-body), 'Manrope', sans-serif;
-  font-size: 14px;
+  font-size: var(--type-body);
   font-weight: 600;
   color: var(--text2);
   cursor: pointer;
@@ -87,9 +87,9 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  font-size: 12px;
+  font-size: var(--type-caption);
   color: var(--text3);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--font-mono);
 }
 
 /* ─── WORKFLOW DETAIL (inline, expands beneath its row) ─── */
@@ -116,7 +116,7 @@
   background: var(--card);
   color: var(--text);
   font-family: var(--font-body), 'Manrope', sans-serif;
-  font-size: 13px;
+  font-size: var(--type-body-sm);
   font-weight: 600;
   cursor: pointer;
   transition: border-color 0.18s, background 0.18s, color 0.18s;
@@ -167,7 +167,7 @@
   border-radius: 10px;
   background: var(--accent);
   color: var(--on-accent);
-  font-size: 13px;
+  font-size: var(--type-body-sm);
   font-weight: 750;
 }
 
@@ -223,7 +223,7 @@
   gap: 7px;
   color: var(--text3);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 10px;
+  font-size: var(--type-label);
   font-weight: 850;
   letter-spacing: 0.13em;
   text-transform: uppercase;
@@ -238,8 +238,8 @@
   border-radius: 999px;
   background: var(--neutral);
   color: var(--text2);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 9px;
+  font-family: var(--font-mono);
+  font-size: var(--type-label);
   letter-spacing: 0;
 }
 
@@ -307,7 +307,7 @@
   gap: 10px;
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 15px;
+  font-size: var(--type-subsection);
   font-weight: 800;
   letter-spacing: -0.015em;
   line-height: 1.25;
@@ -383,7 +383,7 @@
   margin-top: 10px;
   gap: 9px;
   color: var(--text3);
-  font-size: 11px;
+  font-size: var(--type-label);
 }
 
 .workflow-inspector {
@@ -422,7 +422,7 @@
   margin: 0;
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 21px;
+  font-size: var(--type-section);
   font-weight: 850;
   letter-spacing: -0.025em;
 }
@@ -431,8 +431,8 @@
   max-width: 38ch;
   margin: 8px 0 0;
   color: var(--text2);
-  font-size: 12.5px;
-  line-height: 1.55;
+  font-size: var(--type-body-sm);
+  line-height: var(--leading-body);
 }
 
 .workflow-inspector-head {
@@ -462,7 +462,7 @@
   margin-bottom: 8px;
   color: var(--success-ink);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 9.5px;
+  font-size: var(--type-label);
   font-weight: 850;
   letter-spacing: 0.12em;
   text-transform: uppercase;
@@ -497,17 +497,17 @@
   overflow-wrap: anywhere;
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: clamp(24px, 2.7vw, 34px);
+  font-size: var(--type-page);
   font-weight: 900;
   letter-spacing: -0.04em;
-  line-height: 1.02;
+  line-height: var(--leading-page);
 }
 
 .workflow-inspector-head p {
   margin: 8px 0 0;
   color: var(--text2);
-  font-size: 12px;
-  line-height: 1.4;
+  font-size: var(--type-body-sm);
+  line-height: var(--leading-compact);
 }
 
 .workflow-inspector-close {
@@ -552,7 +552,7 @@
 .workflow-drawer-btn {
   min-height: 42px;
   padding: 8px 10px;
-  font-size: 12px;
+  font-size: var(--type-caption);
   font-weight: 700;
   transition:
     border-color 0.16s ease,
@@ -604,7 +604,7 @@
 .workflow-detail-state strong {
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
-  font-size: 16px;
+  font-size: var(--type-subsection);
   font-weight: 800;
 }
 
@@ -618,7 +618,7 @@
   background: var(--card);
   color: var(--accent);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--type-caption);
   font-weight: 750;
   cursor: pointer;
 }
@@ -724,7 +724,7 @@
   }
 
   .workflow-inspector-head h2 {
-    font-size: 25px;
+    font-size: var(--type-page);
   }
 
   .workflow-drawer-actions {
@@ -795,7 +795,7 @@
   overflow-y: auto;
 }
 .builder-msg {
-  font-size: 14px;
+  font-size: var(--type-body);
   line-height: 1.55;
   padding: 10px 14px;
   border-radius: 14px;
@@ -847,8 +847,8 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 14px;
+  font-family: var(--font-mono);
+  font-size: var(--type-body);
   font-weight: 800;
   line-height: 1;
 }
@@ -861,7 +861,7 @@
 }
 .rule-event-eyebrow {
   font-family: var(--font-display), 'Archivo', sans-serif;
-  font-size: 10.5px;
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: 0.13em;
   text-transform: uppercase;
@@ -869,18 +869,18 @@
   opacity: 0.85;
 }
 .rule-event-name {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 13px;
+  font-family: var(--font-mono);
+  font-size: var(--type-body-sm);
   font-weight: 700;
   color: var(--text);
   word-break: break-all;
 }
-.rule-event-meta { font-size: 12px; color: var(--text2); }
+.rule-event-meta { font-size: var(--type-caption); color: var(--text2); }
 .rule-event-sep { opacity: 0.5; margin: 0 4px; }
 .rule-event-limits { color: var(--text3); }
 .rule-event-limits code {
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 11.5px;
+  font-family: var(--font-mono);
+  font-size: var(--type-caption);
   background: var(--hover-wash);
   border-radius: 4px;
   padding: 1px 5px;
@@ -894,7 +894,7 @@
 .workflow-event-tick {
   background: var(--accent);
   color: #fff;
-  font-size: 14px;
+  font-size: var(--type-body);
   font-weight: 700;
 }
 .workflow-event .rule-event-eyebrow { color: var(--accent); }
@@ -907,14 +907,14 @@
 .action-event-tick {
   background: var(--watch);
   color: var(--warn-ink);
-  font-size: 14px;
+  font-size: var(--type-body);
   font-weight: 800;
 }
 .action-event .rule-event-eyebrow { color: var(--warn-ink); }
 .action-event-risk {
   padding: 1px 6px;
   border-radius: 999px;
-  font-size: 10.5px;
+  font-size: var(--type-label);
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -948,8 +948,8 @@
   align-self: center;
   margin-left: 6px;
   color: var(--text3);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 14px;
+  font-family: var(--font-mono);
+  font-size: var(--type-body);
   transition: transform 0.15s ease;
 }
 .rule-event-link:hover .rule-event-arrow {
@@ -963,7 +963,7 @@
   border-radius: 12px;
   padding: 10px 12px;
   font-family: var(--font-body), 'Manrope', sans-serif;
-  font-size: 14px;
+  font-size: var(--type-body);
   color: var(--text);
   background: var(--card);
   resize: none;

--- a/apps/web/src/components/ActCard.tsx
+++ b/apps/web/src/components/ActCard.tsx
@@ -103,7 +103,7 @@ export default function ActCard({
         <Pill variant={STATE_PILL_VARIANT[data.state]}>
           {STATE_LABEL[data.state]}
         </Pill>
-        <span className="font-mono text-[11px] font-bold uppercase tracking-[0.08em] text-text3">
+        <span className="font-mono text-ui-label font-bold uppercase tracking-[0.08em] text-text3">
           {formatTime(data.runAt)}
         </span>
       </header>
@@ -153,7 +153,7 @@ export default function ActCard({
                 )}
               />
               <div className="flex-1 min-w-0 grid gap-1">
-                <p className="m-0 text-[14.5px] font-semibold text-text leading-snug tracking-[-0.005em]">
+                <p className="m-0 text-ui-body font-semibold text-text leading-snug tracking-[-0.005em]">
                   {row.headline}
                 </p>
                 {row.target && (
@@ -162,7 +162,7 @@ export default function ActCard({
                   </p>
                 )}
                 {row.detail && (
-                  <p className="m-0 text-[13px] leading-[1.55] text-text2">
+                  <p className="m-0 text-ui-body-sm leading-[1.55] text-text2">
                     {row.detail}
                   </p>
                 )}
@@ -173,12 +173,12 @@ export default function ActCard({
                   policyContext={isPending ? row.approverPhrase : null}
                 />
                 {row.rejectionReason && (
-                  <p className="m-0 text-[13px] leading-[1.55] text-text2 italic">
+                  <p className="m-0 text-ui-body-sm leading-[1.55] text-text2 italic">
                     {row.rejectionReason}
                   </p>
                 )}
                 {data.state === "live" && (row.approverPhrase || (row.minutesSaved ?? 0) > 0) && (
-                  <p className="mt-1 text-[11.5px] text-text3 flex items-center gap-2 flex-wrap">
+                  <p className="mt-1 text-ui-caption text-text3 flex items-center gap-2 flex-wrap">
                     {row.approverPhrase && (
                       <span>
                         <span className="text-text2 font-medium">
@@ -203,7 +203,7 @@ export default function ActCard({
                     onClick={(e) => e.stopPropagation()}
                   >
                     <textarea
-                      className="border border-border rounded-[10px] px-3 py-2 text-[13px] text-text bg-card resize-y min-h-[50px] outline-none focus:border-accent"
+                      className="border border-border rounded-[10px] px-3 py-2 text-ui-body-sm text-text bg-card resize-y min-h-[50px] outline-none focus:border-accent"
                       value={rejectReason ?? ""}
                       placeholder="Why are you rejecting this? (optional)"
                       onChange={(e) => onRejectReasonChange?.(e.target.value)}
@@ -273,7 +273,7 @@ function RowButton({ tone, disabled, onClick, children }: RowButtonProps) {
       disabled={disabled}
       onClick={onClick}
       className={cn(
-        "px-3 py-1.5 rounded-lg border text-[12.5px] font-semibold cursor-pointer",
+        "px-3 py-1.5 rounded-lg border text-ui-body-sm font-semibold cursor-pointer",
         "disabled:opacity-55 disabled:cursor-not-allowed",
         !tone && "bg-card border-border text-text hover:not-disabled:border-text3",
         tone === "primary" &&

--- a/apps/web/src/components/ActCard.tsx
+++ b/apps/web/src/components/ActCard.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from "next/navigation";
 import { Card } from "@/components/ui/Card";
+import { Button } from "@/components/ui/Button";
 import { Pill, type PillVariant } from "@/components/ui/Pill";
 import { cn } from "@/lib/cn";
 import { formatSavedShort } from "@/lib/hours-saved";
@@ -268,21 +269,19 @@ type RowButtonProps = {
 
 function RowButton({ tone, disabled, onClick, children }: RowButtonProps) {
   return (
-    <button
-      type="button"
+    <Button
+      size="sm"
+      variant={
+        tone === "primary"
+          ? "primary"
+          : tone === "destructive"
+            ? "danger"
+            : "secondary"
+      }
       disabled={disabled}
       onClick={onClick}
-      className={cn(
-        "px-3 py-1.5 rounded-lg border text-ui-body-sm font-semibold cursor-pointer",
-        "disabled:opacity-55 disabled:cursor-not-allowed",
-        !tone && "bg-card border-border text-text hover:not-disabled:border-text3",
-        tone === "primary" &&
-          "bg-accent border-accent text-white hover:not-disabled:bg-[var(--accent-hover)] hover:not-disabled:border-[var(--accent-hover)]",
-        tone === "destructive" &&
-          "bg-danger border-danger text-white hover:not-disabled:bg-[var(--danger-hover)] hover:not-disabled:border-[var(--danger-hover)]",
-      )}
     >
       {children}
-    </button>
+    </Button>
   );
 }

--- a/apps/web/src/components/AppRail.tsx
+++ b/apps/web/src/components/AppRail.tsx
@@ -3,7 +3,7 @@
 import Image from "next/image";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Database,
   LayoutGrid,
@@ -266,6 +266,7 @@ export default function AppRail() {
   const router = useRouter();
   const hidden = hideAppChrome(pathname);
   const pending = useApprovalsCount();
+  const navRef = useRef<HTMLElement>(null);
   const [user, setUser] = useState<SessionUser | null>(
     RECORDS_VISUAL_TEST
       ? { email: "kavya@example.com", name: "Kavya M." }
@@ -330,6 +331,15 @@ export default function AppRail() {
       clearInterval(id);
     };
   }, [hidden]);
+
+  useEffect(() => {
+    const frame = window.requestAnimationFrame(() => {
+      navRef.current
+        ?.querySelector<HTMLElement>('[aria-current="page"]')
+        ?.scrollIntoView({ block: "nearest", inline: "nearest" });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [pathname, recordApps.length, sessionMode]);
 
   useEffect(() => {
     if (hidden || RECORDS_VISUAL_TEST) return;
@@ -425,7 +435,7 @@ export default function AppRail() {
         )}
       </div>
 
-      <nav className="app-rail-nav">
+      <nav ref={navRef} className="app-rail-nav">
         <div className="app-rail-group">
           {grouped.primary.map((item) => (
             <RailLink

--- a/apps/web/src/components/BriefingCard.tsx
+++ b/apps/web/src/components/BriefingCard.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { Copy, RotateCw, Search, X } from "lucide-react";
+import { ChevronDown, Copy, RotateCw, Search, X } from "lucide-react";
 import Chart from "./Chart";
 import type { ChartDataPoint } from "./Chart";
 import KpiHeadline from "./KpiHeadline";
+import { IconButton } from "@/components/ui/Button";
+import { MenuItem, OverflowMenu } from "@/components/ui/OverflowMenu";
 
 async function copyCardToClipboard(ins: BriefingCardData): Promise<void> {
   const lines: string[] = [];
@@ -27,10 +29,10 @@ const MOOD_LABELS: Record<string, string> = {
 };
 
 const MOOD_CHART_ACCENT: Record<string, string> = {
-  good: "#4CAF82",
+  good: "#357A57",
   watch: "#E9A23B",
-  act: "#E05656",
-  bad: "#E05656",
+  act: "#A53535",
+  bad: "#A53535",
 };
 
 export type BriefingCardState = "ok" | "pending" | "failed";
@@ -57,8 +59,9 @@ export default function BriefingCard({ ins, index, onDismiss, onRetry, onDeepDiv
   onRetry?: (metricId: string) => void;
   onDeepDive?: (metricId: string) => void;
 }) {
-  // Briefing cards are always expanded — there is no collapse affordance.
-  const open = true;
+  // Desktop keeps the full analytical card. On phones, only the lead card
+  // starts expanded; the rest stay concise until the operator asks for detail.
+  const [mobileOpen, setMobileOpen] = useState(index === 0);
   const [retrying, setRetrying] = useState(false);
   const state: BriefingCardState = ins.state ?? "ok";
   const moodKey = MOOD_LABELS[ins.mood] ? ins.mood : "good";
@@ -80,7 +83,7 @@ export default function BriefingCard({ ins, index, onDismiss, onRetry, onDeepDiv
 
   return (
     <div
-      className={`icard${open ? " exp" : ""}${state === "failed" ? " icard-failed" : ""}${state === "pending" ? " icard-pending" : ""}`}
+      className={`icard exp${state === "failed" ? " icard-failed" : ""}${state === "pending" ? " icard-pending" : ""}`}
       data-mood={moodKey}
       style={{ animation: `fadeUp 0.5s ease ${index * 0.07}s both` }}
     >
@@ -110,57 +113,56 @@ export default function BriefingCard({ ins, index, onDismiss, onRetry, onDeepDiv
       </div>
       <div className="iactions">
         {onDeepDive && ins.metricId && state === "ok" && (
-          <button
-            className="ipin ipin-deep"
+          <IconButton
+            label="Deep dive in Work"
+            size="icon-sm"
+            variant="ghost"
             onClick={(e) => {
               e.stopPropagation();
               onDeepDive(ins.metricId);
             }}
-            title="Deep dive in Work"
-            aria-label="Deep dive in Work"
           >
-            <Search size={13} strokeWidth={2.25} />
-          </button>
+            <Search aria-hidden="true" strokeWidth={2.25} />
+          </IconButton>
         )}
-        {onRetry && ins.metricId && (
-          <button
-            className="ipin"
-            onClick={handleRetry}
-            disabled={refreshing}
-            title={refreshing ? "Re-running…" : "Re-run this metric"}
-            aria-label="Re-run this metric"
-            aria-busy={refreshing}
-          >
-            <RotateCw
-              size={13}
-              strokeWidth={2}
-              style={{ animation: refreshing ? "spin 0.9s linear infinite" : "none" }}
-            />
-          </button>
-        )}
-        <button
-          className="ipin"
-          onClick={async (e) => {
-            e.stopPropagation();
-            await copyCardToClipboard(ins);
-          }}
-          title="Copy card text"
-          aria-label="Copy card text"
-        >
-          <Copy size={13} strokeWidth={2} />
-        </button>
-        {onDismiss ? (
-          <button
-            className="ipin"
-            onClick={(e) => { e.stopPropagation(); onDismiss(); }}
-            title="Dismiss"
-            aria-label="Dismiss"
-          >
-            <X size={14} strokeWidth={2} />
-          </button>
-        ) : null}
+        <OverflowMenu label="Card actions">
+          {onRetry && ins.metricId ? (
+            <MenuItem
+              onClick={handleRetry}
+              disabled={refreshing}
+              aria-busy={refreshing}
+            >
+              <RotateCw
+                aria-hidden="true"
+                strokeWidth={2}
+                className={refreshing ? "animate-spin" : undefined}
+              />
+              {refreshing ? "Re-running…" : "Re-run metric"}
+            </MenuItem>
+          ) : null}
+          <MenuItem onClick={() => void copyCardToClipboard(ins)}>
+            <Copy aria-hidden="true" strokeWidth={2} />
+            Copy card text
+          </MenuItem>
+          {onDismiss ? (
+            <MenuItem danger onClick={onDismiss}>
+              <X aria-hidden="true" strokeWidth={2} />
+              Dismiss card
+            </MenuItem>
+          ) : null}
+        </OverflowMenu>
       </div>
-      <div className={`idetail${open ? " open" : ""}`}>
+      <button
+        type="button"
+        className="icard-toggle"
+        data-ui-disclosure=""
+        aria-expanded={mobileOpen}
+        onClick={() => setMobileOpen((current) => !current)}
+      >
+        {mobileOpen ? "Hide detail" : "View detail"}
+        <ChevronDown aria-hidden="true" className={mobileOpen ? "is-open" : ""} />
+      </button>
+      <div className="idetail open" data-mobile-open={mobileOpen}>
         {state === "pending" ? (
           <div className="dskel" aria-hidden="true">
             <div className="skel skel-line" />

--- a/apps/web/src/components/Chart.tsx
+++ b/apps/web/src/components/Chart.tsx
@@ -9,8 +9,8 @@ import type { ChartDataPoint } from "@/a2ui/catalog";
 export type { ChartDataPoint } from "@/a2ui/catalog";
 import { formatCompact } from "@/lib/format-number";
 
-const axisProps = { tick: { fontSize: 11, fill: "#b0aa9f" }, axisLine: false, tickLine: false } as const;
-const tooltipStyle = { contentStyle: { borderRadius: 10, border: "none", boxShadow: "0 4px 16px rgba(0,0,0,0.08)", fontSize: 13 }, itemStyle: { color: "#7A756A" } };
+const axisProps = { tick: { fontSize: "var(--type-label)", fill: "#b0aa9f" }, axisLine: false, tickLine: false } as const;
+const tooltipStyle = { contentStyle: { borderRadius: 10, border: "none", boxShadow: "0 4px 16px rgba(0,0,0,0.08)", fontSize: "var(--type-body-sm)" }, itemStyle: { color: "#7A756A" } };
 const BASELINE_COLOR = "#5C5751";
 
 export default function Chart({ type, accent = "#6B5CE7", h = 130, data, centerLabel, valueLabel, baselineLabel }: {
@@ -72,7 +72,7 @@ export default function Chart({ type, accent = "#6B5CE7", h = 130, data, centerL
           </Pie>
           <Tooltip {...tooltipStyle} formatter={donutFormatter as never} />
           <text x="50%" y="50%" textAnchor="middle" dominantBaseline="middle"
-            style={{ fontSize: 13, fill: "#7A756A" }}>
+            style={{ fontSize: "var(--type-body-sm)", fill: "#7A756A" }}>
             {centerLabel ?? formatCompact(total)}
           </text>
         </PieChart>

--- a/apps/web/src/components/ConfirmModal.tsx
+++ b/apps/web/src/components/ConfirmModal.tsx
@@ -105,7 +105,7 @@ function ConfirmDialog({
           {options.title}
         </h2>
         {options.description ? (
-          <p className="mt-2 text-[13.5px] leading-[1.55] text-text2 whitespace-pre-line">
+          <p className="mt-2 text-ui-body leading-[1.55] text-text2 whitespace-pre-line">
             {options.description}
           </p>
         ) : null}
@@ -114,7 +114,7 @@ function ConfirmDialog({
             ref={cancelRef}
             type="button"
             onClick={() => onChoice(false)}
-            className="text-[13px] font-medium px-3.5 py-2 rounded-control border border-border bg-card text-text cursor-pointer transition-all duration-150 hover:bg-black/5 hover:border-text3 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
+            className="text-ui-body-sm font-medium px-3.5 py-2 rounded-control border border-border bg-card text-text cursor-pointer transition-all duration-150 hover:bg-black/5 hover:border-text3 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
           >
             {options.cancelLabel ?? "Cancel"}
           </button>
@@ -122,7 +122,7 @@ function ConfirmDialog({
             type="button"
             onClick={() => onChoice(true)}
             className={cn(
-              "text-[13px] font-medium px-3.5 py-2 rounded-control border cursor-pointer transition-all duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2",
+              "text-ui-body-sm font-medium px-3.5 py-2 rounded-control border cursor-pointer transition-all duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2",
               !options.destructive &&
                 "bg-text border-text text-bg hover:bg-[#1a1814] hover:border-[#1a1814]",
               options.destructive &&

--- a/apps/web/src/components/ConfirmModal.tsx
+++ b/apps/web/src/components/ConfirmModal.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { createRoot, type Root } from "react-dom/client";
-import { cn } from "@/lib/cn";
+import { Button } from "@/components/ui/Button";
 
 export type ConfirmDialogOptions = {
   title: string;
@@ -110,27 +110,20 @@ function ConfirmDialog({
           </p>
         ) : null}
         <div className="mt-[18px] flex justify-end gap-2">
-          <button
+          <Button
             ref={cancelRef}
-            type="button"
+            size="sm"
             onClick={() => onChoice(false)}
-            className="text-ui-body-sm font-medium px-3.5 py-2 rounded-control border border-border bg-card text-text cursor-pointer transition-all duration-150 hover:bg-black/5 hover:border-text3 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2"
           >
             {options.cancelLabel ?? "Cancel"}
-          </button>
-          <button
-            type="button"
+          </Button>
+          <Button
+            variant={options.destructive ? "danger" : "primary"}
+            size="sm"
             onClick={() => onChoice(true)}
-            className={cn(
-              "text-ui-body-sm font-medium px-3.5 py-2 rounded-control border cursor-pointer transition-all duration-150 focus-visible:outline-2 focus-visible:outline-accent focus-visible:outline-offset-2",
-              !options.destructive &&
-                "bg-text border-text text-bg hover:bg-[#1a1814] hover:border-[#1a1814]",
-              options.destructive &&
-                "bg-danger border-danger text-white hover:bg-[var(--danger-hover)] hover:border-[var(--danger-hover)]",
-            )}
           >
             {options.confirmLabel ?? "Confirm"}
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/apps/web/src/components/DensityProvider.tsx
+++ b/apps/web/src/components/DensityProvider.tsx
@@ -28,12 +28,14 @@ export function DensityProvider({ children }: { children: React.ReactNode }) {
   const [density, setDensityState] = useState<Density>(DEFAULT);
 
   useEffect(() => {
-    const stored = (typeof window !== "undefined" &&
-      window.localStorage.getItem(STORAGE_KEY)) as Density | null;
-    if (stored === "comfortable" || stored === "compact") {
-      setDensityState(stored);
-      document.documentElement.setAttribute("data-density", stored);
-    }
+    const initial = window.setTimeout(() => {
+      const stored = window.localStorage.getItem(STORAGE_KEY) as Density | null;
+      if (stored === "comfortable" || stored === "compact") {
+        setDensityState(stored);
+        document.documentElement.setAttribute("data-density", stored);
+      }
+    }, 0);
+    return () => window.clearTimeout(initial);
   }, []);
 
   const setDensity = useCallback((d: Density) => {

--- a/apps/web/src/components/DensityToggle.tsx
+++ b/apps/web/src/components/DensityToggle.tsx
@@ -1,16 +1,20 @@
 "use client";
 
 import { useDensity } from "@/components/DensityProvider";
+import { Segment, SegmentedControl } from "@/components/ui/Tabs";
 
 // Comfortable / Compact segmented control. Lives in the app header; flips the
 // `data-density` attribute that the whole UI keys off.
 export default function DensityToggle() {
   const { density, setDensity } = useDensity();
   return (
-    <div className="density-seg" role="group" aria-label="Information density">
-      <button
-        type="button"
-        aria-pressed={density === "comfortable"}
+    <SegmentedControl
+      className="density-seg"
+      role="group"
+      aria-label="Information density"
+    >
+      <Segment
+        selected={density === "comfortable"}
         onClick={() => setDensity("comfortable")}
         title="Roomy — one column"
       >
@@ -19,10 +23,9 @@ export default function DensityToggle() {
           <rect x="2" y="9.6" width="12" height="3.4" rx="1.2" />
         </svg>
         <span>Comfortable</span>
-      </button>
-      <button
-        type="button"
-        aria-pressed={density === "compact"}
+      </Segment>
+      <Segment
+        selected={density === "compact"}
         onClick={() => setDensity("compact")}
         title="Dense — tiled grid"
       >
@@ -33,7 +36,7 @@ export default function DensityToggle() {
           <rect x="9" y="8.5" width="5" height="5" rx="1.2" />
         </svg>
         <span>Compact</span>
-      </button>
-    </div>
+      </Segment>
+    </SegmentedControl>
   );
 }

--- a/apps/web/src/components/FindingCard.tsx
+++ b/apps/web/src/components/FindingCard.tsx
@@ -138,7 +138,7 @@ export default function FindingCard({
       }}
     >
       <div className="flex items-start justify-between gap-3 mb-1.5">
-        <h3 className="min-w-0 font-display text-[17px] font-bold tracking-[-0.01em] text-text leading-snug m-0 [overflow-wrap:anywhere]">
+        <h3 className="min-w-0 font-display text-ui-subsection font-bold tracking-[-0.01em] text-text leading-snug m-0 [overflow-wrap:anywhere]">
           {data.title}
         </h3>
         <Pill variant={pillVariant} className="flex-shrink-0">
@@ -185,7 +185,7 @@ export default function FindingCard({
         {data.pinId && onUnpin && (
           <button
             type="button"
-            className="bg-transparent border-0 text-text3 font-[inherit] text-[11.5px] p-0 cursor-pointer hover:text-danger hover:underline underline-offset-2"
+            className="bg-transparent border-0 text-text3 font-[inherit] text-ui-caption p-0 cursor-pointer hover:text-danger hover:underline underline-offset-2"
             onClick={(e) => {
               e.stopPropagation();
               onUnpin(data.pinId as string);
@@ -217,14 +217,14 @@ export default function FindingCard({
             style={{ left: muteMenu.x, top: muteMenu.y }}
             onClick={(e) => e.stopPropagation()}
           >
-            <div className="px-3 py-1 text-[11px] text-text3">
+            <div className="px-3 py-1 text-ui-label text-text3">
               Mute <span className="font-mono">{data.scope}</span>
             </div>
             {MUTE_DURATIONS.map((d) => (
               <button
                 key={d}
                 type="button"
-                className="block w-full text-left bg-transparent border-0 px-3 py-1.5 text-[13px] text-text cursor-pointer hover:bg-bg2 font-[inherit]"
+                className="block w-full text-left bg-transparent border-0 px-3 py-1.5 text-ui-body-sm text-text cursor-pointer hover:bg-bg2 font-[inherit]"
                 onClick={(e) => {
                   e.stopPropagation();
                   void muteScope(d);

--- a/apps/web/src/components/HoursSavedHero.tsx
+++ b/apps/web/src/components/HoursSavedHero.tsx
@@ -51,9 +51,9 @@ export default function HoursSavedHero({
         </span>
         <span className="font-display text-[26px] font-extrabold tracking-[-0.03em] text-accent tabular-nums leading-none">
           {hero.value}
-          <span className="text-[13px] font-bold ml-1 opacity-70">{hero.unit}</span>
+          <span className="text-ui-body-sm font-bold ml-1 opacity-70">{hero.unit}</span>
         </span>
-        <span className="text-[12.5px] leading-[1.4] text-text2">
+        <span className="text-ui-body-sm leading-[1.4] text-text2">
           saved {sinceLabel(value.sinceISO)}
           {windowLabel ? (
             <>
@@ -73,14 +73,14 @@ export default function HoursSavedHero({
             <Sparkline values={daily} width={64} height={18} />
           </span>
         )}
-        <span className="ml-1 font-mono text-[11px] font-semibold text-accent opacity-70 group-hover:opacity-100 whitespace-nowrap">
+        <span className="ml-1 font-mono text-ui-label font-semibold text-accent opacity-70 group-hover:opacity-100 whitespace-nowrap">
           how? {open ? "▾" : "→"}
         </span>
       </button>
 
       {open && (
-        <div className="mt-2.5 max-w-[640px] bg-card border border-border rounded-2xl px-5 py-4 shadow-soft text-[13.5px] leading-[1.55] text-text2">
-          <div className="font-display text-[11px] font-bold tracking-[0.13em] uppercase text-text3 mb-2.5">
+        <div className="mt-2.5 max-w-[640px] bg-card border border-border rounded-2xl px-5 py-4 shadow-soft text-ui-body leading-[1.55] text-text2">
+          <div className="font-display text-ui-label font-bold tracking-[0.13em] uppercase text-text3 mb-2.5">
             How we estimate hours saved
           </div>
           <p className="m-0 mb-2.5">
@@ -97,12 +97,12 @@ export default function HoursSavedHero({
 
           {detailed.length > 0 && (
             <div className="mt-3.5 pt-3.5 border-t border-border">
-              <div className="font-display text-[11px] font-bold tracking-[0.13em] uppercase text-text3 mb-2">
+              <div className="font-display text-ui-label font-bold tracking-[0.13em] uppercase text-text3 mb-2">
                 Recent
               </div>
               <ul className="list-none m-0 p-0 grid gap-1.5">
                 {detailed.map((item, i) => (
-                  <li key={i} className="flex items-baseline gap-2.5 text-[12.5px]">
+                  <li key={i} className="flex items-baseline gap-2.5 text-ui-body-sm">
                     <span className="font-mono text-accent tabular-nums flex-none w-[58px]">
                       {formatSavedShort(item.minutes)}
                     </span>

--- a/apps/web/src/components/Select.tsx
+++ b/apps/web/src/components/Select.tsx
@@ -19,7 +19,7 @@ type Props = {
 };
 
 const TRIGGER_BASE =
-  "px-3.5 py-3 rounded-xl border-[1.5px] border-border bg-bg text-text text-[15px] font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
+  "px-3.5 py-3 rounded-xl border-[1.5px] border-border bg-bg text-text text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
 
 export default function Select({
   value,
@@ -170,7 +170,7 @@ export default function Select({
               aria-selected={opt.value === value}
               data-idx={idx}
               data-focused={idx === focusIdx ? "true" : undefined}
-              className="flex items-center justify-between gap-3 px-3 py-2.5 rounded-[10px] text-[15px] text-text cursor-pointer select-none data-[focused=true]:bg-accent-soft data-[focused=true]:text-accent aria-selected:font-semibold"
+              className="flex items-center justify-between gap-3 px-3 py-2.5 rounded-[10px] text-ui-body-lg text-text cursor-pointer select-none data-[focused=true]:bg-accent-soft data-[focused=true]:text-accent aria-selected:font-semibold"
               onMouseEnter={() => setFocusIdx(idx)}
               onMouseDown={(e) => {
                 e.preventDefault();

--- a/apps/web/src/components/Select.tsx
+++ b/apps/web/src/components/Select.tsx
@@ -19,7 +19,7 @@ type Props = {
 };
 
 const TRIGGER_BASE =
-  "px-3.5 py-3 rounded-xl border-[1.5px] border-border bg-bg text-text text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
+  "min-h-10 px-3.5 py-2.5 rounded-control border-[1.5px] border-border bg-card text-text text-ui-body font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.10)]";
 
 export default function Select({
   value,
@@ -113,6 +113,7 @@ export default function Select({
         ref={buttonRef}
         id={id}
         type="button"
+        data-ui-field-control=""
         className={cn(
           TRIGGER_BASE,
           "flex items-center justify-between gap-2.5 w-full text-left cursor-pointer",
@@ -161,16 +162,17 @@ export default function Select({
           id={listboxId}
           role="listbox"
           tabIndex={-1}
-          className="select-panel absolute z-30 top-[calc(100%+6px)] left-0 right-0 m-0 p-1.5 list-none bg-bg border-[1.5px] border-border rounded-[14px] max-h-80 overflow-y-auto"
+          className="select-panel absolute z-30 top-[calc(100%+6px)] left-0 right-0 m-0 p-1.5 list-none bg-card border-[1.5px] border-border rounded-inner max-h-80 overflow-y-auto shadow-lift"
         >
           {options.map((opt, idx) => (
             <li
               key={opt.value}
               role="option"
+              data-ui-menu-item=""
               aria-selected={opt.value === value}
               data-idx={idx}
               data-focused={idx === focusIdx ? "true" : undefined}
-              className="flex items-center justify-between gap-3 px-3 py-2.5 rounded-[10px] text-ui-body-lg text-text cursor-pointer select-none data-[focused=true]:bg-accent-soft data-[focused=true]:text-accent aria-selected:font-semibold"
+              className="flex min-h-10 items-center justify-between gap-3 px-3 py-2.5 rounded-[8px] text-ui-body text-text cursor-pointer select-none data-[focused=true]:bg-accent-soft data-[focused=true]:text-accent aria-selected:font-semibold"
               onMouseEnter={() => setFocusIdx(idx)}
               onMouseDown={(e) => {
                 e.preventDefault();

--- a/apps/web/src/components/StatStrip.tsx
+++ b/apps/web/src/components/StatStrip.tsx
@@ -45,7 +45,7 @@ export default function StatStrip() {
       type="button"
       onClick={onClick}
       disabled={!onClick}
-      className="bg-transparent border-0 p-0 font-[inherit] text-[13px] text-text2 disabled:cursor-default cursor-pointer enabled:hover:text-text"
+      className="bg-transparent border-0 p-0 font-[inherit] text-ui-body-sm text-text2 disabled:cursor-default cursor-pointer enabled:hover:text-text"
     >
       <span className="font-mono font-semibold text-text">{n}</span> {label}
     </button>

--- a/apps/web/src/components/StatStrip.tsx
+++ b/apps/web/src/components/StatStrip.tsx
@@ -29,9 +29,12 @@ export default function StatStrip() {
   }, []);
 
   useEffect(() => {
-    void fetchStats();
-    const id = setInterval(() => void fetchStats(), 30_000);
-    return () => clearInterval(id);
+    const initial = window.setTimeout(() => void fetchStats(), 0);
+    const id = window.setInterval(() => void fetchStats(), 30_000);
+    return () => {
+      window.clearTimeout(initial);
+      window.clearInterval(id);
+    };
   }, [fetchStats]);
 
   if (!stats) return null;
@@ -40,16 +43,28 @@ export default function StatStrip() {
     label: string,
     n: number | string,
     onClick?: () => void,
-  ) => (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={!onClick}
-      className="bg-transparent border-0 p-0 font-[inherit] text-ui-body-sm text-text2 disabled:cursor-default cursor-pointer enabled:hover:text-text"
-    >
+  ) => {
+    const content = (
+      <>
       <span className="font-mono font-semibold text-text">{n}</span> {label}
-    </button>
-  );
+      </>
+    );
+
+    if (!onClick) {
+      return <span className="text-ui-body-sm text-text2">{content}</span>;
+    }
+
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        data-ui-stat-link
+        className="min-h-8 bg-transparent border-0 p-0 font-[inherit] text-ui-body-sm text-text2 cursor-pointer hover:text-text"
+      >
+        {content}
+      </button>
+    );
+  };
 
   return (
     <div className="flex items-center gap-2 flex-wrap text-text3 mb-4">
@@ -67,7 +82,7 @@ export default function StatStrip() {
       {item(
         stats.pendingApprovals === 1 ? "pending approval" : "pending approvals",
         stats.pendingApprovals,
-        () => router.push("/approvals"),
+        () => router.push("/actions"),
       )}
       {stats.budgetPct !== null && stats.budgetPct >= 40 && (
         <>

--- a/apps/web/src/components/records/AppsOverview.tsx
+++ b/apps/web/src/components/records/AppsOverview.tsx
@@ -5,6 +5,7 @@ import {
   Plus,
   RefreshCw,
 } from "lucide-react";
+import { buttonClassName } from "@/components/ui/Button";
 import type { RecordAppNavItem } from "@/lib/records";
 
 const CREATE_APP_PROMPT =
@@ -45,7 +46,13 @@ export function AppsOverview({
           </p>
         </div>
         {canCreate && !unavailable && (
-          <Link className="apps-overview-create" href={createHref}>
+          <Link
+            className={buttonClassName({
+              variant: "primary",
+              className: "apps-overview-create",
+            })}
+            href={createHref}
+          >
             <Plus aria-hidden="true" />
             Create app
           </Link>
@@ -57,7 +64,12 @@ export function AppsOverview({
           <span className="apps-overview-empty-icon"><RefreshCw aria-hidden="true" /></span>
           <h2 id="apps-unavailable-title">Apps are temporarily unavailable</h2>
           <p>The app registry could not be reached. Your access has not changed.</p>
-          <Link href="/apps">Try again</Link>
+          <Link
+            href="/apps"
+            className={buttonClassName({ size: "sm", className: "mt-[18px]" })}
+          >
+            Try again
+          </Link>
         </section>
       ) : apps.length > 0 ? (
         <section className="apps-overview-section" aria-labelledby="accessible-apps-title">
@@ -101,7 +113,13 @@ export function AppsOverview({
             <li><span>2</span><strong>Review the design</strong><small>OpenNeko proposes objects, fields, and relationships.</small></li>
             <li><span>3</span><strong>Approve and launch</strong><small>The governed schema change is applied after approval.</small></li>
           </ol>
-          <Link className="apps-overview-create" href={createHref}>
+          <Link
+            className={buttonClassName({
+              variant: "primary",
+              className: "apps-overview-create",
+            })}
+            href={createHref}
+          >
             <Plus aria-hidden="true" />
             Describe an app
           </Link>

--- a/apps/web/src/components/records/RecordFilterBuilder.tsx
+++ b/apps/web/src/components/records/RecordFilterBuilder.tsx
@@ -7,6 +7,7 @@ import type {
   RecordFilterExpression,
   RecordListFilter,
 } from "@neko/records";
+import { Button } from "@/components/ui/Button";
 
 export type RecordFilterField = {
   apiName: string;
@@ -190,7 +191,9 @@ export function RecordFilterBuilder({
             )}
           </label>
         )}
-        <button type="submit">Apply filter</button>
+        <Button variant="primary" size="sm" type="submit">
+          Apply filter
+        </Button>
       </form>
     </details>
   );

--- a/apps/web/src/components/records/RecordForm.tsx
+++ b/apps/web/src/components/records/RecordForm.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState, type FormEvent, type ReactNode } from "react";
 import { CheckCircle2, LoaderCircle, LockKeyhole } from "lucide-react";
 import type { RecordViewColumn } from "@neko/records";
+import { Button, buttonClassName } from "@/components/ui/Button";
 
 type SubmitResponse = {
   status?: "executed" | "queued";
@@ -367,17 +368,29 @@ export function RecordForm({
           <LockKeyhole aria-hidden="true" />
           Submitted through action policy, registry validation, and durable audit history.
         </p>
-        <Link className="records-form-cancel" href={recordId ? `${base}/${encodeURIComponent(recordId)}` : base}>
+        <Link
+          className={buttonClassName({
+            size: "sm",
+            className: "records-form-cancel",
+          })}
+          href={recordId ? `${base}/${encodeURIComponent(recordId)}` : base}
+        >
           Cancel
         </Link>
-        <button className="records-primary-action" type="submit" disabled={submitting || fields.length === 0}>
+        <Button
+          className="records-primary-action"
+          variant="primary"
+          size="sm"
+          type="submit"
+          disabled={submitting || fields.length === 0}
+        >
           {submitting ? (
             <LoaderCircle className="records-spin" aria-hidden="true" />
           ) : (
             <CheckCircle2 aria-hidden="true" />
           )}
           {submitting ? "Submitting…" : `${operation === "create" ? "Create" : "Save"} ${objectLabel.toLowerCase()}`}
-        </button>
+        </Button>
       </footer>
     </form>
   );

--- a/apps/web/src/components/records/RecordIdentityPanel.tsx
+++ b/apps/web/src/components/records/RecordIdentityPanel.tsx
@@ -15,6 +15,7 @@ import type {
   RecordIdentityAdminMapping,
   RecordIdentityAdminModel,
 } from "@/lib/records-identity";
+import { Button } from "@/components/ui/Button";
 
 type IdentityStatus = RecordIdentityAdminMapping["status"];
 
@@ -107,19 +108,23 @@ function MappingControl({
           </option>
         ))}
       </select>
-      <button type="submit" disabled={pending !== null || !appUserId}>
+      <Button
+        variant="primary"
+        size="sm"
+        type="submit"
+        disabled={pending !== null || !appUserId}
+      >
         {pending === "link" ? <LoaderCircle className="records-spin" /> : <Link2 />}
         Link
-      </button>
-      <button
-        className="is-quiet"
-        type="button"
+      </Button>
+      <Button
+        size="sm"
         disabled={pending !== null}
         onClick={() => void decide("ignore")}
       >
         {pending === "ignore" ? <LoaderCircle className="records-spin" /> : <UserRoundX />}
         Ignore
-      </button>
+      </Button>
       {message && <span role="alert">{message}</span>}
     </form>
   );
@@ -184,10 +189,14 @@ function BackfillControl({ appId, sources }: { appId: string; sources: string[] 
           ))
         )}
       </select>
-      <button type="submit" disabled={pending || !sourceInstanceId}>
+      <Button
+        size="sm"
+        type="submit"
+        disabled={pending || !sourceInstanceId}
+      >
         {pending ? <LoaderCircle className="records-spin" /> : <RefreshCcw />}
         Re-run ownership
-      </button>
+      </Button>
       {message && <span role="status">{message}</span>}
     </form>
   );

--- a/apps/web/src/components/records/RecordImportPanel.tsx
+++ b/apps/web/src/components/records/RecordImportPanel.tsx
@@ -16,6 +16,7 @@ import type {
   RecordImportAdminObject,
   RecordImportRunSummary,
 } from "@/lib/records-imports";
+import { Button } from "@/components/ui/Button";
 
 type ApiResponse = {
   error?: string;
@@ -296,10 +297,16 @@ export function RecordImportPanel({
             CSV file
             <input name="file" type="file" accept=".csv,text/csv" required />
           </label>
-          <button className="records-primary-action" type="submit" disabled={previewing || !objectApiName}>
+          <Button
+            className="records-primary-action"
+            variant="primary"
+            size="sm"
+            type="submit"
+            disabled={previewing || !objectApiName}
+          >
             {previewing ? <LoaderCircle className="records-spin" aria-hidden="true" /> : <Upload aria-hidden="true" />}
             {previewing ? "Inspecting…" : "Review mapping"}
-          </button>
+          </Button>
           </form>
         ) : (
           <section className="records-import-principles">
@@ -374,10 +381,16 @@ export function RecordImportPanel({
               <p>
                 <LockKeyhole aria-hidden="true" /> Insert-only. Existing keys are reported, never overwritten.
               </p>
-              <button className="records-primary-action" type="button" onClick={startImport} disabled={starting}>
+              <Button
+                className="records-primary-action"
+                variant="primary"
+                size="sm"
+                onClick={startImport}
+                disabled={starting}
+              >
                 {starting ? <LoaderCircle className="records-spin" aria-hidden="true" /> : <CheckCircle2 aria-hidden="true" />}
                 {starting ? "Approving…" : `Approve and import ${plan.rowCount.toLocaleString("en")} rows`}
-              </button>
+              </Button>
             </footer>
           </section>
         )}
@@ -444,10 +457,15 @@ export function RecordImportPanel({
               <p className="records-import-error">{String(activeRun.error.message ?? "Import failed.")}</p>
             )}
             {["planned", "running"].includes(activeRun.status) && (
-              <button className="records-import-cancel" type="button" onClick={cancelImport} disabled={cancelling}>
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={cancelImport}
+                disabled={cancelling}
+              >
                 {cancelling ? <LoaderCircle className="records-spin" aria-hidden="true" /> : <Ban aria-hidden="true" />}
                 {cancelling ? "Cancelling…" : "Cancel at batch boundary"}
-              </button>
+              </Button>
             )}
           </section>
         ) : (

--- a/apps/web/src/components/records/RecordRecycleTable.tsx
+++ b/apps/web/src/components/records/RecordRecycleTable.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { RecycledRecordSummary } from "@neko/records";
 import type { RecordOwnerIdentity } from "@/lib/records";
+import { buttonClassName } from "@/components/ui/Button";
 
 function dateLabel(value: string): string {
   const date = new Date(value);
@@ -104,7 +105,10 @@ export function RecordRecycleTable({
         </span>
         {hasMore && (
           <Link
-            className="records-page-button"
+            className={buttonClassName({
+              size: "sm",
+              className: "records-page-button",
+            })}
             href={hrefWith(base, query, {
               after: cursor,
               page: String(page + 1),

--- a/apps/web/src/components/records/RecordRestoreButton.tsx
+++ b/apps/web/src/components/records/RecordRestoreButton.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { LoaderCircle, RotateCcw } from "lucide-react";
+import { Button } from "@/components/ui/Button";
 
 export function RecordRestoreButton({
   appId,
@@ -53,9 +54,10 @@ export function RecordRestoreButton({
 
   return (
     <div className="records-restore-control">
-      <button
+      <Button
         className="records-primary-action"
-        type="button"
+        variant="primary"
+        size="sm"
         onClick={restore}
         disabled={submitting}
       >
@@ -65,7 +67,7 @@ export function RecordRestoreButton({
           <RotateCcw aria-hidden="true" />
         )}
         {submitting ? "Restoring…" : "Restore"}
-      </button>
+      </Button>
       {message && <span role="status">{message}</span>}
     </div>
   );

--- a/apps/web/src/components/records/RecordTable.tsx
+++ b/apps/web/src/components/records/RecordTable.tsx
@@ -8,6 +8,7 @@ import {
 } from "@/lib/records-reference";
 import { RecordCell } from "./RecordCell";
 import { PendingChangeMarker } from "./PendingChangeMarker";
+import { buttonClassName } from "@/components/ui/Button";
 
 function hrefWith(
   base: string,
@@ -148,7 +149,10 @@ export function RecordTable({
         </span>
         {hasMore && (
           <Link
-            className="records-page-button"
+            className={buttonClassName({
+              size: "sm",
+              className: "records-page-button",
+            })}
             href={hrefWith(base, query, {
               after: cursor,
               page: String(page + 1),

--- a/apps/web/src/components/records/RecordViewBar.tsx
+++ b/apps/web/src/components/records/RecordViewBar.tsx
@@ -10,6 +10,7 @@ import {
   RecordFilterBuilder,
   type RecordFilterField,
 } from "./RecordFilterBuilder";
+import { Button } from "@/components/ui/Button";
 
 function hrefWith(base: string, current: Record<string, string | undefined>, mine: boolean) {
   const params = new URLSearchParams();
@@ -62,7 +63,7 @@ export function RecordViewBar({
             </option>
           ))}
         </select>
-        <button type="submit">Open</button>
+        <Button size="sm" type="submit">Open</Button>
       </form>
       {query.q && (
         <span className="records-filter-chip">
@@ -103,14 +104,19 @@ export function RecordViewBar({
               Share with this organization
             </label>
           )}
-          <button type="submit">Save</button>
+          <Button variant="primary" size="sm" type="submit">Save</Button>
         </form>
       </details>
       {selectedView && (!selectedView.shared || canShare) && (
         <form action={`${endpoint}/${selectedView.id}`} method="post">
-          <button className="records-view-delete" type="submit" aria-label={`Delete ${selectedView.label}`}>
+          <Button
+            variant="danger"
+            size="sm"
+            type="submit"
+            aria-label={`Delete ${selectedView.label}`}
+          >
             Delete view
-          </button>
+          </Button>
         </form>
       )}
       {ownerScoped && (

--- a/apps/web/src/components/ui/ActionGroup.tsx
+++ b/apps/web/src/components/ui/ActionGroup.tsx
@@ -1,0 +1,27 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { cn } from "@/lib/cn";
+
+type ActionGroupProps = {
+  align?: "start" | "end";
+  mobile?: "wrap" | "stack";
+} & ComponentPropsWithoutRef<"div">;
+
+export function ActionGroup({
+  align = "end",
+  mobile = "wrap",
+  className,
+  ...props
+}: ActionGroupProps) {
+  return (
+    <div
+      data-ui-action-group=""
+      data-mobile={mobile}
+      className={cn(
+        "flex min-w-0 flex-wrap items-center gap-2",
+        align === "end" ? "justify-end" : "justify-start",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -1,40 +1,133 @@
-import type { ComponentPropsWithoutRef } from "react";
+import { forwardRef, type ComponentPropsWithoutRef, type ReactNode } from "react";
 import { cn } from "@/lib/cn";
 
-type ButtonProps = {
-  variant?: "primary" | "secondary";
+const BUTTON_VARIANTS = {
+  primary:
+    "border-text bg-text text-bg shadow-[0_2px_10px_rgba(20,18,12,0.16)] hover:border-accent hover:bg-accent hover:text-white",
+  secondary:
+    "border-border bg-card/85 text-text2 shadow-soft hover:border-accent hover:bg-accent-soft hover:text-accent",
+  ghost:
+    "border-transparent bg-transparent text-text2 hover:bg-neutral-soft hover:text-text",
+  danger:
+    "border-danger/30 bg-danger-soft text-danger hover:border-danger hover:bg-danger hover:text-white",
+} as const;
+
+const BUTTON_SIZES = {
+  sm: "min-h-8 gap-1.5 px-3 py-1.5 text-ui-body-sm leading-none",
+  md: "min-h-10 gap-2 px-4 py-2 text-ui-body leading-none",
+  lg: "min-h-11 gap-2 px-5 py-2.5 text-ui-body-lg leading-none",
+  "icon-sm": "size-8 shrink-0 p-0 [&_svg]:size-3.5",
+  icon: "size-10 shrink-0 p-0 [&_svg]:size-4",
+} as const;
+
+export type ButtonVariant = keyof typeof BUTTON_VARIANTS;
+export type ButtonSize = keyof typeof BUTTON_SIZES;
+
+type ButtonStyleOptions = {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
   className?: string;
+};
+
+export function buttonClassName({
+  variant = "secondary",
+  size = "md",
+  className,
+}: ButtonStyleOptions = {}) {
+  return cn(
+    "ui-button inline-flex items-center justify-center whitespace-nowrap rounded-control border-[1.5px] font-body font-semibold cursor-pointer",
+    "transition-[color,background-color,border-color,transform,box-shadow,opacity] duration-150",
+    "hover:-translate-y-px active:translate-y-0",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg",
+    "disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:translate-y-0",
+    "aria-disabled:pointer-events-none aria-disabled:opacity-50",
+    "[&_svg]:pointer-events-none [&_svg]:shrink-0",
+    BUTTON_VARIANTS[variant],
+    BUTTON_SIZES[size],
+    className,
+  );
+}
+
+export type ButtonProps = {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
 } & ComponentPropsWithoutRef<"button">;
 
-export function Button({
-  variant = "secondary",
-  type = "button",
-  className,
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+  function Button(
+    {
+      variant = "secondary",
+      size = "md",
+      type = "button",
+      className,
+      children,
+      ...props
+    },
+    ref,
+  ) {
+    return (
+      <button
+        ref={ref}
+        type={type}
+        data-ui-button=""
+        data-variant={variant}
+        data-size={size}
+        className={buttonClassName({ variant, size, className })}
+        {...props}
+      >
+        {children}
+      </button>
+    );
+  },
+);
+
+export type ButtonLinkProps = {
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+} & ComponentPropsWithoutRef<"a">;
+
+export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
+  function ButtonLink(
+    {
+      variant = "secondary",
+      size = "md",
+      className,
+      children,
+      ...props
+    },
+    ref,
+  ) {
+    return (
+      <a
+        ref={ref}
+        data-ui-button=""
+        data-variant={variant}
+        data-size={size}
+        className={buttonClassName({ variant, size, className })}
+        {...props}
+      >
+        {children}
+      </a>
+    );
+  },
+);
+
+type IconButtonProps = Omit<ButtonProps, "aria-label" | "children" | "size"> & {
+  label: string;
+  size?: Extract<ButtonSize, "icon-sm" | "icon">;
+  children: ReactNode;
+};
+
+export function IconButton({
+  label,
+  size = "icon",
+  title,
   children,
   ...props
-}: ButtonProps) {
+}: IconButtonProps) {
   return (
-    <button
-      type={type}
-      className={cn(
-        "inline-flex items-center px-4.5 py-2.5 rounded-full border-[1.5px] font-body text-ui-body font-medium cursor-pointer",
-        "transition-[color,background,border-color,transform,box-shadow] duration-200",
-        "disabled:opacity-55 disabled:cursor-not-allowed",
-        variant === "secondary" &&
-          "bg-white/60 border-border text-text2 not-disabled:hover:border-accent not-disabled:hover:text-accent not-disabled:hover:bg-accent-soft not-disabled:hover:-translate-y-px",
-        variant === "primary" &&
-          "bg-text border-text text-bg shadow-[0_2px_10px_rgba(20,18,12,0.18)]",
-        className,
-      )}
-      {...props}
-    >
-      {variant === "primary" && (
-        <span
-          aria-hidden="true"
-          className="inline-block w-1.5 h-1.5 rounded-full bg-success mr-2 shadow-[0_0_0_3px_rgba(108,255,127,0.18)]"
-        />
-      )}
+    <Button aria-label={label} title={title ?? label} size={size} {...props}>
       {children}
-    </button>
+    </Button>
   );
 }

--- a/apps/web/src/components/ui/Button.tsx
+++ b/apps/web/src/components/ui/Button.tsx
@@ -17,7 +17,7 @@ export function Button({
     <button
       type={type}
       className={cn(
-        "inline-flex items-center px-4.5 py-2.5 rounded-full border-[1.5px] font-body text-[14.5px] font-medium cursor-pointer",
+        "inline-flex items-center px-4.5 py-2.5 rounded-full border-[1.5px] font-body text-ui-body font-medium cursor-pointer",
         "transition-[color,background,border-color,transform,box-shadow] duration-200",
         "disabled:opacity-55 disabled:cursor-not-allowed",
         variant === "secondary" &&

--- a/apps/web/src/components/ui/Disclosure.tsx
+++ b/apps/web/src/components/ui/Disclosure.tsx
@@ -1,0 +1,39 @@
+import { ChevronDown } from "lucide-react";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+type DisclosureProps = Omit<ComponentPropsWithoutRef<"details">, "title"> & {
+  title: ReactNode;
+  meta?: ReactNode;
+};
+
+export function Disclosure({
+  title,
+  meta,
+  className,
+  children,
+  ...props
+}: DisclosureProps) {
+  return (
+    <details
+      className={cn(
+        "group overflow-hidden rounded-inner border border-border bg-card",
+        className,
+      )}
+      {...props}
+    >
+      <summary
+        data-ui-disclosure=""
+        className="flex min-h-10 cursor-pointer list-none items-center gap-3 px-3.5 py-2.5 font-body text-ui-body-sm font-bold text-text marker:hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-accent [&::-webkit-details-marker]:hidden"
+      >
+        <span className="min-w-0 flex-1">{title}</span>
+        {meta ? <span className="text-ui-caption font-semibold text-text3">{meta}</span> : null}
+        <ChevronDown
+          aria-hidden="true"
+          className="size-4 shrink-0 text-text3 transition-transform group-open:rotate-180"
+        />
+      </summary>
+      <div className="border-t border-border px-3.5 py-3">{children}</div>
+    </details>
+  );
+}

--- a/apps/web/src/components/ui/EmptyState.tsx
+++ b/apps/web/src/components/ui/EmptyState.tsx
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+type EmptyStateProps = {
+  title: string;
+  body?: ReactNode;
+  action?: ReactNode;
+  icon?: ReactNode;
+  className?: string;
+};
+
+export function EmptyState({
+  title,
+  body,
+  action,
+  icon,
+  className,
+}: EmptyStateProps) {
+  return (
+    <section
+      className={cn(
+        "mx-auto grid max-w-[520px] justify-items-center gap-3 py-14 text-center",
+        className,
+      )}
+    >
+      {icon ? (
+        <span className="grid size-11 place-items-center rounded-inner bg-neutral text-text2 [&_svg]:size-5">
+          {icon}
+        </span>
+      ) : null}
+      <div className="grid gap-1.5">
+        <h2 className="text-ui-section">{title}</h2>
+        {body ? (
+          <div className="text-ui-body-sm leading-[var(--leading-body)] text-text2">{body}</div>
+        ) : null}
+      </div>
+      {action ? <div className="pt-1">{action}</div> : null}
+    </section>
+  );
+}

--- a/apps/web/src/components/ui/Field.tsx
+++ b/apps/web/src/components/ui/Field.tsx
@@ -1,0 +1,113 @@
+import {
+  forwardRef,
+  useId,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/cn";
+
+const CONTROL_CLASS =
+  "w-full rounded-control border-[1.5px] border-border bg-card px-3.5 py-2.5 font-body text-ui-body text-text outline-none transition-[border-color,box-shadow,background-color] placeholder:text-text3 hover:border-text3 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.10)] disabled:cursor-not-allowed disabled:bg-neutral-soft disabled:opacity-60";
+
+type FieldProps = {
+  label: ReactNode;
+  hint?: ReactNode;
+  error?: ReactNode;
+  htmlFor?: string;
+  className?: string;
+  children: ReactNode;
+};
+
+export function Field({
+  label,
+  hint,
+  error,
+  htmlFor,
+  className,
+  children,
+}: FieldProps) {
+  return (
+    <div className={cn("grid min-w-0 gap-1.5", className)}>
+      <label
+        htmlFor={htmlFor}
+        className="font-body text-ui-caption font-bold text-text2"
+      >
+        {label}
+      </label>
+      {children}
+      {error ? (
+        <span className="text-ui-caption leading-[var(--leading-compact)] text-danger">{error}</span>
+      ) : hint ? (
+        <span className="text-ui-caption leading-[var(--leading-compact)] text-text3">{hint}</span>
+      ) : null}
+    </div>
+  );
+}
+
+export const Input = forwardRef<
+  HTMLInputElement,
+  ComponentPropsWithoutRef<"input">
+>(function Input({ className, ...props }, ref) {
+  return (
+    <input
+      ref={ref}
+      data-ui-field-control=""
+      className={cn(CONTROL_CLASS, className)}
+      {...props}
+    />
+  );
+});
+
+export const Textarea = forwardRef<
+  HTMLTextAreaElement,
+  ComponentPropsWithoutRef<"textarea">
+>(function Textarea({ className, ...props }, ref) {
+  return (
+    <textarea
+      ref={ref}
+      data-ui-field-control=""
+      className={cn(CONTROL_CLASS, "min-h-24 resize-y", className)}
+      {...props}
+    />
+  );
+});
+
+export const NativeSelect = forwardRef<
+  HTMLSelectElement,
+  ComponentPropsWithoutRef<"select">
+>(function NativeSelect({ className, ...props }, ref) {
+  return (
+    <select
+      ref={ref}
+      data-ui-field-control=""
+      className={cn(CONTROL_CLASS, "cursor-pointer", className)}
+      {...props}
+    />
+  );
+});
+
+type FieldControlProps = Omit<FieldProps, "htmlFor" | "children"> &
+  ComponentPropsWithoutRef<"input">;
+
+export function FieldInput({
+  label,
+  hint,
+  error,
+  className,
+  id,
+  ...props
+}: FieldControlProps) {
+  const generatedId = useId();
+  const controlId = id ?? generatedId;
+  return (
+    <Field
+      label={label}
+      hint={hint}
+      error={error}
+      htmlFor={controlId}
+      className={className}
+    >
+      <Input id={controlId} aria-invalid={error ? true : undefined} {...props} />
+    </Field>
+  );
+}

--- a/apps/web/src/components/ui/OverflowMenu.tsx
+++ b/apps/web/src/components/ui/OverflowMenu.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { MoreHorizontal } from "lucide-react";
+import {
+  forwardRef,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
+import { IconButton } from "@/components/ui/Button";
+import { cn } from "@/lib/cn";
+
+type OverflowMenuProps = {
+  label?: string;
+  align?: "start" | "end";
+  children: ReactNode;
+  className?: string;
+};
+
+export function OverflowMenu({
+  label = "More actions",
+  align = "end",
+  children,
+  className,
+}: OverflowMenuProps) {
+  const [open, setOpen] = useState(false);
+  const menuId = useId();
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function closeOnOutside(event: PointerEvent) {
+      if (!rootRef.current?.contains(event.target as Node)) setOpen(false);
+    }
+    function closeOnEscape(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("pointerdown", closeOnOutside);
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.removeEventListener("pointerdown", closeOnOutside);
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className={cn("relative shrink-0", className)}>
+      <IconButton
+        label={label}
+        size="icon-sm"
+        variant="ghost"
+        data-ui-menu-trigger=""
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <MoreHorizontal aria-hidden="true" />
+      </IconButton>
+      {open ? (
+        <div
+          id={menuId}
+          role="menu"
+          className={cn(
+            "absolute top-[calc(100%+6px)] z-[80] grid min-w-44 gap-1 rounded-inner border border-border bg-card p-1.5 shadow-lift",
+            align === "end" ? "right-0" : "left-0",
+          )}
+          onClickCapture={() => setOpen(false)}
+        >
+          {children}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+type MenuItemProps = {
+  danger?: boolean;
+} & ComponentPropsWithoutRef<"button">;
+
+export const MenuItem = forwardRef<HTMLButtonElement, MenuItemProps>(
+  function MenuItem({ danger = false, className, ...props }, ref) {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        role="menuitem"
+        data-ui-menu-item=""
+        className={cn(
+          "flex min-h-9 w-full items-center gap-2 rounded-[8px] border-0 bg-transparent px-3 py-2 text-left font-body text-ui-body-sm font-semibold text-text2 transition-colors hover:bg-neutral-soft hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent disabled:cursor-not-allowed disabled:opacity-50 [&_svg]:size-4 [&_svg]:shrink-0",
+          danger && "text-danger hover:bg-danger-soft hover:text-danger",
+          className,
+        )}
+        {...props}
+      />
+    );
+  },
+);

--- a/apps/web/src/components/ui/Pill.tsx
+++ b/apps/web/src/components/ui/Pill.tsx
@@ -28,7 +28,7 @@ export function Pill({
       className={cn(
         "inline-flex min-w-0 max-w-full min-h-6 shrink-0 items-center px-2.5 py-1 rounded-full",
         "overflow-hidden text-ellipsis whitespace-nowrap leading-none",
-        "text-[11px] font-extrabold tracking-[0.08em] uppercase",
+        "text-ui-label font-extrabold tracking-[0.08em] uppercase",
         "border",
         VARIANTS[variant],
         className,

--- a/apps/web/src/components/ui/Pill.tsx
+++ b/apps/web/src/components/ui/Pill.tsx
@@ -4,9 +4,9 @@ import { cn } from "@/lib/cn";
 const VARIANTS = {
   live: "bg-success/15 text-success-ink border-success/30",
   watch: "bg-watch-soft text-warn-ink border-watch/30",
-  danger: "bg-danger-soft text-danger border-transparent",
+  danger: "bg-danger-soft text-danger border-danger/15",
   muted: "bg-neutral text-text2 border-border",
-  success: "bg-success-soft text-success-mid border-transparent",
+  success: "bg-success-soft text-success-ink border-success-mid/15",
 } as const;
 
 export type PillVariant = keyof typeof VARIANTS;

--- a/apps/web/src/components/ui/README.md
+++ b/apps/web/src/components/ui/README.md
@@ -1,0 +1,33 @@
+# OpenNeko UI system
+
+OpenNeko uses one calm interaction language across product surfaces. Page CSS may compose layouts, but common controls belong in this directory.
+
+## Action hierarchy
+
+- `primary`: the single main action in a working region.
+- `secondary`: ordinary visible actions.
+- `ghost`: low-emphasis or icon-only actions.
+- `danger`: destructive actions; never disguise these as secondary.
+- Put related controls in `ActionGroup`. Move destructive or infrequent row actions into `OverflowMenu` when space is tight.
+
+Use `Button`, `IconButton`, `ButtonLink`, or `buttonClassName` instead of creating page-local button chrome. Desktop sizes are intentionally compact; all shared controls expand to a 44px minimum target on phone widths and coarse pointers.
+
+## Selection and input
+
+- Use `Tabs` for switching content views.
+- Use `SegmentedControl` for filters or a choice within one view.
+- Use `Field` with `Input`, `Textarea`, or `NativeSelect` for labelled form controls.
+- Use `Disclosure` for secondary detail that would otherwise make a page difficult to scan.
+
+## Status and density
+
+Use `Pill` for compact row status. Use plain sentence-case state text when a larger card needs quieter metadata. Do not pair a decorative dot with narrow, letter-spaced text or force status into a fixed-width gutter.
+
+Preserve this hierarchy at every breakpoint:
+
+1. title and orientation;
+2. working content;
+3. one clear primary action;
+4. secondary detail on demand.
+
+Bespoke controls are reserved for interactions whose behavior is genuinely unique, such as the Work composer, chat composer, navigation rail, and timeline playback—not for ordinary buttons, fields, tabs, or menus.

--- a/apps/web/src/components/ui/Tabs.tsx
+++ b/apps/web/src/components/ui/Tabs.tsx
@@ -1,0 +1,78 @@
+import type { ComponentPropsWithoutRef } from "react";
+import { cn } from "@/lib/cn";
+
+export function Tabs({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      role="tablist"
+      className={cn(
+        "inline-flex max-w-full items-center gap-1 overflow-x-auto rounded-control border border-border bg-neutral-soft p-1",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type TabProps = {
+  selected?: boolean;
+} & ComponentPropsWithoutRef<"button">;
+
+export function Tab({ selected = false, className, ...props }: TabProps) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={selected}
+      data-ui-tab=""
+      className={cn(
+        "inline-flex min-h-8 shrink-0 items-center justify-center rounded-[8px] border border-transparent px-3 py-1.5 font-body text-ui-body-sm font-semibold text-text2 transition-[background-color,color,border-color,box-shadow] hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+        selected && "border-border bg-card text-text shadow-soft",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export function SegmentedControl({
+  className,
+  ...props
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn(
+        "inline-flex max-w-full items-center gap-0.5 overflow-x-auto rounded-full border border-border bg-neutral p-1",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+type SegmentProps = {
+  selected?: boolean;
+} & ComponentPropsWithoutRef<"button">;
+
+export function Segment({
+  selected = false,
+  className,
+  ...props
+}: SegmentProps) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      data-ui-segment=""
+      className={cn(
+        "inline-flex min-h-8 shrink-0 items-center justify-center rounded-full border-0 bg-transparent px-3 py-1.5 font-body text-ui-body-sm font-semibold text-text2 transition-[background-color,color,box-shadow] hover:text-text focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent",
+        selected && "bg-card text-text shadow-soft",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/web/src/lib/agent-runtime-readiness.ts
+++ b/apps/web/src/lib/agent-runtime-readiness.ts
@@ -1,0 +1,33 @@
+import "server-only";
+
+import { verifyAgentRuntimeReady } from "@neko/llm";
+
+export const AGENT_RUNTIME_UNAVAILABLE_CODE = "agent_runtime_unavailable";
+
+const RECOVERY_MESSAGE =
+  "The secure agent runtime is not ready. Restart this OpenNeko stack, wait for `openneko status` to show serving, then try again. If it still fails, run `openneko doctor`.";
+
+export class AgentRuntimeUnavailableError extends Error {
+  readonly code = AGENT_RUNTIME_UNAVAILABLE_CODE;
+
+  constructor(options?: { cause?: unknown }) {
+    super(RECOVERY_MESSAGE, options);
+    this.name = "AgentRuntimeUnavailableError";
+  }
+}
+/**
+ * Fail before setup is marked complete or onboarding work is queued unless
+ * the exact OpenShell control-plane path used by the profiler is reachable.
+ * Keep the underlying CLI error in server logs; browser copy is intentionally
+ * stable, actionable, and free of local paths or provider details.
+ */
+export async function requireAgentRuntimeReady(orgId: string): Promise<void> {
+  try {
+    await verifyAgentRuntimeReady(orgId);
+  } catch (cause) {
+    console.warn(
+      `[agent-runtime-readiness] OpenShell preflight failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+    );
+    throw new AgentRuntimeUnavailableError({ cause });
+  }
+}

--- a/apps/web/src/lib/cn.ts
+++ b/apps/web/src/lib/cn.ts
@@ -1,6 +1,23 @@
 import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+const mergeClassNames = extendTailwindMerge({
+  extend: {
+    theme: {
+      text: [
+        "ui-page",
+        "ui-section",
+        "ui-subsection",
+        "ui-body-lg",
+        "ui-body",
+        "ui-body-sm",
+        "ui-caption",
+        "ui-label",
+      ],
+    },
+  },
+});
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return mergeClassNames(clsx(inputs));
 }

--- a/apps/web/src/lib/solution-packs.ts
+++ b/apps/web/src/lib/solution-packs.ts
@@ -1,0 +1,36 @@
+const PACK_ID = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+
+export const packReadActions = ["inspect", "plan", "status", "doctor"] as const;
+export const packWriteActions = ["install", "configure", "upgrade", "uninstall"] as const;
+
+export type PackReadAction = (typeof packReadActions)[number];
+export type PackWriteAction = (typeof packWriteActions)[number];
+
+export function validPackId(packId: string): boolean {
+  return PACK_ID.test(packId);
+}
+
+export function isPackReadAction(value: string): value is PackReadAction {
+  return (packReadActions as readonly string[]).includes(value);
+}
+
+export function isPackWriteAction(value: string): value is PackWriteAction {
+  return (packWriteActions as readonly string[]).includes(value);
+}
+
+function workerAdminBase(): string {
+  return (process.env.WORKER_ADMIN_URL ?? "http://127.0.0.1:4100").replace(/\/+$/, "");
+}
+
+export async function requestPackWorker(
+  path: string,
+  init: RequestInit = {},
+): Promise<{ status: number; body: unknown }> {
+  const response = await fetch(`${workerAdminBase()}${path}`, {
+    ...init,
+    cache: "no-store",
+    signal: AbortSignal.timeout(120_000),
+  });
+  const body = await response.json().catch(() => ({ error: `Worker returned HTTP ${response.status}` }));
+  return { status: response.status, body };
+}

--- a/apps/web/test/a2ui/surface.test.ts
+++ b/apps/web/test/a2ui/surface.test.ts
@@ -272,7 +272,7 @@ describe("bodyChildIds", () => {
   });
 
   it("falls back to top-level orphans without repeating nested form controls", () => {
-    let surfaces = applyMessage(new Map(), {
+    const surfaces = applyMessage(new Map(), {
       version: "v1.0",
       createSurface: {
         surfaceId: "source-form",

--- a/apps/web/test/api/admin-packs.test.ts
+++ b/apps/web/test/api/admin-packs.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
+import { NextResponse } from "next/server";
+import { callRoute } from "../_helpers/route";
+
+const { mockRequireAdminActor } = vi.hoisted(() => ({
+  mockRequireAdminActor: vi.fn(),
+}));
+
+vi.mock("@/lib/admin-auth", () => ({
+  requireAdminActor: mockRequireAdminActor,
+  isDenied: (value: unknown) => value instanceof Response,
+}));
+
+let fetchMock: MockInstance;
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+beforeEach(() => {
+  mockRequireAdminActor.mockResolvedValue({ userId: "admin-1", role: "admin" });
+  fetchMock = vi.spyOn(globalThis, "fetch");
+});
+
+afterEach(() => {
+  fetchMock.mockRestore();
+  vi.clearAllMocks();
+});
+
+describe("/api/admin/packs", () => {
+  it("proxies the embedded pack list", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { packs: [{ id: "magento" }] }));
+    const { GET } = await import("@/app/api/admin/packs/route");
+    const result = await callRoute(GET);
+    expect(result.status).toBe(200);
+    expect(result.body).toEqual({ packs: [{ id: "magento" }] });
+    expect(String(fetchMock.mock.calls[0]?.[0])).toContain("/admin/packs");
+  });
+
+  it("keeps the worker route behind the admin gate", async () => {
+    mockRequireAdminActor.mockResolvedValue(
+      NextResponse.json({ error: "admin only" }, { status: 403 }),
+    );
+    const { GET } = await import("@/app/api/admin/packs/route");
+    const result = await callRoute(GET);
+    expect(result.status).toBe(403);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("/api/admin/packs/[packId]/[action]", () => {
+  it("proxies status reads", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { packId: "magento", status: "installed" }));
+    const { GET } = await import("@/app/api/admin/packs/[packId]/[action]/route");
+    const result = await callRoute(
+      (request) => GET(request, { params: Promise.resolve({ packId: "magento", action: "status" }) }),
+    );
+    expect(result.status).toBe(200);
+    expect(result.body).toMatchObject({ packId: "magento", status: "installed" });
+  });
+
+  it("adds a server-owned actor and idempotency key to writes", async () => {
+    fetchMock.mockResolvedValue(jsonResponse(200, { packId: "magento", status: "installed" }));
+    const { POST } = await import("@/app/api/admin/packs/[packId]/[action]/route");
+    const result = await callRoute(
+      (request) => POST(request, { params: Promise.resolve({ packId: "magento", action: "install" }) }),
+      {
+        method: "POST",
+        body: { actorUserId: "forged", inputs: { "database.host": "db" } },
+      },
+    );
+    expect(result.status).toBe(200);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const body = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(body.actorUserId).toBe("admin-1");
+    expect(body.idempotencyKey).toEqual(expect.any(String));
+  });
+
+  it("rejects unknown operations before contacting the worker", async () => {
+    const { GET } = await import("@/app/api/admin/packs/[packId]/[action]/route");
+    const result = await callRoute(
+      (request) => GET(request, { params: Promise.resolve({ packId: "magento", action: "erase" }) }),
+    );
+    expect(result.status).toBe(404);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed JSON as a client error", async () => {
+    const { POST } = await import("@/app/api/admin/packs/[packId]/[action]/route");
+    const request = new Request("http://localhost/api/admin/packs/magento/install", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{broken",
+    });
+    const response = await POST(request as never, {
+      params: Promise.resolve({ packId: "magento", action: "install" }),
+    });
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized bodies even without a content-length header", async () => {
+    const { POST } = await import("@/app/api/admin/packs/[packId]/[action]/route");
+    const request = new Request("http://localhost/api/admin/packs/magento/install", {
+      method: "POST",
+      body: JSON.stringify({ value: "x".repeat(65 * 1024) }),
+    });
+    request.headers.delete("content-length");
+    const response = await POST(request as never, {
+      params: Promise.resolve({ packId: "magento", action: "install" }),
+    });
+    expect(response.status).toBe(413);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/test/api/admin-signin.test.ts
+++ b/apps/web/test/api/admin-signin.test.ts
@@ -5,10 +5,14 @@ const mocks = vi.hoisted(() => ({
     provider: null as unknown,
     pending: null as unknown,
   },
-  setAuthPluginSecrets: vi.fn(async (_values: unknown) => undefined),
-  beginAuth: vi.fn(async (_params: unknown) => ({
-    authorizationUrl: "https://x",
-  })),
+  setAuthPluginSecrets: vi.fn(async (values: unknown) => {
+    void values;
+    return undefined;
+  }),
+  beginAuth: vi.fn(async (params: unknown) => {
+    void params;
+    return { authorizationUrl: "https://x" };
+  }),
 }));
 
 vi.mock("@/lib/admin-auth", () => ({

--- a/apps/web/test/api/briefing.test.ts
+++ b/apps/web/test/api/briefing.test.ts
@@ -193,6 +193,27 @@ describeIfDb("/api/briefing GET", () => {
     ]);
   });
 
+  it("shows organization-wide pack metrics in every team role briefing", async () => {
+    await db().insert(metric).values({
+      org_id: orgId,
+      role: "operations",
+      slug: "magento-fulfillment-backlog",
+      source: "pack:magento",
+      title: "Fulfillment backlog",
+      why: "Magento operations signal",
+      chart_hint: "kpi",
+      active: true,
+      last_refresh_status: "pending",
+    });
+
+    const res = await callRoute(GET, { url: "http://localhost/api/briefing?role=CEO" });
+    const messages = res.body as A2UIMessage[];
+    const data = (
+      messages[1] as Extract<A2UIMessage, { updateDataModel: unknown }>
+    ).updateDataModel.value as { insights: Record<string, unknown> };
+    expect(data.insights["magento-fulfillment-backlog"]).toBeDefined();
+  });
+
   it("renders state='pending' when a metric has no snapshot yet", async () => {
     await db().insert(metric).values({
       org_id: orgId,

--- a/apps/web/test/api/onboarding-submit.test.ts
+++ b/apps/web/test/api/onboarding-submit.test.ts
@@ -29,9 +29,16 @@ import {
 } from "@neko/db";
 import { callRoute } from "../_helpers/route";
 
-const { mockGetOrgId, mockEnqueue } = vi.hoisted(() => ({
+const {
+  mockGetOrgId,
+  mockEnqueue,
+  mockHasPrimaryProviderSetup,
+  mockRequireAgentRuntimeReady,
+} = vi.hoisted(() => ({
   mockGetOrgId: vi.fn(),
   mockEnqueue: vi.fn(),
+  mockHasPrimaryProviderSetup: vi.fn(),
+  mockRequireAgentRuntimeReady: vi.fn(),
 }));
 
 vi.mock("@/lib/db", async () => {
@@ -42,6 +49,20 @@ vi.mock("@/lib/db", async () => {
 vi.mock("@neko/db/jobs", async () => {
   const actual = await vi.importActual<typeof import("@neko/db/jobs")>("@neko/db/jobs");
   return { ...actual, enqueue: mockEnqueue };
+});
+
+vi.mock("@/lib/provider-settings", () => ({
+  hasPrimaryProviderSetup: mockHasPrimaryProviderSetup,
+}));
+
+vi.mock("@/lib/agent-runtime-readiness", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/agent-runtime-readiness")
+  >("@/lib/agent-runtime-readiness");
+  return {
+    ...actual,
+    requireAgentRuntimeReady: mockRequireAgentRuntimeReady,
+  };
 });
 
 const reachable = await dbReachable();
@@ -65,6 +86,8 @@ describeIfDb("/api/onboarding/submit", () => {
     await createTestOrg(orgId);
     mockGetOrgId.mockResolvedValue(orgId);
     mockEnqueue.mockResolvedValue("queue-id-stub");
+    mockHasPrimaryProviderSetup.mockResolvedValue(true);
+    mockRequireAgentRuntimeReady.mockResolvedValue(undefined);
   });
 
   afterEach(async () => {
@@ -128,6 +151,7 @@ describeIfDb("/api/onboarding/submit", () => {
       expect.objectContaining({ orgId, processingJobId: jobId }),
       { retryLimit: 0 },
     );
+    expect(mockRequireAgentRuntimeReady).toHaveBeenCalledWith(orgId);
   });
 
   it("re-submission replaces the wizard row (no duplicate primary key)", async () => {
@@ -165,6 +189,40 @@ describeIfDb("/api/onboarding/submit", () => {
       },
     });
     expect(res.status).toBe(400);
+    const wizards = await db()
+      .select({ id: onboarding_wizard.org_id })
+      .from(onboarding_wizard)
+      .where(eq(onboarding_wizard.org_id, orgId));
+    expect(wizards).toHaveLength(0);
+  });
+
+  it("does not write or enqueue work when the agent runtime is unavailable", async () => {
+    const { AgentRuntimeUnavailableError } = await import(
+      "@/lib/agent-runtime-readiness"
+    );
+    mockRequireAgentRuntimeReady.mockRejectedValueOnce(
+      new AgentRuntimeUnavailableError(),
+    );
+
+    const res = await callRoute(POST, {
+      method: "POST",
+      body: {
+        companyName: "AdventureWorks Cycles",
+        companyNote: "We sell bikes",
+        fiscalYearStartMonth: 7,
+        activeSeats: ["CEO"],
+        priorities: [],
+      },
+    });
+
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({ code: "agent_runtime_unavailable" });
+    expect(mockEnqueue).not.toHaveBeenCalled();
+    const jobs = await db()
+      .select({ id: processing_job.id })
+      .from(processing_job)
+      .where(eq(processing_job.org_id, orgId));
+    expect(jobs).toHaveLength(0);
     const wizards = await db()
       .select({ id: onboarding_wizard.org_id })
       .from(onboarding_wizard)

--- a/apps/web/test/api/setup-finish.test.ts
+++ b/apps/web/test/api/setup-finish.test.ts
@@ -24,9 +24,10 @@ import {
 import { app_user, db, eq, organization, pool } from "@neko/db";
 import { callRoute } from "../_helpers/route";
 
-const { mockGetOrgId, mockGetCurrentUser } = vi.hoisted(() => ({
+const { mockGetOrgId, mockGetCurrentUser, mockRequireAgentRuntimeReady } = vi.hoisted(() => ({
   mockGetOrgId: vi.fn(),
   mockGetCurrentUser: vi.fn(),
+  mockRequireAgentRuntimeReady: vi.fn(),
 }));
 
 vi.mock("@/lib/db", async () => {
@@ -37,6 +38,16 @@ vi.mock("@/lib/db", async () => {
 vi.mock("@/lib/auth", async () => {
   const actual = await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
   return { ...actual, getCurrentUser: mockGetCurrentUser };
+});
+
+vi.mock("@/lib/agent-runtime-readiness", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/agent-runtime-readiness")
+  >("@/lib/agent-runtime-readiness");
+  return {
+    ...actual,
+    requireAgentRuntimeReady: mockRequireAgentRuntimeReady,
+  };
 });
 
 const reachable = await dbReachable();
@@ -68,6 +79,7 @@ describeIfDb("/settings/finish", () => {
     await createTestOrg(orgId);
     mockGetOrgId.mockResolvedValue(orgId);
     mockGetCurrentUser.mockResolvedValue(null);
+    mockRequireAgentRuntimeReady.mockResolvedValue(undefined);
   });
 
   afterEach(async () => {
@@ -133,5 +145,28 @@ describeIfDb("/settings/finish", () => {
 
     const ts = await readSetupCompleteAt(orgId);
     expect(ts).toBeInstanceOf(Date);
+    expect(mockRequireAgentRuntimeReady).toHaveBeenCalledWith(orgId);
+  });
+
+  it("does not finish setup when the secure agent runtime is unavailable", async () => {
+    const { AgentRuntimeUnavailableError } = await import(
+      "@/lib/agent-runtime-readiness"
+    );
+    await seedDataSource(orgId);
+    await seedProvider(orgId, {
+      scope: "primary",
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      secrets: { apiKey: "sk-ant" },
+    });
+    mockRequireAgentRuntimeReady.mockRejectedValueOnce(
+      new AgentRuntimeUnavailableError(),
+    );
+
+    const res = await callRoute(POST, { method: "POST" });
+
+    expect(res.status).toBe(503);
+    expect(res.body).toMatchObject({ code: "agent_runtime_unavailable" });
+    expect(await readSetupCompleteAt(orgId)).toBeNull();
   });
 });

--- a/apps/web/test/api/work-runs.test.ts
+++ b/apps/web/test/api/work-runs.test.ts
@@ -16,7 +16,6 @@ import {
   uniqueOrgId,
 } from "@neko/db/test-helpers";
 import {
-  and,
   db,
   eq,
   pool,

--- a/apps/web/test/components/briefing-card.test.ts
+++ b/apps/web/test/components/briefing-card.test.ts
@@ -44,7 +44,8 @@ describe("BriefingCard deep-dive button", () => {
       onDeepDive: () => {},
     });
     expect(html).toContain('aria-label="Deep dive in Work"');
-    expect(html).toContain('class="ipin ipin-deep"');
+    expect(html).toContain('data-ui-button=""');
+    expect(html).toContain('data-size="icon-sm"');
   });
 
   it("hides the Deep dive button when onDeepDive is not provided", () => {

--- a/apps/web/test/components/ui-system.test.ts
+++ b/apps/web/test/components/ui-system.test.ts
@@ -1,0 +1,71 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { Button, IconButton } from "@/components/ui/Button";
+import { Disclosure } from "@/components/ui/Disclosure";
+import { FieldInput } from "@/components/ui/Field";
+import { Segment, SegmentedControl, Tab, Tabs } from "@/components/ui/Tabs";
+
+describe("shared UI contracts", () => {
+  it("keeps button hierarchy and icon actions machine-readable", () => {
+    const primary = renderToStaticMarkup(
+      createElement(Button, { variant: "primary", size: "lg" }, "Continue"),
+    );
+    expect(primary).toContain('data-ui-button=""');
+    expect(primary).toContain('data-variant="primary"');
+    expect(primary).toContain('data-size="lg"');
+    expect(primary).toContain('type="button"');
+
+    const icon = renderToStaticMarkup(
+      createElement(
+        IconButton,
+        { label: "More actions" } as Parameters<typeof IconButton>[0],
+        "…",
+      ),
+    );
+    expect(icon).toContain('aria-label="More actions"');
+    expect(icon).toContain('title="More actions"');
+  });
+
+  it("exposes selection state consistently for tabs and segments", () => {
+    const tabs = renderToStaticMarkup(
+      createElement(
+        Tabs,
+        null,
+        createElement(Tab, { selected: true }, "Overview"),
+      ),
+    );
+    expect(tabs).toContain('role="tablist"');
+    expect(tabs).toContain('aria-selected="true"');
+    expect(tabs).toContain('data-ui-tab=""');
+
+    const segments = renderToStaticMarkup(
+      createElement(
+        SegmentedControl,
+        null,
+        createElement(Segment, { selected: true }, "Active"),
+      ),
+    );
+    expect(segments).toContain('aria-pressed="true"');
+    expect(segments).toContain('data-ui-segment=""');
+  });
+
+  it("preserves labelled fields and native disclosure semantics", () => {
+    const field = renderToStaticMarkup(
+      createElement(FieldInput, {
+        id: "workspace-name",
+        label: "Workspace name",
+      }),
+    );
+    expect(field).toContain('for="workspace-name"');
+    expect(field).toContain('id="workspace-name"');
+    expect(field).toContain('data-ui-field-control=""');
+
+    const disclosure = renderToStaticMarkup(
+      createElement(Disclosure, { title: "Advanced" }, "Details"),
+    );
+    expect(disclosure).toContain("<details");
+    expect(disclosure).toContain("<summary");
+    expect(disclosure).toContain('data-ui-disclosure=""');
+  });
+});

--- a/apps/web/test/visual/records-parity.spec.ts
+++ b/apps/web/test/visual/records-parity.spec.ts
@@ -56,3 +56,67 @@ test("non-CRM adversarial fixture stays generic and visually stable", async ({ p
     "support-adversarial-table-tail.png",
   );
 });
+
+for (const viewport of [
+  { name: "tablet", width: 900, height: 1_100 },
+  { name: "phone", width: 390, height: 844 },
+] as const) {
+  test(`generated record pages stay inside the ${viewport.name} viewport`, async ({
+    page,
+  }) => {
+    await page.setViewportSize(viewport);
+    await page.goto("/a/support_lab/support_case", {
+      waitUntil: "networkidle",
+    });
+
+    const heading = page.getByRole("heading", {
+      name: "Customer support requests requiring coordinated investigation across fulfillment, billing, and field service teams",
+    });
+    await expect(heading).toBeVisible();
+
+    const layout = await page.evaluate(() => {
+      const title = document.querySelector<HTMLElement>(
+        ".records-object-title h1",
+      );
+      const tableScroll = document.querySelector<HTMLElement>(
+        ".records-table-scroll",
+      );
+      const titleStyle = title ? getComputedStyle(title) : null;
+      const titleRect = title?.getBoundingClientRect();
+      const sharedControls = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          ":where([data-ui-button], .ui-button)",
+        ),
+      )
+        .filter((element) => {
+          const style = getComputedStyle(element);
+          const rect = element.getBoundingClientRect();
+          return style.display !== "none" && rect.width > 0 && rect.height > 0;
+        })
+        .map((element) => Math.round(element.getBoundingClientRect().height));
+
+      return {
+        viewportWidth: document.documentElement.clientWidth,
+        documentWidth: document.documentElement.scrollWidth,
+        titleRight: titleRect?.right ?? 0,
+        titleLeft: titleRect?.left ?? 0,
+        titleOverflow: titleStyle?.overflow,
+        titleTextOverflow: titleStyle?.textOverflow,
+        tableOverflowX: tableScroll ? getComputedStyle(tableScroll).overflowX : null,
+        sharedControls,
+      };
+    });
+
+    expect(layout.documentWidth).toBeLessThanOrEqual(layout.viewportWidth + 1);
+    expect(layout.titleLeft).toBeGreaterThanOrEqual(0);
+    expect(layout.titleRight).toBeLessThanOrEqual(layout.viewportWidth + 1);
+    expect(layout.titleOverflow).not.toBe("hidden");
+    expect(layout.titleTextOverflow).not.toBe("ellipsis");
+    expect(layout.tableOverflowX).toBe("auto");
+
+    if (viewport.name === "phone") {
+      expect(layout.sharedControls.length).toBeGreaterThan(0);
+      expect(Math.min(...layout.sharedControls)).toBeGreaterThanOrEqual(44);
+    }
+  });
+}

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -21,15 +21,18 @@
     "@neko/evals": "workspace:*",
     "@neko/interaction": "workspace:*",
     "@neko/llm": "workspace:*",
+    "@neko/packs": "workspace:*",
     "@neko/records": "workspace:*",
     "@neko/telemetry": "workspace:*",
     "@open-neko/plugin-install": "workspace:*",
     "@open-neko/plugin-parallel-search": "0.3.1",
     "@open-neko/plugin-types": "workspace:*",
     "dotenv": "^17.4.1",
+    "mysql2": "^3.15.3",
     "pg": "^8.20.0",
     "pg-boss": "^10.1.5",
-    "tsx": "^4.19.2"
+    "tsx": "^4.19.2",
+    "yaml": "^2.8.1"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/apps/worker/src/admin-server.ts
+++ b/apps/worker/src/admin-server.ts
@@ -211,6 +211,18 @@ export interface InstallPolicyHandlerSurface {
   }>;
 }
 
+export interface PacksHandlerSurface {
+  list(): Promise<unknown>;
+  inspect(packId: string): Promise<unknown>;
+  plan(packId: string): Promise<unknown>;
+  status(packId: string): Promise<unknown>;
+  doctor(packId: string): Promise<unknown>;
+  install(packId: string, input: Record<string, unknown>): Promise<unknown>;
+  configure(packId: string, input: Record<string, unknown>): Promise<unknown>;
+  upgrade(packId: string, input: Record<string, unknown>): Promise<unknown>;
+  uninstall(packId: string, input: Record<string, unknown>): Promise<unknown>;
+}
+
 export interface PluginsHandlerSurface {
   status(): PluginRegistryStatus;
   /**
@@ -318,6 +330,8 @@ export type AdminHandlerOptions = {
   recordsImports?: RecordsImportHandlerSurface | null;
   /** Trusted web→worker action creation so worker-owned preflight hooks run. */
   actionRequests?: ActionRequestHandlerSurface | null;
+  /** Embedded, first-party solution-pack lifecycle. */
+  packs?: PacksHandlerSurface | null;
 };
 
 export interface ActionRequestHandlerSurface {
@@ -376,6 +390,7 @@ export function createAdminHandler(opts: AdminHandlerOptions = {}) {
   const recordsWatches = opts.recordsWatches ?? null;
   const recordsImports = opts.recordsImports ?? null;
   const actionRequests = opts.actionRequests ?? null;
+  const packs = opts.packs ?? null;
 
   return function handle(req: IncomingMessage, res: ServerResponse) {
     if (req.method === "GET" && req.url === "/health") {
@@ -541,6 +556,38 @@ export function createAdminHandler(opts: AdminHandlerOptions = {}) {
       void handleInstallPolicy(res, installPolicy);
       return;
     }
+    if (req.method === "GET" && req.url === "/admin/packs") {
+      void handlePacksList(res, packs);
+      return;
+    }
+    const packPath = (req.url ?? "").split(/[?#]/, 1)[0] ?? "";
+    const packRoute = /^\/admin\/packs\/([^/]+)(?:\/(plan|status|doctor|install|configure|upgrade|uninstall))?$/.exec(
+      packPath,
+    );
+    if (packRoute) {
+      let packId: string;
+      try {
+        packId = decodeURIComponent(packRoute[1]!);
+      } catch {
+        json(res, 400, { error: "pack id contains invalid URL encoding" });
+        return;
+      }
+      const action = packRoute[2] ?? "inspect";
+      if (req.method === "GET" && !["install", "configure", "upgrade", "uninstall"].includes(action)) {
+        void handlePackRead(res, packs, packId, action as "inspect" | "plan" | "status" | "doctor");
+        return;
+      }
+      if (req.method === "POST" && ["install", "configure", "upgrade", "uninstall"].includes(action)) {
+        void handlePackApply(
+          req,
+          res,
+          packs,
+          packId,
+          action as "install" | "configure" | "upgrade" | "uninstall",
+        );
+        return;
+      }
+    }
     if (req.method === "GET" && req.url === "/admin/channels/providers") {
       handleChannelProviders(res, channels);
       return;
@@ -561,6 +608,66 @@ export function createAdminHandler(opts: AdminHandlerOptions = {}) {
     }
     res.writeHead(404).end();
   };
+}
+
+async function handlePacksList(
+  res: ServerResponse,
+  packs: PacksHandlerSurface | null,
+): Promise<void> {
+  if (!packs) {
+    json(res, 503, { error: "solution-pack service unavailable" });
+    return;
+  }
+  try {
+    json(res, 200, { packs: await packs.list() });
+  } catch (error) {
+    json(res, 500, { error: error instanceof Error ? error.message : String(error) });
+  }
+}
+
+async function handlePackRead(
+  res: ServerResponse,
+  packs: PacksHandlerSurface | null,
+  packId: string,
+  action: "inspect" | "plan" | "status" | "doctor",
+): Promise<void> {
+  if (!packs) {
+    json(res, 503, { error: "solution-pack service unavailable" });
+    return;
+  }
+  try {
+    const result = await packs[action](packId);
+    if (action === "status" && result === null) {
+      json(res, 404, { error: `pack ${packId} is not installed` });
+      return;
+    }
+    json(res, 200, result);
+  } catch (error) {
+    json(res, 400, { error: error instanceof Error ? error.message : String(error) });
+  }
+}
+
+async function handlePackApply(
+  req: IncomingMessage,
+  res: ServerResponse,
+  packs: PacksHandlerSurface | null,
+  packId: string,
+  action: "install" | "configure" | "upgrade" | "uninstall",
+): Promise<void> {
+  if (!packs) {
+    json(res, 503, { error: "solution-pack service unavailable" });
+    return;
+  }
+  const body = await readJson(req).catch(() => null);
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    json(res, 400, { error: "request body must be a JSON object" });
+    return;
+  }
+  try {
+    json(res, 200, await packs[action](packId, body as Record<string, unknown>));
+  } catch (error) {
+    json(res, 400, { error: error instanceof Error ? error.message : String(error) });
+  }
 }
 
 async function handleActionRequestCreate(

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -103,6 +103,7 @@ import { runBusinessProfileBuild } from "./jobs/business-profile-build.js";
 import { runIndustryInsightsBuild } from "./jobs/industry-insights-build.js";
 import { runBootstrapMetricsBuild } from "./jobs/bootstrap-metrics-build.js";
 import { runMetricRefresh } from "./jobs/metric-refresh.js";
+import { metricRefreshIsDue } from "./jobs/metric-schedule.js";
 import { runWorkRun } from "./jobs/work-run.js";
 import { runWorkflowCronSweep } from "./jobs/workflow-cron-sweep.js";
 import { runWorkflowRunFire } from "./jobs/workflow-run-fire.js";
@@ -164,6 +165,8 @@ import {
   initializeWorkerTelemetry,
   shutdownWorkerTelemetry,
 } from "./telemetry.js";
+import { PackService } from "./packs/service.js";
+import { registerPackActionPreflight } from "./packs/action-preflight.js";
 
 const PORT: number = 4100;
 const MAX_JOB_RETRIES: number = 2;
@@ -176,13 +179,14 @@ const RECONCILE_SWEEP_MIN_AGE_MS: number = Math.max(
   660_000,
   agentTurnTimeoutMs() + 240_000,
 );
-const SCHEDULED_REFRESH_HOURS: number = 24;
+const SCHEDULED_REFRESH_HOURS: number = 1;
 
 if (initializeWorkerTelemetry()) {
   console.log("[telemetry] OTLP trace export enabled");
 }
 
 const ADMIN_ORG_ID = await getOrgId();
+const packService = new PackService(ADMIN_ORG_ID);
 const recordsPool = new pg.Pool({
   ...buildRecordsPoolConfig(),
   application_name: "openneko-worker-records",
@@ -364,16 +368,29 @@ function makeHandler<P extends ProcessingJobPayload>(
 
 async function runMetricRefreshSweep() {
   const cards = await db()
-    .select({ id: metric.id, org_id: metric.org_id })
+    .select({
+      id: metric.id,
+      org_id: metric.org_id,
+      cadence: metric.cadence,
+      last_refresh_status: metric.last_refresh_status,
+      updated_at: metric.updated_at,
+    })
     .from(metric)
     .where(eq(metric.active, true));
-  if (cards.length === 0) {
-    console.log("[worker] scheduled sweep: no active metrics");
+  const now = new Date();
+  const due = cards.filter((card) => metricRefreshIsDue({
+    cadence: card.cadence,
+    lastRefreshStatus: card.last_refresh_status,
+    updatedAt: card.updated_at,
+    now,
+  }));
+  if (due.length === 0) {
+    console.log("[worker] scheduled sweep: no metrics are due");
     return;
   }
 
   let enqueued = 0;
-  for (const card of cards) {
+  for (const card of due) {
     const inserted = await db()
       .insert(processing_job)
       .values({
@@ -386,6 +403,12 @@ async function runMetricRefreshSweep() {
       .returning({ id: processing_job.id });
     const processingJobId = inserted[0]?.id;
     if (!processingJobId) continue;
+    await db().update(metric).set({
+      last_refresh_status: "pending",
+      last_refresh_error: null,
+      last_refresh_job_id: processingJobId,
+      updated_at: now,
+    }).where(eq(metric.id, card.id));
     await enqueue(QUEUE.METRIC_REFRESH, {
       processingJobId,
       orgId: card.org_id,
@@ -544,6 +567,17 @@ const server = createServer(
         return getInstallPolicyForOrg(ADMIN_ORG_ID);
       },
     },
+    packs: {
+      list: () => packService.list(),
+      inspect: (packId) => packService.inspect(packId),
+      plan: (packId) => packService.plan(packId),
+      status: (packId) => packService.status(packId),
+      doctor: (packId) => packService.doctor(packId),
+      install: (packId, input) => packService.install(packId, input),
+      configure: (packId, input) => packService.configure(packId, input),
+      upgrade: (packId, input) => packService.upgrade(packId, input),
+      uninstall: (packId, input) => packService.uninstall(packId, input),
+    },
     connect: {
       getConnectProviders: () => pluginRegistry?.getConnectProviders() ?? [],
       getOperatorConnectStatus: (operatorId) =>
@@ -677,6 +711,7 @@ const unregisterRecordArtifactImportPreflight = registerRecordArtifactImportActi
       singletonKey: `records-import:${payload.importRunId}`,
     }),
 });
+const unregisterPackActionPreflight = registerPackActionPreflight();
 // Only now may the web process create action requests through this worker:
 // every worker-owned preflight hook is registered and will finish before the
 // request id is returned for an approval card.
@@ -1467,6 +1502,7 @@ const shutdown = async (signal: string) => {
   unregisterRecordImportPreflight();
   unregisterRecordArtifactImportPreflight();
   unregisterRecordSalesforcePreflight();
+  unregisterPackActionPreflight();
   server.close();
   const cancelled = cancelAllAgents();
   if (cancelled > 0) {

--- a/apps/worker/src/jobs/deterministic-metric.ts
+++ b/apps/worker/src/jobs/deterministic-metric.ts
@@ -1,0 +1,346 @@
+import type { MetricAgentResult } from "@neko/llm";
+
+type MetricDefinition = {
+  title: string;
+  description?: string;
+  calculationNote?: string;
+  chartHint?: string;
+  unit?: string;
+  directionGood?: "up" | "down" | "neutral";
+  execution: {
+    mode: "saved_query";
+    source: string;
+    query: string;
+    document: string;
+    result: Record<string, unknown>;
+    freshnessSeconds: number;
+    runtime?: {
+      storeIds?: number[];
+      windowDays?: number;
+      staleAfterSeconds?: number;
+      agedAfterSeconds?: number;
+      stockThreshold?: number;
+      currency?: string;
+      timezone?: string;
+    };
+  };
+};
+
+export type DeterministicMetricOutput = {
+  result: MetricAgentResult;
+  value: number | null;
+  valueJson: unknown;
+  baseline: number | null;
+  deltaPct: number | null;
+  sourceFreshnessAt: Date | null;
+};
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+export function parseMetricDefinition(value: unknown): MetricDefinition {
+  const definition = record(value, "saved-query metric definition");
+  const execution = record(definition.execution, "saved-query metric execution");
+  if (execution.mode !== "saved_query") throw new Error("saved-query metric execution.mode is invalid");
+  for (const key of ["source", "query", "document"] as const) {
+    if (typeof execution[key] !== "string" || !String(execution[key]).trim()) {
+      throw new Error(`saved-query metric execution.${key} is required`);
+    }
+  }
+  const freshness = Number(execution.freshnessSeconds);
+  if (!Number.isInteger(freshness) || freshness <= 0) {
+    throw new Error("saved-query metric freshnessSeconds must be a positive integer");
+  }
+  const result = record(execution.result, "saved-query metric result mapping");
+  if (typeof result.kind !== "string") throw new Error("saved-query metric result.kind is required");
+  if (typeof definition.title !== "string" || !definition.title.trim()) {
+    throw new Error("saved-query metric title is required");
+  }
+  return definition as unknown as MetricDefinition;
+}
+
+function iso(date: Date): string {
+  return date.toISOString();
+}
+
+export function buildSavedQueryVariables(
+  definitionValue: unknown,
+  now = new Date(),
+): Record<string, unknown> {
+  const definition = parseMetricDefinition(definitionValue);
+  const runtime = definition.execution.runtime ?? {};
+  const windowDays = positive(runtime.windowDays, 30);
+  const staleAfterSeconds = positive(runtime.staleAfterSeconds, 2 * 60 * 60);
+  const agedAfterSeconds = positive(runtime.agedAfterSeconds, 2 * 24 * 60 * 60);
+  return {
+    from: iso(new Date(now.getTime() - windowDays * 86_400_000)),
+    to: iso(now),
+    now: iso(now),
+    staleBefore: iso(new Date(now.getTime() - staleAfterSeconds * 1_000)),
+    olderThan: iso(new Date(now.getTime() - agedAfterSeconds * 1_000)),
+    storeIds: runtime.storeIds?.length ? runtime.storeIds : [1],
+    threshold: Number.isFinite(runtime.stockThreshold) ? runtime.stockThreshold : 5,
+  };
+}
+
+function positive(value: unknown, fallback: number): number {
+  const number = Number(value);
+  return Number.isFinite(number) && number > 0 ? number : fallback;
+}
+
+function atPath(root: unknown, path: string): unknown {
+  let current = root;
+  for (const segment of path.split(".")) {
+    if (Array.isArray(current) && /^\d+$/.test(segment)) {
+      current = current[Number(segment)];
+    } else if (current && typeof current === "object" && segment in current) {
+      current = (current as Record<string, unknown>)[segment];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}
+
+function numberAt(root: unknown, path: string): number {
+  const value = atPath(root, path);
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed)) throw new Error(`saved-query result path ${path} is not numeric`);
+  return parsed;
+}
+
+function evaluateExpression(root: unknown, expression: unknown): number | null {
+  if (typeof expression === "number") return expression;
+  if (typeof expression === "string") return numberAt(root, expression);
+  const node = record(expression, "saved-query result expression");
+  const entries = Object.entries(node);
+  if (entries.length !== 1) throw new Error("saved-query expression must contain one operator");
+  const [operator, operands] = entries[0]!;
+  if (!Array.isArray(operands) || operands.length < 2) {
+    throw new Error(`saved-query expression ${operator} requires at least two operands`);
+  }
+  const values = operands.map((operand) => evaluateExpression(root, operand));
+  if (values.some((value) => value === null)) return null;
+  const numbers = values as number[];
+  switch (operator) {
+    case "add":
+      return numbers.reduce((sum, value) => sum + value, 0);
+    case "subtract":
+      return numbers.slice(1).reduce((value, operand) => value - operand, numbers[0]!);
+    case "multiply":
+      return numbers.reduce((value, operand) => value * operand, 1);
+    case "divide": {
+      const denominator = numbers.slice(1).reduce((value, operand) => value * operand, 1);
+      return denominator === 0 ? null : numbers[0]! / denominator;
+    }
+    default:
+      throw new Error(`saved-query result expression operator ${operator} is not allowed`);
+  }
+}
+
+function rowsAt(root: unknown, path: string): Record<string, unknown>[] {
+  const value = atPath(root, path);
+  if (!Array.isArray(value)) throw new Error(`saved-query result path ${path} is not an array`);
+  return value.map((row, index) => record(row, `${path}.${index}`));
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0
+    ? (sorted[middle - 1]! + sorted[middle]!) / 2
+    : sorted[middle]!;
+}
+
+function latestTimestamp(value: unknown): Date | null {
+  let latest: Date | null = null;
+  const visit = (candidate: unknown) => {
+    if (typeof candidate === "string" && /^\d{4}-\d{2}-\d{2}[T ]/.test(candidate)) {
+      const parsed = new Date(candidate);
+      if (!Number.isNaN(parsed.getTime()) && (!latest || parsed > latest)) latest = parsed;
+      return;
+    }
+    if (Array.isArray(candidate)) {
+      for (const item of candidate) visit(item);
+      return;
+    }
+    if (candidate && typeof candidate === "object") {
+      for (const item of Object.values(candidate as Record<string, unknown>)) visit(item);
+    }
+  };
+  visit(value);
+  return latest;
+}
+
+function rowLabel(row: Record<string, unknown>, index: number): string {
+  for (const key of ["sku", "indexer_id", "source_code", "store_id", "name", "status"]) {
+    if (row[key] !== undefined && row[key] !== null) return String(row[key]);
+  }
+  return String(index + 1);
+}
+
+function rowValue(row: Record<string, unknown>): number {
+  for (const key of ["sum_base_row_invoiced", "net_revenue", "quantity", "sum_qty_invoiced"]) {
+    const value = Number(row[key]);
+    if (Number.isFinite(value)) return value;
+  }
+  return 1;
+}
+
+function mapValue(
+  mapping: Record<string, unknown>,
+  data: Record<string, unknown>,
+  now: Date,
+): { value: number | null; valueJson: unknown; chartData: Array<{ d: string; v: number }> } {
+  switch (mapping.kind) {
+    case "scalar": {
+      const value = mapping.expression !== undefined
+        ? evaluateExpression(data, mapping.expression)
+        : numberAt(data, String(mapping.path));
+      return { value, valueJson: value, chartData: [{ d: "Current", v: value ?? 0 }] };
+    }
+    case "object": {
+      const paths = Array.isArray(mapping.paths) ? mapping.paths.map(String) : [];
+      const valueJson = Object.fromEntries(paths.map((path) => [path, atPath(data, path) ?? null]));
+      const chartData = paths.flatMap((path) => {
+        const value = Number(atPath(data, path));
+        return Number.isFinite(value) ? [{ d: path.split(".").at(-2) ?? path, v: value }] : [];
+      });
+      return {
+        value: chartData.reduce((sum, item) => sum + item.v, 0),
+        valueJson,
+        chartData: chartData.length ? chartData : [{ d: "Current", v: 0 }],
+      };
+    }
+    case "timestamps": {
+      const paths = Array.isArray(mapping.paths) ? mapping.paths.map(String) : [];
+      const ages = paths.map((path) => {
+        const date = new Date(String(atPath(data, path) ?? ""));
+        return {
+          d: path.split(".").at(-1) ?? path,
+          v: Number.isNaN(date.getTime()) ? null : Math.max(0, (now.getTime() - date.getTime()) / 1_000),
+        };
+      });
+      const valid = ages.filter((item): item is { d: string; v: number } => item.v !== null);
+      return {
+        value: valid.length ? Math.max(...valid.map((item) => item.v)) : null,
+        valueJson: Object.fromEntries(paths.map((path) => [path, atPath(data, path) ?? null])),
+        chartData: valid.length ? valid : [{ d: "Not yet available", v: 0 }],
+      };
+    }
+    case "timestamp_age_summary": {
+      const rows = rowsAt(data, String(mapping.rowsPath));
+      const path = String(mapping.timestampPath);
+      const ages = rows.map((row) => {
+        const date = new Date(String(atPath(row, path) ?? ""));
+        if (Number.isNaN(date.getTime())) throw new Error(`saved-query timestamp ${path} is invalid`);
+        return Math.max(0, (now.getTime() - date.getTime()) / 1_000);
+      });
+      const med = median(ages);
+      const max = ages.length ? Math.max(...ages) : 0;
+      return { value: med, valueJson: { median: med, max, count: rows.length }, chartData: [{ d: "Median", v: med }, { d: "Oldest", v: max }] };
+    }
+    case "rows": {
+      const rows = rowsAt(data, String(mapping.path));
+      return { value: rows.length, valueJson: rows, chartData: rows.slice(0, 20).map((row, index) => ({ d: rowLabel(row, index), v: rowValue(row) })).concat(rows.length ? [] : [{ d: "None", v: 0 }]) };
+    }
+    case "keyed_subtract": {
+      const left = record(mapping.left, "keyed_subtract.left");
+      const right = record(mapping.right, "keyed_subtract.right");
+      const totals = new Map<string, number>();
+      for (const row of rowsAt(data, String(left.rowsPath))) {
+        const key = String(atPath(row, String(left.keyPath)));
+        totals.set(key, (totals.get(key) ?? 0) + numberAt(row, String(left.valuePath)));
+      }
+      for (const row of rowsAt(data, String(right.rowsPath))) {
+        const key = String(atPath(row, String(right.keyPath)));
+        totals.set(key, (totals.get(key) ?? 0) - numberAt(row, String(right.valuePath)));
+      }
+      const chartData = [...totals].sort(([a], [b]) => a.localeCompare(b)).map(([d, v]) => ({ d, v }));
+      return { value: chartData.reduce((sum, item) => sum + item.v, 0), valueJson: Object.fromEntries(totals), chartData: chartData.length ? chartData : [{ d: "None", v: 0 }] };
+    }
+    default:
+      throw new Error(`saved-query result kind ${String(mapping.kind)} is not supported`);
+  }
+}
+
+function chartType(hint: string | undefined, points: number): MetricAgentResult["chartType"] {
+  if (hint === "bar" || hint === "table" || hint === "distribution" || points > 1) return "bar";
+  return "kpi";
+}
+
+function displayValue(value: number | null, unit: string | undefined, currency: string): string {
+  if (value === null) return "Not yet available";
+  const safe = value;
+  if (unit === "currency") {
+    return new Intl.NumberFormat("en-US", { style: "currency", currency, maximumFractionDigits: 2 }).format(safe);
+  }
+  if (unit === "percent") return `${new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(safe * 100)}%`;
+  if (unit === "duration_seconds") {
+    if (safe >= 86_400) return `${(safe / 86_400).toFixed(1)}d`;
+    if (safe >= 3_600) return `${(safe / 3_600).toFixed(1)}h`;
+    return `${Math.round(safe)}s`;
+  }
+  return new Intl.NumberFormat("en-US", { maximumFractionDigits: 2 }).format(safe);
+}
+
+function mood(value: number | null, baseline: number | null, direction: string | undefined): MetricAgentResult["mood"] {
+  if (value === null || baseline === null || direction === "neutral") return "watch";
+  if (value === baseline) return "watch";
+  if (direction === "up") return value > baseline ? "good" : "bad";
+  if (direction === "down") return value < baseline ? "good" : "bad";
+  return "watch";
+}
+
+export function mapSavedQueryMetric(input: {
+  definition: unknown;
+  data: unknown;
+  baseline?: number | null;
+  now?: Date;
+}): DeterministicMetricOutput {
+  const definition = parseMetricDefinition(input.definition);
+  const data = record(input.data, "saved-query response data");
+  const now = input.now ?? new Date();
+  const mapped = mapValue(definition.execution.result, data, now);
+  const baseline = input.baseline ?? null;
+  const deltaPct = mapped.value !== null && baseline !== null && baseline !== 0
+    ? ((mapped.value - baseline) / Math.abs(baseline)) * 100
+    : null;
+  const currency = definition.execution.runtime?.currency ?? "USD";
+  const type = chartType(definition.chartHint, mapped.chartData.length);
+  const chartData = mapped.chartData.map((point) => ({
+    ...point,
+    ...(type === "kpi" ? { t: baseline ?? mapped.value ?? 0 } : {}),
+  }));
+  const headline = displayValue(mapped.value, definition.unit, currency);
+  return {
+    value: mapped.value,
+    valueJson: mapped.valueJson,
+    baseline,
+    deltaPct,
+    sourceFreshnessAt: latestTimestamp(data),
+    result: {
+      reasoning: "Computed deterministically from a reviewed saved query; no language model selected or transformed the value.",
+      headlineMetric: headline,
+      headlineLabel: definition.title,
+      insightText: baseline === null
+        ? `${definition.title} is ${headline}; a comparison will appear after the next refresh.`
+        : `${definition.title} is ${headline}, ${deltaPct === null ? "with no comparable percentage change" : `${Math.abs(deltaPct).toFixed(1)}% ${deltaPct >= 0 ? "above" : "below"} the prior refresh`}.`,
+      detailText: definition.calculationNote ?? definition.description ?? definition.title,
+      mood: mood(mapped.value, baseline, definition.directionGood),
+      chartType: type,
+      chartData,
+      timeWindow: {
+        grain: "month",
+        start: new Date(now.getTime() - positive(definition.execution.runtime?.windowDays, 30) * 86_400_000).toISOString().slice(0, 10),
+        end: now.toISOString().slice(0, 10),
+        label: `Last ${positive(definition.execution.runtime?.windowDays, 30)} days`,
+      },
+    },
+  };
+}

--- a/apps/worker/src/jobs/metric-refresh.ts
+++ b/apps/worker/src/jobs/metric-refresh.ts
@@ -1,6 +1,8 @@
 import {
   and,
+  data_source,
   db,
+  desc,
   eq,
   metric,
   metric_snapshot,
@@ -20,6 +22,12 @@ import {
   persistProcessingJobTelemetry,
 } from "../telemetry.js";
 import { observeSafely } from "@neko/telemetry";
+import { graphjinQuery, mintGraphjinToken } from "@neko/llm/graphjin";
+import {
+  buildSavedQueryVariables,
+  mapSavedQueryMetric,
+  parseMetricDefinition,
+} from "./deterministic-metric.js";
 
 /**
  * metric_refresh job — runs the metric agent for ONE card and writes the
@@ -62,6 +70,8 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
 
   let metricRowId: string;
   let input: MetricAgentInput;
+  let savedQueryDefinition: Record<string, unknown> | null = null;
+  let savedQueryDefinitionHash: string | null = null;
 
   if (payload.metricId) {
     // Path 1: bootstrap card — load from metric table.
@@ -73,6 +83,9 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
         title: metric.title,
         why: metric.why,
         chart_hint: metric.chart_hint,
+        execution_mode: metric.execution_mode,
+        definition_json: metric.definition_json,
+        definition_hash: metric.definition_hash,
       })
       .from(metric)
       .where(eq(metric.id, payload.metricId))
@@ -80,6 +93,13 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
     const card = cards[0];
     if (!card) throw new Error(`metric ${payload.metricId} not found`);
     metricRowId = card.id;
+    if (card.execution_mode === "saved_query") {
+      savedQueryDefinition = card.definition_json;
+      savedQueryDefinitionHash = card.definition_hash;
+      if (!savedQueryDefinition || !savedQueryDefinitionHash) {
+        throw new Error(`saved-query metric ${payload.metricId} has no validated definition`);
+      }
+    }
     input = {
       orgId,
       role: card.role as MetricAgentInput["role"],
@@ -161,6 +181,18 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
     throw new Error(
       `metric_refresh job ${jobId} has neither metricId nor question in trigger_payload`,
     );
+  }
+
+  if (savedQueryDefinition && savedQueryDefinitionHash) {
+    await runDeterministicMetricRefresh({
+      jobId,
+      orgId,
+      metricId: metricRowId,
+      slug: input.slug,
+      definition: savedQueryDefinition,
+      definitionHash: savedQueryDefinitionHash,
+    });
+    return;
   }
 
   await updateProgress(jobId, "Running agent");
@@ -314,6 +346,160 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
         `[metric_refresh.telemetry] ${JSON.stringify(summary)}`,
       );
     }
+  }
+}
+
+function graphjinEndpoint(url: string): string {
+  const clean = url.replace(/\/+$/, "");
+  return clean.endsWith("/api/v1/graphql") ? clean : `${clean}/api/v1/graphql`;
+}
+
+async function runDeterministicMetricRefresh(input: {
+  jobId: string;
+  orgId: string;
+  metricId: string;
+  slug: string;
+  definition: Record<string, unknown>;
+  definitionHash: string;
+}): Promise<void> {
+  const startedAt = Date.now();
+  const telemetry = createWorkerHarnessObserver(input.jobId);
+  let failure: unknown;
+  await observeSafely(telemetry.observer, {
+    kind: "run.start",
+    operationId: `metric:${input.jobId}`,
+    attributes: {
+      "openneko.job.kind": "metric_refresh",
+      "openneko.metric.execution_mode": "saved_query",
+    },
+  });
+  try {
+    const definition = parseMetricDefinition(input.definition);
+    await updateProgress(input.jobId, "Running reviewed saved query");
+    const [source] = await db()
+      .select({
+        graphqlUrl: data_source.graphql_url,
+        authMode: data_source.auth_mode,
+      })
+      .from(data_source)
+      .where(and(eq(data_source.org_id, input.orgId), eq(data_source.enabled, true)))
+      .orderBy(desc(data_source.is_default), data_source.created_at)
+      .limit(1);
+    if (!source?.graphqlUrl) throw new Error("saved-query metric has no enabled GraphJin source");
+
+    const [previous] = await db()
+      .select({ value: metric_snapshot.value })
+      .from(metric_snapshot)
+      .where(eq(metric_snapshot.metric_id, input.metricId))
+      .orderBy(desc(metric_snapshot.captured_at))
+      .limit(1);
+    const previousValue = previous?.value === null || previous?.value === undefined
+      ? null
+      : Number(previous.value);
+    const baseline = previousValue !== null && Number.isFinite(previousValue) ? previousValue : null;
+    const now = new Date();
+    const response = await graphjinQuery<Record<string, unknown>>({
+      baseUrl: graphjinEndpoint(source.graphqlUrl),
+      query: definition.execution.document,
+      variables: buildSavedQueryVariables(input.definition, now),
+      role: "service",
+      ...(source.authMode === "jwt"
+        ? {
+            headers: {
+              authorization: `Bearer ${mintGraphjinToken({
+                orgId: input.orgId,
+                userId: null,
+                role: "service",
+              })}`,
+            },
+          }
+        : {}),
+      signal: AbortSignal.timeout(30_000),
+    });
+    if (response.errors?.length) {
+      throw new Error(`saved-query metric failed: ${response.errors.map((error) => error.message).join("; ")}`);
+    }
+    if (!response.data) throw new Error("saved-query metric returned no data");
+    const mapped = mapSavedQueryMetric({
+      definition: input.definition,
+      data: response.data,
+      baseline,
+      now,
+    });
+    const validationError = validateResult(mapped.result);
+    await observeSafely(telemetry.observer, {
+      kind: "validation.result",
+      operationId: `metric:${input.jobId}:persisted-contract`,
+      parentOperationId: `metric:${input.jobId}`,
+      status: validationError ? "error" : "ok",
+      ...(validationError ? { errorType: "metric_result_invalid" } : {}),
+      attributes: { "openneko.validation.contract": "deterministic-metric-persistence" },
+    });
+    if (validationError) throw new Error(`saved-query metric output invalid: ${validationError}`);
+
+    await updateProgress(input.jobId, "Saving deterministic snapshot");
+    const durationMs = Date.now() - startedAt;
+    await db().insert(metric_snapshot).values({
+      metric_id: input.metricId,
+      value: mapped.value === null ? null : String(mapped.value),
+      value_json: mapped.valueJson,
+      baseline: mapped.baseline === null ? null : String(mapped.baseline),
+      delta_pct: mapped.deltaPct === null ? null : String(mapped.deltaPct),
+      status: mapped.result.mood,
+      payload: mapped.result,
+      definition_hash: input.definitionHash,
+      source_freshness_at: mapped.sourceFreshnessAt,
+      duration_ms: durationMs,
+      error_class: null,
+    });
+    await db()
+      .update(metric)
+      .set({
+        last_refresh_status: "ok",
+        last_refresh_error: null,
+        last_refresh_job_id: input.jobId,
+        updated_at: new Date(),
+      })
+      .where(eq(metric.id, input.metricId));
+    console.log(
+      `[metric_refresh] org=${input.orgId} metric=${input.slug} mode=saved_query mood=${mapped.result.mood} durationMs=${durationMs}`,
+    );
+  } catch (error) {
+    failure = error;
+    const message = error instanceof Error ? error.message : String(error);
+    await db()
+      .update(metric)
+      .set({
+        last_refresh_status: "failed",
+        last_refresh_error: message.slice(0, 500),
+        last_refresh_job_id: input.jobId,
+        updated_at: new Date(),
+      })
+      .where(eq(metric.id, input.metricId));
+    await observeSafely(telemetry.observer, {
+      kind: "error",
+      operationId: `metric:${input.jobId}:saved-query-error`,
+      parentOperationId: `metric:${input.jobId}`,
+      status: "error",
+      errorType: error instanceof Error ? error.name : "unknown",
+    });
+    throw error;
+  } finally {
+    await observeSafely(telemetry.observer, {
+      kind: "run.end",
+      operationId: `metric:${input.jobId}`,
+      status: failure ? "error" : "ok",
+      ...(failure ? { errorType: failure instanceof Error ? failure.name : "unknown" } : {}),
+      attributes: {
+        "openneko.outcome": failure ? "failed" : "completed",
+        "openneko.metric.execution_mode": "saved_query",
+      },
+      measurements: {
+        durationMs: Date.now() - startedAt,
+        coverage: "unavailable",
+      },
+    });
+    await persistProcessingJobTelemetry(input.jobId, telemetry.snapshot());
   }
 }
 

--- a/apps/worker/src/jobs/metric-schedule.ts
+++ b/apps/worker/src/jobs/metric-schedule.ts
@@ -1,0 +1,26 @@
+const HOUR_MS = 60 * 60 * 1_000;
+
+export function metricCadenceMs(cadence: string): number {
+  switch (cadence.trim().toLowerCase()) {
+    case "hourly":
+      return HOUR_MS;
+    case "weekly":
+      return 7 * 24 * HOUR_MS;
+    case "daily":
+    default:
+      // Unknown legacy values fall back to the prior daily behavior instead
+      // of creating an accidental high-frequency refresh loop.
+      return 24 * HOUR_MS;
+  }
+}
+
+export function metricRefreshIsDue(input: {
+  cadence: string;
+  lastRefreshStatus: string | null;
+  updatedAt: Date;
+  now?: Date;
+}): boolean {
+  if (input.lastRefreshStatus === "pending") return false;
+  const now = input.now ?? new Date();
+  return input.updatedAt.getTime() + metricCadenceMs(input.cadence) <= now.getTime();
+}

--- a/apps/worker/src/packs/action-preflight.ts
+++ b/apps/worker/src/packs/action-preflight.ts
@@ -1,0 +1,58 @@
+import { and, db, eq, pack_action_definition } from "@neko/db";
+import {
+  registerActionRequestCreatedHook,
+  type ActionRequestRecord,
+} from "@neko/llm/workflows";
+
+export type PackActionReadiness = {
+  enabled: boolean;
+  readiness: string;
+  reason: string | null;
+};
+
+type PackActionLookup = (
+  orgId: string,
+  kind: string,
+) => Promise<PackActionReadiness | null>;
+
+const defaultLookup: PackActionLookup = async (orgId, kind) => {
+  const [definition] = await db()
+    .select({
+      enabled: pack_action_definition.enabled,
+      readiness: pack_action_definition.readiness,
+      reason: pack_action_definition.readiness_reason,
+    })
+    .from(pack_action_definition)
+    .where(
+      and(
+        eq(pack_action_definition.org_id, orgId),
+        eq(pack_action_definition.kind, kind),
+      ),
+    )
+    .limit(1);
+  return definition ?? null;
+};
+
+export function assertPackActionReady(
+  kind: string,
+  definition: PackActionReadiness,
+): void {
+  if (definition.enabled && definition.readiness === "ready") return;
+  const reason = definition.reason?.trim() || "the pack operator is unavailable";
+  throw new Error(`pack action ${kind} is blocked: ${reason}`);
+}
+
+/**
+ * Fail closed for action kinds owned by an installed pack. A pack action is
+ * allowed to reach approval/execution only after its operator adapter reports
+ * ready. Kinds that are not pack-owned continue through the normal action
+ * pipeline unchanged.
+ */
+export function registerPackActionPreflight(
+  lookup: PackActionLookup = defaultLookup,
+): () => void {
+  return registerActionRequestCreatedHook(async (request: ActionRequestRecord) => {
+    const definition = await lookup(request.orgId, request.kind);
+    if (definition) assertPackActionReady(request.kind, definition);
+  });
+}

--- a/apps/worker/src/packs/artifact-state.ts
+++ b/apps/worker/src/packs/artifact-state.ts
@@ -1,0 +1,285 @@
+import { lstat, readFile, readdir } from "node:fs/promises";
+import { extname, join, relative, resolve, sep } from "node:path";
+import {
+  action_policy,
+  and,
+  db,
+  eq,
+  metric,
+  pack_action_definition,
+  watcher,
+  workflow_definition,
+} from "@neko/db";
+import { canonicalHash, sha256, type PackArtifact } from "@neko/packs";
+import { parse as parseYaml } from "yaml";
+
+type ArtifactMetadata = Record<string, unknown>;
+
+export type PackArtifactLocator = {
+  source?: string;
+  role?: string;
+  slug?: string;
+  name?: string;
+  kind?: string;
+};
+
+const nativeStateKeys = {
+  metric: [
+    "role", "slug", "source", "title", "description", "why", "chart_hint", "unit",
+    "direction_good", "cadence", "active", "execution_mode", "definition_json",
+    "definition_version", "definition_hash",
+  ],
+  workflow: [
+    "name", "description", "enabled", "status", "goal", "cron", "cron_timezone",
+    "cron_enabled", "output_contract",
+  ],
+  watcher: [
+    "workflow_id", "name", "description", "enabled", "query", "value_path", "op",
+    "threshold", "cadence_seconds", "debounce_seconds", "cooldown_seconds", "dedupe_key",
+    "activation", "variables_json", "severity",
+  ],
+  policy: [
+    "name", "description", "applies_to_kinds", "applies_to_scopes", "mode",
+    "allowed_targets", "limits", "approver_role", "priority", "enabled",
+  ],
+  action: ["kind", "description", "definition", "definition_hash", "enabled"],
+} as const;
+
+type NativeStateKind = keyof typeof nativeStateKeys;
+
+export function nativeArtifactStateHash(
+  kind: NativeStateKind,
+  value: Record<string, unknown>,
+): string {
+  return canonicalHash(
+    Object.fromEntries(nativeStateKeys[kind].map((key) => [key, value[key] ?? null])),
+  );
+}
+
+function isMissing(error: unknown): boolean {
+  return (error as NodeJS.ErrnoException).code === "ENOENT";
+}
+
+async function hashMaterializedFile(path: string): Promise<string | null> {
+  let stat;
+  try {
+    stat = await lstat(path);
+  } catch (error) {
+    if (isMissing(error)) return null;
+    throw error;
+  }
+  if (stat.isSymbolicLink()) throw new Error(`pack-owned target became a symlink: ${path}`);
+  if (!stat.isFile()) throw new Error(`pack-owned target is not a file: ${path}`);
+  const raw = (await readFile(path, "utf8")).replace(/\r\n/g, "\n");
+  const extension = extname(path).toLowerCase();
+  if (extension === ".json") return canonicalHash(JSON.parse(raw));
+  if (extension === ".yaml" || extension === ".yml") return canonicalHash(parseYaml(raw));
+  return sha256(raw);
+}
+
+async function hashMarkdownTree(root: string, directory = root): Promise<string | null> {
+  let stat;
+  try {
+    stat = await lstat(directory);
+  } catch (error) {
+    if (isMissing(error)) return null;
+    throw error;
+  }
+  if (stat.isSymbolicLink()) throw new Error(`pack-owned skill became a symlink: ${directory}`);
+  if (!stat.isDirectory()) throw new Error(`pack-owned skill is not a directory: ${directory}`);
+  const entries = await readdir(directory, { withFileTypes: true });
+  const values: Array<{ path: string; hash: string }> = [];
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    const child = join(directory, entry.name);
+    if (entry.isSymbolicLink()) throw new Error(`pack-owned skill contains a symlink: ${child}`);
+    if (entry.isDirectory()) {
+      const hash = await hashMarkdownTree(root, child);
+      if (hash) values.push({ path: relative(root, child), hash });
+      continue;
+    }
+    if (!entry.isFile() || extname(entry.name).toLowerCase() !== ".md") {
+      throw new Error(`pack-owned skill contains a non-Markdown file: ${child}`);
+    }
+    values.push({ path: relative(root, child), hash: sha256((await readFile(child, "utf8")).replace(/\r\n/g, "\n")) });
+  }
+  return canonicalHash(values);
+}
+
+function safeMaterializedTarget(configFile: string, metadata: ArtifactMetadata): string | null {
+  const target = typeof metadata.materializedTarget === "string" ? metadata.materializedTarget : null;
+  if (!target) return null;
+  const root = resolve(configFile, "..");
+  const absolute = resolve(target);
+  const path = relative(root, absolute);
+  if (path === ".." || path.startsWith(`..${sep}`) || path.startsWith(sep)) {
+    throw new Error(`pack materialized target escapes GraphJin config root: ${target}`);
+  }
+  return absolute;
+}
+
+async function graphjinConfigState(
+  configFile: string,
+  kind: "source" | "relationships",
+  targetRef: string,
+  locator: PackArtifactLocator,
+): Promise<string | null> {
+  let raw: string;
+  try {
+    raw = await readFile(configFile, "utf8");
+  } catch (error) {
+    if (isMissing(error)) return null;
+    throw error;
+  }
+  const config = parseYaml(raw) as {
+    sources?: Array<Record<string, unknown>>;
+    tables?: Array<Record<string, unknown>>;
+    relationships?: Array<Record<string, unknown>>;
+  };
+  if (kind === "source") {
+    const source = config.sources?.find((value) => value.name === (locator.name ?? targetRef));
+    return source ? canonicalHash(source) : null;
+  }
+  const source = locator.source ?? targetRef;
+  const tables = (config.tables ?? []).filter(
+    (value) => value.source === source || value.database === source,
+  );
+  const relationships = (config.relationships ?? []).filter(
+    (value) =>
+      String(value.from ?? "").startsWith(`${source}:`) ||
+      String(value.to ?? "").startsWith(`${source}:`),
+  );
+  return tables.length || relationships.length
+    ? canonicalHash({ tables, relationships })
+    : null;
+}
+
+async function inspectNative(
+  orgId: string,
+  kind: "metric" | "workflow" | "watcher" | "policy" | "action",
+  targetRef: string,
+  locator: PackArtifactLocator,
+): Promise<string | null> {
+  switch (kind) {
+    case "metric": {
+      const [row] = await db().select().from(metric).where(and(
+        eq(metric.org_id, orgId),
+        eq(metric.role, locator.role ?? ""),
+        eq(metric.slug, locator.slug ?? targetRef),
+      )).limit(1);
+      return row ? nativeArtifactStateHash("metric", row as unknown as Record<string, unknown>) : null;
+    }
+    case "workflow": {
+      const [row] = await db().select().from(workflow_definition).where(and(
+        eq(workflow_definition.org_id, orgId),
+        eq(workflow_definition.owner_user_id, ""),
+        eq(workflow_definition.name, locator.name ?? targetRef),
+      )).limit(1);
+      return row ? nativeArtifactStateHash("workflow", row as unknown as Record<string, unknown>) : null;
+    }
+    case "watcher": {
+      const [row] = await db().select().from(watcher).where(and(
+        eq(watcher.org_id, orgId),
+        eq(watcher.name, locator.name ?? targetRef),
+      )).limit(1);
+      return row ? nativeArtifactStateHash("watcher", row as unknown as Record<string, unknown>) : null;
+    }
+    case "policy": {
+      const [row] = await db().select().from(action_policy).where(and(
+        eq(action_policy.org_id, orgId),
+        eq(action_policy.name, locator.name ?? targetRef),
+      )).limit(1);
+      return row ? nativeArtifactStateHash("policy", row as unknown as Record<string, unknown>) : null;
+    }
+    case "action": {
+      const [row] = await db().select().from(pack_action_definition).where(and(
+        eq(pack_action_definition.org_id, orgId),
+        eq(pack_action_definition.kind, locator.kind ?? targetRef),
+      )).limit(1);
+      return row ? nativeArtifactStateHash("action", row as unknown as Record<string, unknown>) : null;
+    }
+    default:
+      return null;
+  }
+}
+
+export function packArtifactLocator(artifact: PackArtifact): PackArtifactLocator {
+  const content = artifact.content && typeof artifact.content === "object" && !Array.isArray(artifact.content)
+    ? artifact.content as Record<string, unknown>
+    : {};
+  switch (artifact.kind) {
+    case "source":
+      return { name: artifact.targetRef };
+    case "relationships":
+      return { source: String(content.source ?? artifact.targetRef) };
+    case "metric":
+      return { role: String(content.role ?? ""), slug: artifact.targetRef };
+    case "workflow":
+    case "watcher":
+    case "policy":
+      return { name: String(content.name ?? artifact.targetRef) };
+    case "action":
+      return { kind: String(content.kind ?? artifact.targetRef) };
+    default:
+      return {};
+  }
+}
+
+function locatorFromMetadata(
+  metadata: ArtifactMetadata,
+  fallback?: PackArtifact,
+): PackArtifactLocator {
+  const value = metadata.locator;
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as PackArtifactLocator;
+  }
+  return fallback ? packArtifactLocator(fallback) : {};
+}
+
+export async function inspectInstalledPackArtifactCurrent(input: {
+  orgId: string;
+  kind: PackArtifact["kind"];
+  targetRef: string;
+  metadata: ArtifactMetadata;
+  graphjinConfigFile: string;
+  fallbackArtifact?: PackArtifact;
+}): Promise<string | null> {
+  const locator = locatorFromMetadata(input.metadata, input.fallbackArtifact);
+  switch (input.kind) {
+    case "source":
+    case "relationships":
+      return graphjinConfigState(input.graphjinConfigFile, input.kind, input.targetRef, locator);
+    case "spec":
+    case "saved_query": {
+      const target = safeMaterializedTarget(input.graphjinConfigFile, input.metadata);
+      return target ? hashMaterializedFile(target) : null;
+    }
+    case "skill": {
+      const target = typeof input.metadata.materializedTarget === "string"
+        ? input.metadata.materializedTarget
+        : null;
+      return target ? hashMarkdownTree(target) : null;
+    }
+    case "metric":
+    case "workflow":
+    case "watcher":
+    case "policy":
+    case "action":
+      return inspectNative(input.orgId, input.kind, input.targetRef, locator);
+  }
+}
+
+export async function inspectPackArtifactCurrent(input: {
+  orgId: string;
+  artifact: PackArtifact;
+  metadata: ArtifactMetadata;
+  graphjinConfigFile: string;
+}): Promise<string | null> {
+  return inspectInstalledPackArtifactCurrent({
+    orgId: input.orgId,
+    kind: input.artifact.kind,
+    targetRef: input.artifact.targetRef,
+    metadata: input.metadata,
+    graphjinConfigFile: input.graphjinConfigFile,
+    fallbackArtifact: input.artifact,
+  });
+}

--- a/apps/worker/src/packs/graphjin-config.ts
+++ b/apps/worker/src/packs/graphjin-config.ts
@@ -1,0 +1,288 @@
+import { randomUUID } from "node:crypto";
+import { readFile, rename, stat, writeFile } from "node:fs/promises";
+import { parse, parseDocument } from "yaml";
+import {
+  acquireGraphjinConfigLock,
+  graphjinInputWithJsonVariables,
+  persistGraphjinSourceConfigUpdate,
+} from "@neko/llm/graphjin";
+import {
+  graphjinQuery,
+  mintGraphjinToken,
+  type GraphjinQueryResult,
+} from "@neko/llm/graphjin";
+
+export type AppliedGraphjinConfig = {
+  catalogRevision: string | null;
+  restore: () => Promise<void>;
+};
+
+function configArray(value: unknown): Record<string, unknown>[] {
+  if (typeof value === "string") {
+    try {
+      return configArray(JSON.parse(value));
+    } catch {
+      return [];
+    }
+  }
+  return Array.isArray(value)
+    ? value.filter(
+        (item): item is Record<string, unknown> =>
+          Boolean(item) && typeof item === "object" && !Array.isArray(item),
+      )
+    : [];
+}
+
+export function durablePackTables(value: unknown): Record<string, unknown>[] {
+  return configArray(value).map((table) => {
+    if (typeof table.source !== "string" || !table.source.trim()) return table;
+    const { database: _database, ...durable } = table;
+    return durable;
+  });
+}
+
+function mergeByKey(
+  current: Record<string, unknown>[],
+  additions: Record<string, unknown>[],
+  key: (value: Record<string, unknown>) => string,
+): Record<string, unknown>[] {
+  const merged = new Map(current.map((value) => [key(value), value]));
+  for (const value of additions) merged.set(key(value), value);
+  return [...merged.values()];
+}
+
+function isCatalogRevisionConflict(messages: Array<string | null | undefined>): boolean {
+  return messages.some((message) =>
+    Boolean(message?.includes("expected_catalog_revision") && message.includes("does not match")),
+  );
+}
+
+function currentRevisionFromConflict(messages: Array<string | null | undefined>): string | null {
+  for (const message of messages) {
+    const match = /current catalog_revision[^a-f0-9]*([a-f0-9]{64})/i.exec(message ?? "");
+    if (match?.[1]) return match[1];
+  }
+  return null;
+}
+
+async function persistPackSections(
+  configFile: string,
+  update: Record<string, unknown>,
+): Promise<void> {
+  if (!update.tables && !update.relationships) return;
+  const raw = await readFile(configFile, "utf8");
+  const document = parseDocument(raw);
+  if (document.errors.length > 0 || !document.contents) {
+    throw new Error("GraphJin config is invalid after source persistence");
+  }
+  if (update.tables) {
+    // GraphJin 3.18 needs `database` to resolve a table against a source that
+    // is being introduced in the same live patch, but rejects that legacy
+    // alias on a later config-file reload. Keep it ephemeral.
+    document.set("tables", durablePackTables(update.tables));
+  }
+  if (update.relationships) document.set("relationships", update.relationships);
+  const mode = (await stat(configFile)).mode & 0o777;
+  const temporary = `${configFile}.${randomUUID()}.pack-sections`;
+  await writeFile(temporary, document.toString(), { mode });
+  await rename(temporary, configFile);
+}
+
+/**
+ * Apply one trusted pack update through GraphJin's preview/apply boundary and
+ * persist the source portion to the shared config file. The live preview is
+ * what seals plaintext connection credentials into GraphJin's keystore; the
+ * durable YAML receives only gjsecret:// references.
+ */
+export async function applyPackGraphjinConfig(input: {
+  endpoint: string;
+  orgId: string;
+  configFile: string;
+  update: Record<string, unknown>;
+  ownedSourceNames?: Set<string>;
+  sectionMode?: "merge" | "replace";
+}): Promise<AppliedGraphjinConfig> {
+  const release = await acquireGraphjinConfigLock({ configFile: input.configFile });
+  try {
+    const previous = await readFile(input.configFile);
+    const previousMode = (await stat(input.configFile)).mode & 0o777;
+    const durableConfig = parse(previous.toString("utf8")) as {
+      tables?: unknown;
+      relationships?: unknown;
+    };
+    const headers = {
+      authorization: `Bearer ${mintGraphjinToken({
+        orgId: input.orgId,
+        userId: "pack-installer",
+        role: "admin",
+        ttlSeconds: 120,
+      })}`,
+    };
+    const requestedTables = configArray(input.update.tables);
+    const requestedRelationships = configArray(input.update.relationships);
+    const requestedSources = configArray(input.update.update_sources);
+    let appliedUpdate: Record<string, unknown> | null = null;
+    let catalogRevision: string | null = null;
+    let conflictRevision: string | null = null;
+    const maxRevisionAttempts = 8;
+    for (let attempt = 1; attempt <= maxRevisionAttempts; attempt++) {
+      // GraphJin 3.18's response cache also covers gj_config reads. Give each
+      // optimistic-concurrency attempt a unique operation name so a reload
+      // cannot strand the installer on a cached catalog revision.
+      const revisionOperation = `PackConfigRevision_${attempt}_${randomUUID().replaceAll("-", "")}`;
+      const current = await graphjinQuery<{
+        gj_config?: { catalog_revision?: string; sources?: unknown; tables?: unknown; relationships?: unknown };
+      }>({
+        baseUrl: input.endpoint,
+        headers,
+        query: `query ${revisionOperation} { gj_config(id: "current") { catalog_revision sources tables relationships } }`,
+      });
+      const reportedRevision = current.data?.gj_config?.catalog_revision;
+      if (!reportedRevision || current.errors?.length) {
+        throw new Error(
+          `pack GraphJin config revision unavailable: ${current.errors?.map((error) => error.message).join("; ") ?? "no revision"}`,
+        );
+      }
+      // In GraphJin 3.18.42, filesystem discovery can invalidate the live
+      // catalog before its cached gj_config row catches up. A stale-revision
+      // rejection includes the authoritative current revision; carry that
+      // guarded value into the next preview attempt.
+      const revision = conflictRevision ?? reportedRevision;
+
+      const currentSourceNames = new Set(
+        configArray(current.data?.gj_config?.sources).map((source) => String(source.name ?? "")),
+      );
+      for (const source of requestedSources) {
+        const name = String(source.name ?? "");
+        if (name && currentSourceNames.has(name) && !input.ownedSourceNames?.has(name)) {
+          throw new Error(`GraphJin source ${name} already exists and is not owned by this pack`);
+        }
+      }
+      const update = {
+        ...input.update,
+        ...(input.sectionMode === "replace" && Object.hasOwn(input.update, "tables")
+          ? { tables: requestedTables }
+          : requestedTables.length > 0
+          ? {
+              tables: mergeByKey(
+                configArray(durableConfig.tables),
+                requestedTables,
+                (value) => `${String(value.source ?? "")}:${String(value.name ?? "")}`,
+              ),
+            }
+          : {}),
+        ...(input.sectionMode === "replace" && Object.hasOwn(input.update, "relationships")
+          ? { relationships: requestedRelationships }
+          : requestedRelationships.length > 0
+          ? {
+              relationships: mergeByKey(
+                configArray(durableConfig.relationships),
+                requestedRelationships,
+                (value) => `${String(value.from ?? "")}->${String(value.to ?? "")}`,
+              ),
+            }
+          : {}),
+      };
+      const previewInput = graphjinInputWithJsonVariables({
+        mode: "preview",
+        expected_catalog_revision: revision,
+        ...update,
+      });
+      let preview: GraphjinQueryResult<{
+        gj_config?: { valid?: boolean; preview_id?: string; errors_json?: string };
+      }>;
+      try {
+        preview = await graphjinQuery({
+          baseUrl: input.endpoint,
+          headers,
+          query: `mutation${previewInput.variableDefinitions} { gj_config(id: "current", update: ${previewInput.literal}) { valid preview_id errors_json } }`,
+          variables: previewInput.variables,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (attempt < maxRevisionAttempts && isCatalogRevisionConflict([message])) {
+          conflictRevision = currentRevisionFromConflict([message]);
+          await new Promise((resolve) => setTimeout(resolve, 250));
+          continue;
+        }
+        throw error;
+      }
+      const previewResult = preview.data?.gj_config;
+      const previewMessages = [
+        ...(preview.errors?.map((error) => error.message) ?? []),
+        previewResult?.errors_json,
+      ];
+      if (preview.errors?.length || !previewResult?.valid || !previewResult.preview_id) {
+        if (attempt < maxRevisionAttempts && isCatalogRevisionConflict(previewMessages)) {
+          conflictRevision = currentRevisionFromConflict(previewMessages);
+          await new Promise((resolve) => setTimeout(resolve, 250));
+          continue;
+        }
+        throw new Error(
+          `pack GraphJin config preview failed: ${preview.errors?.map((error) => error.message).join("; ") ?? previewResult?.errors_json ?? "invalid preview"}`,
+        );
+      }
+
+      const applyInput = graphjinInputWithJsonVariables({
+        mode: "apply",
+        preview_id: previewResult.preview_id,
+        expected_catalog_revision: revision,
+        ...update,
+      });
+      let applied: GraphjinQueryResult<{
+        gj_config?: { applied?: boolean; catalog_revision?: string; errors_json?: string };
+      }>;
+      try {
+        applied = await graphjinQuery({
+          baseUrl: input.endpoint,
+          headers,
+          query: `mutation${applyInput.variableDefinitions} { gj_config(id: "current", update: ${applyInput.literal}) { applied catalog_revision errors_json } }`,
+          variables: applyInput.variables,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (attempt < maxRevisionAttempts && isCatalogRevisionConflict([message])) {
+          conflictRevision = currentRevisionFromConflict([message]);
+          await new Promise((resolve) => setTimeout(resolve, 250));
+          continue;
+        }
+        throw error;
+      }
+      const result = applied.data?.gj_config;
+      const applyMessages = [
+        ...(applied.errors?.map((error) => error.message) ?? []),
+        result?.errors_json,
+      ];
+      if (applied.errors?.length || !result?.applied) {
+        if (attempt < maxRevisionAttempts && isCatalogRevisionConflict(applyMessages)) {
+          conflictRevision = currentRevisionFromConflict(applyMessages);
+          await new Promise((resolve) => setTimeout(resolve, 250));
+          continue;
+        }
+        throw new Error(
+          `pack GraphJin config apply failed: ${applied.errors?.map((error) => error.message).join("; ") ?? result?.errors_json ?? "apply rejected"}`,
+        );
+      }
+      appliedUpdate = update;
+      catalogRevision = result.catalog_revision ?? null;
+      break;
+    }
+    if (!appliedUpdate) throw new Error("pack GraphJin config revision did not stabilize");
+
+    await persistGraphjinSourceConfigUpdate({
+      configFile: input.configFile,
+      update: appliedUpdate,
+    });
+    await persistPackSections(input.configFile, appliedUpdate);
+    return {
+      catalogRevision,
+      restore: async () => {
+        const temporary = `${input.configFile}.${randomUUID()}.pack-rollback`;
+        await writeFile(temporary, previous, { mode: previousMode });
+        await rename(temporary, input.configFile);
+      },
+    };
+  } finally {
+    await release();
+  }
+}

--- a/apps/worker/src/packs/magento-preflight.ts
+++ b/apps/worker/src/packs/magento-preflight.ts
@@ -1,0 +1,352 @@
+import { request as httpRequest } from "node:http";
+import { request as httpsRequest } from "node:https";
+import { createConnection, type Connection } from "mysql2/promise";
+import type { RowDataPacket } from "mysql2";
+
+interface GrantRow extends RowDataPacket {}
+
+interface CoreConfigRow extends RowDataPacket {
+  path: string;
+  value: string | null;
+}
+
+interface DatabaseVersionRow extends RowDataPacket {
+  database_version: string;
+  sql_mode: string;
+  database_timezone: string;
+}
+
+interface TableNameRow extends RowDataPacket {
+  table_name: string;
+}
+
+interface StoreRow extends RowDataPacket {
+  store_id: number;
+}
+
+export const MAGENTO_ANALYTICS_TABLES = [
+  "sales_order",
+  "sales_order_item",
+  "sales_invoice",
+  "sales_invoice_item",
+  "sales_creditmemo",
+  "sales_creditmemo_item",
+  "sales_shipment",
+  "sales_shipment_item",
+  "catalog_product_entity",
+  "catalog_product_entity_decimal",
+  "catalog_product_entity_int",
+  "catalog_product_entity_varchar",
+  "catalog_category_product",
+  "inventory_source_item",
+  "inventory_reservation",
+  "cataloginventory_stock_item",
+  "store",
+  "store_group",
+  "store_website",
+  "cron_schedule",
+  "indexer_state",
+] as const;
+
+const REQUIRED_TABLES = [
+  "sales_order",
+  "sales_order_item",
+  "sales_invoice",
+  "sales_invoice_item",
+  "sales_creditmemo",
+  "sales_creditmemo_item",
+  "sales_shipment",
+  "sales_shipment_item",
+  "catalog_product_entity",
+  "inventory_source_item",
+  "store",
+  "store_group",
+  "store_website",
+  "cron_schedule",
+  "indexer_state",
+] as const;
+
+export type MagentoPreflightInput = {
+  host: string;
+  port: number;
+  database: string;
+  username: string;
+  password: string;
+  tablePrefix: string;
+  baseUrl: string;
+  storeCode: string;
+  integrationToken?: string | null;
+};
+
+export type MagentoPreflightResult = {
+  databaseVersion: string;
+  databaseType: "mariadb" | "mysql";
+  sqlMode: string;
+  databaseTimezone: string;
+  tablePrefix: string;
+  tableNames: string[];
+  availableAnalyticsTables: string[];
+  blockedTables: string[];
+  storeIds: number[];
+  baseCurrency: string | null;
+  timezone: string | null;
+  magentoVersion: string;
+  operatorReadiness:
+    | "integration_token_missing"
+    | "integration_token_invalid"
+    | "acl_missing"
+    | "graphjin_version_unsupported";
+};
+
+function quoteIdentifier(value: string): string {
+  if (!/^[A-Za-z0-9_]+$/.test(value)) {
+    throw new Error(`invalid Magento SQL identifier: ${value}`);
+  }
+  return `\`${value}\``;
+}
+
+export function supportedMagentoDatabase(
+  version: string,
+): { type: "mariadb" | "mysql"; version: string } {
+  const match = /^(\d+)\.(\d+)/.exec(version.trim());
+  if (!match) throw new Error(`could not parse MariaDB/MySQL version ${JSON.stringify(version)}`);
+  const major = Number(match[1]);
+  const minor = Number(match[2]);
+  const type = /mariadb/i.test(version) ? "mariadb" : "mysql";
+  const supported = type === "mariadb"
+    ? major > 10 || (major === 10 && minor >= 6)
+    : major >= 8;
+  if (!supported) {
+    throw new Error(
+      `${type === "mariadb" ? "MariaDB 10.6+" : "MySQL 8.0+"} is required; found ${version}`,
+    );
+  }
+  return { type, version };
+}
+
+function grantedPrivileges(grant: string): string[] {
+  const match = /^GRANT\s+(.+?)\s+ON\s+/i.exec(grant);
+  if (!match) return [];
+  return match[1]!
+    .split(",")
+    .map((value) => value.trim().toUpperCase())
+    .filter(Boolean);
+}
+
+async function assertReadOnlyGrants(connection: Connection): Promise<void> {
+  const [rows] = await connection.query<GrantRow[]>("SHOW GRANTS FOR CURRENT_USER()");
+  const allowed = new Set(["SELECT", "SHOW VIEW", "USAGE"]);
+  for (const row of rows) {
+    const grant = Object.values(row as unknown as Record<string, string>)[0] ?? "";
+    if (/WITH\s+GRANT\s+OPTION/i.test(grant)) {
+      throw new Error("analytics account must not have GRANT OPTION");
+    }
+    const unexpected = grantedPrivileges(grant).filter((privilege) => !allowed.has(privilege));
+    if (unexpected.length > 0 || /ALL PRIVILEGES/i.test(grant)) {
+      throw new Error(`analytics account is not read-only (unexpected grants: ${unexpected.join(", ") || "ALL PRIVILEGES"})`);
+    }
+  }
+}
+
+function detectTablePrefix(tableNames: string[], configured: string): string {
+  if (configured && !/^[A-Za-z0-9_]+$/.test(configured)) {
+    throw new Error("magento.table_prefix may contain letters, numbers, and underscores only");
+  }
+  const candidates = configured
+    ? [configured]
+    : tableNames
+        .filter((name) => name.endsWith("sales_order"))
+        .map((name) => name.slice(0, -"sales_order".length));
+  const valid = [...new Set(candidates)].filter((prefix) =>
+    REQUIRED_TABLES.every((table) => tableNames.includes(`${prefix}${table}`)),
+  );
+  if (valid.length === 0) {
+    throw new Error("Magento analytics tables are missing or the table prefix is incorrect");
+  }
+  if (valid.length > 1) {
+    throw new Error(`multiple Magento table prefixes detected: ${valid.map((value) => value || "<empty>").join(", ")}`);
+  }
+  return valid[0]!;
+}
+
+async function discoverCoreConfig(
+  connection: Connection,
+  prefix: string,
+): Promise<{ baseCurrency: string | null; timezone: string | null }> {
+  const table = quoteIdentifier(`${prefix}core_config_data`);
+  const [rows] = await connection.query<CoreConfigRow[]>(
+    `SELECT path, value FROM ${table} WHERE scope = 'default' AND scope_id = 0 AND path IN ('currency/options/base', 'general/locale/timezone')`,
+  );
+  const config = new Map(rows.map((row) => [row.path, row.value]));
+  return {
+    baseCurrency: config.get("currency/options/base") ?? null,
+    timezone: config.get("general/locale/timezone") ?? null,
+  };
+}
+
+async function discoverStoreIds(
+  connection: Connection,
+  prefix: string,
+  storeCode: string,
+): Promise<number[]> {
+  const table = quoteIdentifier(`${prefix}store`);
+  const normalized = storeCode.trim();
+  const [rows] = normalized === "all"
+    ? await connection.execute<StoreRow[]>(
+        `SELECT store_id FROM ${table} WHERE is_active = 1 AND code <> 'admin' ORDER BY store_id`,
+      )
+    : await connection.execute<StoreRow[]>(
+        `SELECT store_id FROM ${table} WHERE is_active = 1 AND code = ? ORDER BY store_id`,
+        [normalized],
+      );
+  const ids = rows.map((row) => Number(row.store_id)).filter(Number.isInteger);
+  if (ids.length === 0) {
+    throw new Error(`Magento store code ${JSON.stringify(storeCode)} is missing or inactive`);
+  }
+  return ids;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+}
+
+type HostHeaderResponse = { status: number; text: string };
+
+async function requestWithHostHeader(endpoint: string, host: string): Promise<HostHeaderResponse> {
+  return new Promise((resolve, reject) => {
+    const url = new URL(endpoint);
+    const request = (url.protocol === "https:" ? httpsRequest : httpRequest)(
+      url,
+      { headers: { host } },
+      (response) => {
+        const chunks: Buffer[] = [];
+        let length = 0;
+        response.on("data", (chunk: Buffer) => {
+          length += chunk.length;
+          if (length > 64 * 1024) {
+            request.destroy(new Error("Magento version response exceeded 64 KiB"));
+            return;
+          }
+          chunks.push(chunk);
+        });
+        response.on("end", () => {
+          resolve({
+            status: response.statusCode ?? 0,
+            text: Buffer.concat(chunks).toString("utf8"),
+          });
+        });
+      },
+    );
+    request.setTimeout(10_000, () => request.destroy(new Error("Magento version preflight timed out")));
+    request.on("error", reject);
+    request.end();
+  });
+}
+
+export async function readMagentoVersion(
+  baseUrl: string,
+  hostHeaderRequest: (endpoint: string, host: string) => Promise<HostHeaderResponse> = requestWithHostHeader,
+): Promise<string> {
+  const endpoint = `${baseUrl.replace(/\/+$/, "")}/magento_version`;
+  const request = { redirect: "manual" as const, signal: AbortSignal.timeout(10_000) };
+  let response = await fetch(endpoint, request);
+  let responseText: string | null = null;
+  let responseStatus = response.status;
+  const location = response.headers.get("location");
+  if (response.status >= 300 && response.status < 400 && location) {
+    const source = new URL(endpoint);
+    const target = new URL(location, source);
+    if (!isLoopbackHostname(source.hostname) && isLoopbackHostname(target.hostname)) {
+      // Local Compose stores commonly advertise http://localhost while callers
+      // reach them through a host gateway. Preserve the routable address and
+      // send Magento its configured Host header so version discovery does not
+      // escape back into the worker container itself.
+      const retried = await hostHeaderRequest(endpoint, target.host);
+      responseStatus = retried.status;
+      responseText = retried.text;
+    } else {
+      response = await fetch(endpoint, {
+        redirect: "follow",
+        signal: AbortSignal.timeout(10_000),
+      });
+      responseStatus = response.status;
+    }
+  }
+  if (responseStatus < 200 || responseStatus >= 300) {
+    throw new Error(`Magento version preflight failed: HTTP ${responseStatus}`);
+  }
+  const text = responseText ?? (await response.text());
+  const match = /2\.4(?:\.\d+(?:-p\d+)?)?/i.exec(text);
+  if (!match) throw new Error("Magento version endpoint did not report a supported 2.4.x version");
+  return match[0] === "2.4" ? "2.4.x" : match[0];
+}
+
+async function operatorReadiness(input: MagentoPreflightInput): Promise<MagentoPreflightResult["operatorReadiness"]> {
+  if (!input.integrationToken) return "integration_token_missing";
+  const url = new URL(
+    `${input.baseUrl.replace(/\/+$/, "")}/rest/${encodeURIComponent(input.storeCode)}/V1/orders`,
+  );
+  url.searchParams.set("searchCriteria[pageSize]", "1");
+  const response = await fetch(url, {
+    headers: { authorization: `Bearer ${input.integrationToken}` },
+    signal: AbortSignal.timeout(10_000),
+  }).catch(() => null);
+  if (!response) return "integration_token_invalid";
+  if (response.status === 401) return "integration_token_invalid";
+  if (response.status === 403) return "acl_missing";
+  if (!response.ok) return "acl_missing";
+  // The current OpenNeko pin lacks the released GraphJin mutation contract.
+  return "graphjin_version_unsupported";
+}
+
+export async function runMagentoPreflight(
+  input: MagentoPreflightInput,
+): Promise<MagentoPreflightResult> {
+  const connection = await createConnection({
+    host: input.host,
+    port: input.port,
+    database: input.database,
+    user: input.username,
+    password: input.password,
+    connectTimeout: 10_000,
+    multipleStatements: false,
+  });
+  try {
+    await assertReadOnlyGrants(connection);
+    const [versionRows] = await connection.query<DatabaseVersionRow[]>(
+      "SELECT VERSION() AS database_version, @@sql_mode AS sql_mode, @@session.time_zone AS database_timezone",
+    );
+    const [tableRows] = await connection.execute<TableNameRow[]>(
+      "SELECT table_name FROM information_schema.tables WHERE table_schema = ? ORDER BY table_name",
+      [input.database],
+    );
+    const tableNames = tableRows.map((row) => row.table_name);
+    const tablePrefix = detectTablePrefix(tableNames, input.tablePrefix);
+    const analyticsTables = new Set<string>(
+      MAGENTO_ANALYTICS_TABLES.map((name) => `${tablePrefix}${name}`),
+    );
+    const config = await discoverCoreConfig(connection, tablePrefix);
+    const storeIds = await discoverStoreIds(connection, tablePrefix, input.storeCode);
+    const database = versionRows[0];
+    if (!database) throw new Error("MariaDB/MySQL version preflight returned no row");
+    const supportedDatabase = supportedMagentoDatabase(database.database_version);
+    return {
+      databaseVersion: database.database_version,
+      databaseType: supportedDatabase.type,
+      sqlMode: database.sql_mode,
+      databaseTimezone: database.database_timezone,
+      tablePrefix,
+      tableNames,
+      availableAnalyticsTables: MAGENTO_ANALYTICS_TABLES.filter((name) =>
+        tableNames.includes(`${tablePrefix}${name}`),
+      ),
+      blockedTables: tableNames.filter((name) => !analyticsTables.has(name)),
+      storeIds,
+      ...config,
+      magentoVersion: await readMagentoVersion(input.baseUrl),
+      operatorReadiness: await operatorReadiness(input),
+    };
+  } finally {
+    await connection.end();
+  }
+}

--- a/apps/worker/src/packs/service.ts
+++ b/apps/worker/src/packs/service.ts
@@ -1,0 +1,2027 @@
+import { randomUUID } from "node:crypto";
+import {
+  cp,
+  lstat,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { basename, dirname, extname, join, relative, resolve, sep } from "node:path";
+import {
+  action_policy,
+  and,
+  data_source,
+  db,
+  desc,
+  eq,
+  metric,
+  pack_action_definition,
+  pack_artifact,
+  pack_install,
+  pack_operation,
+  processing_job,
+  pool,
+  watcher,
+  workflow_definition,
+} from "@neko/db";
+import { ensureOrgWorkspace } from "@neko/llm/work";
+import { graphjinQuery, mintGraphjinToken } from "@neko/llm/graphjin";
+import {
+  canonicalHash,
+  loadSolutionPack,
+  planPack,
+  type PackArtifact,
+  type PackPlan,
+  type SolutionPackBundle,
+} from "@neko/packs";
+import {
+  readSecretsStore,
+  writeSecretsStore,
+} from "@open-neko/plugin-install/secrets";
+import { applyPackGraphjinConfig } from "./graphjin-config.js";
+import {
+  MAGENTO_ANALYTICS_TABLES,
+  runMagentoPreflight,
+  type MagentoPreflightResult,
+} from "./magento-preflight.js";
+import {
+  inspectPackArtifactCurrent,
+  inspectInstalledPackArtifactCurrent,
+  nativeArtifactStateHash,
+  packArtifactLocator,
+} from "./artifact-state.js";
+
+const PACK_ID = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/;
+const PACK_SECRET_PREFIX = "pack.";
+
+type PackInstallRequest = {
+  inputs?: Record<string, unknown>;
+  secrets?: Record<string, string>;
+  secretRefs?: Record<string, string>;
+  idempotencyKey?: string;
+  actorUserId?: string | null;
+};
+
+type PackUninstallRequest = {
+  idempotencyKey?: string;
+  actorUserId?: string | null;
+};
+
+type PackStatus = {
+  packId: string;
+  version: string;
+  status: string;
+  readiness: Record<string, { status: string; reason: string | null }>;
+  installedAt: string | null;
+  lastError: string | null;
+};
+
+type PackDoctorResult = {
+  packId: string;
+  status: "ready" | "degraded" | "blocked";
+  checks: Array<{
+    id: string;
+    status: "ready" | "optional" | "blocked";
+    detail: string;
+  }>;
+};
+
+function operatorReadinessDetail(
+  reason: MagentoPreflightResult["operatorReadiness"] | null,
+): string {
+  switch (reason) {
+    case "integration_token_missing":
+      return "View only. Add a Magento API token if you later want to allow specific, approval-required changes; store insights and automations are fully available without it.";
+    case "integration_token_invalid":
+      return "View only because Magento rejected the saved API token. Store insights and automations are unaffected.";
+    case "acl_missing":
+      return "View only because the saved API token does not have the required Magento permissions. Store insights and automations are unaffected.";
+    case "graphjin_version_unsupported":
+      return "View only in this version. Store insights and automations are fully available.";
+    default:
+      return "View-only access could not be checked because the reporting connection is unavailable.";
+  }
+}
+
+function artifactRecord(artifact: PackArtifact): Record<string, unknown> {
+  if (!artifact.content || typeof artifact.content !== "object" || Array.isArray(artifact.content)) {
+    throw new Error(`${artifact.kind} artifact ${artifact.path} must be an object`);
+  }
+  return artifact.content as Record<string, unknown>;
+}
+
+function artifactLocatorFromMetadata(
+  metadata: Record<string, unknown> | null | undefined,
+  fallback?: PackArtifact,
+): Record<string, unknown> {
+  const value = metadata?.locator;
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return fallback ? packArtifactLocator(fallback) : {};
+}
+
+function secretEnvKey(key: string): string {
+  return key.replace(/[^A-Za-z0-9]+/g, "_").toUpperCase();
+}
+
+function graphjinEndpoint(url: string): string {
+  const clean = url.replace(/\/+$/, "");
+  return clean.endsWith("/api/v1/graphql") ? clean : `${clean}/api/v1/graphql`;
+}
+
+async function runMagentoAnalyticsSmoke(endpoint: string, orgId: string): Promise<void> {
+  const headers = {
+    authorization: `Bearer ${mintGraphjinToken({
+      orgId,
+      userId: "pack-health",
+      role: "service",
+      ttlSeconds: 60,
+    })}`,
+  };
+  const result = await graphjinQuery<{ sales_order?: Array<{ entity_id?: string | number }> }>({
+    baseUrl: endpoint,
+    headers,
+    query:
+      'query MagentoPackAnalyticsSmoke { sales_order(where: { created_at: { gte: "1970-01-01 00:00:00" } }, limit: 1) { entity_id } }',
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (result.errors?.length || !Array.isArray(result.data?.sales_order)) {
+    throw new Error(
+      `Magento analytics smoke query failed: ${result.errors?.map((error) => error.message).join("; ") ?? "sales_order result unavailable"}`,
+    );
+  }
+  const sensitive = await graphjinQuery<{ sales_order?: Array<{ customer_email?: string }> }>({
+    baseUrl: endpoint,
+    headers,
+    query:
+      'query MagentoPackSensitiveColumnCanary { sales_order(where: { created_at: { gte: "1970-01-01 00:00:00" } }, limit: 1) { customer_email } }',
+    signal: AbortSignal.timeout(30_000),
+  });
+  if (!sensitive.errors?.length) {
+    throw new Error(
+      "Magento analytics privacy check failed: GraphJin did not enforce the sales_order customer_email blocklist",
+    );
+  }
+}
+
+function packRoot(): string {
+  return resolve(process.env.OPENNEKO_PACKS_DIR?.trim() || join(process.cwd(), "packs"));
+}
+
+function renderTemplate(value: string, inputs: Record<string, unknown>): string {
+  return value.replace(/\{\{([^}]+)}}/g, (_match, key: string) => {
+    const resolved = inputs[key.trim()];
+    if (resolved === undefined || resolved === null) {
+      throw new Error(`missing pack template input ${key.trim()}`);
+    }
+    return String(resolved);
+  });
+}
+
+function findSavedQuery(bundle: SolutionPackBundle, name: string): string {
+  const artifact = bundle.artifacts.find(
+    (value) =>
+      value.kind === "saved_query" && basename(value.path, extname(value.path)) === name,
+  );
+  if (!artifact || typeof artifact.content !== "string") {
+    throw new Error(`pack saved query ${name} is missing`);
+  }
+  return artifact.content;
+}
+
+async function enqueuePackMetricRefreshes(
+  orgId: string,
+  bundle: SolutionPackBundle,
+): Promise<number> {
+  const { enqueue, QUEUE } = await import("@neko/db/jobs");
+  let enqueued = 0;
+  for (const artifact of bundle.artifacts.filter((value) => value.kind === "metric")) {
+    const definition = artifactRecord(artifact);
+    const [card] = await db().select({ id: metric.id }).from(metric).where(and(
+      eq(metric.org_id, orgId),
+      eq(metric.role, String(definition.role)),
+      eq(metric.slug, artifact.targetRef),
+    )).limit(1);
+    if (!card) continue;
+    const [job] = await db().insert(processing_job).values({
+      org_id: orgId,
+      kind: "metric_refresh",
+      status: "queued",
+      trigger: "pack_install",
+      trigger_payload: { metricId: card.id },
+    }).returning({ id: processing_job.id });
+    if (!job) continue;
+    await db().update(metric).set({
+      last_refresh_status: "pending",
+      last_refresh_error: null,
+      last_refresh_job_id: job.id,
+      updated_at: new Date(),
+    }).where(eq(metric.id, card.id));
+    try {
+      await enqueue(QUEUE.METRIC_REFRESH, { processingJobId: job.id, orgId });
+      enqueued++;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await db().update(processing_job).set({
+        status: "failed",
+        error: message.slice(0, 1_000),
+        finished_at: new Date(),
+        updated_at: new Date(),
+      }).where(eq(processing_job.id, job.id));
+      await db().update(metric).set({
+        last_refresh_status: "failed",
+        last_refresh_error: message.slice(0, 500),
+        updated_at: new Date(),
+      }).where(eq(metric.id, card.id));
+      console.warn(
+        `[packs] could not schedule initial refresh for ${artifact.targetRef}: ${message}`,
+      );
+    }
+  }
+  return enqueued;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  return lstat(path).then(() => true).catch(() => false);
+}
+
+async function writeAtomic(
+  path: string,
+  content: string,
+  alreadyOwned: boolean,
+): Promise<() => Promise<void>> {
+  await mkdir(dirname(path), { recursive: true });
+  const existed = await pathExists(path);
+  if (existed && !alreadyOwned) {
+    throw new Error(`pack file target ${path} already exists and is not owned by this pack`);
+  }
+  const previous = existed ? await readFile(path) : null;
+  const temporary = `${path}.${randomUUID()}.pack-stage`;
+  await writeFile(temporary, content, { mode: 0o644 });
+  await rename(temporary, path);
+  return async () => {
+    if (previous) {
+      const rollback = `${path}.${randomUUID()}.pack-rollback`;
+      await writeFile(rollback, previous, { mode: 0o644 });
+      await rename(rollback, path);
+    } else {
+      await rm(path, { force: true });
+    }
+  };
+}
+
+async function stageOwnedRemoval(path: string): Promise<{
+  restore: () => Promise<void>;
+  commit: () => Promise<void>;
+}> {
+  let target;
+  try {
+    target = await lstat(path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { restore: async () => {}, commit: async () => {} };
+    }
+    throw error;
+  }
+  if (target.isSymbolicLink()) throw new Error(`pack-owned removal target is a symlink: ${path}`);
+  const backup = `${path}.${randomUUID()}.pack-remove-backup`;
+  await rename(path, backup);
+  return {
+    restore: async () => {
+      if (await pathExists(backup)) await rename(backup, path);
+    },
+    commit: async () => {
+      await rm(backup, { recursive: target.isDirectory(), force: true });
+    },
+  };
+}
+
+function assertOwnedPath(root: string, target: string, label: string): string {
+  const absoluteRoot = resolve(root);
+  const absoluteTarget = resolve(target);
+  const path = relative(absoluteRoot, absoluteTarget);
+  if (!path || path === ".." || path.startsWith(`..${sep}`) || path.startsWith(sep)) {
+    throw new Error(`${label} target escapes its managed root: ${target}`);
+  }
+  return absoluteTarget;
+}
+
+async function installGraphjinFiles(input: {
+  bundle: SolutionPackBundle;
+  configFile: string;
+  values: Record<string, unknown>;
+  ownedTargets: Set<string>;
+}): Promise<{ restore: () => Promise<void>; targets: Map<string, string> }> {
+  const configRoot = dirname(input.configFile);
+  const restorers: Array<() => Promise<void>> = [];
+  const targets = new Map<string, string>();
+  try {
+    for (const artifact of input.bundle.artifacts) {
+      let destination: string | null = null;
+      let content: string | null = null;
+      if (artifact.kind === "spec") {
+        destination = join(configRoot, "specs", basename(artifact.path));
+        content = renderTemplate(await readFile(join(input.bundle.root, artifact.path), "utf8"), input.values);
+      } else if (artifact.kind === "saved_query") {
+        destination = join(
+          configRoot,
+          "queries",
+          `${input.bundle.manifest.metadata.id.replaceAll("-", "_")}_${basename(artifact.path)}`,
+        );
+        content = String(artifact.content);
+      }
+      if (destination && content !== null) {
+        restorers.push(
+          await writeAtomic(destination, content, input.ownedTargets.has(destination)),
+        );
+        targets.set(`${artifact.kind}:${artifact.key}`, destination);
+      }
+    }
+    return {
+      targets,
+      restore: async () => {
+        for (const restore of restorers.reverse()) await restore();
+      },
+    };
+  } catch (error) {
+    for (const restore of restorers.reverse()) await restore().catch(() => {});
+    throw error;
+  }
+}
+
+async function assertNativeTargetsAvailable(input: {
+  orgId: string;
+  bundle: SolutionPackBundle;
+  plan: PackPlan;
+}): Promise<void> {
+  const creates = new Set(
+    input.plan.entries
+      .filter((entry) => entry.action === "create")
+      .map((entry) => `${entry.kind}:${entry.key}`),
+  );
+  for (const artifact of input.bundle.artifacts) {
+    if (!creates.has(`${artifact.kind}:${artifact.key}`)) continue;
+    const value = artifact.content && typeof artifact.content === "object" && !Array.isArray(artifact.content)
+      ? artifact.content as Record<string, unknown>
+      : null;
+    let existing: { id: string } | undefined;
+    if (artifact.kind === "metric" && value) {
+      [existing] = await db().select({ id: metric.id }).from(metric).where(and(
+        eq(metric.org_id, input.orgId),
+        eq(metric.role, String(value.role)),
+        eq(metric.slug, artifact.targetRef),
+      )).limit(1);
+    } else if (artifact.kind === "workflow" && value) {
+      [existing] = await db().select({ id: workflow_definition.id }).from(workflow_definition).where(and(
+        eq(workflow_definition.org_id, input.orgId),
+        eq(workflow_definition.owner_user_id, ""),
+        eq(workflow_definition.name, String(value.name)),
+      )).limit(1);
+    } else if (artifact.kind === "watcher" && value) {
+      [existing] = await db().select({ id: watcher.id }).from(watcher).where(and(
+        eq(watcher.org_id, input.orgId),
+        eq(watcher.name, String(value.name)),
+      )).limit(1);
+    } else if (artifact.kind === "policy" && value) {
+      [existing] = await db().select({ id: action_policy.id }).from(action_policy).where(and(
+        eq(action_policy.org_id, input.orgId),
+        eq(action_policy.name, String(value.name)),
+      )).limit(1);
+    } else if (artifact.kind === "action" && value) {
+      [existing] = await db().select({ id: pack_action_definition.id }).from(pack_action_definition).where(and(
+        eq(pack_action_definition.org_id, input.orgId),
+        eq(pack_action_definition.kind, String(value.kind)),
+      )).limit(1);
+    }
+    if (existing) {
+      throw new Error(
+        `${artifact.kind} target ${artifact.targetRef} already exists and is not owned by pack ${input.bundle.manifest.metadata.id}`,
+      );
+    }
+  }
+}
+
+async function installSkills(input: {
+  orgId: string;
+  bundle: SolutionPackBundle;
+  ownedTargets: Set<string>;
+}): Promise<{
+  targets: Map<string, string>;
+  restore: () => Promise<void>;
+  commit: () => Promise<void>;
+}> {
+  const workspace = await ensureOrgWorkspace(input.orgId);
+  const restorers: Array<() => Promise<void>> = [];
+  const committers: Array<() => Promise<void>> = [];
+  const targets = new Map<string, string>();
+  try {
+    for (const artifact of input.bundle.artifacts.filter((value) => value.kind === "skill")) {
+      const source = join(input.bundle.root, dirname(artifact.path));
+      const target = join(workspace.skillsRoot, artifact.targetRef);
+      const backup = `${target}.${randomUUID()}.pack-backup`;
+      const stage = `${target}.${randomUUID()}.pack-stage`;
+      const existed = await pathExists(target);
+      if (existed && !input.ownedTargets.has(target)) {
+        throw new Error(`skill target ${basename(target)} already exists and is not owned by this pack`);
+      }
+      await cp(source, stage, { recursive: true, force: false, errorOnExist: true });
+      if (existed) await rename(target, backup);
+      await rename(stage, target);
+      targets.set(`${artifact.kind}:${artifact.key}`, target);
+      restorers.push(async () => {
+        await rm(target, { recursive: true, force: true });
+        if (existed) await rename(backup, target);
+      });
+      committers.push(async () => {
+        await rm(backup, { recursive: true, force: true });
+      });
+    }
+    return {
+      targets,
+      restore: async () => {
+        for (const restore of restorers.reverse()) await restore();
+      },
+      commit: async () => {
+        for (const commit of committers) await commit();
+      },
+    };
+  } catch (error) {
+    for (const restore of restorers.reverse()) await restore().catch(() => {});
+    throw error;
+  }
+}
+
+export function resolveInputs(bundle: SolutionPackBundle, supplied: Record<string, unknown>): Record<string, unknown> {
+  const declared = new Map(bundle.manifest.inputs.map((input) => [input.key, input]));
+  for (const key of Object.keys(supplied)) {
+    if (!declared.has(key)) throw new Error(`unknown pack input ${key}`);
+  }
+  const resolved: Record<string, unknown> = {};
+  for (const input of bundle.manifest.inputs) {
+    const value = Object.hasOwn(supplied, input.key) ? supplied[input.key] : input.default;
+    if (value === undefined && input.required) throw new Error(`required pack input ${input.key} is missing`);
+    if (value === undefined) continue;
+    switch (input.type) {
+      case "string":
+      case "timezone":
+      case "url": {
+        if (typeof value !== "string" || (input.type !== "string" && !value.trim())) {
+          throw new Error(`pack input ${input.key} must be ${input.type === "string" ? "a string" : `a non-empty ${input.type}`}`);
+        }
+        const normalized = value.trim();
+        if (input.required && !normalized) {
+          throw new Error(`required pack input ${input.key} must not be empty`);
+        }
+        if (input.type === "url") {
+          let parsed: URL;
+          try {
+            parsed = new URL(normalized);
+          } catch {
+            throw new Error(`pack input ${input.key} must be an absolute URL`);
+          }
+          if (!['http:', 'https:'].includes(parsed.protocol)) {
+            throw new Error(`pack input ${input.key} must use HTTP or HTTPS`);
+          }
+          resolved[input.key] = normalized.replace(/\/+$/, "");
+        } else if (input.type === "timezone") {
+          try {
+            new Intl.DateTimeFormat("en-US", { timeZone: normalized }).format();
+          } catch {
+            throw new Error(`pack input ${input.key} must be a valid IANA timezone`);
+          }
+          resolved[input.key] = normalized;
+        } else {
+          resolved[input.key] = normalized;
+        }
+        break;
+      }
+      case "integer": {
+        const number = typeof value === "number" ? value : Number(value);
+        if (!Number.isInteger(number)) throw new Error(`pack input ${input.key} must be an integer`);
+        resolved[input.key] = number;
+        break;
+      }
+      case "boolean":
+        if (typeof value !== "boolean") throw new Error(`pack input ${input.key} must be a boolean`);
+        resolved[input.key] = value;
+        break;
+      case "enum":
+        if (!input.values?.some((candidate) => candidate === value)) {
+          throw new Error(`pack input ${input.key} must be one of: ${input.values?.join(", ")}`);
+        }
+        resolved[input.key] = value;
+        break;
+    }
+  }
+  const port = resolved["database.port"];
+  if (port !== undefined && (typeof port !== "number" || port < 1 || port > 65535)) {
+    throw new Error("database.port must be an integer from 1 to 65535");
+  }
+  return resolved;
+}
+
+async function resolveSecrets(
+  bundle: SolutionPackBundle,
+  request: PackInstallRequest,
+): Promise<{
+  values: Record<string, string>;
+  cleared: Set<string>;
+  store: Awaited<ReturnType<typeof readSecretsStore>>;
+}> {
+  const store = await readSecretsStore();
+  const section = `${PACK_SECRET_PREFIX}${bundle.manifest.metadata.id}`;
+  const current = store[section] ?? {};
+  const declared = new Set(bundle.manifest.secrets.map((secret) => secret.key));
+  for (const key of [...Object.keys(request.secrets ?? {}), ...Object.keys(request.secretRefs ?? {})]) {
+    if (!declared.has(key)) throw new Error(`unknown pack secret ${key}`);
+  }
+  const values: Record<string, string> = {};
+  const cleared = new Set<string>();
+  for (const secret of bundle.manifest.secrets) {
+    const direct = request.secrets?.[secret.key];
+    const ref = request.secretRefs?.[secret.key];
+    if (direct !== undefined && typeof direct !== "string") {
+      throw new Error(`pack secret ${secret.key} must be a string`);
+    }
+    if (direct !== undefined && !direct.trim() && !secret.required) {
+      cleared.add(secret.key);
+      continue;
+    }
+    const stored = ref ? current[ref] : current[secretEnvKey(secret.key)];
+    const value = direct !== undefined ? direct : stored;
+    if (secret.required && (!value || !value.trim())) {
+      throw new Error(`required pack secret ${secret.key} is missing`);
+    }
+    if (value) values[secret.key] = value;
+  }
+  return { values, cleared, store };
+}
+
+function graphjinTables(prefix: string, available: string[]): Record<string, unknown>[] {
+  const sensitiveColumns: Record<string, string[]> = {
+    sales_order: [
+      "protect_code",
+      "customer_id",
+      "billing_address_id",
+      "quote_address_id",
+      "quote_id",
+      "shipping_address_id",
+      "customer_dob",
+      "customer_email",
+      "customer_firstname",
+      "customer_lastname",
+      "customer_middlename",
+      "customer_prefix",
+      "customer_suffix",
+      "customer_taxvat",
+      "ext_customer_id",
+      "remote_ip",
+      "x_forwarded_for",
+      "customer_note",
+      "customer_gender",
+      "gift_message_id",
+    ],
+    sales_order_item: [
+      "quote_item_id",
+      "product_options",
+      "additional_data",
+      "description",
+      "ext_order_item_id",
+      "gift_message_id",
+    ],
+    sales_invoice: [
+      "billing_address_id",
+      "shipping_address_id",
+      "transaction_id",
+      "customer_note",
+    ],
+    sales_invoice_item: ["additional_data", "description"],
+    sales_creditmemo: [
+      "shipping_address_id",
+      "billing_address_id",
+      "transaction_id",
+      "customer_note",
+    ],
+    sales_creditmemo_item: ["additional_data", "description"],
+    sales_shipment: [
+      "customer_id",
+      "shipping_address_id",
+      "billing_address_id",
+      "packages",
+      "shipping_label",
+      "customer_note",
+    ],
+    sales_shipment_item: ["additional_data", "description"],
+    inventory_reservation: ["metadata"],
+    cron_schedule: ["messages"],
+  };
+  return MAGENTO_ANALYTICS_TABLES.filter((name) => available.includes(name)).map((name) => ({
+    name,
+    table: `${prefix}${name}`,
+    source: "magento_analytics",
+    // GraphJin 3.18.42 normalizes sources before it parses newly supplied
+    // table entries in the same config patch. Keep the derived database
+    // explicit so reload validation routes the table to the new source.
+    database: "magento_analytics",
+    read_only: true,
+    ...(sensitiveColumns[name] ? { blocklist: sensitiveColumns[name] } : {}),
+  }));
+}
+
+function graphjinRelationships(bundle: SolutionPackBundle, available: string[]): Record<string, unknown>[] {
+  const artifact = bundle.artifacts.find((value) => value.kind === "relationships");
+  const relationships = artifactRecord(artifact!).relationships as Array<Record<string, unknown>>;
+  const tables = new Set(available);
+  return relationships
+    .filter((relationship) =>
+      tables.has(String(relationship.left).split(".")[0]) &&
+      tables.has(String(relationship.right).split(".")[0]),
+    )
+    .map((relationship) => ({
+      from: `magento_analytics:${String(relationship.left)}`,
+      to: `magento_analytics:${String(relationship.right)}`,
+    }));
+}
+
+function graphjinUpdate(
+  inputs: Record<string, unknown>,
+  secrets: Record<string, string>,
+  preflight: MagentoPreflightResult,
+  bundle: SolutionPackBundle,
+  retiredSourceNames: string[] = [],
+): Record<string, unknown> {
+  return {
+    update_sources: [
+      {
+        name: "magento_analytics",
+        kind: "database",
+        default: false,
+        type: preflight.databaseType,
+        host: String(inputs["database.host"]),
+        port: Number(inputs["database.port"]),
+        dbname: String(inputs["database.name"]),
+        user: secrets["database.analytics_username"],
+        password: secrets["database.analytics_password"],
+        read_only: true,
+        analytics_mode: true,
+        capabilities: {
+          "data.read": true,
+          "data.write": false,
+          "schema.read": true,
+          "schema.write": false,
+        },
+        access: {
+          read: "authenticated",
+          write: "blocked",
+          delete: "blocked",
+          blocked_tables: preflight.blockedTables,
+        },
+      },
+      {
+        name: "magento_operator",
+        kind: "api",
+        default: false,
+        specs_dir: "specs",
+        specs: {
+          "magento-operator-v1": {
+            base_url: String(inputs["magento.base_url"]),
+            ...(secrets["magento.integration_token"]
+              ? {
+                  auth: {
+                    scheme: "bearer",
+                    token: secrets["magento.integration_token"],
+                  },
+                }
+              : {}),
+          },
+        },
+        read_only: true,
+        capabilities: {
+          "api.read": true,
+          "api.write": false,
+        },
+        access: {
+          read: "authenticated",
+          write: "blocked",
+          delete: "blocked",
+        },
+      },
+    ],
+    ...(retiredSourceNames.length > 0
+      ? {
+          source_patches: retiredSourceNames.map((name) => ({
+            name,
+            read_only: true,
+            access: { read: "blocked", write: "blocked", delete: "blocked" },
+          })),
+        }
+      : {}),
+    tables: graphjinTables(preflight.tablePrefix, preflight.availableAnalyticsTables),
+    relationships: graphjinRelationships(bundle, preflight.availableAnalyticsTables),
+  };
+}
+
+export class PackService {
+  constructor(
+    private readonly orgId: string,
+    private readonly embeddedRoot = packRoot(),
+  ) {}
+
+  private async bundle(packId: string): Promise<SolutionPackBundle> {
+    if (!PACK_ID.test(packId)) throw new Error("invalid pack id");
+    return loadSolutionPack(join(this.embeddedRoot, packId));
+  }
+
+  private async replayIdempotentOperation(
+    packId: string,
+    idempotencyKey: string | undefined,
+  ): Promise<PackStatus | null> {
+    if (!idempotencyKey) return null;
+    const [prior] = await db()
+      .select({
+        packId: pack_install.pack_id,
+        status: pack_operation.status,
+        error: pack_operation.error,
+      })
+      .from(pack_operation)
+      .innerJoin(pack_install, eq(pack_install.id, pack_operation.pack_install_id))
+      .where(
+        and(
+          eq(pack_operation.org_id, this.orgId),
+          eq(pack_operation.idempotency_key, idempotencyKey),
+        ),
+      )
+      .limit(1);
+    if (!prior) return null;
+    if (prior.packId !== packId) {
+      throw new Error(`idempotency key was already used for pack ${prior.packId}`);
+    }
+    if (prior.status === "succeeded") {
+      const status = await this.status(packId);
+      if (!status) throw new Error(`pack ${packId} status is missing for completed operation`);
+      return status;
+    }
+    if (prior.status === "failed") {
+      throw new Error(prior.error || `the previous ${packId} operation failed`);
+    }
+    throw new Error(`the ${packId} operation for this idempotency key is still ${prior.status}`);
+  }
+
+  async list(): Promise<Array<{ id: string; name: string; version: string; installed: boolean }>> {
+    const entries = await readdir(this.embeddedRoot, { withFileTypes: true });
+    const installed = await db()
+      .select({ packId: pack_install.pack_id })
+      .from(pack_install)
+      .where(and(eq(pack_install.org_id, this.orgId), eq(pack_install.status, "installed")));
+    const installedIds = new Set(installed.map((row) => row.packId));
+    const packDirectories: string[] = [];
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !PACK_ID.test(entry.name)) continue;
+      try {
+        const manifest = await lstat(join(this.embeddedRoot, entry.name, "pack.yaml"));
+        if (manifest.isFile() || manifest.isSymbolicLink()) packDirectories.push(entry.name);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+    }
+    const bundles = await Promise.all(packDirectories.map((packId) => this.bundle(packId)));
+    return bundles.map((bundle) => ({
+      id: bundle.manifest.metadata.id,
+      name: bundle.manifest.metadata.name,
+      version: bundle.manifest.metadata.version,
+      installed: installedIds.has(bundle.manifest.metadata.id),
+    }));
+  }
+
+  async inspect(packId: string): Promise<Record<string, unknown>> {
+    const bundle = await this.bundle(packId);
+    return {
+      manifest: bundle.manifest,
+      manifestHash: bundle.manifestHash,
+      bundleHash: bundle.bundleHash,
+      permissions: {
+        database: "view-only reporting",
+        apiWrite: "specific Magento changes require approval and must be enabled individually",
+        customerPii: "blocked",
+        paymentData: "blocked",
+      },
+    };
+  }
+
+  async plan(packId: string): Promise<PackPlan> {
+    const bundle = await this.bundle(packId);
+    const [installation] = await db()
+      .select({ id: pack_install.id })
+      .from(pack_install)
+      .where(
+        and(
+          eq(pack_install.org_id, this.orgId),
+          eq(pack_install.pack_id, packId),
+        ),
+      )
+      .orderBy(desc(pack_install.created_at))
+      .limit(1);
+    const artifacts = installation
+      ? await db().select().from(pack_artifact).where(eq(pack_artifact.pack_install_id, installation.id))
+      : [];
+    const desiredByIdentity = new Map(
+      bundle.artifacts.map((artifact) => [`${artifact.kind}:${artifact.key}`, artifact]),
+    );
+    const configFile = process.env.OPENNEKO_GRAPHJIN_CONFIG?.trim() ?? "";
+    const installed = await Promise.all(artifacts.map(async (artifact) => {
+      const desired = desiredByIdentity.get(`${artifact.artifact_kind}:${artifact.artifact_key}`);
+      const metadata = artifact.metadata ?? {};
+      const needsGraphjinConfig = ["source", "relationships", "spec", "saved_query"].includes(
+        artifact.artifact_kind,
+      );
+      const inspected = configFile || !needsGraphjinConfig
+        ? await inspectInstalledPackArtifactCurrent({
+            orgId: this.orgId,
+            kind: artifact.artifact_kind as PackArtifact["kind"],
+            targetRef: artifact.target_ref,
+            metadata,
+            graphjinConfigFile: configFile,
+            ...(desired ? { fallbackArtifact: desired } : {}),
+          })
+        : null;
+      const baseline = metadata.stateHashVersion === 1
+        ? artifact.last_applied_hash
+        : inspected ?? artifact.last_applied_hash;
+      return {
+        kind: artifact.artifact_kind as PackArtifact["kind"],
+        key: artifact.artifact_key,
+        targetRef: artifact.target_ref,
+        desiredHash: artifact.desired_hash,
+        lastAppliedHash: baseline,
+        currentHash: inspected,
+        ownership: artifact.ownership as "managed" | "modified" | "detached" | "retired",
+      };
+    }));
+    return planPack(bundle, installed);
+  }
+
+  private async persistLegacyStateBaselines(
+    installationId: string,
+    plan: PackPlan,
+    bundle: SolutionPackBundle,
+  ): Promise<void> {
+    const rows = await db().select().from(pack_artifact)
+      .where(eq(pack_artifact.pack_install_id, installationId));
+    const entries = new Map(plan.entries.map((entry) => [`${entry.kind}:${entry.key}`, entry]));
+    const desired = new Map(bundle.artifacts.map((artifact) => [`${artifact.kind}:${artifact.key}`, artifact]));
+    await db().transaction(async (tx) => {
+      for (const row of rows) {
+        if (row.metadata?.stateHashVersion === 1) continue;
+        const entry = entries.get(`${row.artifact_kind}:${row.artifact_key}`);
+        if (entry?.action !== "noop" || !entry.currentHash) continue;
+        await tx.update(pack_artifact).set({
+          last_applied_hash: entry.currentHash,
+          metadata: {
+            ...(row.metadata ?? {}),
+            ...(desired.get(`${row.artifact_kind}:${row.artifact_key}`)
+              ? { locator: packArtifactLocator(desired.get(`${row.artifact_kind}:${row.artifact_key}`)!) }
+              : {}),
+            stateHashVersion: 1,
+          },
+          updated_at: new Date(),
+        }).where(eq(pack_artifact.id, row.id));
+      }
+    });
+  }
+
+  async status(packId: string): Promise<PackStatus | null> {
+    const [installation] = await db()
+      .select()
+      .from(pack_install)
+      .where(and(eq(pack_install.org_id, this.orgId), eq(pack_install.pack_id, packId)))
+      .orderBy(desc(pack_install.created_at))
+      .limit(1);
+    if (!installation) return null;
+    const artifacts = await db()
+      .select({ readiness: pack_artifact.readiness, reason: pack_artifact.readiness_reason })
+      .from(pack_artifact)
+      .where(eq(pack_artifact.pack_install_id, installation.id));
+    const readiness: PackStatus["readiness"] = {};
+    for (const artifact of artifacts) {
+      const capability = artifact.reason?.startsWith("operator:") ? "operator" : "analytics";
+      if (!readiness[capability] || artifact.readiness === "blocked") {
+        readiness[capability] = {
+          status: artifact.readiness,
+          reason: artifact.reason?.replace(/^operator:/, "") ?? null,
+        };
+      }
+    }
+    return {
+      packId,
+      version: installation.version,
+      status: installation.status,
+      readiness,
+      installedAt: installation.installed_at?.toISOString() ?? null,
+      lastError: installation.last_error,
+    };
+  }
+
+  async doctor(packId: string): Promise<PackDoctorResult> {
+    const bundle = await this.bundle(packId);
+    const [installation] = await db()
+      .select()
+      .from(pack_install)
+      .where(and(eq(pack_install.org_id, this.orgId), eq(pack_install.pack_id, packId)))
+      .orderBy(desc(pack_install.created_at))
+      .limit(1);
+    if (!installation || installation.status === "removed") {
+      return {
+        packId,
+        status: "blocked",
+        checks: [{ id: "installation", status: "blocked", detail: "pack is not installed" }],
+      };
+    }
+
+    const checks: PackDoctorResult["checks"] = [];
+    const declaredInputs = new Set(bundle.manifest.inputs.map((input) => input.key));
+    const storedInputs = Object.fromEntries(
+      Object.entries(installation.config as Record<string, unknown>)
+        .filter(([key]) => declaredInputs.has(key)),
+    );
+    let preflight: MagentoPreflightResult | null = null;
+    try {
+      const inputs = resolveInputs(bundle, storedInputs);
+      const resolvedSecrets = await resolveSecrets(bundle, {});
+      preflight = await runMagentoPreflight({
+        host: String(inputs["database.host"]),
+        port: Number(inputs["database.port"]),
+        database: String(inputs["database.name"]),
+        username: resolvedSecrets.values["database.analytics_username"]!,
+        password: resolvedSecrets.values["database.analytics_password"]!,
+        tablePrefix: String(inputs["magento.table_prefix"] ?? ""),
+        baseUrl: String(inputs["magento.base_url"]),
+        storeCode: String(inputs["magento.store_code"] ?? "all"),
+        integrationToken: resolvedSecrets.values["magento.integration_token"] ?? null,
+      });
+      checks.push({
+        id: "analytics",
+        status: "ready",
+        detail: `${preflight.databaseType} ${preflight.databaseVersion}; SELECT-only grants verified`,
+      });
+      checks.push({
+        id: "magento",
+        status: "ready",
+        detail: `${preflight.magentoVersion}; store IDs ${preflight.storeIds.join(", ")}`,
+      });
+    } catch (error) {
+      checks.push({
+        id: "analytics",
+        status: "blocked",
+        detail: error instanceof Error ? error.message : String(error),
+      });
+    }
+
+    const [source] = await db()
+      .select({ graphqlUrl: data_source.graphql_url })
+      .from(data_source)
+      .where(and(eq(data_source.org_id, this.orgId), eq(data_source.enabled, true)))
+      .orderBy(desc(data_source.is_default), data_source.created_at)
+      .limit(1);
+    const configFile = process.env.OPENNEKO_GRAPHJIN_CONFIG?.trim();
+    if (!source?.graphqlUrl || !configFile || !(await pathExists(configFile))) {
+      checks.push({
+        id: "graphjin",
+        status: "blocked",
+        detail: "customer GraphJin endpoint/config volume is unavailable",
+      });
+    } else {
+      try {
+        const result = await graphjinQuery<{ gj_config?: { catalog_revision?: string } }>({
+          baseUrl: graphjinEndpoint(source.graphqlUrl),
+          headers: {
+            authorization: `Bearer ${mintGraphjinToken({
+              orgId: this.orgId,
+              userId: "pack-doctor",
+              role: "admin",
+              ttlSeconds: 60,
+            })}`,
+          },
+          query: 'query { gj_config(id: "current") { catalog_revision } }',
+        });
+        if (result.errors?.length || !result.data?.gj_config?.catalog_revision) {
+          throw new Error(result.errors?.map((value) => value.message).join("; ") || "catalog revision unavailable");
+        }
+        await runMagentoAnalyticsSmoke(graphjinEndpoint(source.graphqlUrl), this.orgId);
+        checks.push({
+          id: "graphjin",
+          status: "ready",
+          detail: `catalog ${result.data.gj_config.catalog_revision}`,
+        });
+        checks.push({
+          id: "analytics-query",
+          status: "ready",
+          detail: "Magento sales_order smoke query succeeded",
+        });
+      } catch (error) {
+        checks.push({
+          id: "graphjin",
+          status: "blocked",
+          detail: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
+    checks.push({
+      id: "operator",
+      status: "optional",
+      detail: operatorReadinessDetail(preflight?.operatorReadiness ?? null),
+    });
+    const requiredBlocked = checks.some(
+      (check) => check.id !== "operator" && check.status === "blocked",
+    );
+    return {
+      packId,
+      status: requiredBlocked ? "blocked" : "ready",
+      checks,
+    };
+  }
+
+  async install(packId: string, request: PackInstallRequest = {}): Promise<PackStatus> {
+    return this.apply(packId, request, "install");
+  }
+
+  async configure(packId: string, request: PackInstallRequest = {}): Promise<PackStatus> {
+    const current = await this.status(packId);
+    if (!current || current.status !== "installed") {
+      throw new Error(`pack ${packId} must be installed before it can be configured`);
+    }
+    return this.apply(packId, request, "configure");
+  }
+
+  async upgrade(packId: string, request: PackInstallRequest = {}): Promise<PackStatus> {
+    const current = await this.status(packId);
+    if (!current || current.status !== "installed") {
+      throw new Error(`pack ${packId} must be installed before it can be upgraded`);
+    }
+    return this.apply(packId, request, "upgrade");
+  }
+
+  async uninstall(packId: string, request: PackUninstallRequest = {}): Promise<PackStatus> {
+    const bundle = await this.bundle(packId);
+    const replay = await this.replayIdempotentOperation(packId, request.idempotencyKey);
+    if (replay) return replay;
+    let [installation] = await db().select().from(pack_install).where(and(
+      eq(pack_install.org_id, this.orgId),
+      eq(pack_install.pack_id, packId),
+    )).orderBy(desc(pack_install.created_at)).limit(1);
+    if (!installation) throw new Error(`pack ${packId} is not installed`);
+    if (installation.status === "removed") {
+      const removed = await this.status(packId);
+      if (!removed) throw new Error(`pack ${packId} removal status is missing`);
+      return removed;
+    }
+
+    const client = await pool().connect();
+    let operationId: string | null = null;
+    let graphjinRestore: (() => Promise<void>) | null = null;
+    let secretsRestore: (() => Promise<void>) | null = null;
+    const stagedRemovals: Array<{
+      restore: () => Promise<void>;
+      commit: () => Promise<void>;
+    }> = [];
+    try {
+      await client.query("SELECT pg_advisory_lock(hashtextextended($1, 0))", [`pack:${this.orgId}:${packId}`]);
+      const lockedReplay = await this.replayIdempotentOperation(packId, request.idempotencyKey);
+      if (lockedReplay) return lockedReplay;
+      [installation] = await db().select().from(pack_install).where(and(
+        eq(pack_install.org_id, this.orgId),
+        eq(pack_install.pack_id, packId),
+      )).orderBy(desc(pack_install.created_at)).limit(1);
+      if (!installation) throw new Error(`pack ${packId} is not installed`);
+      if (installation.status === "removed") {
+        const removed = await this.status(packId);
+        if (!removed) throw new Error(`pack ${packId} removal status is missing`);
+        return removed;
+      }
+      if (["installing", "upgrading", "removing"].includes(installation.status)) {
+        throw new Error(`pack ${packId} already has an operation in progress`);
+      }
+      const plan = await this.plan(packId);
+      const conflicts = plan.entries.filter((entry) => entry.action === "conflict");
+      if (conflicts.length > 0) {
+        const conflictKeys = new Set(conflicts.map((entry) => `${entry.kind}:${entry.key}`));
+        const rows = await db().select().from(pack_artifact)
+          .where(eq(pack_artifact.pack_install_id, installation.id));
+        await db().transaction(async (tx) => {
+          for (const row of rows) {
+            if (!conflictKeys.has(`${row.artifact_kind}:${row.artifact_key}`)) continue;
+            await tx.update(pack_artifact).set({ ownership: "modified", updated_at: new Date() })
+              .where(eq(pack_artifact.id, row.id));
+          }
+        });
+        throw new Error(`pack uninstall has ${conflicts.length} drift conflict(s); modified artifacts were preserved`);
+      }
+      await db().update(pack_install).set({
+        status: "removing",
+        last_error: null,
+        updated_at: new Date(),
+      }).where(eq(pack_install.id, installation.id));
+      const [operation] = await db().insert(pack_operation).values({
+        pack_install_id: installation.id,
+        org_id: this.orgId,
+        operation_type: "uninstall",
+        actor_user_id: request.actorUserId ?? null,
+        status: "running",
+        requested_version: installation.version,
+        idempotency_key: request.idempotencyKey ?? randomUUID(),
+        plan: plan as unknown as Record<string, unknown>,
+        plan_hash: plan.hash,
+        phase: "removing_graphjin",
+        started_at: new Date(),
+      }).returning({ id: pack_operation.id });
+      operationId = operation!.id;
+      await db().update(pack_install).set({ operation_id: operationId })
+        .where(eq(pack_install.id, installation.id));
+
+      const [source] = await db().select({ graphqlUrl: data_source.graphql_url })
+        .from(data_source)
+        .where(and(eq(data_source.org_id, this.orgId), eq(data_source.enabled, true)))
+        .orderBy(desc(data_source.is_default), data_source.created_at)
+        .limit(1);
+      const configFile = process.env.OPENNEKO_GRAPHJIN_CONFIG?.trim();
+      if (!source?.graphqlUrl || !configFile) {
+        throw new Error("customer GraphJin endpoint/config volume is unavailable");
+      }
+      const provenance = await db().select().from(pack_artifact)
+        .where(eq(pack_artifact.pack_install_id, installation.id));
+      const desiredByIdentity = new Map(
+        bundle.artifacts.map((artifact) => [`${artifact.kind}:${artifact.key}`, artifact]),
+      );
+      const sourceNames = provenance
+        .filter((artifact) => artifact.artifact_kind === "source")
+        .map((artifact) => artifact.target_ref);
+      // GraphJin 3.18 cannot remove a source while tables still reference it,
+      // does not expose remove_tables through gj_config, and treats tables: []
+      // as a no-op. Revoke every source capability instead. The disabled
+      // source/table metadata is retained so uninstall is fail closed and a
+      // later pack install can safely reclaim it.
+      const revoked = await applyPackGraphjinConfig({
+        endpoint: graphjinEndpoint(source.graphqlUrl),
+        orgId: this.orgId,
+        configFile,
+        update: {
+          source_patches: sourceNames.map((name) => ({
+            name,
+            read_only: true,
+            access: {
+              read: "blocked",
+              write: "blocked",
+              delete: "blocked",
+            },
+          })),
+        },
+        ownedSourceNames: new Set(sourceNames),
+      });
+      graphjinRestore = revoked.restore;
+
+      const configRoot = dirname(configFile);
+      const workspace = await ensureOrgWorkspace(this.orgId);
+      for (const artifact of provenance) {
+        const target = artifact.metadata?.materializedTarget;
+        if (typeof target !== "string") continue;
+        if (artifact.artifact_kind === "spec" || artifact.artifact_kind === "saved_query") {
+          stagedRemovals.push(
+            await stageOwnedRemoval(assertOwnedPath(configRoot, target, "GraphJin pack file")),
+          );
+        } else if (artifact.artifact_kind === "skill") {
+          stagedRemovals.push(
+            await stageOwnedRemoval(assertOwnedPath(workspace.skillsRoot, target, "pack skill")),
+          );
+        }
+      }
+
+      const currentSecrets = await readSecretsStore();
+      const secretSection = `${PACK_SECRET_PREFIX}${packId}`;
+      const nextSecrets = { ...currentSecrets };
+      delete nextSecrets[secretSection];
+      await writeSecretsStore(nextSecrets);
+      secretsRestore = () => writeSecretsStore(currentSecrets);
+
+      const retiredHashes = new Map<string, string>();
+      for (const artifact of provenance.filter(
+        (value) => value.artifact_kind === "source" || value.artifact_kind === "relationships",
+      )) {
+        const identity = `${artifact.artifact_kind}:${artifact.artifact_key}`;
+        const current = await inspectInstalledPackArtifactCurrent({
+          orgId: this.orgId,
+          kind: artifact.artifact_kind as "source" | "relationships",
+          targetRef: artifact.target_ref,
+          metadata: artifact.metadata ?? {},
+          graphjinConfigFile: configFile,
+          ...(desiredByIdentity.get(identity)
+            ? { fallbackArtifact: desiredByIdentity.get(identity)! }
+            : {}),
+        });
+        if (!current) throw new Error(`pack GraphJin artifact ${identity} disappeared during uninstall`);
+        retiredHashes.set(identity, current);
+      }
+      await db().transaction(async (tx) => {
+        for (const artifact of provenance) {
+          const identity = `${artifact.artifact_kind}:${artifact.artifact_key}`;
+          const locator = artifactLocatorFromMetadata(
+            artifact.metadata,
+            desiredByIdentity.get(identity),
+          );
+          if (artifact.artifact_kind === "metric") {
+            const role = String(locator.role ?? "");
+            if (!role) throw new Error(`pack metric ${artifact.artifact_key} has no uninstall locator`);
+            const [row] = await tx.select().from(metric).where(and(
+              eq(metric.org_id, this.orgId),
+              eq(metric.role, role),
+              eq(metric.slug, String(locator.slug ?? artifact.target_ref)),
+            )).limit(1);
+            if (!row) throw new Error(`pack metric ${artifact.target_ref} disappeared during uninstall`);
+            await tx.update(metric).set({ active: false, updated_at: new Date() }).where(eq(metric.id, row.id));
+            retiredHashes.set(identity, nativeArtifactStateHash("metric", { ...row, active: false } as unknown as Record<string, unknown>));
+          } else if (artifact.artifact_kind === "watcher") {
+            const [row] = await tx.select().from(watcher).where(and(
+              eq(watcher.org_id, this.orgId),
+              eq(watcher.name, String(locator.name ?? artifact.target_ref)),
+            )).limit(1);
+            if (!row) throw new Error(`pack watcher ${artifact.target_ref} disappeared during uninstall`);
+            await tx.update(watcher).set({ enabled: false, updated_at: new Date() }).where(eq(watcher.id, row.id));
+            retiredHashes.set(identity, nativeArtifactStateHash("watcher", { ...row, enabled: false } as unknown as Record<string, unknown>));
+          } else if (artifact.artifact_kind === "workflow") {
+            const [row] = await tx.select().from(workflow_definition).where(and(
+              eq(workflow_definition.org_id, this.orgId),
+              eq(workflow_definition.owner_user_id, ""),
+              eq(workflow_definition.name, String(locator.name ?? artifact.target_ref)),
+            )).limit(1);
+            if (!row) throw new Error(`pack workflow ${artifact.target_ref} disappeared during uninstall`);
+            await tx.update(workflow_definition).set({
+              enabled: false,
+              cron_enabled: false,
+              updated_at: new Date(),
+            }).where(eq(workflow_definition.id, row.id));
+            retiredHashes.set(identity, nativeArtifactStateHash("workflow", {
+              ...row,
+              enabled: false,
+              cron_enabled: false,
+            } as unknown as Record<string, unknown>));
+          } else if (artifact.artifact_kind === "policy") {
+            const [row] = await tx.select().from(action_policy).where(and(
+              eq(action_policy.org_id, this.orgId),
+              eq(action_policy.name, String(locator.name ?? artifact.target_ref)),
+            )).limit(1);
+            if (!row) throw new Error(`pack policy ${artifact.target_ref} disappeared during uninstall`);
+            await tx.update(action_policy).set({ enabled: false, updated_at: new Date() })
+              .where(eq(action_policy.id, row.id));
+            retiredHashes.set(identity, nativeArtifactStateHash("policy", { ...row, enabled: false } as unknown as Record<string, unknown>));
+          } else if (artifact.artifact_kind === "action") {
+            const [row] = await tx.select().from(pack_action_definition).where(and(
+              eq(pack_action_definition.org_id, this.orgId),
+              eq(pack_action_definition.kind, String(locator.kind ?? artifact.target_ref)),
+            )).limit(1);
+            if (!row) throw new Error(`pack action ${artifact.target_ref} disappeared during uninstall`);
+            await tx.update(pack_action_definition).set({
+              enabled: false,
+              readiness: "blocked",
+              readiness_reason: "pack_uninstalled",
+              updated_at: new Date(),
+            }).where(eq(pack_action_definition.id, row.id));
+            retiredHashes.set(identity, nativeArtifactStateHash("action", { ...row, enabled: false } as unknown as Record<string, unknown>));
+          }
+
+          const materializedHash = retiredHashes.get(identity) ?? canonicalHash({ retired: true, identity });
+          await tx.update(pack_artifact).set({
+            last_applied_hash: materializedHash,
+            ownership: "retired",
+            readiness: "not_applicable",
+            readiness_reason: null,
+            metadata: {
+              ...(artifact.metadata ?? {}),
+              stateHashVersion: 1,
+              retiredMissing: !retiredHashes.has(identity),
+              ...(
+                artifact.artifact_kind === "source" || artifact.artifact_kind === "relationships"
+                  ? { retainedForGraphjinCompatibility: true }
+                  : {}
+              ),
+            },
+            updated_at: new Date(),
+          }).where(eq(pack_artifact.id, artifact.id));
+        }
+        await tx.update(pack_install).set({
+          status: "removed",
+          removed_at: new Date(),
+          updated_at: new Date(),
+        }).where(eq(pack_install.id, installation.id));
+        await tx.update(pack_operation).set({
+          status: "succeeded",
+          phase: "complete",
+          compensation_status: "not_required",
+          completed_at: new Date(),
+          updated_at: new Date(),
+        }).where(eq(pack_operation.id, operationId!));
+      });
+
+      for (const removal of stagedRemovals) {
+        await removal.commit().catch((error) => {
+          console.warn(`[packs] uninstall cleanup warning: ${error instanceof Error ? error.message : String(error)}`);
+        });
+      }
+      const removed = await this.status(packId);
+      if (!removed) throw new Error("pack status missing after uninstall");
+      return removed;
+    } catch (error) {
+      let compensationFailed = false;
+      if (secretsRestore) await secretsRestore().catch(() => { compensationFailed = true; });
+      for (const removal of stagedRemovals.reverse()) {
+        await removal.restore().catch(() => { compensationFailed = true; });
+      }
+      if (graphjinRestore) await graphjinRestore().catch(() => { compensationFailed = true; });
+      const message = (error instanceof Error ? error.message : String(error)).slice(0, 1000);
+      if (operationId) {
+        await db().update(pack_operation).set({
+          status: "failed",
+          failure_phase: "uninstall",
+          error: message,
+          compensation_status: compensationFailed ? "failed" : "succeeded",
+          completed_at: new Date(),
+          updated_at: new Date(),
+        }).where(eq(pack_operation.id, operationId)).catch(() => {});
+      }
+      await db().update(pack_install).set({
+        status: compensationFailed ? "failed" : installation.status,
+        operation_id: installation.operation_id,
+        last_error: message,
+        updated_at: new Date(),
+      }).where(eq(pack_install.id, installation.id)).catch(() => {});
+      throw error;
+    } finally {
+      await client.query("SELECT pg_advisory_unlock(hashtextextended($1, 0))", [`pack:${this.orgId}:${packId}`]).catch(() => {});
+      client.release();
+    }
+  }
+
+  private async apply(
+    packId: string,
+    request: PackInstallRequest,
+    operationType: "install" | "configure" | "upgrade",
+  ): Promise<PackStatus> {
+    const bundle = await this.bundle(packId);
+    const replay = await this.replayIdempotentOperation(packId, request.idempotencyKey);
+    if (replay) return replay;
+    if (packId !== "magento") throw new Error(`no installer adapter for pack ${packId}`);
+    const secretSection = `${PACK_SECRET_PREFIX}${packId}`;
+    const client = await pool().connect();
+    let priorInstallation: typeof pack_install.$inferSelect | undefined;
+    let installationId: string | null = null;
+    let operationId: string | null = null;
+    let graphjinRestore: (() => Promise<void>) | null = null;
+    let filesRestore: (() => Promise<void>) | null = null;
+    let skillRestore: (() => Promise<void>) | null = null;
+    let skillCommit: (() => Promise<void>) | null = null;
+    let retiredRestore: (() => Promise<void>) | null = null;
+    let retiredCommit: (() => Promise<void>) | null = null;
+    let secretsRestore: (() => Promise<void>) | null = null;
+    try {
+      await client.query("SELECT pg_advisory_lock(hashtextextended($1, 0))", [`pack:${this.orgId}:${packId}`]);
+      const lockedReplay = await this.replayIdempotentOperation(packId, request.idempotencyKey);
+      if (lockedReplay) return lockedReplay;
+      const [existing] = await db()
+        .select()
+        .from(pack_install)
+        .where(and(eq(pack_install.org_id, this.orgId), eq(pack_install.pack_id, packId)))
+        .orderBy(desc(pack_install.created_at))
+        .limit(1);
+      priorInstallation = existing;
+      if (operationType !== "install" && existing?.status !== "installed") {
+        throw new Error(`pack ${packId} must be installed before it can be ${operationType}d`);
+      }
+      if (existing && ["installing", "upgrading", "removing"].includes(existing.status)) {
+        throw new Error(`pack ${packId} already has an operation in progress`);
+      }
+
+      const declaredInputs = new Set(bundle.manifest.inputs.map((input) => input.key));
+      const priorInputs = Object.fromEntries(
+        Object.entries((existing?.config ?? {}) as Record<string, unknown>)
+          .filter(([key]) => declaredInputs.has(key)),
+      );
+      const inputs = resolveInputs(bundle, { ...priorInputs, ...(request.inputs ?? {}) });
+      const resolvedSecrets = await resolveSecrets(bundle, request);
+      const preflight = await runMagentoPreflight({
+        host: String(inputs["database.host"]),
+        port: Number(inputs["database.port"]),
+        database: String(inputs["database.name"]),
+        username: resolvedSecrets.values["database.analytics_username"]!,
+        password: resolvedSecrets.values["database.analytics_password"]!,
+        tablePrefix: String(inputs["magento.table_prefix"] ?? ""),
+        baseUrl: String(inputs["magento.base_url"]),
+        storeCode: String(inputs["magento.store_code"] ?? "all"),
+        integrationToken: resolvedSecrets.values["magento.integration_token"] ?? null,
+      });
+      inputs["database.type"] = preflight.databaseType;
+      inputs["magento.table_prefix"] = preflight.tablePrefix;
+      inputs["magento.base_currency"] = inputs["magento.base_currency"] ?? preflight.baseCurrency;
+      inputs["magento.timezone"] = inputs["magento.timezone"] ?? preflight.timezone;
+
+      const plan = await this.plan(packId);
+      const conflicts = plan.entries.filter((entry) => entry.action === "conflict");
+      if (conflicts.length > 0) {
+        throw new Error(`pack install has ${conflicts.length} drift conflict(s); run pack plan for details`);
+      }
+      const storedSecrets = resolvedSecrets.store[secretSection] ?? {};
+      const secretsChanged = Object.entries(resolvedSecrets.values).some(
+        ([key, value]) => storedSecrets[secretEnvKey(key)] !== value,
+      ) || [...resolvedSecrets.cleared].some((key) => storedSecrets[secretEnvKey(key)] !== undefined);
+      const priorNormalizedInputs = existing ? resolveInputs(bundle, priorInputs) : null;
+      const configChanged = !priorNormalizedInputs ||
+        canonicalHash(priorNormalizedInputs) !== canonicalHash(inputs);
+      if (
+        existing?.status === "installed" &&
+        existing.version === bundle.manifest.metadata.version &&
+        existing.manifest_hash === bundle.manifestHash &&
+        plan.entries.every((entry) => entry.action === "noop") &&
+        !configChanged &&
+        !secretsChanged
+      ) {
+        await this.persistLegacyStateBaselines(existing.id, plan, bundle);
+        const current = await this.status(packId);
+        if (!current) throw new Error(`pack ${packId} status is missing after no-op plan`);
+        return current;
+      }
+      const priorArtifacts = existing
+        ? await db().select({
+            id: pack_artifact.id,
+            kind: pack_artifact.artifact_kind,
+            key: pack_artifact.artifact_key,
+            targetRef: pack_artifact.target_ref,
+            metadata: pack_artifact.metadata,
+          }).from(pack_artifact).where(eq(pack_artifact.pack_install_id, existing.id))
+        : [];
+      const retireIdentities = new Set(
+        plan.entries
+          .filter((entry) => entry.action === "retire")
+          .map((entry) => `${entry.kind}:${entry.key}`),
+      );
+      const retiredArtifacts = priorArtifacts.filter((artifact) =>
+        retireIdentities.has(`${artifact.kind}:${artifact.key}`),
+      );
+      await assertNativeTargetsAvailable({ orgId: this.orgId, bundle, plan });
+      const ownedFileTargets = new Set(
+        priorArtifacts.filter((artifact) => artifact.kind !== "skill").flatMap((artifact) => {
+          const target = artifact.metadata?.materializedTarget;
+          return typeof target === "string" ? [target] : [];
+        }),
+      );
+      const ownedSkillTargets = new Set(
+        priorArtifacts.filter((artifact) => artifact.kind === "skill").flatMap((artifact) => {
+          const target = artifact.metadata?.materializedTarget;
+          return typeof target === "string" ? [target] : [];
+        }),
+      );
+      const ownedSourceNames = new Set(
+        priorArtifacts
+          .filter((artifact) => artifact.kind === "source")
+          .map((artifact) => artifact.targetRef),
+      );
+      if (existing) {
+        installationId = existing.id;
+        await db().update(pack_install).set({
+          version: bundle.manifest.metadata.version,
+          status: operationType === "upgrade" ? "upgrading" : "installing",
+          manifest_hash: bundle.manifestHash,
+          config: inputs,
+          last_error: null,
+          removed_at: null,
+          updated_at: new Date(),
+        }).where(eq(pack_install.id, existing.id));
+      } else {
+        const [created] = await db().insert(pack_install).values({
+          org_id: this.orgId,
+          pack_id: packId,
+          version: bundle.manifest.metadata.version,
+          status: "installing",
+          manifest_hash: bundle.manifestHash,
+          config: inputs,
+          installed_by_user_id: request.actorUserId ?? null,
+        }).returning({ id: pack_install.id });
+        installationId = created!.id;
+      }
+      const [operation] = await db().insert(pack_operation).values({
+        pack_install_id: installationId,
+        org_id: this.orgId,
+        operation_type: operationType,
+        actor_user_id: request.actorUserId ?? null,
+        status: "running",
+        requested_version: bundle.manifest.metadata.version,
+        idempotency_key: request.idempotencyKey ?? randomUUID(),
+        plan: plan as unknown as Record<string, unknown>,
+        plan_hash: plan.hash,
+        phase: "preflight_complete",
+        started_at: new Date(),
+      }).returning({ id: pack_operation.id });
+      operationId = operation!.id;
+      await db().update(pack_install).set({ operation_id: operationId }).where(eq(pack_install.id, installationId));
+
+      const nextPackSecrets = { ...storedSecrets };
+      for (const key of resolvedSecrets.cleared) delete nextPackSecrets[secretEnvKey(key)];
+      for (const [key, value] of Object.entries(resolvedSecrets.values)) {
+        nextPackSecrets[secretEnvKey(key)] = value;
+      }
+      const nextSecrets = {
+        ...resolvedSecrets.store,
+        [secretSection]: nextPackSecrets,
+      };
+      await writeSecretsStore(nextSecrets);
+      secretsRestore = () => writeSecretsStore(resolvedSecrets.store);
+
+      const [source] = await db()
+        .select({ graphqlUrl: data_source.graphql_url })
+        .from(data_source)
+        .where(and(eq(data_source.org_id, this.orgId), eq(data_source.enabled, true)))
+        .orderBy(desc(data_source.is_default), data_source.created_at)
+        .limit(1);
+      const configFile = process.env.OPENNEKO_GRAPHJIN_CONFIG?.trim();
+      if (!source?.graphqlUrl || !configFile) {
+        throw new Error("customer GraphJin endpoint/config volume is unavailable");
+      }
+      const retiredRemovals: Array<{
+        restore: () => Promise<void>;
+        commit: () => Promise<void>;
+      }> = [];
+      const configRoot = dirname(configFile);
+      const workspace = retiredArtifacts.some((artifact) => artifact.kind === "skill")
+        ? await ensureOrgWorkspace(this.orgId)
+        : null;
+      try {
+        for (const artifact of retiredArtifacts) {
+          const target = artifact.metadata?.materializedTarget;
+          if (typeof target !== "string") continue;
+          if (artifact.kind === "spec" || artifact.kind === "saved_query") {
+            retiredRemovals.push(
+              await stageOwnedRemoval(assertOwnedPath(configRoot, target, "GraphJin pack file")),
+            );
+          } else if (artifact.kind === "skill" && workspace) {
+            retiredRemovals.push(
+              await stageOwnedRemoval(assertOwnedPath(workspace.skillsRoot, target, "pack skill")),
+            );
+          }
+        }
+      } catch (error) {
+        for (const removal of retiredRemovals.reverse()) await removal.restore().catch(() => {});
+        throw error;
+      }
+      retiredRestore = async () => {
+        for (const removal of retiredRemovals.reverse()) await removal.restore();
+      };
+      retiredCommit = async () => {
+        for (const removal of retiredRemovals) await removal.commit();
+      };
+      const desiredSourceNames = new Set(
+        bundle.artifacts.filter((artifact) => artifact.kind === "source").map((artifact) => artifact.targetRef),
+      );
+      const retiredSourceNames = retiredArtifacts
+        .filter((artifact) => artifact.kind === "source" && !desiredSourceNames.has(artifact.targetRef))
+        .map((artifact) => artifact.targetRef);
+      await db().update(pack_operation).set({ phase: "graphjin_files", updated_at: new Date() }).where(eq(pack_operation.id, operationId));
+      const files = await installGraphjinFiles({
+        bundle,
+        configFile,
+        values: inputs,
+        ownedTargets: ownedFileTargets,
+      });
+      filesRestore = files.restore;
+
+      const applied = await applyPackGraphjinConfig({
+        endpoint: graphjinEndpoint(source.graphqlUrl),
+        orgId: this.orgId,
+        configFile,
+        update: graphjinUpdate(inputs, resolvedSecrets.values, preflight, bundle, retiredSourceNames),
+        ownedSourceNames,
+      });
+      graphjinRestore = applied.restore;
+      await runMagentoAnalyticsSmoke(graphjinEndpoint(source.graphqlUrl), this.orgId);
+
+      const retiredHashes = new Map<string, string>();
+      for (const artifact of retiredArtifacts.filter(
+        (value) => value.kind === "source" || value.kind === "relationships",
+      )) {
+        const current = await inspectInstalledPackArtifactCurrent({
+          orgId: this.orgId,
+          kind: artifact.kind as "source" | "relationships",
+          targetRef: artifact.targetRef,
+          metadata: artifact.metadata ?? {},
+          graphjinConfigFile: configFile,
+        });
+        if (current) retiredHashes.set(`${artifact.kind}:${artifact.key}`, current);
+      }
+
+      const skills = await installSkills({ orgId: this.orgId, bundle, ownedTargets: ownedSkillTargets });
+      skillRestore = skills.restore;
+      skillCommit = skills.commit;
+
+      const materializedHashes = new Map<string, string>();
+      for (const artifact of bundle.artifacts.filter((value) =>
+        value.kind === "source" ||
+        value.kind === "relationships" ||
+        value.kind === "spec" ||
+        value.kind === "saved_query" ||
+        value.kind === "skill"
+      )) {
+        const target = files.targets.get(`${artifact.kind}:${artifact.key}`) ??
+          skills.targets.get(`${artifact.kind}:${artifact.key}`) ?? artifact.targetRef;
+        const currentHash = await inspectPackArtifactCurrent({
+          orgId: this.orgId,
+          artifact,
+          metadata: { materializedTarget: target, locator: packArtifactLocator(artifact) },
+          graphjinConfigFile: configFile,
+        });
+        if (!currentHash) throw new Error(`pack artifact ${artifact.key} was not materialized`);
+        materializedHashes.set(`${artifact.kind}:${artifact.key}`, currentHash);
+      }
+
+      await db().transaction(async (tx) => {
+        for (const artifact of retiredArtifacts) {
+          const identity = `${artifact.kind}:${artifact.key}`;
+          const locatorValue = artifact.metadata?.locator;
+          const locator = locatorValue && typeof locatorValue === "object" && !Array.isArray(locatorValue)
+            ? locatorValue as Record<string, unknown>
+            : {};
+          if (artifact.kind === "metric") {
+            const role = String(locator.role ?? "");
+            if (!role) throw new Error(`pack metric ${artifact.key} has no retirement locator`);
+            const [row] = await tx.select().from(metric).where(and(
+              eq(metric.org_id, this.orgId),
+              eq(metric.role, role),
+              eq(metric.slug, String(locator.slug ?? artifact.targetRef)),
+            )).limit(1);
+            if (!row) throw new Error(`pack metric ${artifact.targetRef} disappeared during upgrade`);
+            await tx.update(metric).set({ active: false, updated_at: new Date() }).where(eq(metric.id, row.id));
+            retiredHashes.set(identity, nativeArtifactStateHash("metric", { ...row, active: false } as unknown as Record<string, unknown>));
+          } else if (artifact.kind === "workflow") {
+            const [row] = await tx.select().from(workflow_definition).where(and(
+              eq(workflow_definition.org_id, this.orgId),
+              eq(workflow_definition.owner_user_id, ""),
+              eq(workflow_definition.name, String(locator.name ?? artifact.targetRef)),
+            )).limit(1);
+            if (!row) throw new Error(`pack workflow ${artifact.targetRef} disappeared during upgrade`);
+            await tx.update(workflow_definition).set({
+              enabled: false,
+              cron_enabled: false,
+              updated_at: new Date(),
+            }).where(eq(workflow_definition.id, row.id));
+            retiredHashes.set(identity, nativeArtifactStateHash("workflow", {
+              ...row,
+              enabled: false,
+              cron_enabled: false,
+            } as unknown as Record<string, unknown>));
+          } else if (artifact.kind === "watcher") {
+            const [row] = await tx.select().from(watcher).where(and(
+              eq(watcher.org_id, this.orgId),
+              eq(watcher.name, String(locator.name ?? artifact.targetRef)),
+            )).limit(1);
+            if (!row) throw new Error(`pack watcher ${artifact.targetRef} disappeared during upgrade`);
+            await tx.update(watcher).set({ enabled: false, updated_at: new Date() }).where(eq(watcher.id, row.id));
+            retiredHashes.set(identity, nativeArtifactStateHash("watcher", { ...row, enabled: false } as unknown as Record<string, unknown>));
+          } else if (artifact.kind === "policy") {
+            const [row] = await tx.select().from(action_policy).where(and(
+              eq(action_policy.org_id, this.orgId),
+              eq(action_policy.name, String(locator.name ?? artifact.targetRef)),
+            )).limit(1);
+            if (!row) throw new Error(`pack policy ${artifact.targetRef} disappeared during upgrade`);
+            await tx.update(action_policy).set({ enabled: false, updated_at: new Date() }).where(eq(action_policy.id, row.id));
+            retiredHashes.set(identity, nativeArtifactStateHash("policy", { ...row, enabled: false } as unknown as Record<string, unknown>));
+          } else if (artifact.kind === "action") {
+            const [row] = await tx.select().from(pack_action_definition).where(and(
+              eq(pack_action_definition.org_id, this.orgId),
+              eq(pack_action_definition.kind, String(locator.kind ?? artifact.targetRef)),
+            )).limit(1);
+            if (!row) throw new Error(`pack action ${artifact.targetRef} disappeared during upgrade`);
+            await tx.update(pack_action_definition).set({
+              enabled: false,
+              readiness: "blocked",
+              readiness_reason: "removed_from_pack",
+              updated_at: new Date(),
+            }).where(eq(pack_action_definition.id, row.id));
+            retiredHashes.set(identity, nativeArtifactStateHash("action", { ...row, enabled: false } as unknown as Record<string, unknown>));
+          }
+
+          const retiredHash = retiredHashes.get(identity) ?? canonicalHash({ retired: true, identity });
+          await tx.update(pack_artifact).set({
+            last_applied_hash: retiredHash,
+            ownership: "retired",
+            readiness: "not_applicable",
+            readiness_reason: null,
+            metadata: {
+              ...(artifact.metadata ?? {}),
+              stateHashVersion: 1,
+              retiredMissing: !retiredHashes.has(identity),
+              ...(
+                artifact.kind === "source" || artifact.kind === "relationships"
+                  ? { retainedForGraphjinCompatibility: true }
+                  : {}
+              ),
+            },
+            updated_at: new Date(),
+          }).where(eq(pack_artifact.id, artifact.id));
+        }
+
+        const workflows = new Map<string, string>();
+        for (const artifact of bundle.artifacts.filter((value) => value.kind === "workflow")) {
+          const value = artifactRecord(artifact);
+          const name = String(value.name);
+          const [existingWorkflow] = await tx.select({ id: workflow_definition.id }).from(workflow_definition)
+            .where(and(eq(workflow_definition.org_id, this.orgId), eq(workflow_definition.owner_user_id, ""), eq(workflow_definition.name, name))).limit(1);
+          const schedule = value.schedule as Record<string, unknown> | null;
+          const rowValues = {
+            description: String(value.description ?? ""),
+            enabled: Boolean(value.enabled),
+            status: String(value.status),
+            goal: String(value.goal),
+            cron: schedule ? String(schedule.cron) : null,
+            cron_timezone: String(inputs["magento.timezone"] ?? "UTC"),
+            cron_enabled: Boolean(schedule?.enabled),
+            output_contract: value.outputContract as Record<string, unknown>,
+            updated_at: new Date(),
+          };
+          const [row] = existingWorkflow
+            ? await tx.update(workflow_definition).set(rowValues).where(eq(workflow_definition.id, existingWorkflow.id)).returning({ id: workflow_definition.id })
+            : await tx.insert(workflow_definition).values({ org_id: this.orgId, owner_user_id: "", name, ...rowValues }).returning({ id: workflow_definition.id });
+          workflows.set(artifact.key, row!.id);
+          materializedHashes.set(
+            `${artifact.kind}:${artifact.key}`,
+            nativeArtifactStateHash("workflow", { name, ...rowValues }),
+          );
+        }
+
+        for (const artifact of bundle.artifacts.filter((value) => value.kind === "metric")) {
+          const value = artifactRecord(artifact);
+          const execution = value.execution as Record<string, unknown>;
+          const definition = {
+            ...value,
+            execution: {
+              ...execution,
+              document: findSavedQuery(bundle, String(execution.query)),
+              runtime: {
+                storeIds: preflight.storeIds,
+                windowDays: 30,
+                staleAfterSeconds: 2 * 60 * 60,
+                agedAfterSeconds: 2 * 24 * 60 * 60,
+                stockThreshold: 5,
+                currency: String(inputs["magento.base_currency"] ?? "USD"),
+                timezone: String(inputs["magento.timezone"] ?? "UTC"),
+              },
+            },
+          };
+          const set = {
+            source: `pack:${packId}`,
+            title: String(value.title),
+            description: String(value.description),
+            why: String(value.calculationNote),
+            chart_hint: String(value.chartHint),
+            unit: String(value.unit),
+            direction_good: String(value.directionGood),
+            cadence: String(value.cadence),
+            active: true,
+            execution_mode: "saved_query",
+            definition_json: definition,
+            definition_version: 1,
+            definition_hash: canonicalHash(definition),
+            updated_at: new Date(),
+          };
+          await tx.insert(metric).values({
+            org_id: this.orgId,
+            role: String(value.role),
+            slug: String(value.targetRef),
+            ...set,
+          }).onConflictDoUpdate({
+            target: [metric.org_id, metric.role, metric.slug],
+            set,
+          });
+          materializedHashes.set(
+            `${artifact.kind}:${artifact.key}`,
+            nativeArtifactStateHash("metric", { role: String(value.role), slug: String(value.targetRef), ...set }),
+          );
+        }
+
+        for (const artifact of bundle.artifacts.filter((value) => value.kind === "watcher")) {
+          const value = artifactRecord(artifact);
+          const workflowId = workflows.get(String(value.workflow));
+          if (!workflowId) throw new Error(`watcher ${artifact.key} references missing workflow ${String(value.workflow)}`);
+          const query = findSavedQuery(bundle, String(value.query));
+          const set = {
+            workflow_id: workflowId,
+            description: String(value.description),
+            enabled: Boolean(value.enabled),
+            query,
+            value_path: String(value.valuePath),
+            op: String(value.operator),
+            threshold: value.threshold,
+            cadence_seconds: Number(value.cadenceSeconds),
+            debounce_seconds: Number(value.debounceSeconds),
+            cooldown_seconds: Number(value.cooldownSeconds),
+            dedupe_key: String(value.dedupeKey),
+            activation: String(value.activation),
+            variables_json: {
+              from: { kind: "seconds_ago", seconds: 30 * 24 * 60 * 60 },
+              to: { kind: "now" },
+              staleBefore: { kind: "seconds_ago", seconds: 2 * 60 * 60 },
+              olderThan: { kind: "seconds_ago", seconds: 2 * 24 * 60 * 60 },
+              storeIds: { kind: "literal", value: preflight.storeIds },
+              threshold: { kind: "literal", value: 5 },
+            },
+            severity: String(value.severity),
+            updated_at: new Date(),
+          };
+          await tx.insert(watcher).values({ org_id: this.orgId, name: String(value.name), ...set })
+            .onConflictDoUpdate({ target: [watcher.org_id, watcher.name], set });
+          materializedHashes.set(
+            `${artifact.kind}:${artifact.key}`,
+            nativeArtifactStateHash("watcher", { name: String(value.name), ...set }),
+          );
+        }
+
+        for (const artifact of bundle.artifacts.filter((value) => value.kind === "policy")) {
+          const value = artifactRecord(artifact);
+          const [existingPolicy] = await tx.select({ id: action_policy.id }).from(action_policy)
+            .where(and(eq(action_policy.org_id, this.orgId), eq(action_policy.name, String(value.name)))).limit(1);
+          const set = {
+            description: String(value.description),
+            applies_to_kinds: value.appliesToKinds as string[],
+            applies_to_scopes: value.appliesToScopes as string[],
+            mode: value.mode === "ask" ? "approval_required" : String(value.mode),
+            allowed_targets: value.allowedTargets as Record<string, unknown>,
+            limits: value.limits as Record<string, unknown>,
+            approver_role: String(value.approverRole),
+            priority: Number(value.priority),
+            enabled: Boolean(value.enabled),
+            updated_at: new Date(),
+          };
+          if (existingPolicy) await tx.update(action_policy).set(set).where(eq(action_policy.id, existingPolicy.id));
+          else await tx.insert(action_policy).values({ org_id: this.orgId, name: String(value.name), ...set });
+          materializedHashes.set(
+            `${artifact.kind}:${artifact.key}`,
+            nativeArtifactStateHash("policy", { name: String(value.name), ...set }),
+          );
+        }
+
+        for (const artifact of bundle.artifacts.filter((value) => value.kind === "action")) {
+          const value = artifactRecord(artifact);
+          const reason = preflight.operatorReadiness;
+          await tx.insert(pack_action_definition).values({
+            org_id: this.orgId,
+            kind: String(value.kind),
+            description: String(value.description),
+            definition: value,
+            definition_hash: artifact.hash,
+            readiness: "blocked",
+            readiness_reason: reason,
+            enabled: true,
+          }).onConflictDoUpdate({
+            target: [pack_action_definition.org_id, pack_action_definition.kind],
+            set: {
+              description: String(value.description),
+              definition: value,
+              definition_hash: artifact.hash,
+              readiness: "blocked",
+              readiness_reason: reason,
+              enabled: true,
+              updated_at: new Date(),
+            },
+          });
+          materializedHashes.set(
+            `${artifact.kind}:${artifact.key}`,
+            nativeArtifactStateHash("action", {
+              kind: String(value.kind),
+              description: String(value.description),
+              definition: value,
+              definition_hash: artifact.hash,
+              enabled: true,
+            }),
+          );
+        }
+
+        for (const artifact of bundle.artifacts) {
+          const operatorArtifact =
+            artifact.key === "source.magento_operator" ||
+            artifact.kind === "spec" ||
+            artifact.kind === "action" ||
+            (artifact.kind === "saved_query" && basename(artifact.path).startsWith("action_"));
+          const readiness = operatorArtifact ? "blocked" : "ready";
+          const reason = operatorArtifact ? `operator:${preflight.operatorReadiness}` : null;
+          const target = files.targets.get(`${artifact.kind}:${artifact.key}`) ??
+            skills.targets.get(`${artifact.kind}:${artifact.key}`) ?? artifact.targetRef;
+          const materializedHash = materializedHashes.get(`${artifact.kind}:${artifact.key}`);
+          if (!materializedHash) throw new Error(`pack artifact ${artifact.key} has no materialized state hash`);
+          await tx.insert(pack_artifact).values({
+            pack_install_id: installationId!,
+            org_id: this.orgId,
+            artifact_kind: artifact.kind,
+            artifact_key: artifact.key,
+            target_ref: artifact.targetRef,
+            desired_hash: artifact.hash,
+            last_applied_hash: materializedHash,
+            ownership: "managed",
+            readiness,
+            readiness_reason: reason,
+            metadata: {
+              path: artifact.path,
+              materializedTarget: target,
+              locator: packArtifactLocator(artifact),
+              stateHashVersion: 1,
+            },
+          }).onConflictDoUpdate({
+            target: [pack_artifact.org_id, pack_artifact.artifact_kind, pack_artifact.target_ref],
+            set: {
+              pack_install_id: installationId!,
+              artifact_key: artifact.key,
+              desired_hash: artifact.hash,
+              last_applied_hash: materializedHash,
+              ownership: "managed",
+              readiness,
+              readiness_reason: reason,
+              metadata: {
+                path: artifact.path,
+                materializedTarget: target,
+                locator: packArtifactLocator(artifact),
+                stateHashVersion: 1,
+              },
+              updated_at: new Date(),
+            },
+          });
+        }
+        await tx.update(pack_install).set({
+          status: "installed",
+          config: { ...inputs, magentoVersion: preflight.magentoVersion },
+          installed_at: new Date(),
+          updated_at: new Date(),
+        }).where(eq(pack_install.id, installationId!));
+        await tx.update(pack_operation).set({
+          status: "succeeded",
+          phase: "complete",
+          compensation_status: "not_required",
+          completed_at: new Date(),
+          updated_at: new Date(),
+        }).where(eq(pack_operation.id, operationId!));
+      });
+
+      await skillCommit?.().catch((error) => {
+        console.warn(
+          `[packs] installed ${packId}, but could not remove the skill backup: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+      await retiredCommit?.().catch((error) => {
+        console.warn(
+          `[packs] installed ${packId}, but could not remove a retired-artifact backup: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      });
+      await enqueuePackMetricRefreshes(this.orgId, bundle).catch((error) => {
+        console.warn(`[packs] initial metric refresh setup failed: ${error instanceof Error ? error.message : String(error)}`);
+      });
+      const status = await this.status(packId);
+      if (!status) throw new Error("pack status missing after install");
+      return status;
+    } catch (error) {
+      let compensationFailed = false;
+      for (const restore of [skillRestore, graphjinRestore, filesRestore, retiredRestore, secretsRestore]) {
+        if (!restore) continue;
+        await restore().catch(() => {
+          compensationFailed = true;
+        });
+      }
+      const message = (error instanceof Error ? error.message : String(error)).slice(0, 1000);
+      if (operationId) {
+        await db().update(pack_operation).set({
+          status: "failed",
+          failure_phase: "apply",
+          error: message,
+          compensation_status: compensationFailed ? "failed" : "succeeded",
+          completed_at: new Date(),
+          updated_at: new Date(),
+        }).where(eq(pack_operation.id, operationId)).catch(() => {});
+      }
+      if (installationId) {
+        const restorePrior =
+          (priorInstallation?.status === "installed" || priorInstallation?.status === "removed") &&
+          !compensationFailed;
+        await db().update(pack_install).set(restorePrior ? {
+          status: priorInstallation!.status,
+          version: priorInstallation!.version,
+          manifest_hash: priorInstallation!.manifest_hash,
+          config: priorInstallation!.config,
+          operation_id: priorInstallation!.operation_id,
+          installed_at: priorInstallation!.installed_at,
+          removed_at: priorInstallation!.removed_at,
+          last_error: message,
+          updated_at: new Date(),
+        } : { status: "failed", last_error: message, updated_at: new Date() })
+          .where(eq(pack_install.id, installationId)).catch(() => {});
+      }
+      throw error;
+    } finally {
+      await client.query("SELECT pg_advisory_unlock(hashtextextended($1, 0))", [`pack:${this.orgId}:${packId}`]).catch(() => {});
+      client.release();
+    }
+  }
+}

--- a/apps/worker/src/records/adapters.ts
+++ b/apps/worker/src/records/adapters.ts
@@ -379,6 +379,13 @@ async function writeRequest(
 ): Promise<RecordWriteRequest> {
   const payload = request.payload;
   const operation = operationForKind(kind);
+  if (kind === "record_create") {
+    assertOnlyKeys(payload, ["app", "object", "fields"]);
+  } else if (kind === "record_update") {
+    assertOnlyKeys(payload, ["app", "object", "id", "fields", "expected"]);
+  } else {
+    assertOnlyKeys(payload, ["app", "object", "id"]);
+  }
   const common = {
     actionRequestId: request.id,
     orgId: request.orgId,
@@ -389,11 +396,9 @@ async function writeRequest(
   };
 
   if (kind === "record_create") {
-    assertOnlyKeys(payload, ["app", "object", "fields"]);
     return { ...common, fields: requiredRecord(payload, "fields") };
   }
   if (kind === "record_update") {
-    assertOnlyKeys(payload, ["app", "object", "id", "fields", "expected"]);
     return {
       ...common,
       id: requiredString(payload, "id"),
@@ -401,7 +406,6 @@ async function writeRequest(
       expected: optionalRecord(payload, "expected"),
     };
   }
-  assertOnlyKeys(payload, ["app", "object", "id"]);
   return { ...common, id: requiredString(payload, "id") };
 }
 

--- a/apps/worker/test/admin-server.test.ts
+++ b/apps/worker/test/admin-server.test.ts
@@ -168,6 +168,123 @@ describe("worker admin HTTP handler", () => {
   });
 });
 
+describe("worker solution-pack admin routes", () => {
+  it("routes the supported pack lifecycle without filtering artifacts", async () => {
+    const surface = {
+      list: vi.fn(async () => [{ id: "magento", installed: false }]),
+      inspect: vi.fn(async (packId: string) => ({ packId })),
+      plan: vi.fn(async (packId: string) => ({ packId, entries: [{ key: "action.add_internal_order_comment" }] })),
+      status: vi.fn(async (packId: string) => ({ packId, status: "installed" })),
+      doctor: vi.fn(async (packId: string) => ({ packId, status: "degraded" })),
+      install: vi.fn(async (packId: string, input: Record<string, unknown>) => ({
+        packId,
+        status: "installed",
+        input,
+      })),
+      configure: vi.fn(async (packId: string, input: Record<string, unknown>) => ({
+        packId,
+        status: "installed",
+        input,
+      })),
+      upgrade: vi.fn(async (packId: string, input: Record<string, unknown>) => ({
+        packId,
+        status: "installed",
+        input,
+      })),
+      uninstall: vi.fn(async (packId: string, input: Record<string, unknown>) => ({
+        packId,
+        status: "removed",
+        input,
+      })),
+    };
+    const srv = await startServer(createAdminHandler({ packs: surface }));
+    try {
+      const list = await fetch(`http://127.0.0.1:${srv.port}/admin/packs`);
+      expect(list.status).toBe(200);
+      expect(await list.json()).toEqual({ packs: [{ id: "magento", installed: false }] });
+
+      for (const [suffix, method] of [
+        ["", "inspect"],
+        ["/plan", "plan"],
+        ["/status", "status"],
+        ["/doctor", "doctor"],
+      ] as const) {
+        const response = await fetch(
+          `http://127.0.0.1:${srv.port}/admin/packs/magento${suffix}`,
+        );
+        expect(response.status).toBe(200);
+        expect(surface[method]).toHaveBeenCalledWith("magento");
+      }
+
+      const input = {
+        inputs: { "magento.base_url": "http://magento.test" },
+        secrets: { "database.analytics_username": "analytics" },
+      };
+      const install = await fetch(
+        `http://127.0.0.1:${srv.port}/admin/packs/magento/install`,
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(input),
+        },
+      );
+      expect(install.status).toBe(200);
+      expect(surface.install).toHaveBeenCalledWith("magento", input);
+
+      for (const action of ["configure", "upgrade", "uninstall"] as const) {
+        const response = await fetch(
+          `http://127.0.0.1:${srv.port}/admin/packs/magento/${action}`,
+          {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify(input),
+          },
+        );
+        expect(response.status).toBe(200);
+        expect(surface[action]).toHaveBeenCalledWith("magento", input);
+      }
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("fails closed when no pack surface is wired", async () => {
+    const srv = await startServer(createAdminHandler());
+    try {
+      const response = await fetch(`http://127.0.0.1:${srv.port}/admin/packs`);
+      expect(response.status).toBe(503);
+    } finally {
+      await srv.close();
+    }
+  });
+
+  it("does not accept trailing junk as a pack lifecycle route", async () => {
+    const inspect = vi.fn(async () => ({ packId: "magento" }));
+    const srv = await startServer(createAdminHandler({
+      packs: {
+        list: async () => [],
+        inspect,
+        plan: async () => ({}),
+        status: async () => ({}),
+        doctor: async () => ({}),
+        install: async () => ({}),
+        configure: async () => ({}),
+        upgrade: async () => ({}),
+        uninstall: async () => ({}),
+      },
+    }));
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${srv.port}/admin/packs/magento/status-extra`,
+      );
+      expect(response.status).toBe(404);
+      expect(inspect).not.toHaveBeenCalled();
+    } finally {
+      await srv.close();
+    }
+  });
+});
+
 describe("worker native records-watch ingress", () => {
   const secret = "records-watch-test-secret-that-is-at-least-thirty-two-bytes";
   const body = JSON.stringify({

--- a/apps/worker/test/deterministic-metric.test.ts
+++ b/apps/worker/test/deterministic-metric.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { buildSavedQueryVariables, mapSavedQueryMetric } from "../src/jobs/deterministic-metric.js";
+
+function definition(result: Record<string, unknown>, extra: Record<string, unknown> = {}) {
+  return {
+    title: "Net revenue",
+    description: "Reviewed metric",
+    calculationNote: "Invoice less refund.",
+    chartHint: "metric",
+    unit: "currency",
+    directionGood: "up",
+    execution: {
+      mode: "saved_query",
+      source: "magento_analytics",
+      query: "net_invoiced_revenue",
+      document: "query { sales_invoice { sum_base_grand_total } }",
+      result,
+      freshnessSeconds: 3600,
+      runtime: { storeIds: [2, 3], currency: "USD", windowDays: 7, ...extra },
+    },
+  };
+}
+
+describe("deterministic saved-query metrics", () => {
+  it("builds bounded variables without an LLM", () => {
+    const now = new Date("2026-08-20T12:00:00.000Z");
+    expect(buildSavedQueryVariables(definition({ kind: "scalar", path: "orders.0.count" }), now)).toMatchObject({
+      from: "2026-08-13T12:00:00.000Z",
+      to: "2026-08-20T12:00:00.000Z",
+      storeIds: [2, 3],
+      threshold: 5,
+    });
+  });
+
+  it("evaluates only the allowlisted arithmetic expression", () => {
+    const mapped = mapSavedQueryMetric({
+      definition: definition({ kind: "scalar", expression: { subtract: ["invoice.0.total", "refund.0.total"] } }),
+      data: { invoice: [{ total: "120.50" }], refund: [{ total: 20.5 }] },
+      baseline: 90,
+      now: new Date("2026-08-20T12:00:00.000Z"),
+    });
+    expect(mapped.value).toBe(100);
+    expect(mapped.result.headlineMetric).toBe("$100.00");
+    expect(mapped.result.chartData).toEqual([{ d: "Current", v: 100, t: 90 }]);
+    expect(mapped.result.mood).toBe("good");
+  });
+
+  it("returns null for a zero denominator", () => {
+    const mapped = mapSavedQueryMetric({
+      definition: definition({ kind: "scalar", expression: { divide: ["a.0.value", "b.0.value"] } }),
+      data: { a: [{ value: 10 }], b: [{ value: 0 }] },
+    });
+    expect(mapped.value).toBeNull();
+    expect(mapped.result.headlineMetric).toBe("Not yet available");
+    expect(mapped.result.mood).toBe("watch");
+  });
+
+  it("supports nested arithmetic used by average order value", () => {
+    const mapped = mapSavedQueryMetric({
+      definition: definition({
+        kind: "scalar",
+        expression: {
+          divide: [
+            { subtract: ["invoice.0.total", "refund.0.total"] },
+            "orders.0.count",
+          ],
+        },
+        zeroDenominator: null,
+      }),
+      data: {
+        invoice: [{ total: 125 }],
+        refund: [{ total: 25 }],
+        orders: [{ count: 4 }],
+      },
+    });
+    expect(mapped.value).toBe(25);
+    expect(mapped.result.headlineMetric).toBe("$25.00");
+  });
+
+  it("does not report missing freshness timestamps as zero seconds old", () => {
+    const mapped = mapSavedQueryMetric({
+      definition: definition({ kind: "timestamps", paths: ["orders.0.latest"] }),
+      data: { orders: [] },
+      now: new Date("2026-08-20T12:00:00Z"),
+    });
+    expect(mapped.value).toBeNull();
+    expect(mapped.result.headlineMetric).toBe("Not yet available");
+  });
+
+  it("maps keyed store totals and timestamp-age summaries", () => {
+    const stores = mapSavedQueryMetric({
+      definition: definition({
+        kind: "keyed_subtract",
+        left: { rowsPath: "invoice", keyPath: "store_id", valuePath: "total" },
+        right: { rowsPath: "refund", keyPath: "store_id", valuePath: "total" },
+      }),
+      data: { invoice: [{ store_id: 1, total: 100 }, { store_id: 2, total: 50 }], refund: [{ store_id: 1, total: 25 }] },
+    });
+    expect(stores.value).toBe(125);
+    expect(stores.result.chartData).toEqual([{ d: "1", v: 75 }, { d: "2", v: 50 }]);
+
+    const ages = mapSavedQueryMetric({
+      definition: definition({ kind: "timestamp_age_summary", rowsPath: "orders", timestampPath: "created_at" }),
+      data: { orders: [{ created_at: "2026-08-18T12:00:00Z" }, { created_at: "2026-08-16T12:00:00Z" }] },
+      now: new Date("2026-08-20T12:00:00Z"),
+    });
+    expect(ages.value).toBe(3 * 86_400);
+    expect(ages.valueJson).toEqual({ median: 3 * 86_400, max: 4 * 86_400, count: 2 });
+  });
+
+  it("rejects unreviewed expression operators", () => {
+    expect(() => mapSavedQueryMetric({
+      definition: definition({ kind: "scalar", expression: { eval: ["a", "b"] } }),
+      data: { a: 1, b: 2 },
+    })).toThrow(/operator eval is not allowed/);
+  });
+});

--- a/apps/worker/test/jobs/metric-refresh.test.ts
+++ b/apps/worker/test/jobs/metric-refresh.test.ts
@@ -27,6 +27,7 @@ import {
 } from "@neko/db/test-helpers";
 import {
   and,
+  data_source,
   db,
   eq,
   metric,
@@ -35,9 +36,10 @@ import {
   processing_job,
 } from "@neko/db";
 
-const { mockRunMetricAgent, mockResolveBackendId } = vi.hoisted(() => ({
+const { mockRunMetricAgent, mockResolveBackendId, mockGraphjinQuery } = vi.hoisted(() => ({
   mockRunMetricAgent: vi.fn(),
   mockResolveBackendId: vi.fn(),
+  mockGraphjinQuery: vi.fn(),
 }));
 
 vi.mock("@neko/llm", async () => {
@@ -46,6 +48,14 @@ vi.mock("@neko/llm", async () => {
     ...actual,
     runMetricAgent: mockRunMetricAgent,
     resolveAgentBackendId: mockResolveBackendId,
+  };
+});
+
+vi.mock("@neko/llm/graphjin", async () => {
+  const actual = await vi.importActual<typeof import("@neko/llm/graphjin")>("@neko/llm/graphjin");
+  return {
+    ...actual,
+    graphjinQuery: mockGraphjinQuery,
   };
 });
 
@@ -180,6 +190,79 @@ describeIfDb("runMetricRefresh", () => {
           runId: jobId,
           status: "completed",
         },
+      });
+    });
+
+    it("runs a reviewed saved query deterministically without an LLM", async () => {
+      await db().insert(data_source).values({
+        org_id: orgId,
+        kind: "customer",
+        name: "magento",
+        graphql_url: "http://magento-graphjin.test",
+        auth_mode: "none",
+        is_default: true,
+        enabled: true,
+      });
+      const definition = {
+        title: "Orders placed",
+        description: "Orders in the selected period.",
+        calculationNote: "Cancellations remain included.",
+        chartHint: "metric",
+        unit: "count",
+        directionGood: "up",
+        execution: {
+          mode: "saved_query",
+          source: "magento_analytics",
+          query: "orders_placed",
+          document: "query Orders($from: String!, $to: String!, $storeIds: [Int!]!) { sales_order { orders: count } }",
+          result: { kind: "scalar", path: "sales_order.0.orders" },
+          freshnessSeconds: 7200,
+          runtime: { storeIds: [1], windowDays: 30 },
+        },
+      };
+      const [card] = await db().insert(metric).values({
+        org_id: orgId,
+        role: "executive",
+        slug: "magento-orders-placed",
+        source: "magento",
+        title: "Orders placed",
+        why: "Reviewed Magento order count.",
+        chart_hint: "metric",
+        active: true,
+        execution_mode: "saved_query",
+        definition_json: definition,
+        definition_version: 1,
+        definition_hash: "definition-hash",
+      }).returning({ id: metric.id });
+      mockGraphjinQuery.mockResolvedValueOnce({
+        data: { sales_order: [{ orders: 42 }] },
+      });
+      const jobId = await insertProcessingJob(orgId, { metricId: card!.id });
+
+      await runMetricRefresh(jobId, orgId);
+
+      expect(mockRunMetricAgent).not.toHaveBeenCalled();
+      expect(mockResolveBackendId).not.toHaveBeenCalled();
+      expect(mockGraphjinQuery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: "http://magento-graphjin.test/api/v1/graphql",
+          query: definition.execution.document,
+          role: "service",
+          variables: expect.objectContaining({ storeIds: [1] }),
+        }),
+      );
+      const [snapshot] = await db()
+        .select({
+          value: metric_snapshot.value,
+          definitionHash: metric_snapshot.definition_hash,
+          status: metric_snapshot.status,
+        })
+        .from(metric_snapshot)
+        .where(eq(metric_snapshot.metric_id, card!.id));
+      expect(snapshot).toMatchObject({
+        value: "42",
+        definitionHash: "definition-hash",
+        status: "watch",
       });
     });
 

--- a/apps/worker/test/magento-preflight.test.ts
+++ b/apps/worker/test/magento-preflight.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  readMagentoVersion,
+  supportedMagentoDatabase,
+} from "../src/packs/magento-preflight.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Magento version preflight", () => {
+  it("keeps a host-gateway address when Magento redirects to localhost", async () => {
+    const request = vi.fn<typeof fetch>().mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: "http://localhost:8080/magento_version" },
+      }),
+    );
+    vi.stubGlobal("fetch", request);
+    const hostHeaderRequest = vi
+      .fn()
+      .mockResolvedValue({ status: 200, text: "Magento/2.4 (Community)" });
+
+    await expect(
+      readMagentoVersion("http://host.docker.internal:8080", hostHeaderRequest),
+    ).resolves.toBe("2.4.x");
+    expect(hostHeaderRequest).toHaveBeenCalledWith(
+      "http://host.docker.internal:8080/magento_version",
+      "localhost:8080",
+    );
+  });
+
+  it("rejects a version outside the supported 2.4 family", async () => {
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(new Response("Magento/2.3.7", { status: 200 })));
+
+    await expect(readMagentoVersion("https://store.example.com")).rejects.toThrow(
+      "did not report a supported 2.4.x version",
+    );
+  });
+});
+
+describe("Magento database compatibility", () => {
+  it("accepts the declared MariaDB and MySQL floors", () => {
+    expect(supportedMagentoDatabase("10.6.18-MariaDB").type).toBe("mariadb");
+    expect(supportedMagentoDatabase("8.0.39").type).toBe("mysql");
+  });
+
+  it("rejects versions below the manifest contract", () => {
+    expect(() => supportedMagentoDatabase("10.5.27-MariaDB")).toThrow(/MariaDB 10\.6\+/);
+    expect(() => supportedMagentoDatabase("5.7.44")).toThrow(/MySQL 8\.0\+/);
+  });
+});

--- a/apps/worker/test/metric-schedule.test.ts
+++ b/apps/worker/test/metric-schedule.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { metricCadenceMs, metricRefreshIsDue } from "../src/jobs/metric-schedule.js";
+
+describe("metric refresh scheduling", () => {
+  it("honors hourly, daily, and weekly cadences", () => {
+    expect(metricCadenceMs("hourly")).toBe(60 * 60 * 1_000);
+    expect(metricCadenceMs("daily")).toBe(24 * 60 * 60 * 1_000);
+    expect(metricCadenceMs("weekly")).toBe(7 * 24 * 60 * 60 * 1_000);
+  });
+
+  it("refreshes only after the card cadence has elapsed", () => {
+    const now = new Date("2026-08-20T12:00:00Z");
+    expect(metricRefreshIsDue({
+      cadence: "hourly",
+      lastRefreshStatus: "ok",
+      updatedAt: new Date("2026-08-20T10:59:59Z"),
+      now,
+    })).toBe(true);
+    expect(metricRefreshIsDue({
+      cadence: "daily",
+      lastRefreshStatus: "ok",
+      updatedAt: new Date("2026-08-20T10:59:59Z"),
+      now,
+    })).toBe(false);
+  });
+
+  it("does not enqueue a second refresh while one is pending", () => {
+    expect(metricRefreshIsDue({
+      cadence: "hourly",
+      lastRefreshStatus: "pending",
+      updatedAt: new Date("2026-08-01T00:00:00Z"),
+      now: new Date("2026-08-20T12:00:00Z"),
+    })).toBe(false);
+  });
+});

--- a/apps/worker/test/pack-action-preflight.test.ts
+++ b/apps/worker/test/pack-action-preflight.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { assertPackActionReady } from "../src/packs/action-preflight.js";
+
+describe("pack action preflight", () => {
+  it("accepts an enabled ready action", () => {
+    expect(() =>
+      assertPackActionReady("magento.add_internal_order_comment", {
+        enabled: true,
+        readiness: "ready",
+        reason: null,
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects an action while its operator is blocked", () => {
+    expect(() =>
+      assertPackActionReady("magento.add_internal_order_comment", {
+        enabled: true,
+        readiness: "blocked",
+        reason: "GraphJin REST mutations require a newer release",
+      }),
+    ).toThrow(
+      "pack action magento.add_internal_order_comment is blocked: GraphJin REST mutations require a newer release",
+    );
+  });
+
+  it("rejects a disabled action even when marked ready", () => {
+    expect(() =>
+      assertPackActionReady("magento.add_internal_order_comment", {
+        enabled: false,
+        readiness: "ready",
+        reason: null,
+      }),
+    ).toThrow("pack action magento.add_internal_order_comment is blocked");
+  });
+});

--- a/apps/worker/test/pack-artifact-state.test.ts
+++ b/apps/worker/test/pack-artifact-state.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { nativeArtifactStateHash } from "../src/packs/artifact-state";
+
+describe("pack materialized state", () => {
+  it("ignores database timestamps but detects managed metric edits", () => {
+    const original = {
+      role: "owner",
+      slug: "orders",
+      title: "Orders",
+      active: true,
+      updated_at: new Date("2026-01-01"),
+    };
+    expect(nativeArtifactStateHash("metric", {
+      ...original,
+      updated_at: new Date("2026-08-20"),
+    })).toBe(nativeArtifactStateHash("metric", original));
+    expect(nativeArtifactStateHash("metric", {
+      ...original,
+      title: "Orders edited by user",
+    })).not.toBe(nativeArtifactStateHash("metric", original));
+  });
+});

--- a/apps/worker/test/pack-graphjin-config.test.ts
+++ b/apps/worker/test/pack-graphjin-config.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { durablePackTables } from "../src/packs/graphjin-config";
+
+describe("pack GraphJin config persistence", () => {
+  it("keeps the live source-resolution hint out of durable YAML", () => {
+    expect(durablePackTables([
+      {
+        name: "sales_order",
+        source: "magento_analytics",
+        database: "magento_analytics",
+        read_only: true,
+      },
+      {
+        name: "legacy_table",
+        database: "legacy_database",
+      },
+    ])).toEqual([
+      {
+        name: "sales_order",
+        source: "magento_analytics",
+        read_only: true,
+      },
+      {
+        name: "legacy_table",
+        database: "legacy_database",
+      },
+    ]);
+  });
+});

--- a/apps/worker/test/pack-input-validation.test.ts
+++ b/apps/worker/test/pack-input-validation.test.ts
@@ -1,0 +1,35 @@
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { loadSolutionPack } from "@neko/packs";
+import { resolveInputs } from "../src/packs/service.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const packRoot = resolve(here, "../../../packs/magento");
+
+describe("pack API input validation", () => {
+  it("validates enum values on the server, not only in the CLI", async () => {
+    const bundle = await loadSolutionPack(packRoot);
+    expect(() => resolveInputs(bundle, {
+      "magento.base_url": "https://store.example.com",
+      "database.host": "db.example.com",
+      "database.name": "magento",
+      "database.port": 3306,
+      "database.connectivity_mode": "anything-goes",
+    })).toThrow(/database\.connectivity_mode must be one of/);
+  });
+
+  it("normalizes valid URL/string inputs and retains an empty table prefix", async () => {
+    const bundle = await loadSolutionPack(packRoot);
+    expect(resolveInputs(bundle, {
+      "magento.base_url": "https://store.example.com/",
+      "database.host": " db.example.com ",
+      "database.name": "magento",
+    })).toMatchObject({
+      "magento.base_url": "https://store.example.com",
+      "magento.table_prefix": "",
+      "database.host": "db.example.com",
+      "database.port": 3306,
+    });
+  });
+});

--- a/compose.openshell.yml
+++ b/compose.openshell.yml
@@ -4,11 +4,9 @@
 #
 #   docker compose -f compose.yml -f compose.openshell.yml up
 #
-# STATUS: VALIDATED end-to-end on the Linux target (neko-vm / GCP, 2026-06-03):
-# containerised gateway boots with mTLS, the Docker driver creates a sandbox,
-# the supervisor fetches policy + reaches Ready, exec runs, and default-deny
-# egress is enforced. On macOS/OrbStack the same compose stalls at JWT delivery
-# (see requirement #4) — run it on Linux.
+# STATUS: VALIDATED end-to-end on Linux and macOS/OrbStack. On macOS, set
+# OPENSHELL_STATE_DIR to an absolute path under $HOME; the commands in
+# INSTALL.md do this automatically (see requirement #4).
 #
 # Hard requirements proven during bring-up:
 #  1. Docker sandboxes REQUIRE mTLS (JWT + client-cert auth); --disable-tls is a
@@ -36,6 +34,16 @@
 #     the egress netns). The plugin-base + agent images provide both.
 
 services:
+  # Build and tag the agent image from this checkout. The one-shot proves the
+  # image starts and leaves the tag available for OpenShell sandbox creation.
+  agent-image:
+    image: ${OPENNEKO_AGENT_IMAGE:-openneko-agent:dev}
+    build:
+      context: .
+      target: agent
+    restart: "no"
+    command: ["node", "--version"]
+
   # Generate the mTLS PKI (CA + server + client + JWT signing key). Distroless
   # image → run the binary directly. The state dir is mounted at an identical
   # path so generate-certs' temp-dir rename stays on one device (requirement #2).
@@ -92,7 +100,7 @@ services:
       # `docker compose -p ...` supplies COMPOSE_PROJECT_NAME during
       # interpolation; the explicit name must match the runtime network below.
       OPENNEKO_COMPOSE_NETWORK: "${COMPOSE_PROJECT_NAME}_runtime"
-      OPENSHELL_GATEWAY_IP: "${OPENSHELL_GATEWAY_IP:-172.29.0.2}"
+      OPENSHELL_GATEWAY_IP: "${OPENSHELL_GATEWAY_IP:-172.29.3.2}"
     volumes:
       - ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/pki:${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/pki:ro
       - openshell-config:/config/openshell
@@ -116,7 +124,7 @@ services:
         condition: service_completed_successfully
     environment:
       OPENSHELL_DRIVERS: docker
-      OPENSHELL_DB_URL: ${OPENSHELL_DB_URL:-postgres://neko:secret@neko-db:5432/neko}
+      OPENSHELL_DB_URL: ${OPENSHELL_DB_URL:-postgres://openshell:${OPENNEKO_OPENSHELL_DB_PASSWORD:-openneko-openshell-development-password}@neko-db:5432/neko}
       OPENSHELL_LOCAL_TLS_DIR: ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/pki
       XDG_DATA_HOME: ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/cache
       # Matched, host-shared HOME (requirement #4) — NOT /tmp.
@@ -127,7 +135,7 @@ services:
       - "127.0.0.1:${OPENSHELL_PORT:-18080}:${OPENSHELL_PORT:-18080}"
     networks:
       default:
-        ipv4_address: "${OPENSHELL_GATEWAY_IP:-172.29.0.2}"
+        ipv4_address: "${OPENSHELL_GATEWAY_IP:-172.29.3.2}"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - openshell-config:/config/openshell:ro
@@ -135,13 +143,46 @@ services:
       # path the gateway hands the daemon resolves identically on the host.
       - ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}:${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}
 
+  # Do not let web/worker advertise readiness until a real mTLS gateway RPC
+  # succeeds. Container state alone is not enough on a fresh install.
+  openshell-ready:
+    build:
+      context: .
+      target: worker
+    restart: "no"
+    entrypoint: ["/bin/sh", "-ceu"]
+    command:
+      - |
+        attempt=0
+        until openshell --gateway openneko provider list --names >/dev/null 2>&1; do
+          attempt=$$((attempt + 1))
+          if [ "$$attempt" -ge 60 ]; then
+            echo "OpenShell gateway did not become ready within 120 seconds" >&2
+            openshell --gateway openneko provider list --names
+            exit 1
+          fi
+          sleep 2
+        done
+        echo "OpenShell gateway ready"
+    environment:
+      HOME: /tmp/openneko-home
+      XDG_CONFIG_HOME: /config
+    volumes:
+      - openshell-config:/config/openshell:ro
+    depends_on:
+      agent-image:
+        condition: service_completed_successfully
+      openshell-gateway:
+        condition: service_started
+
   # Worker: channel-triggered agent runs + plugins, both in OpenShell sandboxes.
   worker:
     environment:
       OPENNEKO_PLUGIN_BASE_IMAGE: ${OPENNEKO_PLUGIN_BASE_IMAGE:-ghcr.io/open-neko/plugin-base:${OPENNEKO_VERSION:-latest}}
-      OPENNEKO_AGENT_IMAGE: ${OPENNEKO_AGENT_IMAGE:-ghcr.io/open-neko/agent:${OPENNEKO_VERSION:-latest}}
+      OPENNEKO_AGENT_IMAGE: ${OPENNEKO_AGENT_IMAGE:-openneko-agent:dev}
       # provider / egress host / connecting binary / key-env are derived from the
       # org's model config by provisionHostConfig — no per-deploy egress wiring.
+      OPENNEKO_AGENT_MODEL_BINARY: ${OPENNEKO_AGENT_MODEL_BINARY:-}
       OPENSHELL_GATEWAY: openneko
       # The sandbox shares this Compose network and receives the broker's
       # private container IP, without crossing the host network.
@@ -152,15 +193,16 @@ services:
     volumes:
       - openshell-config:/config/openshell
     depends_on:
-      openshell-gateway:
-        condition: service_started
+      openshell-ready:
+        condition: service_completed_successfully
 
   # Web: interactive chat launches the agent in a sandbox too (the Next.js server
   # is the control plane; the agent never runs in-process). Same flags; egress
   # self-derives on the first settings save (provisionHostConfig).
   web:
     environment:
-      OPENNEKO_AGENT_IMAGE: ${OPENNEKO_AGENT_IMAGE:-ghcr.io/open-neko/agent:${OPENNEKO_VERSION:-latest}}
+      OPENNEKO_AGENT_IMAGE: ${OPENNEKO_AGENT_IMAGE:-openneko-agent:dev}
+      OPENNEKO_AGENT_MODEL_BINARY: ${OPENNEKO_AGENT_MODEL_BINARY:-}
       OPENSHELL_GATEWAY: openneko
       OPENNEKO_SANDBOX_SHARED_NETWORK: "1"
       OPENNEKO_BROKER_PORT: ${OPENNEKO_WEB_BROKER_PORT:-4198}
@@ -169,8 +211,8 @@ services:
     volumes:
       - openshell-config:/config/openshell
     depends_on:
-      openshell-gateway:
-        condition: service_started
+      openshell-ready:
+        condition: service_completed_successfully
 
 volumes:
   # Holds the worker/web CLI's gateway registration at /config/openshell (the
@@ -187,7 +229,8 @@ networks:
     name: "${COMPOSE_PROJECT_NAME}_runtime"
     ipam:
       config:
-        - subnet: "${OPENNEKO_DOCKER_SUBNET:-172.29.0.0/24}"
+        - subnet: "${OPENNEKO_DOCKER_SUBNET:-172.29.3.0/24}"
+          gateway: "${OPENNEKO_DOCKER_GATEWAY:-172.29.3.1}"
           # Keep dynamic service/sandbox allocation away from the gateway's
           # fixed .2 address (the CLI derives this range for custom subnets).
-          ip_range: "${OPENNEKO_DOCKER_IP_RANGE:-172.29.0.128/25}"
+          ip_range: "${OPENNEKO_DOCKER_IP_RANGE:-172.29.3.128/25}"

--- a/compose.yml
+++ b/compose.yml
@@ -357,11 +357,16 @@ services:
     restart: "no"
 
   graphjin:
-    image: dosco/graphjin:3.18.42
+    image: ${OPENNEKO_GRAPHJIN_IMAGE:-dosco/graphjin:3.18.42}
     restart: unless-stopped
     depends_on:
       graphjin-config-init:
         condition: service_completed_successfully
+      # The worker reconciles the per-org JWT secret into agentic.yml during
+      # startup. GraphJin 3.18 does not hot-reload auth keys, so start it only
+      # after that reconciliation has completed.
+      worker:
+        condition: service_healthy
     ports:
       - "127.0.0.1:${GRAPHJIN_PORT:-8080}:8080"
     environment:
@@ -395,11 +400,37 @@ services:
       NEKO_PG_USER: neko
       NEKO_PG_PASSWORD: ${NEKO_PG_PASSWORD:-secret}
       NEKO_PG_DATABASE: neko
-      OPENNEKO_OPENSHELL_DB_PASSWORD: ${OPENNEKO_OPENSHELL_DB_PASSWORD:-}
+      # Direct source Compose has no host supervisor process to inject the
+      # per-install derived gateway password. Keep migration + gateway on one
+      # stable development-only value; packaged installs derive a unique one.
+      OPENNEKO_OPENSHELL_DB_PASSWORD: ${OPENNEKO_OPENSHELL_DB_PASSWORD:-openneko-openshell-development-password}
       OPENNEKO_SKIP_MIGRATE: ${OPENNEKO_SKIP_MIGRATE:-}
       XDG_CONFIG_HOME: /config
     volumes:
       - ${OPENNEKO_CONFIG_VOLUME:-openneko-config}:/config/openneko
+
+  # The migration CLI runs as root and may create the shared config directory
+  # and secret key on first boot. Repair ownership before the non-root worker
+  # mounts the volume so a completely fresh Compose project can start.
+  openneko-config-init:
+    build:
+      context: .
+      target: worker
+    user: "0:0"
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        mkdir -p /config/openneko
+        chown -R neko:neko /config/openneko
+        chmod 0700 /config/openneko
+    depends_on:
+      neko-migrate:
+        condition: service_completed_successfully
+    volumes:
+      - openneko-config:/config/openneko
+    restart: "no"
 
   neko-graphjin:
     build:
@@ -480,6 +511,8 @@ services:
       # Schema is guaranteed ready by neko-migrate before worker boots.
       neko-migrate:
         condition: service_completed_successfully
+      openneko-config-init:
+        condition: service_completed_successfully
       records-db:
         condition: service_healthy
       neko-backup:
@@ -488,8 +521,10 @@ services:
         condition: service_started
       records-watch-graphjin:
         condition: service_started
-      graphjin:
-        condition: service_started
+      # The worker must patch the per-org JWT secret before customer GraphJin
+      # starts; depending on the one-shot seed avoids a startup cycle.
+      graphjin-config-init:
+        condition: service_completed_successfully
     environment:
       <<: *neko-app-env
       OPENNEKO_GRAPHJIN_URL: http://neko-graphjin:8089

--- a/db/migrations/0059_solution_packs.sql
+++ b/db/migrations/0059_solution_packs.sql
@@ -1,0 +1,117 @@
+-- First-class, organization-scoped solution-pack lifecycle and provenance.
+-- Pack application is a durable saga because GraphJin files and metadata
+-- Postgres cannot share one transaction.
+
+create table if not exists pack_install (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null references organization(id) on delete cascade,
+  pack_id text not null,
+  version text not null,
+  status text not null default 'planning'
+    check (status in ('planning', 'installing', 'installed', 'upgrading', 'failed', 'removing', 'removed')),
+  manifest_hash text not null,
+  config jsonb not null default '{}'::jsonb,
+  source text not null default 'embedded'
+    check (source in ('embedded')),
+  installed_by_user_id text references app_user(id) on delete set null,
+  operation_id uuid,
+  last_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  installed_at timestamptz,
+  removed_at timestamptz
+);
+
+create unique index if not exists pack_install_org_pack_active_unique
+  on pack_install (org_id, pack_id)
+  where status <> 'removed';
+create index if not exists pack_install_org_status_idx
+  on pack_install (org_id, status, updated_at desc);
+
+create table if not exists pack_artifact (
+  id uuid primary key default gen_random_uuid(),
+  pack_install_id uuid not null references pack_install(id) on delete cascade,
+  org_id text not null references organization(id) on delete cascade,
+  artifact_kind text not null
+    check (artifact_kind in ('source', 'relationships', 'spec', 'saved_query', 'metric', 'workflow', 'watcher', 'action', 'policy', 'skill')),
+  artifact_key text not null,
+  target_ref text not null,
+  desired_hash text not null,
+  last_applied_hash text not null,
+  ownership text not null default 'managed'
+    check (ownership in ('managed', 'modified', 'detached', 'retired')),
+  readiness text not null default 'not_applicable'
+    check (readiness in ('ready', 'blocked', 'degraded', 'not_applicable')),
+  readiness_reason text,
+  previous_snapshot jsonb,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  detached_at timestamptz,
+  unique (org_id, artifact_kind, target_ref),
+  unique (pack_install_id, artifact_kind, artifact_key)
+);
+
+create index if not exists pack_artifact_install_idx
+  on pack_artifact (pack_install_id, ownership, artifact_kind);
+create index if not exists pack_artifact_org_readiness_idx
+  on pack_artifact (org_id, readiness, updated_at desc);
+
+create table if not exists pack_action_definition (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null references organization(id) on delete cascade,
+  kind text not null,
+  description text not null default '',
+  definition jsonb not null,
+  definition_hash text not null,
+  readiness text not null default 'blocked'
+    check (readiness in ('ready', 'blocked', 'degraded')),
+  readiness_reason text,
+  enabled boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (org_id, kind)
+);
+
+create index if not exists pack_action_definition_discovery_idx
+  on pack_action_definition (org_id, readiness, enabled, updated_at desc);
+
+create table if not exists pack_operation (
+  id uuid primary key default gen_random_uuid(),
+  pack_install_id uuid not null references pack_install(id) on delete cascade,
+  org_id text not null references organization(id) on delete cascade,
+  operation_type text not null
+    check (operation_type in ('install', 'upgrade', 'configure', 'doctor', 'uninstall')),
+  actor_user_id text references app_user(id) on delete set null,
+  status text not null default 'planned'
+    check (status in ('planned', 'running', 'compensating', 'succeeded', 'failed')),
+  requested_version text,
+  idempotency_key text not null,
+  plan jsonb not null default '{}'::jsonb,
+  plan_hash text not null,
+  phase text not null default 'planned',
+  failure_phase text,
+  error text,
+  compensation_status text
+    check (compensation_status is null or compensation_status in ('not_required', 'pending', 'running', 'succeeded', 'failed')),
+  started_at timestamptz,
+  completed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (org_id, idempotency_key)
+);
+
+create index if not exists pack_operation_install_recent_idx
+  on pack_operation (pack_install_id, created_at desc);
+create index if not exists pack_operation_org_status_idx
+  on pack_operation (org_id, status, created_at desc);
+
+alter table pack_install
+  add constraint pack_install_operation_fk
+  foreign key (operation_id) references pack_operation(id) on delete set null;
+
+alter table watcher
+  add column if not exists cooldown_seconds integer not null default 0,
+  add column if not exists dedupe_key text,
+  add column if not exists activation text,
+  add column if not exists variables_json jsonb not null default '{}'::jsonb;

--- a/db/migrations/0060_deterministic_metrics.sql
+++ b/db/migrations/0060_deterministic_metrics.sql
@@ -1,0 +1,34 @@
+-- Deterministic saved-query metrics. Existing agent-authored metrics retain the
+-- current execution mode; pack metrics opt into a validated declarative query.
+
+alter table metric
+  add column if not exists execution_mode text not null default 'agent',
+  add column if not exists definition_json jsonb,
+  add column if not exists definition_version integer,
+  add column if not exists definition_hash text;
+
+alter table metric
+  add constraint metric_execution_mode_check
+  check (execution_mode in ('agent', 'saved_query'));
+
+alter table metric
+  add constraint metric_saved_query_definition_check
+  check (
+    execution_mode = 'agent'
+    or (
+      definition_json is not null
+      and definition_version is not null
+      and definition_version > 0
+      and definition_hash is not null
+    )
+  );
+
+create index if not exists metric_saved_query_active_idx
+  on metric (org_id, cadence, updated_at)
+  where active = true and execution_mode = 'saved_query';
+
+alter table metric_snapshot
+  add column if not exists definition_hash text,
+  add column if not exists source_freshness_at timestamptz,
+  add column if not exists duration_ms integer,
+  add column if not exists error_class text;

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "bootstrap": "AX_SKIP_SKILL_INSTALL=1 pnpm install && [ -f db/graphjin/dev.example.yml ] && [ ! -f db/graphjin/dev.yml ] && cp db/graphjin/dev.example.yml db/graphjin/dev.yml || true",
     "dev": "concurrently -n web,worker -c blue,magenta \"pnpm dev:web\" \"pnpm dev:worker\"",
     "dev:web": "WORKER_ADMIN_URL=\"${WORKER_ADMIN_URL:-http://127.0.0.1:4100}\" pnpm --filter @neko/web dev",
+    "dev:web:stack": "sh scripts/dev-web-stack.sh",
     "dev:worker": "pnpm --filter @neko/worker dev",
     "dev:up": "mkdir -p \"$HOME/.config/openneko\" .openneko && if [ ! -s .openneko/development-backup-key ]; then openssl rand -hex 32 > .openneko/development-backup-key && chmod 600 .openneko/development-backup-key; fi && OPENNEKO_CONFIG_VOLUME=\"$HOME/.config/openneko\" docker compose -f compose.yml -f compose.adventureworks.yml up -d neko-db neko-graphjin graphjin adventureworks-simulator adventureworks-scenario-injector",
     "dev:seed": "ADVENTUREWORKS_GRAPHJIN_ROOT=\"http://localhost:${GRAPHJIN_PORT:-8080}\" ADVENTUREWORKS_UPDATE_DATA_SOURCE=1 pnpm --filter @neko/worker exec tsx ../../packages/db/src/seed-adventureworks.mjs",

--- a/packages/db/src/connection.ts
+++ b/packages/db/src/connection.ts
@@ -51,21 +51,23 @@ function envPort(): number | undefined {
 
 export function buildPoolConfig(overrides: { database?: string } = {}): PoolConfig {
   const cfg = readLocalConfig().pg ?? {};
+  const environmentFirst = nonEmptyEnv("OPENNEKO_PG_ENV_OVERRIDE") === "1";
+  const choose = <T>(environmentValue: T | undefined, localValue: T | undefined): T | undefined =>
+    environmentFirst ? environmentValue ?? localValue : localValue ?? environmentValue;
   const poolCfg: PoolConfig = {
-    host: cfg.host ?? nonEmptyEnv("NEKO_PG_HOST") ?? DEFAULT_PG.host,
-    port: cfg.port ?? envPort() ?? DEFAULT_PG.port,
-    user: cfg.user ?? nonEmptyEnv("NEKO_PG_USER") ?? DEFAULT_PG.user,
+    host: choose(nonEmptyEnv("NEKO_PG_HOST"), cfg.host) ?? DEFAULT_PG.host,
+    port: choose(envPort(), cfg.port) ?? DEFAULT_PG.port,
+    user: choose(nonEmptyEnv("NEKO_PG_USER"), cfg.user) ?? DEFAULT_PG.user,
     password:
-      cfg.password ?? nonEmptyEnv("NEKO_PG_PASSWORD") ?? DEFAULT_PG.password,
+      choose(nonEmptyEnv("NEKO_PG_PASSWORD"), cfg.password) ?? DEFAULT_PG.password,
     database:
       overrides.database ??
-      cfg.database ??
-      nonEmptyEnv("NEKO_PG_DATABASE") ??
+      choose(nonEmptyEnv("NEKO_PG_DATABASE"), cfg.database) ??
       DEFAULT_PG.database,
     max: 10,
   };
 
-  if ((cfg.sslmode ?? nonEmptyEnv("NEKO_PG_SSLMODE")) === "require") {
+  if (choose(nonEmptyEnv("NEKO_PG_SSLMODE"), cfg.sslmode) === "require") {
     poolCfg.ssl = { rejectUnauthorized: false };
   }
 

--- a/packages/db/src/records-migrate.ts
+++ b/packages/db/src/records-migrate.ts
@@ -25,21 +25,27 @@ export function buildRecordsPoolConfig(
   overrides: { database?: string; localConfig?: LocalPgConfig } = {},
 ): PoolConfig {
   const local = overrides.localConfig ?? readLocalConfig().recordsPg ?? {};
-  const port = local.port ?? Number.parseInt(env.RECORDS_PG_PORT ?? "5434", 10);
+  const environmentFirst = env.OPENNEKO_PG_ENV_OVERRIDE?.trim() === "1";
+  const choose = <T>(environmentValue: T | undefined, localValue: T | undefined): T | undefined =>
+    environmentFirst ? environmentValue ?? localValue : localValue ?? environmentValue;
+  const environmentPort = env.RECORDS_PG_PORT
+    ? Number.parseInt(env.RECORDS_PG_PORT, 10)
+    : undefined;
+  const port = choose(environmentPort, local.port) ?? 5434;
   if (!Number.isInteger(port) || port < 1 || port > 65_535) {
     throw new Error(`invalid RECORDS_PG_PORT: ${env.RECORDS_PG_PORT ?? ""}`);
   }
 
   const config: PoolConfig = {
-    host: local.host ?? env.RECORDS_PG_HOST ?? "localhost",
+    host: choose(env.RECORDS_PG_HOST, local.host) ?? "localhost",
     port,
-    user: local.user ?? env.RECORDS_PG_USER ?? "records",
-    password: local.password ?? env.RECORDS_PG_PASSWORD ?? "records-secret",
+    user: choose(env.RECORDS_PG_USER, local.user) ?? "records",
+    password: choose(env.RECORDS_PG_PASSWORD, local.password) ?? "records-secret",
     database:
-      overrides.database ?? local.database ?? env.RECORDS_PG_DATABASE ?? "records",
+      overrides.database ?? choose(env.RECORDS_PG_DATABASE, local.database) ?? "records",
     max: 5,
   };
-  if ((local.sslmode ?? env.RECORDS_PG_SSLMODE) === "require") {
+  if (choose(env.RECORDS_PG_SSLMODE, local.sslmode) === "require") {
     config.ssl = { rejectUnauthorized: false };
   }
   return config;

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -411,6 +411,12 @@ export const metric = pgTable(
     direction_good: text("direction_good"),
     cadence: text("cadence").notNull().default("daily"),
     active: boolean("active").notNull().default(true),
+    // Pack metrics execute a reviewed saved query and declarative result
+    // mapping. Existing/custom cards retain the agent execution path.
+    execution_mode: text("execution_mode").notNull().default("agent"),
+    definition_json: jsonb("definition_json").$type<Record<string, unknown>>(),
+    definition_version: integer("definition_version"),
+    definition_hash: text("definition_hash"),
     created_by_job: uuid("created_by_job").references(() => processing_job.id),
     // Denormalized refresh status — read by /api/briefing so the dashboard
     // can render pending vs failed cards without joining processing_job.
@@ -452,6 +458,10 @@ export const metric_snapshot = pgTable(
     status: text("status"),
     created_at: ts("created_at").notNull().defaultNow(),
     payload: jsonb("payload"),
+    definition_hash: text("definition_hash"),
+    source_freshness_at: ts("source_freshness_at"),
+    duration_ms: integer("duration_ms"),
+    error_class: text("error_class"),
   },
   (t) => ({
     metric_recent_idx: index("metric_snapshot_metric_recent_idx").on(
@@ -744,6 +754,13 @@ export const watcher = pgTable(
     threshold: jsonb("threshold"),
     cadence_seconds: integer("cadence_seconds").notNull().default(300),
     debounce_seconds: integer("debounce_seconds").notNull().default(3600),
+    cooldown_seconds: integer("cooldown_seconds").notNull().default(0),
+    dedupe_key: text("dedupe_key"),
+    activation: text("activation"),
+    variables_json: jsonb("variables_json")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default({}),
     severity: text("severity").notNull().default("medium"),
     last_checked_at: ts("last_checked_at"),
     last_fired_at: ts("last_fired_at"),
@@ -1919,6 +1936,180 @@ export const action_execution = pgTable(
       t.created_at.desc(),
     ),
     org_status_idx: index("action_execution_org_status_idx").on(
+      t.org_id,
+      t.status,
+      t.created_at.desc(),
+    ),
+  }),
+);
+
+// Solution packs are organization-scoped, versioned bundles. The provenance
+// rows make install/upgrade/uninstall drift-aware without claiming a database
+// transaction can also cover GraphJin config files.
+export const pack_install = pgTable(
+  "pack_install",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    org_id: text("org_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    pack_id: text("pack_id").notNull(),
+    version: text("version").notNull(),
+    status: text("status").notNull().default("planning"),
+    manifest_hash: text("manifest_hash").notNull(),
+    config: jsonb("config")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default(sql`'{}'::jsonb`),
+    source: text("source").notNull().default("embedded"),
+    installed_by_user_id: text("installed_by_user_id").references(
+      () => app_user.id,
+      { onDelete: "set null" },
+    ),
+    operation_id: uuid("operation_id"),
+    last_error: text("last_error"),
+    created_at: ts("created_at").notNull().defaultNow(),
+    updated_at: ts("updated_at").notNull().defaultNow(),
+    installed_at: ts("installed_at"),
+    removed_at: ts("removed_at"),
+  },
+  (t) => ({
+    org_pack_active_unique: uniqueIndex("pack_install_org_pack_active_unique")
+      .on(t.org_id, t.pack_id)
+      .where(sql`${t.status} <> 'removed'`),
+    org_status_idx: index("pack_install_org_status_idx").on(
+      t.org_id,
+      t.status,
+      t.updated_at.desc(),
+    ),
+  }),
+);
+
+export const pack_artifact = pgTable(
+  "pack_artifact",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    pack_install_id: uuid("pack_install_id")
+      .notNull()
+      .references(() => pack_install.id, { onDelete: "cascade" }),
+    org_id: text("org_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    artifact_kind: text("artifact_kind").notNull(),
+    artifact_key: text("artifact_key").notNull(),
+    target_ref: text("target_ref").notNull(),
+    desired_hash: text("desired_hash").notNull(),
+    last_applied_hash: text("last_applied_hash").notNull(),
+    ownership: text("ownership").notNull().default("managed"),
+    readiness: text("readiness").notNull().default("not_applicable"),
+    readiness_reason: text("readiness_reason"),
+    previous_snapshot: jsonb("previous_snapshot").$type<Record<string, unknown>>(),
+    metadata: jsonb("metadata")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default(sql`'{}'::jsonb`),
+    created_at: ts("created_at").notNull().defaultNow(),
+    updated_at: ts("updated_at").notNull().defaultNow(),
+    detached_at: ts("detached_at"),
+  },
+  (t) => ({
+    org_kind_target_unique: uniqueIndex("pack_artifact_org_kind_target_unique").on(
+      t.org_id,
+      t.artifact_kind,
+      t.target_ref,
+    ),
+    install_kind_key_unique: uniqueIndex("pack_artifact_install_kind_key_unique").on(
+      t.pack_install_id,
+      t.artifact_kind,
+      t.artifact_key,
+    ),
+    install_idx: index("pack_artifact_install_idx").on(
+      t.pack_install_id,
+      t.ownership,
+      t.artifact_kind,
+    ),
+    org_readiness_idx: index("pack_artifact_org_readiness_idx").on(
+      t.org_id,
+      t.readiness,
+      t.updated_at.desc(),
+    ),
+  }),
+);
+
+export const pack_action_definition = pgTable(
+  "pack_action_definition",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    org_id: text("org_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    kind: text("kind").notNull(),
+    description: text("description").notNull().default(""),
+    definition: jsonb("definition")
+      .$type<Record<string, unknown>>()
+      .notNull(),
+    definition_hash: text("definition_hash").notNull(),
+    readiness: text("readiness").notNull().default("blocked"),
+    readiness_reason: text("readiness_reason"),
+    enabled: boolean("enabled").notNull().default(true),
+    created_at: ts("created_at").notNull().defaultNow(),
+    updated_at: ts("updated_at").notNull().defaultNow(),
+  },
+  (t) => ({
+    org_kind_unique: uniqueIndex("pack_action_definition_org_kind_unique").on(
+      t.org_id,
+      t.kind,
+    ),
+    discovery_idx: index("pack_action_definition_discovery_idx").on(
+      t.org_id,
+      t.readiness,
+      t.enabled,
+      t.updated_at.desc(),
+    ),
+  }),
+);
+
+export const pack_operation = pgTable(
+  "pack_operation",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    pack_install_id: uuid("pack_install_id")
+      .notNull()
+      .references(() => pack_install.id, { onDelete: "cascade" }),
+    org_id: text("org_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    operation_type: text("operation_type").notNull(),
+    actor_user_id: text("actor_user_id").references(() => app_user.id, {
+      onDelete: "set null",
+    }),
+    status: text("status").notNull().default("planned"),
+    requested_version: text("requested_version"),
+    idempotency_key: text("idempotency_key").notNull(),
+    plan: jsonb("plan")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default(sql`'{}'::jsonb`),
+    plan_hash: text("plan_hash").notNull(),
+    phase: text("phase").notNull().default("planned"),
+    failure_phase: text("failure_phase"),
+    error: text("error"),
+    compensation_status: text("compensation_status"),
+    started_at: ts("started_at"),
+    completed_at: ts("completed_at"),
+    created_at: ts("created_at").notNull().defaultNow(),
+    updated_at: ts("updated_at").notNull().defaultNow(),
+  },
+  (t) => ({
+    org_idempotency_unique: uniqueIndex("pack_operation_org_idempotency_unique").on(
+      t.org_id,
+      t.idempotency_key,
+    ),
+    install_recent_idx: index("pack_operation_install_recent_idx").on(
+      t.pack_install_id,
+      t.created_at.desc(),
+    ),
+    org_status_idx: index("pack_operation_org_status_idx").on(
       t.org_id,
       t.status,
       t.created_at.desc(),

--- a/packages/db/test/pool-config.test.ts
+++ b/packages/db/test/pool-config.test.ts
@@ -21,6 +21,7 @@ describe("metadata DB pool config", () => {
     "NEKO_PG_PASSWORD",
     "NEKO_PG_DATABASE",
     "NEKO_PG_SSLMODE",
+    "OPENNEKO_PG_ENV_OVERRIDE",
   ] as const;
   const ORIGINAL_PG_ENV = Object.fromEntries(
     PG_ENV_KEYS.map((key) => [key, process.env[key]]),
@@ -73,6 +74,18 @@ describe("metadata DB pool config", () => {
     expect(buildPoolConfig()).toMatchObject({
       host: "localhost",
       port: 5433,
+    });
+  });
+
+  it("can prefer explicit host-development environment values", () => {
+    process.env.NEKO_PG_HOST = "127.0.0.1";
+    process.env.NEKO_PG_PORT = "56432";
+    process.env.OPENNEKO_PG_ENV_OVERRIDE = "1";
+    writeLocalConfig({ pg: { host: "neko-db", port: 5432 } });
+
+    expect(buildPoolConfig()).toMatchObject({
+      host: "127.0.0.1",
+      port: 56432,
     });
   });
 

--- a/packages/db/test/records-migrate.test.ts
+++ b/packages/db/test/records-migrate.test.ts
@@ -86,6 +86,30 @@ describe("buildRecordsPoolConfig", () => {
       ssl: { rejectUnauthorized: false },
     });
   });
+
+  it("can prefer explicit host-development environment values", () => {
+    expect(
+      buildRecordsPoolConfig(
+        {
+          OPENNEKO_PG_ENV_OVERRIDE: "1",
+          RECORDS_PG_HOST: "127.0.0.1",
+          RECORDS_PG_PORT: "56434",
+          RECORDS_PG_PASSWORD: "host-password",
+        },
+        {
+          localConfig: {
+            host: "records-db",
+            port: 5432,
+            password: "container-password",
+          },
+        },
+      ),
+    ).toMatchObject({
+      host: "127.0.0.1",
+      port: 56434,
+      password: "host-password",
+    });
+  });
 });
 
 describe("discoverRecordsMigrations", () => {

--- a/packages/llm/src/graphjin/persist-source-config.ts
+++ b/packages/llm/src/graphjin/persist-source-config.ts
@@ -76,17 +76,68 @@ function secretRefSegment(value: string): string {
     .replaceAll("\0", "_");
 }
 
-function sourceForDisk(patch: SourcePatch): SourcePatch {
-  const copy = structuredClone(patch);
-  if (
-    typeof copy.password === "string" &&
-    copy.password.trim() &&
-    !copy.password.trim().startsWith("gjsecret://") &&
-    !copy.password.includes("${")
-  ) {
-    copy.password = `gjsecret://sources/${secretRefSegment(sourceName(copy))}/password`;
+function isSensitiveConfigKey(key: string): boolean {
+  const normalized = key.toLowerCase().replaceAll("-", "_");
+  return (
+    normalized.includes("password") ||
+    normalized.includes("secret") ||
+    normalized.includes("token") ||
+    normalized.includes("passphrase") ||
+    normalized.includes("private_key") ||
+    normalized.includes("client_key") ||
+    normalized.includes("api_key") ||
+    normalized.includes("apikey") ||
+    normalized.includes("authorization") ||
+    normalized.includes("cookie") ||
+    normalized === "connection_string" ||
+    normalized === "key_value"
+  );
+}
+
+function shouldReplaceWithSecretRef(value: string): boolean {
+  const trimmed = value.trim();
+  return Boolean(trimmed) && !trimmed.startsWith("gjsecret://") && !value.includes("${");
+}
+
+function sealSourceForDisk(
+  value: unknown,
+  path: string[],
+  parentKey = "",
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item, index) => {
+      const named = item && typeof item === "object" && !Array.isArray(item) &&
+        typeof (item as Record<string, unknown>).name === "string"
+        ? String((item as Record<string, unknown>).name)
+        : String(index);
+      return sealSourceForDisk(item, [...path, secretRefSegment(named)]);
+    });
   }
-  return copy;
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, child]) => [
+        key,
+        sealSourceForDisk(child, [...path, secretRefSegment(key)], key),
+      ]),
+    );
+  }
+  if (
+    typeof value === "string" &&
+    (isSensitiveConfigKey(parentKey) ||
+      (path.length >= 2 && path.at(-2)?.toLowerCase() === "headers" && isSensitiveConfigKey(parentKey))) &&
+    shouldReplaceWithSecretRef(value)
+  ) {
+    return `gjsecret://${path.filter(Boolean).join("/")}`;
+  }
+  return value;
+}
+
+function sourceForDisk(patch: SourcePatch): SourcePatch {
+  const name = sourceName(patch);
+  return sealSourceForDisk(
+    structuredClone(patch),
+    ["sources", secretRefSegment(name)],
+  ) as SourcePatch;
 }
 
 function mapByName(sources: YAMLSeq, name: string): YAMLMap | null {
@@ -177,6 +228,21 @@ export async function persistGraphjinSourceConfigUpdate(input: {
       if (existing) mergeMap(existing, patch);
       else sourcesNode.add(document.createNode(patch));
     }
+  }
+
+  const removals = input.update.remove_sources;
+  if (Array.isArray(removals)) {
+    const names = new Set(
+      removals.map((value, index) => {
+        if (typeof value !== "string" || !value.trim()) {
+          throw new Error(`GraphJin remove_sources[${index}] must be a source name`);
+        }
+        return value.trim().toLowerCase();
+      }),
+    );
+    sourcesNode.items = sourcesNode.items.filter(
+      (item) => !isMap(item) || !names.has(String(item.get("name") ?? "").trim().toLowerCase()),
+    );
   }
 
   const accessPatches = input.update.source_patches;

--- a/packages/llm/src/host-provision.ts
+++ b/packages/llm/src/host-provision.ts
@@ -6,7 +6,10 @@ import { join } from "node:path";
 import { and, data_source, db, desc, eq, llm_provider_config } from "@neko/db";
 import { isAgentBackendId } from "./agent-backend";
 import { maybeDecryptSecret } from "./secrets";
-import { ensureOpenShellProvider } from "./work/sandbox-launcher";
+import {
+  ensureOpenShellProvider,
+  verifyOpenShellGateway,
+} from "./work/sandbox-launcher";
 
 const HERMES_DEFAULT_MAX_TURNS = 25;
 const HERMES_DELEGATION_DEFAULT_MAX_ITERATIONS = 50;
@@ -521,6 +524,32 @@ async function provisionOpenShellRuntime(orgId: string, backend: string): Promis
   );
 }
 
+async function resolveAgentBackendForOrg(orgId: string): Promise<string> {
+  const agentRow = await loadProviderRow(orgId, "agent");
+  const backendCfg = (agentRow?.config ?? {}) as { backend?: unknown };
+  return typeof backendCfg.backend === "string" &&
+    isAgentBackendId(backendCfg.backend)
+    ? backendCfg.backend
+    : "hermes";
+}
+
+/**
+ * Readiness gate for any operation that is about to launch an agent sandbox.
+ * This deliberately performs a fresh gateway RPC instead of consulting a
+ * process-local flag: the gateway may have failed or been omitted from a
+ * Compose invocation after the web/worker process itself became healthy.
+ *
+ * Once connectivity is proven, re-sync the org's model provider so the exact
+ * path onboarding will use is configured before work is enqueued.
+ */
+export async function verifyAgentRuntimeReady(orgId: string): Promise<void> {
+  await verifyOpenShellGateway({
+    gatewayName: process.env.OPENSHELL_GATEWAY || undefined,
+    gatewayEndpoint: process.env.OPENSHELL_GATEWAY_ENDPOINT || undefined,
+  });
+  await provisionOpenShellRuntime(orgId, await resolveAgentBackendForOrg(orgId));
+}
+
 const provisionedOrgs = new Map<string, Promise<void>>();
 
 type ProvisionHostConfigOptions = {
@@ -566,12 +595,7 @@ export async function provisionHostConfig(
     );
   }
 
-  const agentRow = await loadProviderRow(orgId, "agent");
-  const backendCfg = (agentRow?.config ?? {}) as { backend?: unknown };
-  const backend =
-    typeof backendCfg.backend === "string" && isAgentBackendId(backendCfg.backend)
-      ? backendCfg.backend
-      : "hermes";
+  const backend = await resolveAgentBackendForOrg(orgId);
 
   let openShellError: unknown;
   try {

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -38,6 +38,7 @@ export {
   ensureHostConfigProvisioned,
   provisionHostConfig,
   resolveHermesModelBinary,
+  verifyAgentRuntimeReady,
 } from "./host-provision";
 export {
   prefetchKnowledgePack,

--- a/packages/llm/src/work/index.ts
+++ b/packages/llm/src/work/index.ts
@@ -92,6 +92,7 @@ export {
   buildSandboxPolicy,
   buildScopedEgressArgs,
   ensureOpenShellProvider,
+  verifyOpenShellGateway,
   makeSandboxJobRunCore,
   makeSandboxRunCore,
   makeSandboxWorkflowRunCore,

--- a/packages/llm/src/work/sandbox-launcher.ts
+++ b/packages/llm/src/work/sandbox-launcher.ts
@@ -1002,6 +1002,31 @@ export async function ensureOpenShellProvider(opts: {
 }
 
 /**
+ * Prove that the configured OpenShell gateway is reachable over its real mTLS
+ * control-plane path. `openshell status` is not suitable for readiness: it
+ * exits successfully even when no gateway is configured. Listing providers is
+ * a read-only gateway RPC, so a successful call proves both registration and
+ * connectivity without creating a sandbox or exposing credentials.
+ */
+export async function verifyOpenShellGateway(opts: {
+  cli?: string;
+  gatewayName?: string;
+  gatewayEndpoint?: string;
+} = {}): Promise<void> {
+  const cli = opts.cli ?? "openshell";
+  const gatewayArgs = opts.gatewayName
+    ? ["--gateway", opts.gatewayName]
+    : opts.gatewayEndpoint
+      ? ["--gateway-endpoint", opts.gatewayEndpoint]
+      : [];
+  await runProcessOnce(
+    cli,
+    [...gatewayArgs, "provider", "list", "--names"],
+    15_000,
+  );
+}
+
+/**
  * Mirror a host HERMES_HOME into `destination` KEYLESS: copy
  * config.yaml, write an empty `.env`. hermes reads `.env` before the process
  * env, so an empty `.env` lets the proxy-injected key (keyAliases) win — and

--- a/packages/llm/src/work/workspace.ts
+++ b/packages/llm/src/work/workspace.ts
@@ -22,8 +22,21 @@ import type { AgentWorkspace } from "../agent-backend";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const BUILTIN_SKILLS_ROOT = resolve(HERE, "..", "..", "assets", "builtin-skills");
 
+function useHostWebDevelopmentHome(): boolean {
+  return (
+    process.env.OPENNEKO_HOST_WEB_DEV === "1" &&
+    process.env.NODE_ENV === "development" &&
+    process.env.OPENNEKO_STACK_MODE !== "demo" &&
+    process.env.NEXT_PUBLIC_DEMO !== "true" &&
+    process.env.DEMO !== "true"
+  );
+}
+
 function getHome(): string {
-  return process.env.HOME || homedir();
+  const developmentHome = useHostWebDevelopmentHome()
+    ? process.env.OPENNEKO_AGENT_HOME?.trim()
+    : undefined;
+  return developmentHome || process.env.HOME || homedir();
 }
 
 function safeSegment(raw: string): string {

--- a/packages/llm/src/workflows/watchers.ts
+++ b/packages/llm/src/workflows/watchers.ts
@@ -1,5 +1,6 @@
 import { and, data_source, db, desc, eq, watcher } from "@neko/db";
 import { graphjinQuery } from "../graphjin/client";
+import { mintGraphjinToken } from "../graphjin/token";
 
 /**
  * OL4 — watchers, polling v1. A watcher runs a GraphJin query on its
@@ -25,6 +26,10 @@ export type WatcherRecord = {
   threshold: unknown;
   cadenceSeconds: number;
   debounceSeconds: number;
+  cooldownSeconds: number;
+  dedupeKey: string | null;
+  activation: string | null;
+  variables: Record<string, unknown>;
   severity: string;
   lastCheckedAt: Date | null;
   lastFiredAt: Date | null;
@@ -63,6 +68,10 @@ function toRecord(row: typeof watcher.$inferSelect): WatcherRecord {
     threshold: row.threshold,
     cadenceSeconds: row.cadence_seconds,
     debounceSeconds: row.debounce_seconds,
+    cooldownSeconds: row.cooldown_seconds,
+    dedupeKey: row.dedupe_key,
+    activation: row.activation,
+    variables: row.variables_json,
     severity: row.severity,
     lastCheckedAt: row.last_checked_at,
     lastFiredAt: row.last_fired_at,
@@ -216,6 +225,42 @@ export function watcherConditionMet(
   return false;
 }
 
+export function resolveWatcherVariables(
+  definition: Record<string, unknown> | null | undefined,
+  now: Date,
+): Record<string, unknown> {
+  const resolved: Record<string, unknown> = {};
+  for (const [name, raw] of Object.entries(definition ?? {})) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      throw new Error(`watcher variable ${name} must be a descriptor`);
+    }
+    const descriptor = raw as Record<string, unknown>;
+    if (descriptor.kind === "now") {
+      resolved[name] = now.toISOString();
+      continue;
+    }
+    if (descriptor.kind === "seconds_ago") {
+      const seconds = Number(descriptor.seconds);
+      if (!Number.isFinite(seconds) || seconds < 0) {
+        throw new Error(`watcher variable ${name}.seconds must be non-negative`);
+      }
+      resolved[name] = new Date(now.getTime() - seconds * 1_000).toISOString();
+      continue;
+    }
+    if (descriptor.kind === "literal") {
+      resolved[name] = descriptor.value;
+      continue;
+    }
+    throw new Error(`watcher variable ${name} uses unsupported kind ${String(descriptor.kind)}`);
+  }
+  return resolved;
+}
+
+function graphjinEndpoint(url: string): string {
+  const clean = url.replace(/\/+$/, "");
+  return clean.endsWith("/api/v1/graphql") ? clean : `${clean}/api/v1/graphql`;
+}
+
 export type WatcherSweepDeps = {
   query?: typeof graphjinQuery;
   enqueueFire?: (payload: {
@@ -265,9 +310,9 @@ export async function sweepWatchers(
   if (due.length === 0) return { checked: 0, fired: [] };
 
   const [src] = await db()
-    .select({ graphqlUrl: data_source.graphql_url })
+    .select({ graphqlUrl: data_source.graphql_url, authMode: data_source.auth_mode })
     .from(data_source)
-    .where(eq(data_source.org_id, orgId))
+    .where(and(eq(data_source.org_id, orgId), eq(data_source.enabled, true)))
     .orderBy(desc(data_source.is_default), data_source.created_at)
     .limit(1);
   if (!src?.graphqlUrl) return { checked: 0, fired: [] };
@@ -277,7 +322,24 @@ export async function sweepWatchers(
     let value: unknown;
     let error: string | null = null;
     try {
-      const result = await query({ baseUrl: src.graphqlUrl, query: row.query });
+      const result = await query({
+        baseUrl: graphjinEndpoint(src.graphqlUrl),
+        query: row.query,
+        variables: resolveWatcherVariables(row.variables_json, now),
+        role: "service",
+        ...(src.authMode === "jwt"
+          ? {
+              headers: {
+                authorization: `Bearer ${mintGraphjinToken({
+                  orgId,
+                  userId: null,
+                  role: "service",
+                })}`,
+              },
+            }
+          : {}),
+        signal: AbortSignal.timeout(30_000),
+      });
       if (result.errors?.length) {
         error = result.errors.map((e) => e.message).join("; ").slice(0, 500);
       } else {
@@ -290,9 +352,10 @@ export async function sweepWatchers(
     const met =
       error === null &&
       watcherConditionMet(row.op as WatcherOp, value, row.threshold, row.last_value);
+    const suppressionSeconds = Math.max(row.debounce_seconds, row.cooldown_seconds);
     const outsideDebounce =
       !row.last_fired_at ||
-      row.last_fired_at.getTime() + row.debounce_seconds * 1000 <= now.getTime();
+      row.last_fired_at.getTime() + suppressionSeconds * 1000 <= now.getTime();
     const fires = met && outsideDebounce;
 
     await db()

--- a/packages/llm/test/host-provision.test.ts
+++ b/packages/llm/test/host-provision.test.ts
@@ -37,8 +37,12 @@ import {
   provisionHostConfig,
   resolveHermesModelBinary,
   shouldReconcileDemoSourceAuthMode,
+  verifyAgentRuntimeReady,
 } from "../src/host-provision";
-import { ensureOpenShellProvider } from "../src/work/sandbox-launcher";
+import {
+  ensureOpenShellProvider,
+  verifyOpenShellGateway,
+} from "../src/work/sandbox-launcher";
 import { graphjinSigningSecretB64 } from "../src/graphjin/token";
 
 vi.mock("../src/work/sandbox-launcher", async (importOriginal) => {
@@ -46,6 +50,7 @@ vi.mock("../src/work/sandbox-launcher", async (importOriginal) => {
   return {
     ...actual,
     ensureOpenShellProvider: vi.fn().mockResolvedValue(undefined),
+    verifyOpenShellGateway: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -83,6 +88,7 @@ const ORIGINAL_DELEGATION_ENV = Object.fromEntries(
   DELEGATION_ENV_KEYS.map((key) => [key, process.env[key]]),
 );
 const ensureOpenShellProviderMock = vi.mocked(ensureOpenShellProvider);
+const verifyOpenShellGatewayMock = vi.mocked(verifyOpenShellGateway);
 
 describe("resolveHermesModelBinary", () => {
   it("returns the exact interpreter behind Hermes' uv entrypoint", async () => {
@@ -222,6 +228,8 @@ describeIfDb("provisionHostConfig", () => {
   beforeEach(async () => {
     ensureOpenShellProviderMock.mockReset();
     ensureOpenShellProviderMock.mockResolvedValue(undefined);
+    verifyOpenShellGatewayMock.mockReset();
+    verifyOpenShellGatewayMock.mockResolvedValue(undefined);
     tempHome = await mkdtemp(join(tmpdir(), "neko-test-home-"));
     hermesHome = join(tempHome, ".hermes");
     process.env.HOME = tempHome;
@@ -512,6 +520,39 @@ describeIfDb("provisionHostConfig", () => {
 
     const yaml = await readFile(join(hermesHome, "config.yaml"), "utf8");
     expect(yaml).toContain('provider: "gemini"');
+  });
+
+  it("verifies the gateway and syncs the provider before an agent job", async () => {
+    await seedProvider(orgId, {
+      scope: "agent",
+      provider: "hermes",
+      config: { backend: "hermes" },
+    });
+    await seedProvider(orgId, {
+      scope: "primary",
+      provider: "google-gemini",
+      model: "gemini-pro-latest",
+      secrets: { apiKey: "test-gemini-key" },
+    });
+
+    await verifyAgentRuntimeReady(orgId);
+
+    expect(verifyOpenShellGatewayMock).toHaveBeenCalledWith({
+      gatewayName: process.env.OPENSHELL_GATEWAY || undefined,
+      gatewayEndpoint: process.env.OPENSHELL_GATEWAY_ENDPOINT || undefined,
+    });
+    expect(ensureOpenShellProviderMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails readiness when the gateway RPC fails", async () => {
+    verifyOpenShellGatewayMock.mockRejectedValueOnce(
+      new Error("No active gateway"),
+    );
+
+    await expect(verifyAgentRuntimeReady(orgId)).rejects.toThrow(
+      "No active gateway",
+    );
+    expect(ensureOpenShellProviderMock).not.toHaveBeenCalled();
   });
 
   it("retries memoized provisioning after an OpenShell provider sync failure", async () => {

--- a/packages/llm/test/persist-source-config.test.ts
+++ b/packages/llm/test/persist-source-config.test.ts
@@ -110,6 +110,18 @@ describe("persistGraphjinSourceConfigUpdate", () => {
     });
   });
 
+  it("removes only explicitly named managed sources", async () => {
+    const file = await configFile();
+    await persistGraphjinSourceConfigUpdate({
+      configFile: file,
+      update: { remove_sources: ["warehouse"] },
+    });
+    const parsed = parse(await readFile(file, "utf8")) as {
+      sources: Array<{ name: string }>;
+    };
+    expect(parsed.sources.map((source) => source.name)).toEqual(["graphjin"]);
+  });
+
   it("persists GraphJin's deterministic secret reference, not a password", async () => {
     const file = await configFile();
     await persistGraphjinSourceConfigUpdate({
@@ -129,6 +141,34 @@ describe("persistGraphjinSourceConfigUpdate", () => {
     expect(raw).toContain("gjsecret://sources/billing_db/password");
   });
 
+  it("persists nested API credentials using GraphJin's deterministic secret paths", async () => {
+    const file = await configFile();
+    await persistGraphjinSourceConfigUpdate({
+      configFile: file,
+      update: {
+        update_sources: [
+          {
+            name: "magento_operator",
+            kind: "api",
+            specs: {
+              "magento-operator-v1": {
+                auth: {
+                  scheme: "bearer",
+                  token: "plain-integration-token",
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    const raw = await readFile(file, "utf8");
+    expect(raw).not.toContain("plain-integration-token");
+    expect(raw).toContain(
+      "gjsecret://sources/magento_operator/specs/magento-operator-v1/auth/token",
+    );
+  });
+
   it("serializes writers of the shared durable config", async () => {
     const file = await configFile();
     const release = await acquireGraphjinConfigLock({ configFile: file });
@@ -139,4 +179,5 @@ describe("persistGraphjinSourceConfigUpdate", () => {
     const releaseAgain = await acquireGraphjinConfigLock({ configFile: file });
     await releaseAgain();
   });
+
 });

--- a/packages/llm/test/sandbox-launcher.test.ts
+++ b/packages/llm/test/sandbox-launcher.test.ts
@@ -117,6 +117,7 @@ const {
   buildScopedEgressArgs,
   ensureOpenShellProvider,
   stageSandboxWorkspace,
+  verifyOpenShellGateway,
 } = await import("../src/work/sandbox-launcher");
 
 function fakeInput(
@@ -733,5 +734,18 @@ describe("ensureOpenShellProvider", () => {
     expect(create).toContain("--name org-x");
     expect(create).toContain("--type openneko-agent");
     expect(create).toContain("--credential api_key=SECRET-KEY");
+  });
+});
+
+describe("verifyOpenShellGateway", () => {
+  beforeEach(() => {
+    h.calls.length = 0;
+  });
+
+  it("uses a read-only gateway RPC with the configured registration", async () => {
+    await verifyOpenShellGateway({ gatewayName: "openneko" });
+    expect(h.calls).toEqual([
+      { args: ["--gateway", "openneko", "provider", "list", "--names"] },
+    ]);
   });
 });

--- a/packages/llm/test/work-workspace.test.ts
+++ b/packages/llm/test/work-workspace.test.ts
@@ -19,6 +19,7 @@ import {
 } from "../src/work/workspace";
 
 const cleanupPaths: string[] = [];
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
 
 afterEach(async () => {
   while (cleanupPaths.length > 0) {
@@ -26,9 +27,48 @@ afterEach(async () => {
     if (path) await rm(path, { recursive: true, force: true });
   }
   delete process.env.HOME;
+  delete process.env.OPENNEKO_AGENT_HOME;
+  delete process.env.OPENNEKO_HOST_WEB_DEV;
+  delete process.env.OPENNEKO_STACK_MODE;
+  delete process.env.NEXT_PUBLIC_DEMO;
+  delete process.env.DEMO;
+  if (ORIGINAL_NODE_ENV === undefined) delete process.env.NODE_ENV;
+  else process.env.NODE_ENV = ORIGINAL_NODE_ENV;
 });
 
 describe("work workspace", () => {
+  it("supports an isolated agent home in explicit host-web development mode", async () => {
+    const agentHome = await mkdtemp(join(tmpdir(), "neko-agent-home-"));
+    cleanupPaths.push(agentHome);
+    process.env.OPENNEKO_AGENT_HOME = agentHome;
+    process.env.OPENNEKO_HOST_WEB_DEV = "1";
+    process.env.NODE_ENV = "development";
+
+    const workspace = await ensureOrgWorkspace("org-test");
+    expect(workspace.orgRoot).toBe(
+      join(agentHome, ".config", "openneko", "agents", "orgs", "org-test"),
+    );
+  }, 30_000);
+
+  it.each([
+    ["production", { NODE_ENV: "production" }],
+    ["demo stack", { NODE_ENV: "development", OPENNEKO_STACK_MODE: "demo" }],
+    ["demo UI", { NODE_ENV: "development", NEXT_PUBLIC_DEMO: "true" }],
+  ])("ignores the host-web agent home in %s mode", async (_label, mode) => {
+    const home = await mkdtemp(join(tmpdir(), "neko-work-home-"));
+    const agentHome = await mkdtemp(join(tmpdir(), "neko-agent-home-"));
+    cleanupPaths.push(home, agentHome);
+    process.env.HOME = home;
+    process.env.OPENNEKO_AGENT_HOME = agentHome;
+    process.env.OPENNEKO_HOST_WEB_DEV = "1";
+    Object.assign(process.env, mode);
+
+    const workspace = await ensureOrgWorkspace("org-test");
+    expect(workspace.orgRoot).toBe(
+      join(home, ".config", "openneko", "agents", "orgs", "org-test"),
+    );
+  }, 30_000);
+
   it("seeds built-in skills into the org workspace", async () => {
     const home = await mkdtemp(join(tmpdir(), "neko-work-home-"));
     cleanupPaths.push(home);

--- a/packages/packs/package.json
+++ b/packages/packs/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@neko/packs",
+  "version": "2.27.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "description": "Validated, deterministic solution-pack manifests and install planning for OpenNeko.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./manifest": "./src/manifest.ts",
+    "./bundle": "./src/bundle.ts",
+    "./planner": "./src/planner.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "yaml": "^2.8.1",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/packs/src/artifact-schema.ts
+++ b/packages/packs/src/artifact-schema.ts
@@ -1,0 +1,203 @@
+import { z } from "zod";
+import type { PackArtifactKind } from "./bundle.js";
+
+const artifactKey = z.string().regex(/^[a-z][a-z0-9_]*\.[a-z][a-z0-9_.-]*$/);
+const targetRef = z.string().regex(/^[a-z][a-z0-9_.-]*$/);
+const base = {
+  key: artifactKey,
+  targetRef,
+};
+
+const sourceSchema = z
+  .object({
+    key: artifactKey.optional(),
+    name: targetRef,
+    kind: z.enum(["database", "api"]),
+  })
+  .loose();
+
+const sourceFileSchema = z
+  .object({
+    sources: z.array(sourceSchema).min(1),
+  })
+  .strict();
+
+const metricSchema = z
+  .object({
+    ...base,
+    title: z.string().min(1),
+    description: z.string().min(1),
+    role: z.string().min(1),
+    chartHint: z.string().min(1),
+    unit: z.string().min(1),
+    directionGood: z.enum(["up", "down", "neutral"]),
+    cadence: z.string().min(1),
+    calculationNote: z.string().min(1),
+    execution: z
+      .object({
+        mode: z.literal("saved_query"),
+        source: z.string().min(1),
+        query: z.string().min(1),
+        result: z.record(z.string(), z.unknown()),
+        freshnessSeconds: z.number().int().positive(),
+      })
+      .strict(),
+  })
+  .strict();
+
+const workflowSchema = z
+  .object({
+    ...base,
+    name: z.string().min(1),
+    description: z.string(),
+    enabled: z.boolean(),
+    status: z.literal("active"),
+    goal: z.string().min(1),
+    schedule: z
+      .object({
+        cron: z.string().min(1),
+        timezoneInput: z.string().min(1),
+        enabled: z.boolean(),
+      })
+      .strict()
+      .nullable(),
+    activation: z.string().optional(),
+    outputContract: z
+      .object({
+        kind: z.string().min(1),
+        required: z.array(z.string()).min(1),
+      })
+      .strict(),
+  })
+  .strict();
+
+const watcherSchema = z
+  .object({
+    ...base,
+    name: z.string().min(1),
+    description: z.string(),
+    workflow: artifactKey,
+    enabled: z.boolean(),
+    activation: z.string().min(1),
+    query: z.string().min(1),
+    valuePath: z.string().min(1),
+    operator: z.enum(["gt", "gte", "lt", "lte", "eq", "ne"]),
+    threshold: z.union([z.number(), z.string(), z.boolean(), z.null()]),
+    cadenceSeconds: z.number().int().positive(),
+    debounceSeconds: z.number().int().nonnegative(),
+    cooldownSeconds: z.number().int().nonnegative(),
+    severity: z.enum(["low", "medium", "high", "critical"]),
+    dedupeKey: z.string().min(1),
+    readinessSignals: z.array(z.string()).optional(),
+  })
+  .strict();
+
+const mappingLeafSchema: z.ZodType<unknown> = z.union([
+  z.object({ input: z.string().min(1) }).strict(),
+  z.object({ packInput: z.string().min(1) }).strict(),
+  z.object({ const: z.union([z.string(), z.number(), z.boolean(), z.null()]) }).strict(),
+]);
+
+const mappingSchema: z.ZodType<unknown> = z.lazy(() =>
+  z.union([mappingLeafSchema, z.record(z.string(), mappingSchema)]),
+);
+
+const actionSchema = z
+  .object({
+    ...base,
+    kind: targetRef,
+    description: z.string().min(1),
+    readiness: z
+      .object({
+        capability: z.string().min(1),
+        unavailableReasons: z.array(z.string()).min(1),
+      })
+      .strict(),
+    inputSchema: z.record(z.string(), z.unknown()),
+    adapter: z
+      .object({
+        kind: z.literal("graphjin_api_operation"),
+        source: z.string().min(1),
+        operationId: z.string().min(1),
+        mutationRoot: z.string().min(1),
+        preconditionQuery: z.string().min(1),
+        mutationQuery: z.string().min(1),
+        reconciliationQuery: z.string().min(1),
+        request: z
+          .object({
+            path: z.record(z.string(), mappingSchema),
+            body: z.record(z.string(), mappingSchema),
+          })
+          .strict(),
+        receipt: z
+          .object({
+            fields: z.array(z.string()),
+            redact: z.array(z.string()),
+          })
+          .strict(),
+        ambiguousOutcome: z.literal("reconcile_required"),
+        retry: z.literal("never"),
+      })
+      .strict(),
+  })
+  .strict();
+
+const policySchema = z
+  .object({
+    ...base,
+    name: z.string().min(1),
+    description: z.string(),
+    appliesToKinds: z.array(targetRef).min(1),
+    appliesToScopes: z.array(targetRef).min(1),
+    mode: z.literal("ask"),
+    approverRole: z.literal("admin"),
+    priority: z.number().int(),
+    enabled: z.boolean(),
+    allowedTargets: z.record(z.string(), z.unknown()),
+    limits: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
+const relationshipsSchema = z
+  .object({
+    ...base,
+    source: z.string().min(1),
+    relationships: z
+      .array(
+        z
+          .object({
+            left: z.string().min(1),
+            right: z.string().min(1),
+            cardinality: z.enum(["one_to_one", "one_to_many", "many_to_one", "many_to_many"]),
+          })
+          .strict(),
+      )
+      .min(1),
+  })
+  .strict();
+
+const schemas: Partial<Record<PackArtifactKind, z.ZodType>> = {
+  source: sourceFileSchema,
+  metric: metricSchema,
+  workflow: workflowSchema,
+  watcher: watcherSchema,
+  action: actionSchema,
+  policy: policySchema,
+  relationships: relationshipsSchema,
+};
+
+export function validateArtifactContent(kind: PackArtifactKind, content: unknown, path: string): void {
+  const schema = schemas[kind];
+  if (schema) {
+    const parsed = schema.safeParse(content);
+    if (!parsed.success) {
+      throw new Error(`invalid ${kind} artifact ${path}: ${z.prettifyError(parsed.error)}`);
+    }
+  }
+  if (kind === "spec") {
+    const spec = content as Record<string, unknown> | null;
+    if (!spec || typeof spec !== "object" || typeof spec.openapi !== "string" || !spec.paths) {
+      throw new Error(`invalid OpenAPI artifact ${path}`);
+    }
+  }
+}

--- a/packages/packs/src/bundle.ts
+++ b/packages/packs/src/bundle.ts
@@ -1,0 +1,303 @@
+import { lstat, readFile, readdir, realpath } from "node:fs/promises";
+import { basename, extname, join, relative, resolve, sep } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { validateArtifactContent } from "./artifact-schema.js";
+import { canonicalHash, sha256 } from "./canonicalize.js";
+import { parseManifest, type SolutionPackManifest } from "./manifest.js";
+
+export type PackArtifactKind =
+  | "source"
+  | "relationships"
+  | "spec"
+  | "saved_query"
+  | "metric"
+  | "workflow"
+  | "watcher"
+  | "action"
+  | "policy"
+  | "skill";
+
+export interface PackArtifact {
+  kind: PackArtifactKind;
+  key: string;
+  targetRef: string;
+  path: string;
+  hash: string;
+  content: unknown;
+}
+
+export interface SolutionPackBundle {
+  root: string;
+  manifest: SolutionPackManifest;
+  manifestHash: string;
+  bundleHash: string;
+  artifacts: PackArtifact[];
+}
+
+const structuredExtensions = new Set([".yaml", ".yml", ".json"]);
+
+function stableFileKey(kind: PackArtifactKind, file: string): string {
+  const stem = basename(file, extname(file)).replace(/_/g, "-");
+  return `${kind}.${stem}`;
+}
+
+async function assertSafePath(root: string, candidate: string): Promise<string> {
+  const rootReal = await realpath(root);
+  const absolute = resolve(root, candidate);
+  const lexical = relative(rootReal, absolute);
+  if (lexical === ".." || lexical.startsWith(`..${sep}`) || lexical.startsWith(sep)) {
+    throw new Error(`pack path escapes root: ${candidate}`);
+  }
+  const segments = lexical.split(sep).filter(Boolean);
+  let cursor = rootReal;
+  for (const segment of segments) {
+    cursor = join(cursor, segment);
+    const stat = await lstat(cursor);
+    if (stat.isSymbolicLink()) throw new Error(`pack path cannot contain symlinks: ${candidate}`);
+  }
+  const resolved = await realpath(absolute);
+  const physical = relative(rootReal, resolved);
+  if (physical === ".." || physical.startsWith(`..${sep}`) || physical.startsWith(sep)) {
+    throw new Error(`pack path resolves outside root: ${candidate}`);
+  }
+  return resolved;
+}
+
+async function readArtifactContent(path: string): Promise<{ content: unknown; hash: string }> {
+  const raw = (await readFile(path, "utf8")).replace(/\r\n/g, "\n");
+  if (structuredExtensions.has(extname(path).toLowerCase())) {
+    const content = extname(path).toLowerCase() === ".json" ? JSON.parse(raw) : parseYaml(raw);
+    return { content, hash: canonicalHash(content) };
+  }
+  return { content: raw, hash: sha256(raw) };
+}
+
+function artifactIdentity(
+  kind: PackArtifactKind,
+  path: string,
+  content: unknown,
+): { key: string; targetRef: string } {
+  if (content && typeof content === "object" && !Array.isArray(content)) {
+    const record = content as Record<string, unknown>;
+    const key = typeof record.key === "string" ? record.key : stableFileKey(kind, path);
+    const targetRef = typeof record.targetRef === "string" ? record.targetRef : key;
+    return { key, targetRef };
+  }
+  return { key: stableFileKey(kind, path), targetRef: stableFileKey(kind, path) };
+}
+
+async function filesInDirectory(root: string, path: string): Promise<string[]> {
+  const directory = await assertSafePath(root, path);
+  const entries = await readdir(directory, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (entry.isSymbolicLink()) throw new Error(`pack directory cannot contain symlinks: ${path}/${entry.name}`);
+    if (!entry.isFile()) continue;
+    files.push(relative(root, join(directory, entry.name)));
+  }
+  return files;
+}
+
+async function artifactFromFile(
+  root: string,
+  kind: PackArtifactKind,
+  path: string,
+): Promise<PackArtifact> {
+  const safePath = await assertSafePath(root, path);
+  const { content, hash } = await readArtifactContent(safePath);
+  validateArtifactContent(kind, content, path);
+  const { key, targetRef } = artifactIdentity(kind, path, content);
+  return { kind, key, targetRef, path: relative(root, safePath), hash, content };
+}
+
+async function sourceArtifacts(root: string, path: string): Promise<PackArtifact[]> {
+  const artifact = await artifactFromFile(root, "source", path);
+  const record = artifact.content as { sources?: unknown };
+  if (!record || !Array.isArray(record.sources)) {
+    throw new Error(`${path} must contain a sources array`);
+  }
+  return record.sources.map((source, index) => {
+    if (!source || typeof source !== "object" || Array.isArray(source)) {
+      throw new Error(`${path} source ${index} must be an object`);
+    }
+    const value = source as Record<string, unknown>;
+    if (typeof value.name !== "string" || !value.name) {
+      throw new Error(`${path} source ${index} requires name`);
+    }
+    const key = typeof value.key === "string" ? value.key : `source.${value.name}`;
+    const content = Object.fromEntries(Object.entries(value).filter(([name]) => name !== "key"));
+    return {
+      kind: "source" as const,
+      key,
+      targetRef: value.name,
+      path: artifact.path,
+      hash: canonicalHash(content),
+      content,
+    };
+  });
+}
+
+async function directoryArtifacts(
+  root: string,
+  kind: PackArtifactKind,
+  path: string,
+): Promise<PackArtifact[]> {
+  const files = await filesInDirectory(root, path);
+  const allowed = kind === "saved_query" ? new Set([".gql", ".graphql"]) : new Set([".yaml", ".yml"]);
+  for (const file of files) {
+    if (!allowed.has(extname(file).toLowerCase())) {
+      throw new Error(`unsupported ${kind} artifact file: ${file}`);
+    }
+  }
+  return Promise.all(files.map((file) => artifactFromFile(root, kind, file)));
+}
+
+async function skillArtifact(root: string, path: string): Promise<PackArtifact> {
+  const skillPath = join(path, "SKILL.md");
+  const artifact = await artifactFromFile(root, "skill", skillPath);
+  const skillName = basename(path);
+  return {
+    ...artifact,
+    key: `skill.${skillName}`,
+    targetRef: skillName,
+    hash: await hashTree(root, path),
+  };
+}
+
+async function hashTree(root: string, path: string): Promise<string> {
+  const directory = await assertSafePath(root, path);
+  const entries = await readdir(directory, { withFileTypes: true });
+  const values: Array<{ path: string; hash: string }> = [];
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (entry.isSymbolicLink()) throw new Error(`pack skill cannot contain symlinks: ${path}/${entry.name}`);
+    const child = join(directory, entry.name);
+    const childPath = relative(root, child);
+    if (entry.isDirectory()) {
+      values.push({ path: childPath, hash: await hashTree(root, childPath) });
+    } else if (entry.isFile()) {
+      if (extname(entry.name).toLowerCase() !== ".md") {
+        throw new Error(`pack skills may contain Markdown only: ${childPath}`);
+      }
+      const value = await readArtifactContent(child);
+      values.push({ path: childPath, hash: value.hash });
+    }
+  }
+  return canonicalHash(values);
+}
+
+function recordArtifact(artifact: PackArtifact): Record<string, unknown> {
+  if (!artifact.content || typeof artifact.content !== "object" || Array.isArray(artifact.content)) {
+    throw new Error(`${artifact.kind} artifact ${artifact.path} must be an object`);
+  }
+  return artifact.content as Record<string, unknown>;
+}
+
+function validateArtifactReferences(artifacts: PackArtifact[]): void {
+  const sourceNames = new Set(
+    artifacts.filter((artifact) => artifact.kind === "source").map((artifact) => artifact.targetRef),
+  );
+  const savedQueries = new Set(
+    artifacts
+      .filter((artifact) => artifact.kind === "saved_query")
+      .map((artifact) => basename(artifact.path, extname(artifact.path))),
+  );
+  const workflowKeys = new Set(
+    artifacts.filter((artifact) => artifact.kind === "workflow").map((artifact) => artifact.key),
+  );
+
+  const requireSource = (artifact: PackArtifact, source: unknown) => {
+    if (!sourceNames.has(String(source))) {
+      throw new Error(`${artifact.kind} artifact ${artifact.path} references missing source ${String(source)}`);
+    }
+  };
+  const requireQuery = (artifact: PackArtifact, query: unknown) => {
+    if (!savedQueries.has(String(query))) {
+      throw new Error(`${artifact.kind} artifact ${artifact.path} references missing saved query ${String(query)}`);
+    }
+  };
+
+  for (const artifact of artifacts) {
+    if (artifact.kind === "relationships") {
+      requireSource(artifact, recordArtifact(artifact).source);
+    } else if (artifact.kind === "metric") {
+      const execution = recordArtifact(artifact).execution as Record<string, unknown>;
+      requireSource(artifact, execution.source);
+      requireQuery(artifact, execution.query);
+    } else if (artifact.kind === "watcher") {
+      const watcher = recordArtifact(artifact);
+      if (!workflowKeys.has(String(watcher.workflow))) {
+        throw new Error(
+          `watcher artifact ${artifact.path} references missing workflow ${String(watcher.workflow)}`,
+        );
+      }
+      requireQuery(artifact, watcher.query);
+    } else if (artifact.kind === "action") {
+      const adapter = recordArtifact(artifact).adapter as Record<string, unknown>;
+      requireSource(artifact, adapter.source);
+      for (const field of ["preconditionQuery", "mutationQuery", "reconciliationQuery"] as const) {
+        requireQuery(artifact, adapter[field]);
+      }
+    }
+  }
+}
+
+export async function loadSolutionPack(rootInput: string): Promise<SolutionPackBundle> {
+  const root = await realpath(rootInput);
+  const manifestPath = await assertSafePath(root, "pack.yaml");
+  const manifestRaw = await readFile(manifestPath, "utf8");
+  const manifest = parseManifest(parseYaml(manifestRaw));
+  const graphjin = manifest.artifacts.graphjin;
+
+  // Validate every manifest target serially before parallel parsing. Besides
+  // making failures deterministic, this guarantees a symlink in an early
+  // target cannot be hidden by a racing ENOENT or parse failure elsewhere.
+  for (const path of [
+    graphjin.sources,
+    graphjin.relationships,
+    ...graphjin.specs,
+    graphjin.savedQueries,
+    manifest.artifacts.metrics,
+    manifest.artifacts.workflows,
+    manifest.artifacts.watchers,
+    manifest.artifacts.actions,
+    manifest.artifacts.policies,
+    ...manifest.artifacts.skills,
+  ]) {
+    await assertSafePath(root, path);
+  }
+
+  const artifacts = (
+    await Promise.all([
+      sourceArtifacts(root, graphjin.sources),
+      artifactFromFile(root, "relationships", graphjin.relationships).then((value) => [value]),
+      Promise.all(graphjin.specs.map((path) => artifactFromFile(root, "spec", path))),
+      directoryArtifacts(root, "saved_query", graphjin.savedQueries),
+      directoryArtifacts(root, "metric", manifest.artifacts.metrics),
+      directoryArtifacts(root, "workflow", manifest.artifacts.workflows),
+      directoryArtifacts(root, "watcher", manifest.artifacts.watchers),
+      directoryArtifacts(root, "action", manifest.artifacts.actions),
+      directoryArtifacts(root, "policy", manifest.artifacts.policies),
+      Promise.all(manifest.artifacts.skills.map((path) => skillArtifact(root, path))),
+    ])
+  ).flat();
+
+  const identities = new Set<string>();
+  const targets = new Set<string>();
+  for (const artifact of artifacts) {
+    const identity = `${artifact.kind}:${artifact.key}`;
+    const target = `${artifact.kind}:${artifact.targetRef}`;
+    if (identities.has(identity)) throw new Error(`duplicate artifact key: ${identity}`);
+    if (targets.has(target)) throw new Error(`duplicate artifact target: ${target}`);
+    identities.add(identity);
+    targets.add(target);
+  }
+  validateArtifactReferences(artifacts);
+
+  artifacts.sort((a, b) => `${a.kind}:${a.key}`.localeCompare(`${b.kind}:${b.key}`));
+  const manifestHash = canonicalHash(manifest);
+  const bundleHash = canonicalHash({
+    manifest: manifestHash,
+    artifacts: artifacts.map(({ kind, key, targetRef, hash }) => ({ kind, key, targetRef, hash })),
+  });
+  return { root, manifest, manifestHash, bundleHash, artifacts };
+}

--- a/packages/packs/src/canonicalize.ts
+++ b/packages/packs/src/canonicalize.ts
@@ -1,0 +1,42 @@
+import { createHash } from "node:crypto";
+
+export type CanonicalValue =
+  | null
+  | boolean
+  | number
+  | string
+  | CanonicalValue[]
+  | { [key: string]: CanonicalValue };
+
+export function canonicalize(value: unknown): CanonicalValue {
+  if (value === null || typeof value === "boolean" || typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) throw new Error("cannot canonicalize a non-finite number");
+    return value;
+  }
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return Object.fromEntries(
+      Object.keys(record)
+        .sort()
+        .filter((key) => record[key] !== undefined)
+        .map((key) => [key, canonicalize(record[key])]),
+    );
+  }
+  throw new Error(`cannot canonicalize ${typeof value}`);
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function sha256(value: string | Uint8Array): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function canonicalHash(value: unknown): string {
+  return sha256(canonicalJson(value));
+}

--- a/packages/packs/src/index.ts
+++ b/packages/packs/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./bundle.js";
+export * from "./artifact-schema.js";
+export * from "./canonicalize.js";
+export * from "./manifest.js";
+export * from "./planner.js";

--- a/packages/packs/src/manifest.ts
+++ b/packages/packs/src/manifest.ts
@@ -1,0 +1,143 @@
+import { z } from "zod";
+
+const slug = z
+  .string()
+  .regex(/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/, "must be a lowercase slug");
+const version = z
+  .string()
+  .regex(/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/, "must be a semantic version");
+const relativePath = z.string().min(1).superRefine((value, ctx) => {
+  if (value.includes("\\")) {
+    ctx.addIssue({ code: "custom", message: "must use forward slashes" });
+  }
+  if (value.startsWith("/") || value.split("/").some((part) => part === "..")) {
+    ctx.addIssue({ code: "custom", message: "must stay within the pack root" });
+  }
+});
+
+const metadataSchema = z
+  .object({
+    id: slug,
+    name: z.string().min(1),
+    version,
+    publisher: slug,
+    category: slug,
+  })
+  .strict();
+
+const applicationCompatibilitySchema = z
+  .object({
+    id: slug,
+    editions: z.array(slug).min(1),
+    versions: z.string().min(1),
+  })
+  .strict();
+
+const databaseCompatibilitySchema = z
+  .object({
+    engine: z.enum(["mariadb", "mysql", "postgres"]),
+    versions: z.string().min(1),
+  })
+  .strict();
+
+const compatibilitySchema = z
+  .object({
+    openneko: z.string().min(1),
+    graphjin: z
+      .object({
+        analytics: z.string().min(1),
+        operator: z.string().min(1),
+      })
+      .strict(),
+    applications: z.array(applicationCompatibilitySchema).min(1),
+    databases: z.array(databaseCompatibilitySchema).min(1),
+  })
+  .strict();
+
+const inputSchema = z
+  .object({
+    key: z.string().regex(/^[a-z][a-z0-9_.-]+$/),
+    type: z.enum(["string", "url", "integer", "enum", "timezone", "boolean"]),
+    required: z.boolean().optional(),
+    default: z.union([z.string(), z.number(), z.boolean()]).optional(),
+    discover: z.boolean().optional(),
+    values: z.array(z.union([z.string(), z.number(), z.boolean()])).optional(),
+    description: z.string().optional(),
+  })
+  .strict()
+  .superRefine((input, ctx) => {
+    if (input.type === "enum" && (!input.values || input.values.length === 0)) {
+      ctx.addIssue({ code: "custom", message: "enum inputs require values", path: ["values"] });
+    }
+    if (input.type !== "enum" && input.values) {
+      ctx.addIssue({ code: "custom", message: "values are valid only for enum inputs", path: ["values"] });
+    }
+  });
+
+const secretSchema = z
+  .object({
+    key: z.string().regex(/^[a-z][a-z0-9_.-]+$/),
+    purpose: z.enum(["graphjin_source", "graphjin_api_auth", "pack_runtime"]),
+    required: z.boolean().optional().default(true),
+  })
+  .strict();
+
+const graphjinArtifactsSchema = z
+  .object({
+    sources: relativePath,
+    relationships: relativePath,
+    specs: z.array(relativePath),
+    savedQueries: relativePath,
+  })
+  .strict();
+
+const artifactsSchema = z
+  .object({
+    graphjin: graphjinArtifactsSchema,
+    metrics: relativePath,
+    workflows: relativePath,
+    watchers: relativePath,
+    actions: relativePath,
+    policies: relativePath,
+    skills: z.array(relativePath).min(1),
+  })
+  .strict();
+
+const healthSchema = z
+  .object({
+    requiredPreflight: z.array(slug),
+    readiness: z.record(slug, z.array(slug)),
+    postInstall: z.array(slug),
+    postWriteCanary: z.array(slug),
+  })
+  .strict();
+
+export const solutionPackManifestSchema = z
+  .object({
+    apiVersion: z.literal("openneko.app/v1"),
+    kind: z.literal("SolutionPack"),
+    metadata: metadataSchema,
+    compatibility: compatibilitySchema,
+    inputs: z.array(inputSchema),
+    secrets: z.array(secretSchema),
+    artifacts: artifactsSchema,
+    health: healthSchema,
+  })
+  .strict()
+  .superRefine((manifest, ctx) => {
+    for (const field of ["inputs", "secrets"] as const) {
+      const seen = new Set<string>();
+      manifest[field].forEach((entry, index) => {
+        if (seen.has(entry.key)) {
+          ctx.addIssue({ code: "custom", message: `duplicate ${field} key`, path: [field, index, "key"] });
+        }
+        seen.add(entry.key);
+      });
+    }
+  });
+
+export type SolutionPackManifest = z.infer<typeof solutionPackManifestSchema>;
+
+export function parseManifest(input: unknown): SolutionPackManifest {
+  return solutionPackManifestSchema.parse(input);
+}

--- a/packages/packs/src/planner.ts
+++ b/packages/packs/src/planner.ts
@@ -1,0 +1,92 @@
+import { canonicalHash } from "./canonicalize.js";
+import type { PackArtifact, PackArtifactKind, SolutionPackBundle } from "./bundle.js";
+
+export type PackPlanAction = "create" | "update" | "noop" | "conflict" | "retire";
+
+export interface InstalledPackArtifact {
+  kind: PackArtifactKind;
+  key: string;
+  targetRef: string;
+  desiredHash: string;
+  lastAppliedHash: string;
+  currentHash: string | null;
+  ownership: "managed" | "modified" | "detached" | "retired";
+}
+
+export interface PackPlanEntry {
+  action: PackPlanAction;
+  kind: PackArtifactKind;
+  key: string;
+  targetRef: string;
+  desiredHash: string | null;
+  currentHash: string | null;
+  reason?: "user_modified" | "target_missing" | "removed_from_pack" | "detached";
+}
+
+export interface PackPlan {
+  packId: string;
+  version: string;
+  bundleHash: string;
+  entries: PackPlanEntry[];
+  hash: string;
+}
+
+function desiredEntry(artifact: PackArtifact, installed?: InstalledPackArtifact): PackPlanEntry {
+  const base = {
+    kind: artifact.kind,
+    key: artifact.key,
+    targetRef: artifact.targetRef,
+    desiredHash: artifact.hash,
+    currentHash: installed?.currentHash ?? null,
+  };
+  if (!installed) return { action: "create", ...base };
+  if (installed.ownership === "detached") return { action: "conflict", ...base, reason: "detached" };
+  if (installed.ownership === "retired") {
+    if (installed.currentHash !== null && installed.currentHash !== installed.lastAppliedHash) {
+      return { action: "conflict", ...base, reason: "user_modified" };
+    }
+    return { action: "update", ...base };
+  }
+  if (installed.currentHash === null) return { action: "conflict", ...base, reason: "target_missing" };
+  if (installed.currentHash !== installed.lastAppliedHash) {
+    return { action: "conflict", ...base, reason: "user_modified" };
+  }
+  if (installed.desiredHash === artifact.hash) return { action: "noop", ...base };
+  return { action: "update", ...base };
+}
+
+export function planPack(
+  bundle: SolutionPackBundle,
+  installedArtifacts: InstalledPackArtifact[],
+): PackPlan {
+  const installed = new Map(
+    installedArtifacts.map((artifact) => [`${artifact.kind}:${artifact.key}`, artifact]),
+  );
+  const entries = bundle.artifacts.map((artifact) => {
+    const identity = `${artifact.kind}:${artifact.key}`;
+    const entry = desiredEntry(artifact, installed.get(identity));
+    installed.delete(identity);
+    return entry;
+  });
+  for (const artifact of installed.values()) {
+    if (artifact.ownership === "detached" || artifact.ownership === "retired") continue;
+    const modified = artifact.currentHash !== artifact.lastAppliedHash;
+    entries.push({
+      action: modified ? "conflict" : "retire",
+      kind: artifact.kind,
+      key: artifact.key,
+      targetRef: artifact.targetRef,
+      desiredHash: null,
+      currentHash: artifact.currentHash,
+      reason: modified ? "user_modified" : "removed_from_pack",
+    });
+  }
+  entries.sort((a, b) => `${a.kind}:${a.key}`.localeCompare(`${b.kind}:${b.key}`));
+  const plan = {
+    packId: bundle.manifest.metadata.id,
+    version: bundle.manifest.metadata.version,
+    bundleHash: bundle.bundleHash,
+    entries,
+  };
+  return { ...plan, hash: canonicalHash(plan) };
+}

--- a/packages/packs/test/magento-bundle.test.ts
+++ b/packages/packs/test/magento-bundle.test.ts
@@ -1,0 +1,238 @@
+import { mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { loadSolutionPack } from "../src/bundle.js";
+import { validateArtifactContent } from "../src/artifact-schema.js";
+import { canonicalJson } from "../src/canonicalize.js";
+import { parseManifest } from "../src/manifest.js";
+import { planPack } from "../src/planner.js";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const magentoRoot = resolve(here, "../../../packs/magento");
+
+describe("Magento solution pack", () => {
+  it("loads the complete pack with stable, globally unique identities", async () => {
+    const bundle = await loadSolutionPack(magentoRoot);
+    expect(bundle.manifest.metadata.id).toBe("magento");
+    expect(bundle.manifest.secrets.find((value) => value.key === "magento.integration_token")?.required).toBe(false);
+
+    const count = (kind: string) => bundle.artifacts.filter((artifact) => artifact.kind === kind).length;
+    expect(count("source")).toBe(2);
+    expect(count("metric")).toBe(13);
+    expect(count("workflow")).toBe(6);
+    expect(count("watcher")).toBe(6);
+    expect(count("action")).toBe(1);
+    expect(count("policy")).toBe(1);
+    expect(count("skill")).toBe(6);
+    expect(
+      bundle.artifacts
+        .filter((artifact) => artifact.kind === "skill")
+        .map((artifact) => artifact.targetRef)
+        .sort(),
+    ).toEqual([
+      "magento-check-inventory",
+      "magento-diagnose-platform-health",
+      "magento-investigate-order",
+      "magento-investigate-refunds",
+      "magento-review-performance",
+      "magento-triage-fulfillment",
+    ]);
+    expect(bundle.artifacts.some((artifact) => artifact.targetRef === "magento-ops")).toBe(false);
+    expect(new Set(bundle.artifacts.map((artifact) => `${artifact.kind}:${artifact.key}`)).size).toBe(
+      bundle.artifacts.length,
+    );
+  });
+
+  it("discovers every artifact without filtering on optional write readiness", async () => {
+    const bundle = await loadSolutionPack(magentoRoot);
+    const plan = planPack(bundle, []);
+    expect(plan.entries.every((entry) => entry.action === "create")).toBe(true);
+    expect(plan.entries.some((entry) => entry.key === "action.add_internal_order_comment")).toBe(true);
+    expect(plan.entries.some((entry) => entry.key === "policy.internal_order_comment")).toBe(true);
+    expect(plan.entries.some((entry) => entry.key === "source.magento_operator")).toBe(true);
+  });
+
+  it("produces the same manifest and bundle hashes on repeated loads", async () => {
+    const first = await loadSolutionPack(magentoRoot);
+    const second = await loadSolutionPack(magentoRoot);
+    expect(second.manifestHash).toBe(first.manifestHash);
+    expect(second.bundleHash).toBe(first.bundleHash);
+  });
+
+  it("keeps the operator source blocked until readiness enables it", async () => {
+    const bundle = await loadSolutionPack(magentoRoot);
+    const operator = bundle.artifacts.find((artifact) => artifact.key === "source.magento_operator");
+    expect(operator?.content).toMatchObject({
+      read_only: true,
+      capabilities: { "api.write": false, "api.delete": false },
+      access: { write: "blocked", delete: "blocked" },
+    });
+  });
+});
+
+describe("manifest and bundle safety", () => {
+  it("canonicalizes object keys without reordering arrays", () => {
+    expect(canonicalJson({ z: 1, a: [{ y: 2, x: 1 }, 3] })).toBe(
+      '{"a":[{"x":1,"y":2},3],"z":1}',
+    );
+  });
+
+  it("rejects unknown manifest fields", async () => {
+    const raw = parseYaml(await readFile(join(magentoRoot, "pack.yaml"), "utf8"));
+    raw.installScript = "./install.sh";
+    expect(() => parseManifest(raw)).toThrow(/unrecognized key/i);
+  });
+
+  it("rejects manifest path traversal before reading artifacts", async () => {
+    const raw = parseYaml(await readFile(join(magentoRoot, "pack.yaml"), "utf8"));
+    raw.artifacts.metrics = "../metrics";
+    expect(() => parseManifest(raw)).toThrow(/pack root/);
+  });
+
+  it("rejects symlinks in a pack path", async () => {
+    const temporary = await mkdtemp(join(tmpdir(), "openneko-pack-"));
+    const manifest = parseYaml(await readFile(join(magentoRoot, "pack.yaml"), "utf8"));
+    manifest.artifacts.graphjin.sources = "sources.yaml";
+    await writeFile(join(temporary, "pack.yaml"), stringifyYaml(manifest));
+    await symlink(join(magentoRoot, "graphjin/sources.yaml"), join(temporary, "sources.yaml"));
+    await expect(loadSolutionPack(temporary)).rejects.toThrow(/symlinks/);
+  });
+
+  it("rejects malformed source identities and unsupported watcher operators", () => {
+    expect(() => validateArtifactContent("source", {
+      sources: [{ key: "bad key", name: "magento", kind: "database" }],
+    }, "sources.yaml")).toThrow(/invalid source artifact/);
+    expect(() => validateArtifactContent("watcher", {
+      key: "watcher.test",
+      targetRef: "magento.watcher.test",
+      name: "Test",
+      description: "Test",
+      workflow: "workflow.test",
+      enabled: false,
+      activation: "admin",
+      query: "test",
+      valuePath: "value",
+      operator: "neq",
+      threshold: 0,
+      cadenceSeconds: 60,
+      debounceSeconds: 0,
+      cooldownSeconds: 0,
+      severity: "low",
+      dedupeKey: "test",
+    }, "watcher.yaml")).toThrow(/invalid watcher artifact/);
+  });
+});
+
+describe("drift-aware planning", () => {
+  it("is idempotent for unchanged installed artifacts", async () => {
+    const bundle = await loadSolutionPack(magentoRoot);
+    const installed = bundle.artifacts.map((artifact) => ({
+      kind: artifact.kind,
+      key: artifact.key,
+      targetRef: artifact.targetRef,
+      desiredHash: artifact.hash,
+      lastAppliedHash: artifact.hash,
+      currentHash: artifact.hash,
+      ownership: "managed" as const,
+    }));
+    expect(planPack(bundle, installed).entries.every((entry) => entry.action === "noop")).toBe(true);
+  });
+
+  it("preserves a user-modified artifact as a conflict", async () => {
+    const bundle = await loadSolutionPack(magentoRoot);
+    const desired = bundle.artifacts.find((artifact) => artifact.kind === "metric");
+    expect(desired).toBeDefined();
+    const plan = planPack(bundle, [
+      {
+        kind: desired!.kind,
+        key: desired!.key,
+        targetRef: desired!.targetRef,
+        desiredHash: desired!.hash,
+        lastAppliedHash: desired!.hash,
+        currentHash: "user-edited-hash",
+        ownership: "managed",
+      },
+    ]);
+    expect(plan.entries.find((entry) => entry.key === desired!.key)).toMatchObject({
+      action: "conflict",
+      reason: "user_modified",
+    });
+  });
+
+  it("reclaims an unchanged retired artifact on reinstall", async () => {
+    const bundle = await loadSolutionPack(magentoRoot);
+    const desired = bundle.artifacts.find((artifact) => artifact.kind === "metric")!;
+    const plan = planPack(bundle, [
+      {
+        kind: desired.kind,
+        key: desired.key,
+        targetRef: desired.targetRef,
+        desiredHash: desired.hash,
+        lastAppliedHash: "disabled-state",
+        currentHash: "disabled-state",
+        ownership: "retired",
+      },
+    ]);
+    expect(plan.entries.find((entry) => entry.key === desired.key)).toMatchObject({
+      action: "update",
+    });
+  });
+
+  it("preserves a modified retired artifact on reinstall", async () => {
+    const bundle = await loadSolutionPack(magentoRoot);
+    const desired = bundle.artifacts.find((artifact) => artifact.kind === "metric")!;
+    const plan = planPack(bundle, [
+      {
+        kind: desired.kind,
+        key: desired.key,
+        targetRef: desired.targetRef,
+        desiredHash: desired.hash,
+        lastAppliedHash: "disabled-state",
+        currentHash: "edited-after-uninstall",
+        ownership: "retired",
+      },
+    ]);
+    expect(plan.entries.find((entry) => entry.key === desired.key)).toMatchObject({
+      action: "conflict",
+      reason: "user_modified",
+    });
+  });
+
+  it("retires the prototype umbrella skill while adding focused operator skills", async () => {
+    const bundle = await loadSolutionPack(magentoRoot);
+    const plan = planPack(bundle, [{
+      kind: "skill",
+      key: "skill.magento-ops",
+      targetRef: "magento-ops",
+      desiredHash: "prototype-skill",
+      lastAppliedHash: "prototype-skill",
+      currentHash: "prototype-skill",
+      ownership: "managed",
+    }]);
+
+    expect(plan.entries.find((entry) => entry.key === "skill.magento-ops")).toMatchObject({
+      action: "retire",
+      reason: "removed_from_pack",
+    });
+    expect(
+      plan.entries.filter((entry) => entry.kind === "skill" && entry.action === "create"),
+    ).toHaveLength(6);
+  });
+
+  it("does not repeatedly retire an artifact already removed by an earlier upgrade", async () => {
+    const bundle = await loadSolutionPack(magentoRoot);
+    const plan = planPack(bundle, [{
+      kind: "saved_query",
+      key: "saved_query.removed-in-prior-version",
+      targetRef: "saved_query.removed-in-prior-version",
+      desiredHash: "old-definition",
+      lastAppliedHash: "retired-state",
+      currentHash: null,
+      ownership: "retired",
+    }]);
+    expect(plan.entries.some((entry) => entry.key === "saved_query.removed-in-prior-version")).toBe(false);
+  });
+});

--- a/packages/packs/tsconfig.json
+++ b/packages/packs/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitOverride": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": false,
+    "isolatedModules": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "test"]
+}

--- a/packages/packs/vitest.config.ts
+++ b/packages/packs/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+  },
+});

--- a/packs/magento/README.md
+++ b/packs/magento/README.md
@@ -1,0 +1,151 @@
+# Magento solution pack
+
+The Magento pack connects OpenNeko to Magento Open Source or Adobe Commerce
+2.4.x. Analytics use a dedicated SELECT-only MariaDB/MySQL account. Governed
+writes use a Magento Integration token through GraphJin's curated REST adapter.
+
+The complete pack is installed every time. With the current GraphJin release,
+analytics and all six operator skills are ready while the governed-write
+capability remains installed but blocked. A missing Integration token has the
+same effect; it does not produce a partial installation.
+
+Adobe Marketplace/Composer keys are not pack inputs. They are needed only when
+Composer downloads Magento itself from Adobe's repository.
+
+## Prerequisites
+
+- A running OpenNeko production stack.
+- Magento 2.4.6 through 2.4.x with `/magento_version` reachable from the
+  OpenNeko worker.
+- MariaDB 10.6+ or MySQL 8.0+ reachable from the customer GraphJin container.
+- A dedicated analytics account with SELECT-only grants. Start with
+  [`docs/analytics-user.sql`](docs/analytics-user.sql) and narrow its host and
+  table grants for production.
+- Optionally, a least-privilege Magento Integration token for the governed
+  action. This does not make writes executable until OpenNeko is upgraded to a
+  tagged GraphJin release that supports curated OpenAPI mutations.
+
+If Magento and OpenNeko share a Docker/OrbStack network, use MariaDB's service
+name as `--database-host`. If they are separate stacks, publish MariaDB on a
+host port and use `host.docker.internal` with
+`--database-connectivity host_gateway`. A remote database hostname also works
+with `--database-connectivity remote`.
+
+## Install
+
+For a normal installation, run one command:
+
+```sh
+openneko pack install magento
+```
+
+The guided installer asks only for the Magento URL, database address/name, and
+the dedicated read-only analytics username/password. Password input is hidden,
+and the credentials are saved in OpenNeko's local secret store automatically.
+The Magento table prefix, database engine, currency, timezone, and active store
+IDs are discovered. The first metric refresh is queued as soon as installation
+finishes.
+
+For automation or unattended installs, store credentials first and use the
+advanced flags. This example targets the US sample catalog's `default` store
+view:
+
+```sh
+openneko secrets set pack.magento ANALYTICS_USER
+openneko secrets set pack.magento ANALYTICS_PASSWORD
+
+openneko pack install magento \
+  --non-interactive \
+  --base-url http://host.docker.internal:8080 \
+  --store-code default \
+  --database-connectivity host_gateway \
+  --database-host host.docker.internal \
+  --database-port 3306 \
+  --database-name magento \
+  --analytics-username-ref ANALYTICS_USER \
+  --analytics-password-ref ANALYTICS_PASSWORD
+```
+
+The flags are an automation interface, not the expected first-run user
+experience.
+
+## Everyday operator skills
+
+Installation adds focused skills for recurring Magento work:
+
+- reviewing store performance and producing a daily or weekly briefing;
+- investigating one order and optionally proposing a private internal note;
+- triaging aged or partially shipped fulfillment work;
+- investigating refund-value and cancellation spikes;
+- checking low stock, MSI sources, and reservation discrepancies; and
+- diagnosing cron, indexer, data-freshness, and pack-health problems.
+
+Ask OpenNeko for the task in ordinary language. The matching skill is selected
+automatically; operators do not need to remember its installed ID. All six
+skills install even when governed Magento writes are unavailable. The order
+investigation still works read-only when its optional private-note action is
+blocked.
+
+## Optional Magento Integration token
+
+Create a Magento Integration with only the ACL required by the installed
+operation, then store and apply its token:
+
+```sh
+openneko secrets set pack.magento MAGENTO_INTEGRATION_TOKEN
+openneko pack configure magento \
+  --integration-token-ref MAGENTO_INTEGRATION_TOKEN
+```
+
+The action continues to fail closed while GraphJin reports the operator
+capability as unsupported. OpenNeko never asks for a Magento admin password.
+
+## Operate and troubleshoot
+
+For day-to-day administration, open **Admin → Settings → Solution packs →
+Magento**. The page shows plain-language health checks and provides buttons to
+recheck the connection, change credentials, update the pack, or remove it
+safely. An analytics-only installation is shown as healthy; governed write
+actions are listed separately as optional until their runtime and token are
+ready.
+
+Use one overview command for day-to-day administration:
+
+```sh
+openneko pack manage magento
+```
+
+It shows installation/readiness state, runs the health summary, and prints the
+exact commands for common maintenance tasks. The individual commands are:
+
+```sh
+openneko pack status magento
+openneko pack doctor magento
+openneko pack plan magento
+openneko pack upgrade magento
+```
+
+`doctor` rechecks database connectivity, SELECT-only grants, Magento/store
+discovery, the GraphJin catalog, and operator readiness. JSON output is
+available on all of these commands with `--output json`.
+
+To remove the pack configuration while retaining metric history, workflow run
+history, and other business data:
+
+```sh
+openneko pack uninstall magento
+```
+
+Uninstall revokes read, write, and delete access on the pack-owned GraphJin
+sources. GraphJin 3.18 retains that disabled source/table metadata so a later
+install can safely reclaim it. Pack-owned queries, the OpenAPI spec, skills,
+and stored OpenNeko secret section are removed. Native metrics, workflows,
+watchers, policy, and action records are disabled instead of deleted. If a managed
+artifact was edited after installation, uninstall stops and preserves it; use
+`openneko pack plan magento` to identify the drift. A later
+`openneko pack install magento` reclaims and re-enables unchanged retired
+artifacts.
+
+The development defaults used for the local US sample catalog are recorded in
+[`fixtures/us-sample-profile.yaml`](fixtures/us-sample-profile.yaml). They are
+not production credentials or production sizing guidance.

--- a/packs/magento/actions/add_internal_order_comment.yaml
+++ b/packs/magento/actions/add_internal_order_comment.yaml
@@ -1,0 +1,40 @@
+key: action.add_internal_order_comment
+targetRef: magento.add_internal_order_comment
+kind: magento.add_internal_order_comment
+description: Add a private note to a Magento order after an administrator approves it.
+readiness:
+  capability: operator
+  unavailableReasons:
+    - graphjin_version_unsupported
+    - integration_token_missing
+    - integration_token_invalid
+    - acl_missing
+inputSchema:
+  type: object
+  additionalProperties: false
+  required: [order_id, comment]
+  properties:
+    order_id: { type: string, pattern: "^[1-9][0-9]*$" }
+    comment: { type: string, minLength: 1, maxLength: 1000 }
+adapter:
+  kind: graphjin_api_operation
+  source: magento_operator
+  operationId: magentoAddInternalOrderComment
+  mutationRoot: magento_add_order_comment
+  preconditionQuery: action_order_precondition
+  mutationQuery: action_add_internal_order_comment
+  reconciliationQuery: action_order_reconciliation
+  request:
+    path:
+      id: { input: order_id }
+      storeCode: { packInput: magento.store_code }
+    body:
+      statusHistory:
+        comment: { input: comment }
+        is_customer_notified: { const: 0 }
+        is_visible_on_front: { const: 0 }
+  receipt:
+    fields: [order_id, increment_id, request_id, status_code, comment_created_at]
+    redact: [response_json]
+  ambiguousOutcome: reconcile_required
+  retry: never

--- a/packs/magento/docs/analytics-user.sql
+++ b/packs/magento/docs/analytics-user.sql
@@ -1,0 +1,12 @@
+-- Run as a MariaDB/MySQL administrator after replacing the placeholders.
+-- Do not provide the administrator credential to OpenNeko.
+CREATE USER IF NOT EXISTS 'magento_analytics'@'<GRAPHJIN_NETWORK_HOST>'
+  IDENTIFIED BY '<GENERATE_A_UNIQUE_PASSWORD>';
+
+GRANT SELECT ON `<MAGENTO_DATABASE>`.*
+  TO 'magento_analytics'@'<GRAPHJIN_NETWORK_HOST>';
+
+-- OpenNeko doctor verifies that this account cannot create or mutate data.
+-- For stricter deployments, replace the database-wide SELECT grant with
+-- explicit SELECT grants for only the tables listed in graphjin/sources.yaml.
+SHOW GRANTS FOR 'magento_analytics'@'<GRAPHJIN_NETWORK_HOST>';

--- a/packs/magento/fixtures/graphjin-validation/dev.yml
+++ b/packs/magento/fixtures/graphjin-validation/dev.yml
@@ -1,0 +1,51 @@
+app_name: OpenNeko Magento pack validation
+mode: dev
+host_port: 127.0.0.1:8182
+web_ui: false
+production: false
+disable_allow_list: true
+enable_schema: false
+secret_key: local-magento-pack-validation-only
+
+auth:
+  type: none
+  development: true
+
+# This fixture uses the legacy single-database spelling so its password can be
+# supplied through GraphJin's documented GJ_DATABASE_PASSWORD override. The
+# installed pack itself uses the named, read-only magento_analytics source.
+database:
+  type: mariadb
+  host: 127.0.0.1
+  port: 3306
+  dbname: magento
+  user: openneko_analytics
+  password: ${GJ_DATABASE_PASSWORD}
+
+system:
+  capabilities:
+    catalog.read: false
+    security.read: false
+    config.read: false
+    config.write: false
+    runtime.read: false
+    raw_graphql.query: true
+    raw_graphql.mutate: false
+
+tables:
+  - { name: sales_order, read_only: true }
+  - { name: sales_order_item, read_only: true }
+  - { name: sales_invoice, read_only: true }
+  - { name: sales_invoice_item, read_only: true }
+  - { name: sales_creditmemo, read_only: true }
+  - { name: cron_schedule, read_only: true }
+  - { name: indexer_state, read_only: true }
+  - { name: inventory_source_item, read_only: true }
+
+relationships:
+  - from: sales_order.entity_id
+    to: sales_order_item.order_id
+  - from: sales_order.entity_id
+    to: sales_invoice.order_id
+  - from: sales_invoice.entity_id
+    to: sales_invoice_item.parent_id

--- a/packs/magento/fixtures/us-sample-profile.yaml
+++ b/packs/magento/fixtures/us-sample-profile.yaml
@@ -1,0 +1,8 @@
+profile: us-sample
+description: Development defaults for Magento's US sample catalog.
+storeCode: default
+baseCurrency: USD
+timezone: America/Los_Angeles
+locale: en_US
+catalog: sample-data
+productionSafe: false

--- a/packs/magento/graphjin/relationships.yaml
+++ b/packs/magento/graphjin/relationships.yaml
@@ -1,0 +1,40 @@
+key: relationships.magento
+targetRef: magento
+source: magento_analytics
+relationships:
+  - left: sales_order.entity_id
+    right: sales_order_item.order_id
+    cardinality: one_to_many
+  - left: sales_order.entity_id
+    right: sales_invoice.order_id
+    cardinality: one_to_many
+  - left: sales_invoice.entity_id
+    right: sales_invoice_item.parent_id
+    cardinality: one_to_many
+  - left: sales_order.entity_id
+    right: sales_creditmemo.order_id
+    cardinality: one_to_many
+  - left: sales_creditmemo.entity_id
+    right: sales_creditmemo_item.parent_id
+    cardinality: one_to_many
+  - left: sales_order.entity_id
+    right: sales_shipment.order_id
+    cardinality: one_to_many
+  - left: sales_shipment.entity_id
+    right: sales_shipment_item.parent_id
+    cardinality: one_to_many
+  - left: sales_order.store_id
+    right: store.store_id
+    cardinality: many_to_one
+  - left: store.group_id
+    right: store_group.group_id
+    cardinality: many_to_one
+  - left: store_group.website_id
+    right: store_website.website_id
+    cardinality: many_to_one
+  - left: sales_order_item.product_id
+    right: catalog_product_entity.entity_id
+    cardinality: many_to_one
+  - left: inventory_source_item.sku
+    right: catalog_product_entity.sku
+    cardinality: many_to_one

--- a/packs/magento/graphjin/saved-queries/action_add_internal_order_comment.gql
+++ b/packs/magento/graphjin/saved-queries/action_add_internal_order_comment.gql
@@ -1,0 +1,9 @@
+mutation MagentoAddInternalOrderComment($request: JSON!) {
+  magento_add_order_comment(call: $request) {
+    ok
+    status_code
+    operation_id
+    request_id
+    response_json
+  }
+}

--- a/packs/magento/graphjin/saved-queries/action_order_precondition.gql
+++ b/packs/magento/graphjin/saved-queries/action_order_precondition.gql
@@ -1,0 +1,8 @@
+query MagentoOrderCommentPrecondition($orderId: BigInt!) {
+  sales_order(where: {entity_id: {eq: $orderId}}, limit: 1) {
+    entity_id
+    increment_id
+    state
+    status
+  }
+}

--- a/packs/magento/graphjin/saved-queries/action_order_reconciliation.gql
+++ b/packs/magento/graphjin/saved-queries/action_order_reconciliation.gql
@@ -1,0 +1,9 @@
+query MagentoOrderCommentReconciliation($request: JSON!) {
+  magento_get_order(call: $request) {
+    ok
+    status_code
+    operation_id
+    request_id
+    response_json
+  }
+}

--- a/packs/magento/graphjin/saved-queries/average_order_value.gql
+++ b/packs/magento/graphjin/saved-queries/average_order_value.gql
@@ -1,0 +1,11 @@
+query MagentoAverageOrderValue($from: String!, $to: String!, $storeIds: [Int!]) {
+  sales_invoice(where: {and: [{created_at: {gte: $from}}, {created_at: {lt: $to}}], store_id: {in: $storeIds}}) {
+    invoiced: sum_base_grand_total
+  }
+  sales_creditmemo(where: {and: [{created_at: {gte: $from}}, {created_at: {lt: $to}}], store_id: {in: $storeIds}}) {
+    refunded: sum_base_grand_total
+  }
+  invoiced_orders: sales_order(where: {and: [{created_at: {gte: $from}}, {created_at: {lt: $to}}], store_id: {in: $storeIds}, base_total_invoiced: {gt: 0}}) {
+    count: count_entity_id
+  }
+}

--- a/packs/magento/graphjin/saved-queries/cancellation_rate.gql
+++ b/packs/magento/graphjin/saved-queries/cancellation_rate.gql
@@ -1,0 +1,8 @@
+query MagentoCancellationRate($from: String!, $to: String!, $storeIds: [Int!]) {
+  all_orders: sales_order(where: {and: [{created_at: {gte: $from}}, {created_at: {lt: $to}}], store_id: {in: $storeIds}}) {
+    count: count_entity_id
+  }
+  cancelled_orders: sales_order(where: {and: [{created_at: {gte: $from}}, {created_at: {lt: $to}}], store_id: {in: $storeIds}, state: {eq: "canceled"}}) {
+    count: count_entity_id
+  }
+}

--- a/packs/magento/graphjin/saved-queries/cron_health.gql
+++ b/packs/magento/graphjin/saved-queries/cron_health.gql
@@ -1,0 +1,9 @@
+query MagentoCronHealth($staleBefore: String!, $from: String!) {
+  failed: cron_schedule(where: {created_at: {gte: $from}, status: {eq: "error"}}) {
+    count: count_schedule_id
+  }
+  stuck: cron_schedule(where: {created_at: {gte: $from}, status: {eq: "running"}, executed_at: {lt: $staleBefore}}) {
+    count: count_schedule_id
+    oldest_started_at: min_executed_at
+  }
+}

--- a/packs/magento/graphjin/saved-queries/data_freshness.gql
+++ b/packs/magento/graphjin/saved-queries/data_freshness.gql
@@ -1,0 +1,8 @@
+query MagentoDataFreshness($from: String!) {
+  sales_order(where: {created_at: {gte: $from}}, order_by: {created_at: desc}, limit: 1) {
+    newest_order_at: created_at
+  }
+  cron_schedule(where: {created_at: {gte: $from}, status: {eq: "success"}}, order_by: {finished_at: desc}, limit: 1) {
+    newest_successful_cron_at: finished_at
+  }
+}

--- a/packs/magento/graphjin/saved-queries/fulfillment_age.gql
+++ b/packs/magento/graphjin/saved-queries/fulfillment_age.gql
@@ -1,0 +1,15 @@
+query MagentoFulfillmentAge($from: String!, $storeIds: [Int!]) {
+  sales_order(
+    where: {
+      store_id: {in: $storeIds}
+      created_at: {gte: $from}
+      state: {nin: ["canceled", "closed", "complete"]}
+      base_total_paid: {gt: 0}
+    }
+    order_by: {created_at: asc}
+    limit: 5000
+  ) {
+    entity_id
+    created_at
+  }
+}

--- a/packs/magento/graphjin/saved-queries/fulfillment_backlog.gql
+++ b/packs/magento/graphjin/saved-queries/fulfillment_backlog.gql
@@ -1,0 +1,16 @@
+query MagentoFulfillmentBacklog($from: String!, $storeIds: [Int!]) {
+  sales_order_item(
+    where: {
+      store_id: {in: $storeIds}
+      created_at: {gte: $from}
+      parent_item_id: {is_null: true}
+      qty_invoiced: {gt: 0}
+      qty_shipped: {lt: {col: "qty_invoiced"}}
+    }
+  ) {
+    backlog_lines: count_item_id
+    invoiced_quantity: sum_qty_invoiced
+    shipped_quantity: sum_qty_shipped
+    refunded_quantity: sum_qty_refunded
+  }
+}

--- a/packs/magento/graphjin/saved-queries/indexer_health.gql
+++ b/packs/magento/graphjin/saved-queries/indexer_health.gql
@@ -1,0 +1,7 @@
+query MagentoIndexerHealth($staleBefore: String!) {
+  indexer_state(where: {or: [{status: {neq: "valid"}}, {updated: {lt: $staleBefore}}]}, order_by: {updated: asc}) {
+    indexer_id
+    status
+    updated
+  }
+}

--- a/packs/magento/graphjin/saved-queries/net_invoiced_revenue.gql
+++ b/packs/magento/graphjin/saved-queries/net_invoiced_revenue.gql
@@ -1,0 +1,8 @@
+query MagentoNetInvoicedRevenue($from: String!, $to: String!, $storeIds: [Int!]) {
+  sales_invoice(where: {and: [{created_at: {gte: $from}}, {created_at: {lt: $to}}], store_id: {in: $storeIds}}) {
+    invoiced: sum_base_grand_total
+  }
+  sales_creditmemo(where: {and: [{created_at: {gte: $from}}, {created_at: {lt: $to}}], store_id: {in: $storeIds}}) {
+    refunded: sum_base_grand_total
+  }
+}

--- a/packs/magento/graphjin/saved-queries/orders_placed.gql
+++ b/packs/magento/graphjin/saved-queries/orders_placed.gql
@@ -1,0 +1,5 @@
+query MagentoOrdersPlaced($from: String!, $to: String!, $storeIds: [Int!]) {
+  sales_order(where: {and: [{created_at: {gte: $from}}, {created_at: {lt: $to}}], store_id: {in: $storeIds}}) {
+    orders: count_entity_id
+  }
+}

--- a/packs/magento/graphjin/saved-queries/refund_rate.gql
+++ b/packs/magento/graphjin/saved-queries/refund_rate.gql
@@ -1,0 +1,8 @@
+query MagentoRefundRate($from: String!, $to: String!, $storeIds: [Int!]) {
+  sales_invoice(where: {and: [{created_at: {gte: $from}}, {created_at: {lt: $to}}], store_id: {in: $storeIds}}) {
+    invoiced: sum_base_grand_total
+  }
+  sales_creditmemo(where: {and: [{created_at: {gte: $from}}, {created_at: {lt: $to}}], store_id: {in: $storeIds}}) {
+    refunded: sum_base_grand_total
+  }
+}

--- a/packs/magento/graphjin/saved-queries/sales_by_store.gql
+++ b/packs/magento/graphjin/saved-queries/sales_by_store.gql
@@ -1,0 +1,18 @@
+query MagentoSalesByStore($from: String!, $to: String!, $storeIds: [Int!]) {
+  sales_invoice(
+    distinct: [store_id]
+    where: {and: [{created_at: {gte: $from}}, {created_at: {lt: $to}}], store_id: {in: $storeIds}}
+    order_by: {store_id: asc}
+  ) {
+    store_id
+    invoiced: sum_base_grand_total
+  }
+  sales_creditmemo(
+    distinct: [store_id]
+    where: {and: [{created_at: {gte: $from}}, {created_at: {lt: $to}}], store_id: {in: $storeIds}}
+    order_by: {store_id: asc}
+  ) {
+    store_id
+    refunded: sum_base_grand_total
+  }
+}

--- a/packs/magento/graphjin/saved-queries/stock_status.gql
+++ b/packs/magento/graphjin/saved-queries/stock_status.gql
@@ -1,0 +1,12 @@
+query MagentoStockStatus($threshold: Float = 5) {
+  inventory_source_item(
+    where: {or: [{status: {eq: 0}}, {quantity: {lte: $threshold}}]}
+    order_by: {quantity: asc}
+    limit: 100
+  ) {
+    sku
+    source_code
+    quantity
+    status
+  }
+}

--- a/packs/magento/graphjin/saved-queries/top_products.gql
+++ b/packs/magento/graphjin/saved-queries/top_products.gql
@@ -1,0 +1,13 @@
+query MagentoTopProducts($from: String!, $to: String!, $storeIds: [Int!]) {
+  sales_order_item(
+    distinct: [sku]
+    where: {and: [{created_at: {gte: $from}}, {created_at: {lt: $to}}], store_id: {in: $storeIds}, parent_item_id: {is_null: true}, qty_invoiced: {gt: 0}}
+    order_by: {sum_base_row_invoiced: desc}
+    limit: 20
+  ) {
+    sku
+    name
+    sum_qty_invoiced
+    sum_base_row_invoiced
+  }
+}

--- a/packs/magento/graphjin/saved-queries/watch_aged_fulfillment.gql
+++ b/packs/magento/graphjin/saved-queries/watch_aged_fulfillment.gql
@@ -1,0 +1,6 @@
+query MagentoWatchAgedFulfillment($from: String!, $olderThan: String!, $storeIds: [Int!]) {
+  sales_order(where: {and: [{created_at: {gte: $from}}, {created_at: {lt: $olderThan}}], store_id: {in: $storeIds}, state: {nin: ["canceled", "closed", "complete"]}, base_total_paid: {gt: 0}}) {
+    count: count_entity_id
+    oldest_created_at: min_created_at
+  }
+}

--- a/packs/magento/graphjin/saved-queries/watch_api_data_freshness.gql
+++ b/packs/magento/graphjin/saved-queries/watch_api_data_freshness.gql
@@ -1,0 +1,5 @@
+query MagentoWatchDataFreshness($staleBefore: String!, $storeIds: [Int!]) {
+  sales_order(where: {created_at: {gte: $staleBefore}, store_id: {in: $storeIds}}) {
+    count: count_entity_id
+  }
+}

--- a/packs/magento/graphjin/saved-queries/watch_cron_health.gql
+++ b/packs/magento/graphjin/saved-queries/watch_cron_health.gql
@@ -1,0 +1,5 @@
+query MagentoWatchCronHealth($staleBefore: String!, $from: String!) {
+  cron_schedule(where: {created_at: {gte: $from}, or: [{status: {eq: "error"}}, {status: {eq: "running"}, executed_at: {lt: $staleBefore}}]}) {
+    count: count_schedule_id
+  }
+}

--- a/packs/magento/graphjin/saved-queries/watch_indexer_health.gql
+++ b/packs/magento/graphjin/saved-queries/watch_indexer_health.gql
@@ -1,0 +1,3 @@
+query MagentoWatchIndexerHealth($staleBefore: String!) {
+  indexer_state(where: {or: [{status: {neq: "valid"}}, {updated: {lt: $staleBefore}}]}) { count: count_indexer_id }
+}

--- a/packs/magento/graphjin/saved-queries/watch_refund_cancellation.gql
+++ b/packs/magento/graphjin/saved-queries/watch_refund_cancellation.gql
@@ -1,0 +1,6 @@
+query MagentoWatchRefundCancellation($from: String!, $storeIds: [Int!]) {
+  sales_invoice(where: {created_at: {gte: $from}, store_id: {in: $storeIds}}) { invoiced: sum_base_grand_total }
+  sales_creditmemo(where: {created_at: {gte: $from}, store_id: {in: $storeIds}}) { refunded: sum_base_grand_total }
+  all_orders: sales_order(where: {created_at: {gte: $from}, store_id: {in: $storeIds}}) { count: count_entity_id }
+  cancelled_orders: sales_order(where: {created_at: {gte: $from}, store_id: {in: $storeIds}, state: {eq: "canceled"}}) { count: count_entity_id }
+}

--- a/packs/magento/graphjin/saved-queries/watch_stock_threshold.gql
+++ b/packs/magento/graphjin/saved-queries/watch_stock_threshold.gql
@@ -1,0 +1,5 @@
+query MagentoWatchStockThreshold($threshold: Float = 5) {
+  inventory_source_item(where: {or: [{status: {eq: 0}}, {quantity: {lte: $threshold}}]}) {
+    count: count_sku
+  }
+}

--- a/packs/magento/graphjin/sources.yaml
+++ b/packs/magento/graphjin/sources.yaml
@@ -1,0 +1,114 @@
+sources:
+  - key: source.magento_analytics
+    name: magento_analytics
+    kind: database
+    default: true
+    type: "{{database.type}}"
+    host: "{{database.host}}"
+    port: "{{database.port}}"
+    dbname: "{{database.name}}"
+    user: "{{secret.database.analytics_username}}"
+    password: "{{secret.database.analytics_password}}"
+    read_only: true
+    analytics_mode: true
+    capabilities:
+      data.read: true
+      data.write: false
+      schema.read: true
+      schema.write: false
+    access:
+      read: authenticated
+      write: blocked
+      delete: blocked
+    allowlist:
+      tables:
+        - sales_order
+        - sales_order_item
+        - sales_invoice
+        - sales_invoice_item
+        - sales_creditmemo
+        - sales_creditmemo_item
+        - sales_shipment
+        - sales_shipment_item
+        - catalog_product_entity
+        - catalog_product_entity_decimal
+        - catalog_product_entity_int
+        - catalog_product_entity_varchar
+        - catalog_category_product
+        - inventory_source_item
+        - inventory_reservation
+        - cataloginventory_stock_item
+        - store
+        - store_group
+        - store_website
+        - cron_schedule
+        - indexer_state
+    blocklist:
+      tables:
+        - admin_user
+        - admin_passwords
+        - authorization_role
+        - authorization_rule
+        - oauth_token
+        - oauth_consumer
+        - password_reset_request_event
+        - quote_payment
+        - sales_order_payment
+        - vault_payment_token
+        - customer_entity
+        - customer_address_entity
+      columns:
+        - password_hash
+        - rp_token
+        - token
+        - email
+        - telephone
+        - protect_code
+        - customer_id
+        - billing_address_id
+        - shipping_address_id
+        - quote_address_id
+        - quote_id
+        - customer_dob
+        - customer_firstname
+        - customer_lastname
+        - customer_middlename
+        - customer_prefix
+        - customer_suffix
+        - customer_taxvat
+        - ext_customer_id
+        - remote_ip
+        - x_forwarded_for
+        - customer_note
+        - customer_gender
+        - gift_message_id
+        - product_options
+        - additional_data
+        - transaction_id
+        - packages
+        - shipping_label
+
+  # This source is installed unconditionally but cannot execute writes until
+  # pack readiness validates the released GraphJin capability, token, and ACL.
+  - key: source.magento_operator
+    name: magento_operator
+    kind: api
+    default: false
+    base_url: "{{magento.base_url}}"
+    openapi: graphjin/specs/magento-operator-v1.yaml
+    auth:
+      type: bearer
+      token: "{{secret.magento.integration_token}}"
+    read_only: true
+    capabilities:
+      api.read: true
+      api.write: false
+      api.delete: false
+    access:
+      read: authenticated
+      write: blocked
+      delete: blocked
+    readiness:
+      capability: operator
+      enable_when: [graphjin-mutations, magento-api-token, magento-api-acl]
+      write_role: magento_action_executor

--- a/packs/magento/graphjin/specs/magento-operator-v1.yaml
+++ b/packs/magento/graphjin/specs/magento-operator-v1.yaml
@@ -1,0 +1,108 @@
+openapi: 3.0.3
+info:
+  title: Magento governed operator API
+  version: 1.0.0
+  description: Curated Magento operations used by the OpenNeko Magento pack.
+servers:
+  - url: "{{magento.base_url}}"
+security:
+  - integrationToken: []
+paths:
+  /rest/{storeCode}/V1/orders/{id}:
+    get:
+      operationId: magentoGetOrder
+      summary: Read one order for action preconditions and reconciliation
+      x-openneko-purpose: action-precondition
+      parameters:
+        - $ref: "#/components/parameters/StoreCode"
+        - $ref: "#/components/parameters/OrderId"
+      responses:
+        "200":
+          description: Order
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+  /rest/{storeCode}/V1/orders/{id}/comments:
+    post:
+      operationId: magentoAddInternalOrderComment
+      summary: Add a private, non-customer-visible order comment
+      x-graphjin-operation-type: mutation
+      x-graphjin-allowed-roles: [magento_action_executor]
+      x-openneko-action-kind: magento.add_internal_order_comment
+      parameters:
+        - $ref: "#/components/parameters/StoreCode"
+        - $ref: "#/components/parameters/OrderId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [statusHistory]
+              properties:
+                statusHistory:
+                  $ref: "#/components/schemas/OrderStatusHistory"
+      responses:
+        "200":
+          description: Comment accepted
+          content:
+            application/json:
+              schema: { type: boolean }
+        "400": { $ref: "#/components/responses/BadRequest" }
+        "401": { $ref: "#/components/responses/Unauthorized" }
+        "404": { $ref: "#/components/responses/NotFound" }
+components:
+  securitySchemes:
+    integrationToken:
+      type: http
+      scheme: bearer
+      bearerFormat: Magento integration token
+  parameters:
+    StoreCode:
+      name: storeCode
+      in: path
+      required: true
+      schema: { type: string, pattern: "^[A-Za-z0-9_]+$" }
+    OrderId:
+      name: id
+      in: path
+      required: true
+      schema: { type: integer, format: int64, minimum: 1 }
+  schemas:
+    OrderStatusHistory:
+      type: object
+      additionalProperties: false
+      required: [comment, is_customer_notified, is_visible_on_front]
+      properties:
+        comment: { type: string, minLength: 1, maxLength: 1000 }
+        is_customer_notified: { type: integer, enum: [0] }
+        is_visible_on_front: { type: integer, enum: [0] }
+    OrderStatusHistoryResult:
+      allOf:
+        - $ref: "#/components/schemas/OrderStatusHistory"
+        - type: object
+          properties:
+            entity_id: { type: integer, format: int64 }
+            created_at: { type: string }
+    Order:
+      type: object
+      required: [entity_id, increment_id, status]
+      properties:
+        entity_id: { type: integer, format: int64 }
+        increment_id: { type: string }
+        status: { type: string }
+        state: { type: string }
+        status_histories:
+          type: array
+          items: { $ref: "#/components/schemas/OrderStatusHistoryResult" }
+  responses:
+    BadRequest:
+      description: Invalid request
+    Unauthorized:
+      description: Missing, invalid, or insufficiently privileged integration token
+    NotFound:
+      description: Order not found

--- a/packs/magento/metrics/average_order_value.yaml
+++ b/packs/magento/metrics/average_order_value.yaml
@@ -1,0 +1,22 @@
+key: metric.average_order_value
+targetRef: magento.metric.average_order_value
+title: Average order value
+description: Net invoiced base-currency revenue divided by invoiced orders placed in the period.
+role: executive
+chartHint: metric
+unit: currency
+directionGood: up
+cadence: hourly
+calculationNote: Counts orders placed in the period whose base invoiced total is positive; returns null when there are none.
+execution:
+  mode: saved_query
+  source: magento_analytics
+  query: average_order_value
+  result:
+    kind: scalar
+    expression:
+      divide:
+        - { subtract: [sales_invoice.0.invoiced, sales_creditmemo.0.refunded] }
+        - invoiced_orders.0.count
+    zeroDenominator: null
+  freshnessSeconds: 7200

--- a/packs/magento/metrics/cancellation_rate.yaml
+++ b/packs/magento/metrics/cancellation_rate.yaml
@@ -1,0 +1,19 @@
+key: metric.cancellation_rate
+targetRef: magento.metric.cancellation_rate
+title: Cancellation rate
+description: Cancelled orders divided by orders placed in the selected period.
+role: executive
+chartHint: metric
+unit: percent
+directionGood: down
+cadence: hourly
+calculationNote: Uses the Magento order state `canceled` and order created timestamp.
+execution:
+  mode: saved_query
+  source: magento_analytics
+  query: cancellation_rate
+  result:
+    kind: scalar
+    expression: { divide: [cancelled_orders.0.count, all_orders.0.count] }
+    zeroDenominator: null
+  freshnessSeconds: 7200

--- a/packs/magento/metrics/cron_health.yaml
+++ b/packs/magento/metrics/cron_health.yaml
@@ -1,0 +1,16 @@
+key: metric.cron_health
+targetRef: magento.metric.cron_health
+title: Magento cron health
+description: Failed and long-running Magento cron jobs in the configured window.
+role: operations
+chartHint: status
+unit: count
+directionGood: down
+cadence: hourly
+calculationNote: Running jobs become stuck only after the configured age threshold.
+execution:
+  mode: saved_query
+  source: magento_analytics
+  query: cron_health
+  result: { kind: object, paths: [failed.0.count, stuck.0.count, stuck.0.oldest_started_at] }
+  freshnessSeconds: 3600

--- a/packs/magento/metrics/data_freshness.yaml
+++ b/packs/magento/metrics/data_freshness.yaml
@@ -1,0 +1,16 @@
+key: metric.data_freshness
+targetRef: magento.metric.data_freshness
+title: Magento data freshness
+description: Age of the newest order and most recent successful cron observation.
+role: operations
+chartHint: status
+unit: duration_seconds
+directionGood: down
+cadence: hourly
+calculationNote: Helps distinguish a quiet store from a stale analytics connection.
+execution:
+  mode: saved_query
+  source: magento_analytics
+  query: data_freshness
+  result: { kind: timestamps, paths: [sales_order.0.newest_order_at, cron_schedule.0.newest_successful_cron_at] }
+  freshnessSeconds: 3600

--- a/packs/magento/metrics/fulfillment_age.yaml
+++ b/packs/magento/metrics/fulfillment_age.yaml
@@ -1,0 +1,20 @@
+key: metric.fulfillment_age
+targetRef: magento.metric.fulfillment_age
+title: Fulfillment age
+description: Median and oldest age of paid orders that have not reached a terminal fulfillment state.
+role: operations
+chartHint: distribution
+unit: duration_seconds
+directionGood: down
+cadence: hourly
+calculationNote: Uses paid orders outside canceled, closed, and complete states; age is calculated from order creation in the configured Magento timezone.
+execution:
+  mode: saved_query
+  source: magento_analytics
+  query: fulfillment_age
+  result:
+    kind: timestamp_age_summary
+    rowsPath: sales_order
+    timestampPath: created_at
+    summaries: [median, max]
+  freshnessSeconds: 3600

--- a/packs/magento/metrics/fulfillment_backlog.yaml
+++ b/packs/magento/metrics/fulfillment_backlog.yaml
@@ -1,0 +1,21 @@
+key: metric.fulfillment_backlog
+targetRef: magento.metric.fulfillment_backlog
+title: Fulfillment backlog
+description: Invoiced item quantity that has not been shipped or refunded.
+role: operations
+chartHint: metric
+unit: count
+directionGood: down
+cadence: hourly
+calculationNote: Parent order items only; quantity is invoiced less shipped and refunded. Terminal-state order filtering is intentionally omitted because it is not reliable through MariaDB relationship filters.
+execution:
+  mode: saved_query
+  source: magento_analytics
+  query: fulfillment_backlog
+  result:
+    kind: scalar
+    expression:
+      subtract:
+        - sales_order_item.0.invoiced_quantity
+        - { add: [sales_order_item.0.shipped_quantity, sales_order_item.0.refunded_quantity] }
+  freshnessSeconds: 3600

--- a/packs/magento/metrics/indexer_health.yaml
+++ b/packs/magento/metrics/indexer_health.yaml
@@ -1,0 +1,16 @@
+key: metric.indexer_health
+targetRef: magento.metric.indexer_health
+title: Magento indexer health
+description: Indexers that are invalid, working unexpectedly, or stale.
+role: operations
+chartHint: table
+unit: count
+directionGood: down
+cadence: hourly
+calculationNote: Staleness is evaluated against the configured indexer age threshold.
+execution:
+  mode: saved_query
+  source: magento_analytics
+  query: indexer_health
+  result: { kind: rows, path: indexer_state }
+  freshnessSeconds: 3600

--- a/packs/magento/metrics/net_invoiced_revenue.yaml
+++ b/packs/magento/metrics/net_invoiced_revenue.yaml
@@ -1,0 +1,18 @@
+key: metric.net_invoiced_revenue
+targetRef: magento.metric.net_invoiced_revenue
+title: Net invoiced revenue
+description: Invoiced base-currency value less refunded base-currency value.
+role: executive
+chartHint: metric
+unit: currency
+directionGood: up
+cadence: hourly
+calculationNote: Uses Magento base currency and invoice/refund timestamps in the configured store timezone.
+execution:
+  mode: saved_query
+  source: magento_analytics
+  query: net_invoiced_revenue
+  result:
+    kind: scalar
+    expression: { subtract: [sales_invoice.0.invoiced, sales_creditmemo.0.refunded] }
+  freshnessSeconds: 7200

--- a/packs/magento/metrics/orders_placed.yaml
+++ b/packs/magento/metrics/orders_placed.yaml
@@ -1,0 +1,16 @@
+key: metric.orders_placed
+targetRef: magento.metric.orders_placed
+title: Orders placed
+description: Distinct Magento orders created during the selected period.
+role: executive
+chartHint: metric
+unit: count
+directionGood: up
+cadence: hourly
+calculationNote: Cancellations are included in orders placed and reported separately.
+execution:
+  mode: saved_query
+  source: magento_analytics
+  query: orders_placed
+  result: { kind: scalar, path: sales_order.0.orders }
+  freshnessSeconds: 7200

--- a/packs/magento/metrics/refund_rate.yaml
+++ b/packs/magento/metrics/refund_rate.yaml
@@ -1,0 +1,19 @@
+key: metric.refund_rate
+targetRef: magento.metric.refund_rate
+title: Refund rate
+description: Refunded base-currency value divided by invoiced base-currency value.
+role: executive
+chartHint: metric
+unit: percent
+directionGood: down
+cadence: hourly
+calculationNote: This is a value rate, not a count of refunded orders.
+execution:
+  mode: saved_query
+  source: magento_analytics
+  query: refund_rate
+  result:
+    kind: scalar
+    expression: { divide: [sales_creditmemo.0.refunded, sales_invoice.0.invoiced] }
+    zeroDenominator: null
+  freshnessSeconds: 7200

--- a/packs/magento/metrics/sales_by_store.yaml
+++ b/packs/magento/metrics/sales_by_store.yaml
@@ -1,0 +1,19 @@
+key: metric.sales_by_store
+targetRef: magento.metric.sales_by_store
+title: Sales by store
+description: Net invoiced base-currency revenue grouped by Magento store.
+role: executive
+chartHint: bar
+unit: currency
+directionGood: up
+cadence: hourly
+calculationNote: Values remain in base currency; display-currency totals are not mixed.
+execution:
+  mode: saved_query
+  source: magento_analytics
+  query: sales_by_store
+  result:
+    kind: keyed_subtract
+    left: { rowsPath: sales_invoice, keyPath: store_id, valuePath: invoiced }
+    right: { rowsPath: sales_creditmemo, keyPath: store_id, valuePath: refunded }
+  freshnessSeconds: 7200

--- a/packs/magento/metrics/stock_status.yaml
+++ b/packs/magento/metrics/stock_status.yaml
@@ -1,0 +1,16 @@
+key: metric.stock_status
+targetRef: magento.metric.stock_status
+title: Low and out-of-stock SKUs
+description: Source-level Magento MSI items at or below the configured quantity threshold.
+role: operations
+chartHint: table
+unit: count
+directionGood: down
+cadence: hourly
+calculationNote: Source quantity is an approximation, not Magento salable quantity; reservations may change availability.
+execution:
+  mode: saved_query
+  source: magento_analytics
+  query: stock_status
+  result: { kind: rows, path: inventory_source_item }
+  freshnessSeconds: 3600

--- a/packs/magento/metrics/top_products.yaml
+++ b/packs/magento/metrics/top_products.yaml
@@ -1,0 +1,16 @@
+key: metric.top_products
+targetRef: magento.metric.top_products
+title: Top products and SKUs
+description: Highest invoiced order-item revenue and invoiced quantity by SKU.
+role: merchandising
+chartHint: table
+unit: currency
+directionGood: up
+cadence: hourly
+calculationNote: Based on Magento order-item base_row_invoiced; refunds are represented in the separate refund metrics.
+execution:
+  mode: saved_query
+  source: magento_analytics
+  query: top_products
+  result: { kind: rows, path: sales_order_item }
+  freshnessSeconds: 7200

--- a/packs/magento/pack.yaml
+++ b/packs/magento/pack.yaml
@@ -1,0 +1,95 @@
+apiVersion: openneko.app/v1
+kind: SolutionPack
+metadata:
+  id: magento
+  name: Magento
+  version: 0.2.0
+  publisher: openneko
+  category: commerce
+
+compatibility:
+  openneko: ">=2.27.0 <3.0.0"
+  graphjin:
+    analytics: ">=3.18.42 <4.0.0"
+    # Replaced with an exact released floor as part of the GraphJin handoff.
+    # Keeping this explicit prevents an unreleased write capability from being
+    # treated as production-ready while allowing the full pack to install.
+    operator: "UNRELEASED_OPENAPI_MUTATION_VERSION"
+  applications:
+    - id: magento
+      editions: [open-source, adobe-commerce]
+      versions: ">=2.4.6 <2.5.0"
+  databases:
+    - engine: mariadb
+      versions: ">=10.6"
+    - engine: mysql
+      versions: ">=8.0"
+
+inputs:
+  - key: magento.base_url
+    type: url
+    required: true
+  - key: magento.store_code
+    type: string
+    default: all
+  - key: magento.table_prefix
+    type: string
+    default: ""
+  - key: magento.base_currency
+    type: string
+    discover: true
+  - key: magento.timezone
+    type: timezone
+    discover: true
+  - key: database.connectivity_mode
+    type: enum
+    values: [external_network, host_gateway, remote]
+    default: external_network
+  - key: database.host
+    type: string
+    required: true
+  - key: database.port
+    type: integer
+    default: 3306
+  - key: database.name
+    type: string
+    required: true
+  - key: database.type
+    type: enum
+    values: [mariadb, mysql]
+    discover: true
+
+secrets:
+  - key: database.analytics_username
+    purpose: graphjin_source
+  - key: database.analytics_password
+    purpose: graphjin_source
+  - key: magento.integration_token
+    purpose: graphjin_api_auth
+    required: false
+
+artifacts:
+  graphjin:
+    sources: graphjin/sources.yaml
+    relationships: graphjin/relationships.yaml
+    specs: [graphjin/specs/magento-operator-v1.yaml]
+    savedQueries: graphjin/saved-queries
+  metrics: metrics
+  workflows: workflows
+  watchers: watchers
+  actions: actions
+  policies: policies
+  skills:
+    - skills/magento-review-performance
+    - skills/magento-investigate-order
+    - skills/magento-triage-fulfillment
+    - skills/magento-investigate-refunds
+    - skills/magento-check-inventory
+    - skills/magento-diagnose-platform-health
+
+health:
+  requiredPreflight: [mariadb-connect, mariadb-read-only, magento-version]
+  readiness:
+    operator: [graphjin-mutations, magento-api-token, magento-api-acl]
+  postInstall: [graphjin-reload, analytics-smoke]
+  postWriteCanary: [internal-comment-reconciled]

--- a/packs/magento/policies/internal_order_comment.yaml
+++ b/packs/magento/policies/internal_order_comment.yaml
@@ -1,0 +1,18 @@
+key: policy.internal_order_comment
+targetRef: magento.policy.internal_order_comment
+name: Magento internal order comment approval
+description: Every private note added to a Magento order requires an OpenNeko administrator to approve it.
+appliesToKinds: [magento.add_internal_order_comment]
+appliesToScopes: [internal]
+mode: ask
+approverRole: admin
+priority: 10
+enabled: true
+allowedTargets:
+  source: magento_operator
+  operationId: magentoAddInternalOrderComment
+limits:
+  maxCommentLength: 1000
+  maxExecutionsPerRequest: 1
+  customerNotified: false
+  visibleOnFront: false

--- a/packs/magento/skills/magento-check-inventory/SKILL.md
+++ b/packs/magento/skills/magento-check-inventory/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: magento-check-inventory
+description: Investigate Magento low stock, stockouts, source quantities, reservations, and suspected MSI availability discrepancies, then prepare a replenishment handoff. Use for SKU or source availability questions, stock-threshold watcher findings, and inventory constraints; do not use for sales-only product rankings.
+license: Apache-2.0
+metadata:
+  hermes:
+    tags: [magento, inventory, msi, stock, reservations, replenishment]
+    category: commerce
+    requires_toolsets: [graphjin]
+    related_skills: [magento-triage-fulfillment, magento-investigate-order, magento-review-performance]
+---
+
+# Check Magento inventory
+
+Explain source-level stock evidence and prepare a human replenishment or
+configuration handoff. Query `magento_analytics` only; inventory writes and
+reservation changes are outside this pack version.
+
+When someone asks you to change stock, answer in operator language rather than
+implementation language. Do not say "mutation," "write capability," or
+"GraphJin" unless the user explicitly asks for technical details. Say:
+
+> I can review stock and identify what needs attention, but this Magento
+> connection cannot change stock levels. Update them in Magento Admin or your
+> inventory system.
+
+Then offer the useful work you can do now: verify the SKU/source quantities,
+explain the discrepancy, and prepare the exact replenishment handoff. Do not
+imply that adding an API token will enable inventory changes; this pack version
+does not ship an inventory-changing action.
+
+Read [Magento MSI](references/magento-msi.md) before using the words
+"available" or "salable."
+
+## Establish the inventory question
+
+Resolve the requested SKU(s), source code(s), configured low-stock threshold,
+and observation time. When responding to a watcher, use the threshold that
+actually triggered it. Do not infer a threshold from a low quantity.
+
+## Gather evidence
+
+1. Use `stock_status` for the installed source-quantity approximation.
+2. Use `watch_stock_threshold` when validating a watcher count.
+3. Query `inventory_source_item` for SKU, source, quantity, and enabled status.
+4. Inspect aggregate reservations or legacy stock configuration only when the
+   question requires it and the installation exposes the needed stock mapping.
+5. Correlate with fulfillment exceptions only to identify potential impact;
+   do not claim stock caused an order delay without order-level evidence.
+
+Avoid reservation metadata or other fields that could reveal order/customer
+context when aggregate quantity is sufficient. Never retrieve customer,
+address, payment, credential, token, password, or admin data.
+
+## Classify carefully
+
+- `status = 0` means the source item is disabled/out of stock at that source.
+- A low physical source quantity is not automatically low salable quantity.
+- Reservations, stock-to-source assignment, backorders, manage-stock settings,
+  and Magento version-specific index logic can change storefront availability.
+- Do not calculate a definitive salable quantity by simply adding reservations
+  unless the installation's stock mapping and formula have been validated.
+
+## Deliver the handoff
+
+Return a bounded list containing SKU, source, observed quantity/status,
+threshold, observation time, and the MSI approximation warning. Separate
+confirmed source-level stockouts from suspected salability discrepancies.
+Provide a proposed replenishment/configuration check, not an inventory change.
+
+Never adjust source quantity, reservations, stock status, backorders, or a
+product through SQL, GraphQL mutation, raw REST, `curl`, or a terminal.

--- a/packs/magento/skills/magento-check-inventory/references/magento-msi.md
+++ b/packs/magento/skills/magento-check-inventory/references/magento-msi.md
@@ -1,0 +1,24 @@
+# Magento Multi-Source Inventory
+
+Magento MSI separates several concepts:
+
+- `inventory_source_item.quantity` is physical quantity recorded for one SKU
+  at one source.
+- `inventory_source_item.status` enables or disables that source item.
+- `inventory_reservation.quantity` records reservation deltas associated with
+  sales events.
+- Stocks map sales channels to sources, and indexed configuration determines
+  the quantity Magento considers salable.
+- Legacy `cataloginventory_stock_item` settings can still influence behavior,
+  including manage-stock and backorder rules.
+
+The pack's shipped stock metric intentionally reports source-level quantity.
+Always label it as an approximation, not salable quantity. A correct salable
+calculation requires the installation's stock/source assignments, reservation
+semantics, configuration, and supported Magento version to pass a specific
+preflight.
+
+For a replenishment proposal, show SKU, source, observed quantity/status,
+threshold, and observation time. Keep any reservation evidence aggregated and
+do not expose reservation metadata unless the operator explicitly needs a
+non-personal event reference.

--- a/packs/magento/skills/magento-diagnose-platform-health/SKILL.md
+++ b/packs/magento/skills/magento-diagnose-platform-health/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: magento-diagnose-platform-health
+description: Diagnose Magento cron failures, stale running jobs, unhealthy indexers, data freshness, and Magento pack connectivity or readiness. Use for cron/indexer watcher findings, stale dashboards, API or analytics health questions, and pack-doctor remediation; do not use for ordinary sales or inventory analysis.
+license: Apache-2.0
+metadata:
+  hermes:
+    tags: [magento, cron, indexers, diagnostics, freshness, pack-doctor]
+    category: commerce
+    requires_toolsets: [graphjin]
+    related_skills: [magento-review-performance, magento-triage-fulfillment, magento-check-inventory]
+---
+
+# Diagnose Magento platform health
+
+Separate store-runtime health, analytics freshness, and optional governed-write
+readiness. Query `magento_analytics` for evidence and keep remediation
+read-only unless an administrator performs a separately governed operation.
+
+## Select the diagnostic path
+
+- For cron failures or stalls, use `cron_health` and `watch_cron_health`.
+- For invalid, working, or stale indexers, use `indexer_health` and
+  `watch_indexer_health`.
+- For a stale dashboard or suspected connection gap, use `data_freshness` and
+  `watch_api_data_freshness`.
+- For installation, credential, GraphJin, or action readiness, use the Magento
+  pack status/doctor path described in
+  [the runbook](references/platform-runbook.md).
+
+Resolve the configured Magento timezone and the exact stale/failure threshold
+before labelling a row stuck or stale. A quiet store with no recent order may be
+healthy; corroborate order freshness with successful cron evidence and pack
+connectivity.
+
+## Diagnose cron and indexers
+
+For cron, distinguish `error`, `missed`, `pending`, and a genuinely stale
+`running` row. Report job code, status, scheduled/executed/finished timestamps,
+and error text only when those fields are approved and necessary. Do not expose
+arguments or payload fields that may contain sensitive application data.
+
+For indexers, report indexer ID, state, update time, and threshold. A non-valid
+state or old timestamp is evidence of indexer health, not proof of the upstream
+cause. Correlate time windows before connecting a cron failure to an indexer.
+
+## Deliver a bounded runbook
+
+Return the affected subsystem, observation window, exact evidence, likely
+impact, and ordered next checks. Separate verified facts from hypotheses and
+state what would confirm each hypothesis.
+
+Commands such as `cron:run`, `indexer:reindex`, queue restarts, cache flushes,
+process termination, and container restarts change runtime state. Do not run or
+claim to run them as part of this diagnostic. Never request Magento admin
+credentials, Integration bearer tokens, database passwords, or Adobe
+Marketplace/Composer keys.

--- a/packs/magento/skills/magento-diagnose-platform-health/references/platform-runbook.md
+++ b/packs/magento/skills/magento-diagnose-platform-health/references/platform-runbook.md
@@ -1,0 +1,30 @@
+# Magento pack and platform runbook
+
+For deployment-level health, direct an administrator to **Admin → Settings →
+Solution packs → Magento** or the equivalent local commands:
+
+```text
+openneko pack status magento
+openneko pack doctor magento
+```
+
+The doctor verifies database connectivity, SELECT-only grants, Magento/store
+discovery, the GraphJin catalog, and optional operator readiness. Readiness
+reasons have specific remediations:
+
+- `graphjin_version_unsupported`: keep analytics available and upgrade only to
+  the tagged GraphJin release supported by the pack.
+- `integration_token_missing`: configure a least-privilege Magento Integration
+  token through OpenNeko's encrypted secret flow if governed writes are wanted.
+- `integration_token_invalid`: rotate or replace the Integration token through
+  the pack administration flow.
+- `acl_missing`: grant only the Magento API resources required by the curated
+  operation.
+
+Write readiness is optional. Its blocked state must not be reported as an
+analytics outage.
+
+For cron, identify the exact job code/status/timestamps before recommending an
+operator-run command. For indexers, identify the exact indexer state and age.
+Reindexing, cron execution, cache flushes, restarts, and process termination are
+outside this read-only skill and require a separate operator decision.

--- a/packs/magento/skills/magento-investigate-order/SKILL.md
+++ b/packs/magento/skills/magento-investigate-order/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: magento-investigate-order
+description: Investigate one Magento order and reconstruct its order, invoice, shipment, credit-memo, and cancellation state for customer-service or operations questions. Use when an order ID or increment ID is supplied, an order appears stuck or inconsistent, or an operator wants to add a private internal note; do not use for aggregate fulfillment or sales reporting.
+license: Apache-2.0
+metadata:
+  hermes:
+    tags: [magento, order, customer-service, invoice, shipment, credit-memo]
+    category: commerce
+    requires_toolsets: [graphjin]
+    related_skills: [magento-triage-fulfillment, magento-investigate-refunds, magento-review-performance]
+---
+
+# Investigate a Magento order
+
+Produce a privacy-minimized lifecycle explanation for one exact order. Query
+`magento_analytics` for evidence and treat it as read-only.
+
+## Resolve the order
+
+Accept a numeric Magento `entity_id` or storefront `increment_id`. Resolve it
+to exactly one order before continuing. If there are no matches, say which
+identifier was checked. If multiple stores can contain the supplied identifier,
+use store scope and other non-personal facts to disambiguate; never choose the
+first match silently.
+
+Keep both identifiers in working context. The governed comment action requires
+the numeric `entity_id`, even when the user supplied an increment ID.
+
+## Reconstruct the lifecycle
+
+Read [order lifecycle](references/order-lifecycle.md), then gather only the
+fields necessary to answer the question:
+
+1. Order creation time, store ID, state, status, base totals, and paid,
+   invoiced, shipped, refunded, and cancelled quantities.
+2. Invoice documents and item quantities.
+3. Shipment documents and item quantities.
+4. Credit memos and credited item quantities.
+5. Parent order-item SKU, name, and lifecycle quantities when line-level
+   reconciliation is needed.
+
+Use document timestamps to form a timeline. Explain discrepancies explicitly:
+an order can be placed without being paid, invoiced without being shipped, or
+credited without being cancelled. Do not infer an event from status text when
+the corresponding document is absent.
+
+Do not request, query, or display customer names, email, phone, addresses, IP
+addresses, payment/vault details, credentials, tokens, password data, or Adobe
+Marketplace keys. The pack excludes those fields deliberately. If internal
+status-history records are unavailable through an approved source, say so
+instead of claiming the timeline is complete.
+
+## Explain the finding
+
+Return:
+
+- the identifiers and store scope;
+- a chronological lifecycle summary;
+- reconciled order- and item-level quantities;
+- the exact inconsistency or blocker, if any; and
+- the safest next operational check.
+
+Never cancel, invoice, ship, refund, reorder, or edit an order through SQL,
+raw GraphQL, raw HTTP, `curl`, or a terminal.
+
+## Optional private note
+
+Only when the user asks to record a note, read
+[private order comments](references/private-order-comments.md). The diagnostic
+portion remains available even when Magento write readiness is blocked.

--- a/packs/magento/skills/magento-investigate-order/references/order-lifecycle.md
+++ b/packs/magento/skills/magento-investigate-order/references/order-lifecycle.md
@@ -1,0 +1,23 @@
+# Magento order lifecycle and reconciliation
+
+Sales documents use an entity header plus item rows:
+
+- `sales_order` / `sales_order_item`: commercial intent and current order
+  state.
+- `sales_invoice` / `sales_invoice_item`: invoiced value and quantity.
+- `sales_shipment` / `sales_shipment_item`: fulfillment evidence.
+- `sales_creditmemo` / `sales_creditmemo_item`: credited or refunded value and
+  quantity.
+
+Join each document header to its order, and each document item through the
+relationship overlay's `order_id` or `parent_id`. Prefer parent order items when
+configurable or bundle children would otherwise double-count value or quantity.
+
+An order status is a workflow label; it is not proof that a payment, invoice,
+shipment, or refund document exists. Cancellation is an order state and is not
+the same as a credit memo. A credit memo proves Magento recorded a credit, but
+does not by itself prove the payment processor settled money externally.
+
+For each relevant line, reconcile ordered, cancelled, invoiced, shipped, and
+refunded quantities. Keep base-currency values separate from display-currency
+values. Use the configured Magento timezone when presenting timestamps.

--- a/packs/magento/skills/magento-investigate-order/references/private-order-comments.md
+++ b/packs/magento/skills/magento-investigate-order/references/private-order-comments.md
@@ -1,0 +1,26 @@
+# Governed private order comments
+
+The pack supports only `magento.add_internal_order_comment`. Use it only after
+the user explicitly asks to record a note and an OpenNeko administrator
+approves the proposed action.
+
+Supply the resolved numeric Magento order `entity_id` and a concise factual
+comment. The adapter fixes these values and they must not be overridden:
+
+```json
+{
+  "is_customer_notified": 0,
+  "is_visible_on_front": 0
+}
+```
+
+OpenNeko performs a precondition read, one write attempt, and a reconciliation
+read. Do not report success until the action receipt confirms it. A timeout may
+have committed upstream; an outcome of `reconcile_required` must be checked and
+must never be blindly retried.
+
+If the action reports `graphjin_version_unsupported`,
+`integration_token_missing`, `integration_token_invalid`, or `acl_missing`,
+explain that the private-note step is unavailable and preserve the completed
+read-only investigation. Never substitute raw REST, GraphQL, SQL, `curl`, or an
+admin credential.

--- a/packs/magento/skills/magento-investigate-refunds/SKILL.md
+++ b/packs/magento/skills/magento-investigate-refunds/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: magento-investigate-refunds
+description: Investigate Magento refund-value or cancellation spikes, reconcile credit memos, and locate affected stores, orders, or SKUs. Use for refund-rate changes, cancellation anomalies, credit-memo questions, or the refund/cancellation watcher; use magento-investigate-order for a single known order.
+license: Apache-2.0
+metadata:
+  hermes:
+    tags: [magento, refunds, cancellations, credit-memo, revenue, investigation]
+    category: commerce
+    requires_toolsets: [graphjin]
+    related_skills: [magento-investigate-order, magento-review-performance, magento-triage-fulfillment]
+---
+
+# Investigate Magento refunds and cancellations
+
+Determine what changed and where it is concentrated without conflating
+Magento lifecycle events or claiming unsupported causality. Treat
+`magento_analytics` as read-only.
+
+## Fix the comparison frame
+
+Resolve store IDs, base currency, Magento timezone, and a half-open current
+interval `[from, to)`. For a spike investigation, use the configured baseline
+or an equal-length immediately preceding interval with identical scope. If no
+baseline is available, describe the current level without calling it a spike.
+
+Read [refund and cancellation semantics](references/refunds-and-cancellations.md)
+before interpreting results.
+
+## Measure the change
+
+- Use `refund_rate` for refunded base value divided by invoiced base value.
+- Use `cancellation_rate` for cancelled orders divided by orders placed.
+- Use `net_invoiced_revenue` to show the commercial effect of credit memos.
+- Use `sales_by_store` to locate store-level concentration.
+- Use `watch_refund_cancellation` when explaining a watcher event.
+
+Show numerator and denominator with each rate, particularly for sparse stores
+or short windows. A high percentage based on one order is materially different
+from the same percentage at scale.
+
+## Trace the concentration
+
+When the aggregate change is material, inspect credit memo headers/items and
+cancelled orders using approved fields only. Break down by store, order ID, SKU,
+credited base value, and quantity when the data supports it. Prefer parent
+items where product structures would double-count.
+
+Do not expose customer identity, addresses, contact data, payment or processor
+details, credentials, tokens, or admin data. Do not use correlation with a SKU,
+store, or status as proof of root cause. State which operational evidence would
+be needed to confirm the cause.
+
+## Report and hand off
+
+Return the comparison frame, current and baseline values, absolute change,
+concentrated stores/orders/SKUs, data limitations, and the highest-value next
+check. Use `magento-investigate-order` for a selected order timeline.
+
+Never issue or reverse a refund, cancel an order, edit a credit memo, or bypass
+the pack through SQL, raw GraphQL, raw HTTP, `curl`, or a terminal.

--- a/packs/magento/skills/magento-investigate-refunds/references/refunds-and-cancellations.md
+++ b/packs/magento/skills/magento-investigate-refunds/references/refunds-and-cancellations.md
@@ -1,0 +1,31 @@
+# Refund and cancellation semantics
+
+Magento records different events in different places:
+
+- `sales_invoice` is invoiced commerce value.
+- `sales_creditmemo` is credited/refunded value recorded in Magento.
+- `sales_creditmemo_item` ties credited quantities and value to order items.
+- `sales_order.state = canceled` is an order-state outcome.
+
+A cancellation is not a refund. An order may be cancelled before capture and
+therefore have no credit memo. An order may have a partial credit memo without
+being cancelled. A credit memo proves Magento recorded the credit; it does not
+prove the external payment processor completed settlement.
+
+The pack's refund rate is value-based:
+
+```text
+sum(sales_creditmemo.base_grand_total)
+------------------------------------------------
+sum(sales_invoice.base_grand_total)
+```
+
+The cancellation rate is count-based:
+
+```text
+orders in state canceled / orders placed
+```
+
+Use document timestamps in the configured Magento timezone and base-currency
+columns. Keep current and baseline windows identical, and show a null rate when
+the denominator is zero.

--- a/packs/magento/skills/magento-review-performance/SKILL.md
+++ b/packs/magento/skills/magento-review-performance/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: magento-review-performance
+description: Review Magento sales and operating performance using the pack's governed metrics. Use for daily or weekly briefings, revenue and order trends, store or product comparisons, and questions such as "how is the store doing?"; use a diagnostic Magento skill for a specific order, refund, fulfillment, inventory, cron, or indexer incident.
+license: Apache-2.0
+metadata:
+  hermes:
+    tags: [magento, commerce, sales, revenue, metrics, briefing]
+    category: commerce
+    requires_toolsets: [graphjin]
+    related_skills: [magento-investigate-order, magento-triage-fulfillment, magento-investigate-refunds, magento-check-inventory, magento-diagnose-platform-health]
+---
+
+# Review Magento performance
+
+Build an evidence-backed store briefing from the installed Magento metrics.
+Treat `magento_analytics` as read-only and preserve the pack's checked-in
+metric definitions instead of silently inventing alternative formulas.
+
+## Establish the reporting frame
+
+Before interpreting values, resolve and state:
+
+- the Magento store scope or selected store IDs;
+- the configured base currency;
+- the Magento timezone; and
+- a half-open reporting interval `[from, to)`.
+
+Use the user's requested comparison period. If none is requested, report the
+current period without manufacturing a trend. For a comparison, use an
+equal-length immediately preceding period with the same store scope. Read
+[scope and time](references/scope-and-time.md) when resolving store, currency,
+or local-day boundaries.
+
+## Gather evidence
+
+Prefer the installed saved queries and their metric snapshots:
+
+- commercial result: `net_invoiced_revenue`, `orders_placed`, and
+  `average_order_value`;
+- leakage: `refund_rate` and `cancellation_rate`;
+- mix: `sales_by_store` and `top_products`;
+- operating context for a full briefing: `fulfillment_backlog`,
+  `fulfillment_age`, `stock_status`, `cron_health`, `indexer_health`, and
+  `data_freshness`.
+
+Read [metric definitions](references/metric-definitions.md) before calculating
+or explaining a shipped metric. When a snapshot is stale, refresh or query the
+same saved-query definition and disclose the observation time. Do not replace a
+missing or null metric with zero.
+
+## Interpret without overclaiming
+
+- Separate order placement, invoicing, credit memos, cancellation, and
+  shipment. They measure different lifecycle events.
+- Treat a change as a fact only when both periods use identical scope and
+  definitions. Show absolute values alongside percentages when the sample is
+  small.
+- Describe a store or SKU as associated with a result, not as its cause, unless
+  direct evidence establishes causality.
+- Do not report conversion rate without a connected traffic/session source.
+- Do not report gross margin without a validated and sufficiently complete cost
+  source.
+- Do not query or expose customer, address, payment, credential, OAuth, admin,
+  or password data.
+
+## Deliver the briefing
+
+Lead with the reporting frame and a compact scorecard. Then identify the few
+material drivers, name the single highest-priority issue supported by the
+evidence, and recommend the next diagnostic task. Route detailed follow-up to
+the related Magento skill rather than expanding this reporting skill into an
+incident investigation.

--- a/packs/magento/skills/magento-review-performance/references/metric-definitions.md
+++ b/packs/magento/skills/magento-review-performance/references/metric-definitions.md
@@ -1,0 +1,33 @@
+# Shipped Magento metric definitions
+
+Use these definitions exactly when the user names a pack metric:
+
+- **Net invoiced revenue:** invoiced base value minus refunded base value.
+- **Orders placed:** distinct orders created in the period, including orders
+  later cancelled.
+- **Average order value:** net invoiced revenue divided by distinct orders in
+  the period whose invoiced base value is positive; null for a zero
+  denominator.
+- **Refund rate:** refunded base value divided by invoiced base value. It is a
+  value rate, not a count of refunded orders.
+- **Cancellation rate:** orders whose Magento state is `canceled` divided by
+  orders placed.
+- **Fulfillment backlog:** parent-item invoiced quantity less shipped and
+  refunded quantity. The shipped aggregate intentionally lacks a terminal-order
+  filter because that relationship filter is unreliable in the supported
+  GraphJin/MariaDB path; do not describe it as an exact count of open orders.
+- **Fulfillment age:** median and oldest age of paid, non-terminal orders in the
+  selected lookback window.
+- **Sales by store:** net invoiced base value grouped by store.
+- **Top products:** invoiced item value and quantity by parent-item SKU. Refunds
+  are not subtracted from this ranking.
+- **Stock status:** source-level quantity approximation, not Magento salable
+  quantity.
+- **Cron health:** failed jobs plus running jobs older than the configured
+  limit.
+- **Indexer health:** non-valid or stale indexer state.
+- **Data freshness:** age of newest order and successful cron evidence, plus the
+  metric snapshot observation time.
+
+Do not silently reinterpret null as zero. State numerator, denominator, and
+small-sample caveats for rates when they affect the conclusion.

--- a/packs/magento/skills/magento-review-performance/references/scope-and-time.md
+++ b/packs/magento/skills/magento-review-performance/references/scope-and-time.md
@@ -1,0 +1,18 @@
+# Magento store scope, currency, and time
+
+Magento websites contain store groups, which contain store views. Resolve
+`store_id` from the installed pack's selected store code or from the user's
+explicit scope. Admin/all-store scope is not automatically equivalent to every
+storefront unless the query deliberately expands it.
+
+Pack financial metrics use base-currency values. Do not sum display-currency
+amounts across stores. Name the base currency in the result.
+
+Convert user periods to half-open `[from, to)` boundaries in the configured
+Magento timezone before querying. Daylight-saving transitions can produce
+local days that are not 24 hours, so derive local calendar boundaries rather
+than subtracting a fixed number of seconds.
+
+Keep comparison windows identical in duration, store IDs, currency basis, and
+metric definition. If any of those differ, present separate observations rather
+than a percentage trend.

--- a/packs/magento/skills/magento-triage-fulfillment/SKILL.md
+++ b/packs/magento/skills/magento-triage-fulfillment/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: magento-triage-fulfillment
+description: Triage Magento paid or invoiced orders that remain unshipped, quantify backlog and aging, and prepare a prioritized fulfillment exception list. Use for shipping SLA breaches, fulfillment backlog, partially shipped orders, or watcher findings; use magento-investigate-order for one already-identified order.
+license: Apache-2.0
+metadata:
+  hermes:
+    tags: [magento, fulfillment, shipping, backlog, sla, operations]
+    category: commerce
+    requires_toolsets: [graphjin]
+    related_skills: [magento-investigate-order, magento-check-inventory, magento-review-performance]
+---
+
+# Triage Magento fulfillment
+
+Identify orders that need human fulfillment attention and rank them using
+observable lifecycle evidence. Query `magento_analytics` only and do not mutate
+orders or shipments.
+
+## Define the queue
+
+Resolve the store scope, Magento timezone, lookback window, and the user's SLA
+threshold. If no SLA is supplied, report ages without labeling any order
+overdue. Use order IDs and operational timestamps only; do not retrieve customer
+identity, address, contact, payment, or credential data.
+
+Read [fulfillment rules](references/fulfillment-rules.md) before reconciling
+quantities.
+
+## Measure, then investigate
+
+1. Use `fulfillment_backlog` for the installed aggregate quantity definition.
+2. Use `fulfillment_age` for median and oldest age among paid non-terminal
+   orders in the configured lookback.
+3. Use `watch_aged_fulfillment` when evaluating the watcher threshold.
+4. For the exception list, query candidate orders and parent items, then
+   reconcile invoiced, shipped, refunded, and cancelled quantities. Do not
+   assume the aggregate backlog and age queries have identical populations.
+
+Exclude cancelled, closed, and complete orders from the actionable queue after
+checking their actual documents. For a partially shipped order, report the
+remaining quantity by SKU. Do not treat order age alone as proof of a warehouse
+failure; payment review, stock allocation, holds, and external fulfillment can
+require checks outside the analytics allowlist.
+
+## Prioritize exceptions
+
+Rank with transparent evidence, normally:
+
+1. age beyond the confirmed SLA;
+2. paid/invoiced quantity still outstanding;
+3. partial shipment or lifecycle inconsistency; and
+4. repeated concentration by SKU or store.
+
+Do not invent customer value, shipping promise dates, or priority fields that
+the source does not expose. Label any heuristic as a heuristic.
+
+## Deliver the handoff
+
+Return the reporting frame, aggregate backlog and age, a bounded exception list
+with order ID/store/age/quantities, the reason each item was selected, and the
+next check. Use `magento-investigate-order` for a deeper single-order timeline
+and `magento-check-inventory` for a suspected stock constraint.
+
+Never ship, cancel, invoice, refund, alter stock, terminate a process, or call a
+Magento endpoint through raw tools.

--- a/packs/magento/skills/magento-triage-fulfillment/references/fulfillment-rules.md
+++ b/packs/magento/skills/magento-triage-fulfillment/references/fulfillment-rules.md
@@ -1,0 +1,24 @@
+# Fulfillment eligibility and quantities
+
+An order is not fulfilled merely because it is paid or invoiced. Shipment
+documents are the fulfillment evidence.
+
+At parent-item level, the pack's backlog quantity is:
+
+```text
+qty_invoiced - qty_shipped - qty_refunded
+```
+
+The shipped `fulfillment_backlog` aggregate intentionally does not filter by
+terminal order state because that relationship filter is unreliable through
+the supported MariaDB path. Use the saved query unchanged for the metric, but
+join candidate items to their order and remove cancelled, closed, and complete
+orders from the human action queue.
+
+Use invoice and shipment item documents to verify any surprising order-item
+quantity. Configurable and bundle children can double-count; prefer parent
+items unless the investigation explicitly needs component detail.
+
+Show age in the configured Magento timezone and preserve the query timestamp.
+An SLA breach requires an operator-confirmed threshold; a long age without a
+threshold is an old order, not automatically a breach.

--- a/packs/magento/watchers/aged_fulfillment.yaml
+++ b/packs/magento/watchers/aged_fulfillment.yaml
@@ -1,0 +1,16 @@
+key: watcher.aged_fulfillment
+targetRef: magento.watcher.aged_fulfillment
+name: Magento aged fulfillment backlog
+description: Fires when paid, unshipped orders exceed the configured SLA.
+workflow: workflow.fulfillment_exceptions
+enabled: false
+activation: admin_confirms_threshold
+query: watch_aged_fulfillment
+valuePath: sales_order.0.count
+operator: gt
+threshold: 0
+cadenceSeconds: 900
+debounceSeconds: 3600
+cooldownSeconds: 14400
+severity: high
+dedupeKey: "aged-fulfillment:{oldest_created_at}"

--- a/packs/magento/watchers/api_data_freshness.yaml
+++ b/packs/magento/watchers/api_data_freshness.yaml
@@ -1,0 +1,17 @@
+key: watcher.api_data_freshness
+targetRef: magento.watcher.api_data_freshness
+name: Magento recent-order data freshness
+description: Fires when no order has appeared during the configured freshness window; quiet stores can legitimately meet this condition.
+workflow: workflow.cron_indexer_health
+enabled: false
+activation: analytics_ready_and_admin_confirms_threshold
+query: watch_api_data_freshness
+valuePath: sales_order.0.count
+operator: eq
+threshold: 0
+cadenceSeconds: 900
+debounceSeconds: 3600
+cooldownSeconds: 14400
+severity: medium
+dedupeKey: "data-freshness:{window_start}"
+readinessSignals: [analytics]

--- a/packs/magento/watchers/cron_health.yaml
+++ b/packs/magento/watchers/cron_health.yaml
@@ -1,0 +1,16 @@
+key: watcher.cron_health
+targetRef: magento.watcher.cron_health
+name: Magento cron failure or stall
+description: Fires when cron failures or stale running jobs are observed.
+workflow: workflow.cron_indexer_health
+enabled: false
+activation: admin_confirms_threshold
+query: watch_cron_health
+valuePath: cron_schedule.0.count
+operator: gt
+threshold: 0
+cadenceSeconds: 900
+debounceSeconds: 1800
+cooldownSeconds: 7200
+severity: high
+dedupeKey: "cron-health:{oldest_started_at}"

--- a/packs/magento/watchers/indexer_health.yaml
+++ b/packs/magento/watchers/indexer_health.yaml
@@ -1,0 +1,16 @@
+key: watcher.indexer_health
+targetRef: magento.watcher.indexer_health
+name: Magento invalid or stale indexer
+description: Fires when an indexer is non-valid or older than the configured threshold.
+workflow: workflow.cron_indexer_health
+enabled: false
+activation: admin_confirms_threshold
+query: watch_indexer_health
+valuePath: indexer_state.0.count
+operator: gt
+threshold: 0
+cadenceSeconds: 1800
+debounceSeconds: 3600
+cooldownSeconds: 14400
+severity: high
+dedupeKey: "indexer-health:{count}"

--- a/packs/magento/watchers/refund_cancellation_spike.yaml
+++ b/packs/magento/watchers/refund_cancellation_spike.yaml
@@ -1,0 +1,16 @@
+key: watcher.refund_cancellation_spike
+targetRef: magento.watcher.refund_cancellation_spike
+name: Magento cancellation threshold
+description: Fires when cancellations in the configured window exceed the administrator-confirmed threshold; the workflow also reviews refunds.
+workflow: workflow.refund_cancellation_spike
+enabled: false
+activation: admin_confirms_threshold
+query: watch_refund_cancellation
+valuePath: cancelled_orders.0.count
+operator: gt
+threshold: 0
+cadenceSeconds: 1800
+debounceSeconds: 7200
+cooldownSeconds: 21600
+severity: high
+dedupeKey: "cancellation-threshold:{window_start}"

--- a/packs/magento/watchers/stock_threshold.yaml
+++ b/packs/magento/watchers/stock_threshold.yaml
@@ -1,0 +1,16 @@
+key: watcher.stock_threshold
+targetRef: magento.watcher.stock_threshold
+name: Magento low-stock threshold
+description: Fires when the count of source-level low/out-of-stock SKUs crosses a threshold.
+workflow: workflow.low_stock_investigation
+enabled: false
+activation: admin_confirms_threshold
+query: watch_stock_threshold
+valuePath: inventory_source_item.0.count
+operator: gt
+threshold: 0
+cadenceSeconds: 900
+debounceSeconds: 3600
+cooldownSeconds: 14400
+severity: medium
+dedupeKey: "stock-threshold:{count}"

--- a/packs/magento/workflows/cron_indexer_health.yaml
+++ b/packs/magento/workflows/cron_indexer_health.yaml
@@ -1,0 +1,15 @@
+key: workflow.cron_indexer_health
+targetRef: magento.workflow.cron_indexer_health
+name: Magento cron and indexer health review
+description: Diagnose failed cron jobs, stuck schedules, and unhealthy indexers.
+enabled: true
+status: active
+goal: >-
+  Use the magento-diagnose-platform-health skill and the cron/indexer health
+  saved queries to summarize failures, oldest stuck work, and affected
+  indexers. Recommend bounded next checks; do not run reindexing, cron,
+  restarts, or process termination.
+schedule: null
+outputContract:
+  kind: recommendation
+  required: [title, body, mood, evidence]

--- a/packs/magento/workflows/customer_service_order_summary.yaml
+++ b/packs/magento/workflows/customer_service_order_summary.yaml
@@ -1,0 +1,16 @@
+key: workflow.customer_service_order_summary
+targetRef: magento.workflow.customer_service_order_summary
+name: Magento customer-service order summary
+description: Produce a privacy-minimized order lifecycle summary for a supplied order ID.
+enabled: true
+status: active
+goal: >-
+  Use the magento-investigate-order skill. Given an order ID, reconstruct state,
+  invoices, shipments, and credit memos using approved fields only. Include
+  internal history only when an approved source exposes it. Do not return email,
+  phone, address, payment, token, or password data. Any proposed private comment
+  must use the governed action and require approval.
+schedule: null
+outputContract:
+  kind: note
+  required: [title, body, evidence]

--- a/packs/magento/workflows/daily_commerce_briefing.yaml
+++ b/packs/magento/workflows/daily_commerce_briefing.yaml
@@ -1,0 +1,20 @@
+key: workflow.daily_commerce_briefing
+targetRef: magento.workflow.daily_commerce_briefing
+name: Magento daily commerce briefing
+description: Summarize revenue, orders, refunds, cancellations, fulfillment, stock, and platform health.
+enabled: false
+status: active
+goal: >-
+  Use the magento-review-performance skill and only the installed Magento
+  saved-query metrics. Produce a concise daily commerce briefing with scope,
+  calculation notes, and freshness. Do not infer conversion rate, margin,
+  customer identity, or payment details. Separate observed facts from
+  recommendations and route a detailed incident to its focused Magento skill.
+schedule:
+  cron: "0 9 * * *"
+  timezoneInput: magento.timezone
+  enabled: false
+activation: admin_confirms_schedule_and_channel
+outputContract:
+  kind: finding
+  required: [title, body, mood, evidence]

--- a/packs/magento/workflows/fulfillment_exceptions.yaml
+++ b/packs/magento/workflows/fulfillment_exceptions.yaml
@@ -1,0 +1,15 @@
+key: workflow.fulfillment_exceptions
+targetRef: magento.workflow.fulfillment_exceptions
+name: Magento fulfillment exceptions
+description: Investigate paid orders that remain unshipped beyond the configured SLA.
+enabled: true
+status: active
+goal: >-
+  Use the magento-triage-fulfillment skill with fulfillment backlog and age
+  evidence to identify operational exceptions. Report order IDs only, exclude
+  customer information, and recommend the next check. Never cancel, ship,
+  refund, or edit an order.
+schedule: null
+outputContract:
+  kind: recommendation
+  required: [title, body, mood, evidence]

--- a/packs/magento/workflows/low_stock_investigation.yaml
+++ b/packs/magento/workflows/low_stock_investigation.yaml
@@ -1,0 +1,15 @@
+key: workflow.low_stock_investigation
+targetRef: magento.workflow.low_stock_investigation
+name: Magento low-stock investigation
+description: Review source-level low stock and prepare a replenishment proposal.
+enabled: true
+status: active
+goal: >-
+  Use the magento-check-inventory skill to investigate low-stock SKUs across
+  MSI sources. Clearly label source quantity as an approximation unless salable
+  quantity has been validated. Prepare a replenishment proposal but do not
+  mutate inventory or create purchase orders.
+schedule: null
+outputContract:
+  kind: recommendation
+  required: [title, body, mood, evidence]

--- a/packs/magento/workflows/refund_cancellation_spike.yaml
+++ b/packs/magento/workflows/refund_cancellation_spike.yaml
@@ -1,0 +1,15 @@
+key: workflow.refund_cancellation_spike
+targetRef: magento.workflow.refund_cancellation_spike
+name: Magento refund and cancellation spike
+description: Investigate a material increase in refund value or cancelled-order rate.
+enabled: true
+status: active
+goal: >-
+  Use the magento-investigate-refunds skill. Compare the current refund value
+  rate and cancellation count rate with the configured baseline. Break down by
+  store, order, and SKU only when evidence is sufficient. Do not expose customer
+  or payment data and do not issue refunds.
+schedule: null
+outputContract:
+  kind: finding
+  required: [title, body, mood, evidence]

--- a/packs/schema/solution-pack.v1.schema.json
+++ b/packs/schema/solution-pack.v1.schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://openneko.app/schemas/solution-pack.v1.schema.json",
+  "title": "OpenNeko solution pack",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["apiVersion", "kind", "metadata", "compatibility", "inputs", "secrets", "artifacts", "health"],
+  "properties": {
+    "apiVersion": { "const": "openneko.app/v1" },
+    "kind": { "const": "SolutionPack" },
+    "metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "name", "version", "publisher", "category"],
+      "properties": {
+        "id": { "$ref": "#/$defs/slug" },
+        "name": { "type": "string", "minLength": 1 },
+        "version": { "$ref": "#/$defs/version" },
+        "publisher": { "$ref": "#/$defs/slug" },
+        "category": { "$ref": "#/$defs/slug" }
+      }
+    },
+    "compatibility": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["openneko", "graphjin", "applications", "databases"],
+      "properties": {
+        "openneko": { "type": "string", "minLength": 1 },
+        "graphjin": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["analytics", "operator"],
+          "properties": {
+            "analytics": { "type": "string", "minLength": 1 },
+            "operator": { "type": "string", "minLength": 1 }
+          }
+        },
+        "applications": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "editions", "versions"],
+            "properties": {
+              "id": { "$ref": "#/$defs/slug" },
+              "editions": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/slug" } },
+              "versions": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "databases": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["engine", "versions"],
+            "properties": {
+              "engine": { "enum": ["mariadb", "mysql", "postgres"] },
+              "versions": { "type": "string", "minLength": 1 }
+            }
+          }
+        }
+      }
+    },
+    "inputs": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["key", "type"],
+        "properties": {
+          "key": { "$ref": "#/$defs/dottedKey" },
+          "type": { "enum": ["string", "url", "integer", "enum", "timezone", "boolean"] },
+          "required": { "type": "boolean" },
+          "default": { "type": ["string", "number", "boolean"] },
+          "discover": { "type": "boolean" },
+          "values": { "type": "array", "items": { "type": ["string", "number", "boolean"] } },
+          "description": { "type": "string" }
+        }
+      }
+    },
+    "secrets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["key", "purpose"],
+        "properties": {
+          "key": { "$ref": "#/$defs/dottedKey" },
+          "purpose": { "enum": ["graphjin_source", "graphjin_api_auth", "pack_runtime"] },
+          "required": { "type": "boolean", "default": true }
+        }
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["graphjin", "metrics", "workflows", "watchers", "actions", "policies", "skills"],
+      "properties": {
+        "graphjin": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["sources", "relationships", "specs", "savedQueries"],
+          "properties": {
+            "sources": { "$ref": "#/$defs/path" },
+            "relationships": { "$ref": "#/$defs/path" },
+            "specs": { "type": "array", "items": { "$ref": "#/$defs/path" } },
+            "savedQueries": { "$ref": "#/$defs/path" }
+          }
+        },
+        "metrics": { "$ref": "#/$defs/path" },
+        "workflows": { "$ref": "#/$defs/path" },
+        "watchers": { "$ref": "#/$defs/path" },
+        "actions": { "$ref": "#/$defs/path" },
+        "policies": { "$ref": "#/$defs/path" },
+        "skills": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/path" } }
+      }
+    },
+    "health": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requiredPreflight", "readiness", "postInstall", "postWriteCanary"],
+      "properties": {
+        "requiredPreflight": { "$ref": "#/$defs/checks" },
+        "readiness": { "type": "object", "additionalProperties": { "$ref": "#/$defs/checks" } },
+        "postInstall": { "$ref": "#/$defs/checks" },
+        "postWriteCanary": { "$ref": "#/$defs/checks" }
+      }
+    }
+  },
+  "$defs": {
+    "slug": { "type": "string", "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$" },
+    "version": { "type": "string", "pattern": "^\\d+\\.\\d+\\.\\d+(?:-[0-9A-Za-z.-]+)?$" },
+    "dottedKey": { "type": "string", "pattern": "^[a-z][a-z0-9_.-]+$" },
+    "path": { "type": "string", "minLength": 1, "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$))(?!.*\\\\).+$" },
+    "checks": { "type": "array", "items": { "$ref": "#/$defs/slug" } }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,6 +131,9 @@ importers:
       '@neko/llm':
         specifier: workspace:*
         version: link:../../packages/llm
+      '@neko/packs':
+        specifier: workspace:*
+        version: link:../../packages/packs
       '@neko/records':
         specifier: workspace:*
         version: link:../../packages/records
@@ -149,6 +152,9 @@ importers:
       dotenv:
         specifier: ^17.4.1
         version: 17.4.2
+      mysql2:
+        specifier: ^3.15.3
+        version: 3.23.4(@types/node@20.19.39)
       pg:
         specifier: ^8.20.0
         version: 8.20.0
@@ -158,6 +164,9 @@ importers:
       tsx:
         specifier: ^4.19.2
         version: 4.21.0
+      yaml:
+        specifier: ^2.8.1
+        version: 2.9.0
     devDependencies:
       '@types/node':
         specifier: ^20
@@ -198,7 +207,7 @@ importers:
         version: link:../secret-crypt
       drizzle-orm:
         specifier: ^0.36.4
-        version: 0.36.4(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@types/react@19.2.14)(pg@8.20.0)(react@19.2.4)
+        version: 0.36.4(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@types/react@19.2.14)(mysql2@3.23.4(@types/node@20.19.39))(pg@8.20.0)(react@19.2.4)
       pg:
         specifier: ^8.13.1
         version: 8.20.0
@@ -298,6 +307,25 @@ importers:
       '@types/pg':
         specifier: ^8.20.0
         version: 8.20.0
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.19.39)(lightningcss@1.32.0)
+
+  packages/packs:
+    dependencies:
+      yaml:
+        specifier: ^2.8.1
+        version: 2.9.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^20
+        version: 20.19.39
+      typescript:
+        specifier: ^5
+        version: 5.9.3
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.39)(lightningcss@1.32.0)
@@ -1885,6 +1913,10 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
+  aws-ssl-profiles@1.1.2:
+    resolution: {integrity: sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g==}
+    engines: {node: '>= 6.0.0'}
+
   axe-core@4.11.3:
     resolution: {integrity: sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==}
     engines: {node: '>=4'}
@@ -2050,6 +2082,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -2633,6 +2666,9 @@ packages:
     resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
     engines: {node: '>=18'}
 
+  generate-function@2.3.1:
+    resolution: {integrity: sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==}
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -2758,6 +2794,10 @@ packages:
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
@@ -2893,6 +2933,9 @@ packages:
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-property@1.0.2:
+    resolution: {integrity: sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g==}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -3110,6 +3153,10 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lru.min@1.1.4:
+    resolution: {integrity: sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA==}
+    engines: {bun: '>=1.0.0', deno: '>=1.30.0', node: '>=8.0.0'}
+
   lucide-react@1.14.0:
     resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
     peerDependencies:
@@ -3298,6 +3345,16 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  mysql2@3.23.4:
+    resolution: {integrity: sha512-J1Rgl8Oy5iw3mOBjKeTMQ3cJNjMYtJYavQVXShsMtSj9rKV8Q1+QaGKNJqDVQFcNINqYYp6Vxd90r69cCoBxBA==}
+    engines: {node: '>= 8.0'}
+    peerDependencies:
+      '@types/node': '>= 8'
+
+  named-placeholders@1.1.6:
+    resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
+    engines: {node: '>=8.0.0'}
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
@@ -3814,6 +3871,10 @@ packages:
 
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  sql-escaper@1.5.1:
+    resolution: {integrity: sha512-4toX5E1fQbBrpfXidaHnF0669nkAdETeIPTs2SUjxxD7RRIs9ICG4gtpmfc68JCEKehsdwLFqBu9VlQqZ1P1gg==}
+    engines: {bun: '>=1.0.0', deno: '>=2.0.0', node: '>=12.0.0'}
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
@@ -5499,6 +5560,8 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
+  aws-ssl-profiles@1.1.2: {}
+
   axe-core@4.11.3: {}
 
   axobject-query@4.1.0: {}
@@ -5770,11 +5833,12 @@ snapshots:
 
   dotenv@17.4.2: {}
 
-  drizzle-orm@0.36.4(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@types/react@19.2.14)(pg@8.20.0)(react@19.2.4):
+  drizzle-orm@0.36.4(@opentelemetry/api@1.9.1)(@types/pg@8.20.0)(@types/react@19.2.14)(mysql2@3.23.4(@types/node@20.19.39))(pg@8.20.0)(react@19.2.4):
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/pg': 8.20.0
       '@types/react': 19.2.14
+      mysql2: 3.23.4(@types/node@20.19.39)
       pg: 8.20.0
       react: 19.2.4
 
@@ -6345,6 +6409,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  generate-function@2.3.1:
+    dependencies:
+      is-property: 1.0.2
+
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
@@ -6499,6 +6567,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -6619,6 +6691,8 @@ snapshots:
   is-plain-obj@4.1.0: {}
 
   is-promise@4.0.0: {}
+
+  is-property@1.0.2: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -6812,6 +6886,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lru.min@1.1.4: {}
 
   lucide-react@1.14.0(react@19.2.4):
     dependencies:
@@ -7203,6 +7279,21 @@ snapshots:
   minimist@1.2.8: {}
 
   ms@2.1.3: {}
+
+  mysql2@3.23.4(@types/node@20.19.39):
+    dependencies:
+      '@types/node': 20.19.39
+      aws-ssl-profiles: 1.1.2
+      generate-function: 2.3.1
+      iconv-lite: 0.7.3
+      long: 5.3.2
+      lru.min: 1.1.4
+      named-placeholders: 1.1.6
+      sql-escaper: 1.5.1
+
+  named-placeholders@1.1.6:
+    dependencies:
+      lru.min: 1.1.4
 
   nanoid@3.3.11: {}
 
@@ -7871,6 +7962,8 @@ snapshots:
   split2@4.2.0: {}
 
   sprintf-js@1.1.3: {}
+
+  sql-escaper@1.5.1: {}
 
   stable-hash@0.0.5: {}
 

--- a/scripts/dev-web-stack.sh
+++ b/scripts/dev-web-stack.sh
@@ -1,0 +1,128 @@
+#!/bin/sh
+set -eu
+
+refuse_non_development_mode() {
+  echo "Host web + OpenShell registration is development-only." >&2
+  echo "Production and demo modes must run the web service inside the stack." >&2
+  exit 1
+}
+
+case "${NODE_ENV:-development}" in
+  development) ;;
+  *) refuse_non_development_mode ;;
+esac
+
+case "${OPENNEKO_STACK_MODE:-}" in
+  demo|DEMO) refuse_non_development_mode ;;
+esac
+
+case "${NEXT_PUBLIC_DEMO:-false}" in
+  1|true|TRUE|yes|YES|on|ON) refuse_non_development_mode ;;
+esac
+
+case "${DEMO:-false}" in
+  1|true|TRUE|yes|YES|on|ON) refuse_non_development_mode ;;
+esac
+
+web_port="${OPENNEKO_PORT:-3200}"
+state_root="${OPENNEKO_HOST_WEB_STATE_DIR:-$PWD/.openneko/host-web}"
+
+if [ -n "${OPENNEKO_DEV_STACK:-}" ]; then
+  project_name="$OPENNEKO_DEV_STACK"
+else
+  running_projects="$(
+    docker ps \
+      --filter label=com.docker.compose.service=worker \
+      --format '{{.Label "com.docker.compose.project"}}' |
+      sed '/^$/d' |
+      sort -u
+  )"
+  set -f
+  set -- $running_projects
+  set +f
+  case "$#" in
+    1) project_name="$1" ;;
+    0)
+      echo "No running OpenNeko Compose stack was found." >&2
+      echo "Start the development backing stack before running the host web server." >&2
+      exit 1
+      ;;
+    *)
+      echo "More than one OpenNeko Compose stack is running:" >&2
+      printf '  %s\n' "$@" >&2
+      echo "Choose one with OPENNEKO_DEV_STACK=<project> pnpm dev:web:stack." >&2
+      exit 1
+      ;;
+  esac
+fi
+
+container_prefix="$project_name"
+
+container_ip() {
+  docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' "$1"
+}
+
+published_port() {
+  docker port "$1" "$2/tcp" | sed -n '1s/.*://p'
+}
+
+worker_container="${container_prefix}-worker-1"
+records_graphjin_container="${container_prefix}-records-graphjin-1"
+metadata_db_container="${container_prefix}-neko-db-1"
+records_db_container="${container_prefix}-records-db-1"
+metadata_graphjin_container="${container_prefix}-neko-graphjin-1"
+
+for required_container in \
+  "$worker_container" \
+  "$records_graphjin_container" \
+  "$metadata_db_container" \
+  "$records_db_container" \
+  "$metadata_graphjin_container"
+do
+  if ! docker inspect "$required_container" >/dev/null 2>&1 || \
+     [ "$(docker inspect -f '{{.State.Running}}' "$required_container")" != "true" ]; then
+    echo "OpenNeko service is unavailable: $required_container" >&2
+    echo "Start the ${project_name} stack before running the host web server." >&2
+    exit 1
+  fi
+done
+
+if [ ! -f "$state_root/config/openneko/secret-key" ] || \
+   [ ! -f "$state_root/config/openshell/gateways/openneko/metadata.json" ]; then
+  echo "Host web state is missing at $state_root." >&2
+  echo "Copy the stack config, OpenShell registration, and agent workspace there before first use." >&2
+  exit 1
+fi
+
+mkdir -p "$state_root/tmp"
+
+export OPENNEKO_AGENT_HOME="$state_root/home"
+export OPENNEKO_HOST_WEB_DEV=1
+export NODE_ENV=development
+export TMPDIR="$state_root/tmp"
+export XDG_CONFIG_HOME="$state_root/config"
+export XDG_CACHE_HOME="$state_root/home/.cache"
+export XDG_DATA_HOME="$state_root/home/.local/share"
+export XDG_STATE_HOME="$state_root/home/.local/state"
+
+export NEKO_PG_HOST=127.0.0.1
+export NEKO_PG_PORT="$(published_port "$metadata_db_container" 5432)"
+
+export RECORDS_PG_HOST=127.0.0.1
+export RECORDS_PG_PORT="$(published_port "$records_db_container" 5432)"
+export OPENNEKO_PG_ENV_OVERRIDE=1
+
+export WORKER_ADMIN_URL="http://$(container_ip "$worker_container"):4100"
+export OPENNEKO_RECORDS_GRAPHJIN_URL="http://$(container_ip "$records_graphjin_container"):8090"
+export OPENNEKO_GRAPHJIN_URL="http://127.0.0.1:$(published_port "$metadata_graphjin_container" 8089)"
+export OPENNEKO_GRAPHJIN_CONFIG="$state_root/config/graphjin/agentic.yml"
+
+export OPENSHELL_STATE_DIR="${OPENSHELL_STATE_DIR:-$PWD/.openneko/openshell}"
+export OPENSHELL_GATEWAY="${OPENSHELL_GATEWAY:-openneko}"
+export OPENNEKO_AGENT_IMAGE="${OPENNEKO_AGENT_IMAGE:-openneko-agent:dev}"
+export OPENNEKO_SANDBOX_SHARED_NETWORK=0
+export OPENNEKO_BROKER_PORT="${OPENNEKO_WEB_BROKER_PORT:-4198}"
+
+echo "OpenNeko web: http://localhost:${web_port} (hot reload)"
+echo "Backing services: Docker Compose project ${project_name}"
+exec pnpm --filter @neko/web exec next dev --port "$web_port"


### PR DESCRIPTION
## Summary

- Add the solution-pack schema, bundle planner, CLI commands, persistence, admin lifecycle APIs, worker reconciliation, and deterministic metric jobs.
- Ship a bundled Magento operations pack with GraphJin sources and queries, metrics, watchers, workflows, skills, policies, and a guarded internal-order-comment action.
- Integrate pack setup, readiness, onboarding, compose configuration, and the admin management surface.
- Standardize the web typography hierarchy and introduce shared buttons, fields, tabs, segmented controls, disclosures, overflow menus, pills, and empty states.
- Apply responsive polish across desktop, tablet, and mobile layouts, including 44px touch targets and removal of duplicated page-specific control styling.

## Verification

- `pnpm --filter @neko/web lint`
- `pnpm --filter @neko/web typecheck`
- `pnpm --filter @neko/web test` — 267 passed; 106 database-dependent tests skipped by existing environment guards
- Live smoke checks on `/apps`, `/library`, `/work`, and `/admin/settings` — HTTP 200
- Manual responsive audit at 1440px, 900px, and 390px

## Database changes

- Add migration `0059_solution_packs.sql`.
- Add migration `0060_deterministic_metrics.sql`.