### PR TITLE
fix(startup): eliminate startup and onboarding races across all stack modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,26 @@ openneko install @open-neko/plugin-scalekit
 - **Agent in a sandbox by default.** The agent loop itself runs inside an OpenShell policy sandbox — default-deny egress, and the model API key never enters the box (the gateway proxy injects it on the wire). See [OPENSHELL.md](OPENSHELL.md).
 - **Apache-2.0.** Read the source, self-host, fork, and build on it. OpenNeko trademarks are separately controlled — see [LICENSING.md](LICENSING.md) and [TRADEMARKS.md](TRADEMARKS.md).
 
+## Stack modes
+
+`openneko start|setup|upgrade --mode prod|dev|demo` picks which Compose layers the
+CLI deploys. Every mode shares the same core: app + records Postgres, migrations,
+backup/restore, web, worker, three internal GraphJin instances (app
+subscriptions, records, records-watch), plus the customer-facing GraphJin in
+sources (agentic) mode. The OpenShell sandbox runtime (gateway, registry,
+certgen) is always layered on top — it is the only way agents and plugins run,
+in every mode.
+
+| Mode | Layers on top of core | What's different |
+|------|----------------------|------------------|
+| **prod** (default) | none | Core stack only. You connect your own data source; actions run for real. |
+| **demo** | AdventureWorks sample DB, seed job, order simulator, scenario injector | Customer GraphJin points at the sample data; external actions default to dry-run (`NEKO_ACTIONS_DRY_RUN=true`). What `openneko setup --mode demo` gives you. |
+| **dev** | none (reserved overlay) | For working on OpenNeko itself: Docker runs only the dependency services while web and worker hot-reload as host processes (`pnpm dev:setup && pnpm dev`, using the repo's root `compose.yml`) — see [CONTRIBUTING.md](CONTRIBUTING.md). |
+
+**Solution packs** (e.g. `openneko pack install magento`) are not a mode: they
+layer onto a running stack in any mode, adding sources, specs, and saved queries
+to the customer GraphJin config at runtime.
+
 ## Docs
 
 - [INSTALL.md](INSTALL.md) — install, [upgrade](INSTALL.md#upgrade), requirements, troubleshooting, connecting your data, full demo trial

--- a/apps/openneko/assets/compose/core.yml
+++ b/apps/openneko/assets/compose/core.yml
@@ -285,17 +285,46 @@ services:
       - openneko-graphjin-cli:/config
     restart: "no"
 
+  # One-shot: resolves (or creates, under an advisory lock) the single org
+  # row and reconciles the per-org JWT secret into the customer GraphJin
+  # sources config BEFORE the server's first start. GraphJin 3.18 does not
+  # hot-reload auth keys; expressing that as `graphjin -> worker` cycled
+  # against the demo/dev overlays' `worker -> graphjin` edge, so this
+  # one-shot carries the ordering instead. It reconciles unconditionally on
+  # every run, so secret-key rotation, restores, and partial volume wipes
+  # self-heal on the next stack start. Unlike the seeding inits it holds DB
+  # credentials and reads the deployment secret-key, so it runs as the
+  # image's non-root user rather than a root shell.
+  graphjin-secret-init:
+    image: ghcr.io/open-neko/neko-worker:${OPENNEKO_VERSION:-latest}
+    working_dir: /app
+    command: ["node", "--import", "tsx/esm", "node_modules/@neko/llm/src/graphjin/init-secret.mjs"]
+    depends_on:
+      neko-migrate:
+        condition: service_completed_successfully
+      openneko-config-init:
+        condition: service_completed_successfully
+      graphjin-config-init:
+        condition: service_completed_successfully
+    environment:
+      <<: *neko-app-env
+      GRAPHJIN_SOURCES_CONFIG: /config/graphjin/agentic.yml
+    volumes:
+      - openneko-config:/config/openneko
+      - openneko-graphjin-cli:/config/graphjin
+    restart: "no"
+
   graphjin:
     image: ${OPENNEKO_GRAPHJIN_IMAGE:-dosco/graphjin:3.18.42}
     restart: unless-stopped
     depends_on:
       graphjin-config-init:
         condition: service_completed_successfully
-      # The worker reconciles the per-org JWT secret into agentic.yml during
-      # startup. GraphJin 3.18 does not hot-reload auth keys, so start it only
-      # after that reconciliation has completed.
-      worker:
-        condition: service_healthy
+      # The per-org JWT secret is reconciled into agentic.yml by the
+      # graphjin-secret-init one-shot. GraphJin 3.18 does not hot-reload
+      # auth keys, so start only after that reconciliation has completed.
+      graphjin-secret-init:
+        condition: service_completed_successfully
     expose:
       - "8080"
     environment:
@@ -398,6 +427,8 @@ services:
         condition: service_started
       graphjin:
         condition: service_started
+      graphjin-secret-init:
+        condition: service_completed_successfully
       # Web is the user-facing readiness boundary. Do not serve the temporary
       # recovery screen while the control plane is still starting.
       worker:
@@ -427,6 +458,12 @@ services:
       neko-migrate:
         condition: service_completed_successfully
       openneko-config-init:
+        condition: service_completed_successfully
+      # Serializes first-boot bootstrap: secret-init is the sole first
+      # creator of the org row and the deployment secret-key, so the worker
+      # (and web, transitively) always reads the same identity it derived
+      # the GraphJin secret from.
+      graphjin-secret-init:
         condition: service_completed_successfully
       records-db:
         condition: service_healthy

--- a/apps/openneko/assets/compose/demo.yml
+++ b/apps/openneko/assets/compose/demo.yml
@@ -118,6 +118,11 @@ services:
         condition: service_completed_successfully
       adventureworks-init:
         condition: service_completed_successfully
+      # openneko-config-init repairs the config volume's ownership; reading
+      # config.json / the secret-key before that chown returned EACCES, which
+      # older secret-crypt turned into a destructive key regeneration.
+      openneko-config-init:
+        condition: service_completed_successfully
     environment:
       XDG_CONFIG_HOME: /config
       NEKO_PG_HOST: neko-db

--- a/apps/openneko/assets/compose/demo.yml
+++ b/apps/openneko/assets/compose/demo.yml
@@ -55,9 +55,10 @@ services:
         set -eu
         if [ ! -f /config/agentic.yml ]; then
           # Sources (agentic) mode is the default. The per-org JWT secret
-          # placeholder is substituted by the worker at boot
-          # (OPENNEKO_GRAPHJIN_CONFIG) — the org id only exists then. The
-          # keystore key must be real at boot, so generate it here once.
+          # placeholder is substituted by the graphjin-secret-init one-shot
+          # (which creates the org row if needed) before GraphJin starts;
+          # the worker re-verifies at boot. The keystore key must be real
+          # at boot, so generate it here once.
           cp /app/db/graphjin/dev.sources.example.yml /config/agentic.yml
           KEY=$(node -e 'console.log(require("crypto").randomBytes(32).toString("base64"))')
           sed -i "s|REPLACE_WITH_BASE64_32_BYTE_KEY|$$KEY|" /config/agentic.yml
@@ -66,6 +67,18 @@ services:
     volumes:
       - graphjin-config:/config
     restart: "no"
+
+  # The demo keeps its GraphJin config on the dedicated graphjin-config
+  # volume; point the secret one-shot's /config/graphjin mount there
+  # (Compose replaces the core mount for the same container path). Running
+  # after the seed keeps the demo's 'adventureworks' org the first (and
+  # only) org row, so the derived secret matches the org the demo uses.
+  graphjin-secret-init:
+    depends_on:
+      neko-adventureworks-seed:
+        condition: service_completed_successfully
+    volumes:
+      - graphjin-config:/config/graphjin
 
   graphjin:
     # Data-source GraphJin over the AdventureWorks DB. This is what the

--- a/apps/openneko/assets/compose/openshell.yml
+++ b/apps/openneko/assets/compose/openshell.yml
@@ -44,9 +44,12 @@ services:
     restart: "no"
     user: "0:0"
     command:
+      # Generates into a STAGING dir; openshell-reg promotes it to pki/ only
+      # when no complete PKI is active. certgen re-runs on every `up`, and
+      # rewriting the CA under a live gateway broke every issued client cert.
       - generate-certs
       - --output-dir
-      - ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/pki
+      - ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/pki-staging
       - --server-san
       - host.openshell.internal
       - --server-san
@@ -72,29 +75,62 @@ services:
       - |
         set -e
         PKI=${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/pki
+        STAGING=${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/pki-staging
+        # Promote certgen's staged PKI only when no complete set is active:
+        # an existing CA always wins, so a hand-run `compose up` (which
+        # re-runs the one-shots but not the unchanged gateway) can never
+        # invalidate the material a live gateway already loaded.
+        if [ ! -f "$$PKI/ca.crt" ] || [ ! -f "$$PKI/server/tls.key" ] || [ ! -f "$$PKI/client/tls.key" ]; then
+          rm -rf "$$PKI"
+          mv "$$STAGING" "$$PKI"
+        elif [ -d "$$STAGING" ]; then
+          rm -rf "$$STAGING"
+        fi
         # web + worker have XDG_CONFIG_HOME=/config and the CLI reads gateway
         # registrations from $$XDG_CONFIG_HOME/openshell — so write to
         # /config/openshell (the shared openshell-config volume), NOT under the
         # openneko-config volume (which mounts at /config/openneko).
         REG=/config/openshell/gateways/openneko
         mkdir -p "$$REG/mtls"
-        cp "$$PKI/ca.crt"         "$$REG/mtls/ca.crt"
-        cp "$$PKI/client/tls.crt" "$$REG/mtls/tls.crt"
-        cp "$$PKI/client/tls.key" "$$REG/mtls/tls.key"
+        chmod a+rx /config/openshell /config/openshell/gateways "$$REG" "$$REG/mtls"
+        # Per-file atomic publish: stage next to the destination with final
+        # permissions, then rename(2) into place — every `openshell` CLI
+        # spawn re-reads these files, and an in-place truncate-and-write
+        # handed concurrent spawns truncated keys and half-written JSON.
+        # active_gateway goes LAST: it is the pointer that makes the
+        # registration live.
+        pub() {
+          tmp="$$2.tmp.$$$$"
+          cp "$$1" "$$tmp"
+          chmod a+r "$$tmp"
+          mv "$$tmp" "$$2"
+        }
+        pub "$$PKI/ca.crt"         "$$REG/mtls/ca.crt"
+        pub "$$PKI/client/tls.crt" "$$REG/mtls/tls.crt"
+        pub "$$PKI/client/tls.key" "$$REG/mtls/tls.key"
+        tmp="$$REG/metadata.json.tmp.$$$$"
         printf '{"name":"openneko","gateway_endpoint":"https://openshell-gateway:%s","is_remote":false,"gateway_port":0,"auth_mode":"mtls"}\n' "${OPENSHELL_PORT:-18080}" \
-          > "$$REG/metadata.json"
-        printf 'openneko' > /config/openshell/active_gateway
+          > "$$tmp"
+        chmod a+r "$$tmp"
+        mv "$$tmp" "$$REG/metadata.json"
+        tmp="/config/openshell/gateway.toml.tmp.$$$$"
         printf '[openshell]\nversion = 1\n\n[openshell.drivers.docker]\nnetwork_name = "%s"\ngrpc_endpoint = "https://openshell-gateway:%s"\nhost_gateway_ip = "%s"\n' \
           "$$OPENNEKO_COMPOSE_NETWORK" "${OPENSHELL_PORT:-18080}" "$$OPENSHELL_GATEWAY_IP" \
-          > /config/openshell/gateway.toml
-        chmod -R a+rX /config/openshell
+          > "$$tmp"
+        chmod a+r "$$tmp"
+        mv "$$tmp" /config/openshell/gateway.toml
+        tmp="/config/openshell/active_gateway.tmp.$$$$"
+        printf 'openneko' > "$$tmp"
+        chmod a+r "$$tmp"
+        mv "$$tmp" /config/openshell/active_gateway
     environment:
       # `docker compose -p ...` supplies COMPOSE_PROJECT_NAME during
       # interpolation; the explicit name must match the runtime network below.
       OPENNEKO_COMPOSE_NETWORK: "${COMPOSE_PROJECT_NAME}_runtime"
       OPENSHELL_GATEWAY_IP: "${OPENSHELL_GATEWAY_IP:-172.29.0.2}"
     volumes:
-      - ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/pki:${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/pki:ro
+      # Whole state dir read-write: reg promotes pki-staging -> pki.
+      - ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}:${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}
       - openshell-config:/config/openshell
 
   openshell-gateway:
@@ -188,6 +224,11 @@ services:
     depends_on:
       openshell-ready:
         condition: service_completed_successfully
+      # openshell-ready's exit-0 is a historical fact; the direct edge keeps
+      # `up -d worker`/`up -d web` from starting an app process with no
+      # gateway container at all.
+      openshell-gateway:
+        condition: service_started
 
   # Web: interactive chat launches the agent in a sandbox too (the Next.js server
   # is the control plane; the agent never runs in-process). Same flags; egress
@@ -206,6 +247,11 @@ services:
     depends_on:
       openshell-ready:
         condition: service_completed_successfully
+      # openshell-ready's exit-0 is a historical fact; the direct edge keeps
+      # `up -d worker`/`up -d web` from starting an app process with no
+      # gateway container at all.
+      openshell-gateway:
+        condition: service_started
 
 volumes:
   # Holds the worker/web CLI's gateway registration at /config/openshell (the

--- a/apps/openneko/assets/compose_cycle_test.go
+++ b/apps/openneko/assets/compose_cycle_test.go
@@ -1,0 +1,162 @@
+package assets
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"testing"
+)
+
+// The dependency graph is only real once the mode overlays are merged:
+// Compose unions depends_on maps across files, so an edge that is harmless
+// in one file can close a cycle against an edge in another (exactly how
+// `graphjin -> worker` in core met `worker -> graphjin` in the demo overlay
+// and broke every demo and dev bring-up). These tests merge each shipped
+// file combination the way Compose does and reject cycles.
+
+func mergedDependencyGraph(t *testing.T, rawFiles ...[]byte) map[string][]string {
+	t.Helper()
+	graph := map[string][]string{}
+	for _, raw := range rawFiles {
+		document := loadComposeParityDocument(t, raw)
+		for name, service := range document.Services {
+			if _, ok := graph[name]; !ok {
+				graph[name] = nil
+			}
+			for dep := range service.DependsOn {
+				graph[name] = append(graph[name], dep)
+			}
+		}
+	}
+	for name := range graph {
+		sort.Strings(graph[name])
+	}
+	return graph
+}
+
+func findDependencyCycle(graph map[string][]string) []string {
+	const (
+		unvisited = 0
+		visiting  = 1
+		done      = 2
+	)
+	state := map[string]int{}
+	var stack []string
+
+	var visit func(node string) []string
+	visit = func(node string) []string {
+		switch state[node] {
+		case visiting:
+			// Trim the stack to the cycle itself for a readable failure.
+			for i, n := range stack {
+				if n == node {
+					return append(append([]string{}, stack[i:]...), node)
+				}
+			}
+			return []string{node, node}
+		case done:
+			return nil
+		}
+		state[node] = visiting
+		stack = append(stack, node)
+		for _, dep := range graph[node] {
+			if cycle := visit(dep); cycle != nil {
+				return cycle
+			}
+		}
+		stack = stack[:len(stack)-1]
+		state[node] = done
+		return nil
+	}
+
+	for _, node := range sortedKeys(graph) {
+		if cycle := visit(node); cycle != nil {
+			return cycle
+		}
+	}
+	return nil
+}
+
+func readEmbeddedCompose(t *testing.T, name string) []byte {
+	t.Helper()
+	raw, err := ComposeFS.ReadFile("compose/" + name)
+	if err != nil {
+		t.Fatalf("read embedded %s: %v", name, err)
+	}
+	return raw
+}
+
+func readRootCompose(t *testing.T, name string) []byte {
+	t.Helper()
+	raw, err := os.ReadFile("../../../" + name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return raw
+}
+
+func TestPackagedComposeModesAreAcyclic(t *testing.T) {
+	// Mirrors internal/compose.Materialize: core + mode overlay, and the
+	// OpenShell overlay always applies.
+	combos := map[string][]string{
+		"prod": {"core.yml", "openshell.yml"},
+		"dev":  {"core.yml", "dev.yml", "openshell.yml"},
+		"demo": {"core.yml", "demo.yml", "openshell.yml"},
+	}
+	for mode, files := range combos {
+		t.Run(mode, func(t *testing.T) {
+			var raws [][]byte
+			for _, file := range files {
+				raws = append(raws, readEmbeddedCompose(t, file))
+			}
+			if cycle := findDependencyCycle(mergedDependencyGraph(t, raws...)); cycle != nil {
+				t.Fatalf("mode %s: dependency cycle in merged compose graph: %s",
+					mode, fmt.Sprint(cycle))
+			}
+		})
+	}
+}
+
+func TestSourceComposeOverlaysAreAcyclic(t *testing.T) {
+	combos := map[string][]string{
+		"base":           {"compose.yml"},
+		"adventureworks": {"compose.yml", "compose.adventureworks.yml"},
+		"graphjin-agent": {"compose.yml", "compose.adventureworks.yml", "compose.graphjin-agent.yml"},
+		"openshell-host": {"compose.yml", "compose.openshell-host.yml"},
+	}
+	for name, files := range combos {
+		t.Run(name, func(t *testing.T) {
+			var raws [][]byte
+			for _, file := range files {
+				raws = append(raws, readRootCompose(t, file))
+			}
+			if cycle := findDependencyCycle(mergedDependencyGraph(t, raws...)); cycle != nil {
+				t.Fatalf("%s: dependency cycle in merged compose graph: %s",
+					name, fmt.Sprint(cycle))
+			}
+		})
+	}
+}
+
+// The one-shot that seeds the per-org JWT secret must gate every consumer
+// of that secret: GraphJin must not start before the secret is in its
+// config (3.18 does not hot-reload auth keys), and worker/web must not
+// race the org-row bootstrap it performs.
+func TestGraphjinSecretInitGatesItsConsumers(t *testing.T) {
+	graph := mergedDependencyGraph(t,
+		readEmbeddedCompose(t, "core.yml"),
+		readEmbeddedCompose(t, "openshell.yml"),
+	)
+	for _, consumer := range []string{"graphjin", "worker", "web"} {
+		deps := graph[consumer]
+		found := false
+		for _, dep := range deps {
+			if dep == "graphjin-secret-init" {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("%s does not depend on graphjin-secret-init (deps: %v)", consumer, deps)
+		}
+	}
+}

--- a/apps/openneko/assets/compose_cycle_test.go
+++ b/apps/openneko/assets/compose_cycle_test.go
@@ -122,6 +122,7 @@ func TestSourceComposeOverlaysAreAcyclic(t *testing.T) {
 		"base":           {"compose.yml"},
 		"adventureworks": {"compose.yml", "compose.adventureworks.yml"},
 		"graphjin-agent": {"compose.yml", "compose.adventureworks.yml", "compose.graphjin-agent.yml"},
+		"openshell":      {"compose.yml", "compose.openshell.yml"},
 		"openshell-host": {"compose.yml", "compose.openshell-host.yml"},
 	}
 	for name, files := range combos {

--- a/apps/openneko/assets/migrations/0061_app_user_identity_unique.sql
+++ b/apps/openneko/assets/migrations/0061_app_user_identity_unique.sql
@@ -1,0 +1,48 @@
+-- The concurrent first-sign-in race could insert two app_user rows for one
+-- identity (same sub, or same email), after which every later sign-in threw
+-- "already bound to a different SSO subject" until an operator did manual
+-- SQL. Repair existing duplicates, then add the unique indexes that make
+-- the race lose loudly instead of persisting.
+--
+-- Duplicate repair keeps the OLDEST row (the one later sign-ins would have
+-- matched first) and neutralizes newer ones in place rather than deleting
+-- them: rows may be referenced by runs/personas, so they are detached from
+-- the identity (sub cleared, email made unique) and disabled.
+
+with ranked_sub as (
+  select id,
+         row_number() over (
+           partition by org_id, sub
+           order by created_at asc, id asc
+         ) as rn
+  from app_user
+  where sub is not null
+)
+update app_user u
+set sub = null,
+    disabled_at = coalesce(u.disabled_at, now()),
+    updated_at = now()
+from ranked_sub r
+where u.id = r.id and r.rn > 1;
+
+with ranked_email as (
+  select id,
+         row_number() over (
+           partition by org_id, lower(email)
+           order by created_at asc, id asc
+         ) as rn
+  from app_user
+)
+update app_user u
+set email = u.email || '+duplicate-' || u.id,
+    disabled_at = coalesce(u.disabled_at, now()),
+    updated_at = now()
+from ranked_email r
+where u.id = r.id and r.rn > 1;
+
+create unique index if not exists app_user_org_sub_unique
+  on app_user (org_id, sub)
+  where sub is not null;
+
+create unique index if not exists app_user_org_email_unique
+  on app_user (org_id, lower(email));

--- a/apps/openneko/internal/cli/setup.go
+++ b/apps/openneko/internal/cli/setup.go
@@ -84,6 +84,17 @@ at the prompt) to finish at the web UI. Credential flags
 			// since a live OpenNeko legitimately holds those ports.
 			if alreadyUp {
 				ui.Info(out, "Existing OpenNeko detected — skipping preflight and bring-up.")
+				// The wizard configures WHATEVER stack answers on this port.
+				// `setup --mode demo` next to a live prod stack silently
+				// configured prod with demo defaults; refuse the mismatch.
+				if project := runningWebProject(); project != "" {
+					if detected, ok := compose.ModeFromProjectName(project); ok && detected != m {
+						return fmt.Errorf(
+							"the stack answering %s is %q (mode %s), but --mode %s was requested; stop that stack first or re-run with --mode %s",
+							baseURL, project, detected, m, detected,
+						)
+					}
+				}
 			} else {
 				if err := runPreflight(out); err != nil {
 					return err
@@ -311,6 +322,27 @@ func matchPlugins(tokens []string, plugins []marketplace.Plugin) []string {
 
 // webBaseURL resolves the local web app URL from the published port (matching
 // status.go's probeWeb).
+// runningWebProject returns the compose project of the running web
+// container, or "" when none is found / docker is unreachable. Used to
+// detect which stack actually owns the port setup is about to configure.
+func runningWebProject() string {
+	out, err := exec.Command(
+		"docker", "ps",
+		"--filter", "status=running",
+		"--filter", "label=com.docker.compose.service=web",
+		"--format", `{{.Label "com.docker.compose.project"}}`,
+	).Output()
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
 func webBaseURL() string {
 	port := strings.TrimSpace(os.Getenv("OPENNEKO_PORT"))
 	if port == "" {

--- a/apps/openneko/internal/cli/setup.go
+++ b/apps/openneko/internal/cli/setup.go
@@ -128,23 +128,25 @@ at the prompt) to finish at the web UI. Credential flags
 				ResearchKey:      researchKey,
 				NoResearch:       noResearch,
 			}
-			outcome, err := setup.Run(ctx, client, out, cfg)
-			if err != nil {
-				return err
-			}
+			outcome, runErr := setup.Run(ctx, client, out, cfg)
 
 			// Persist the rotated password to the host config (the source the
 			// CLI's own `neko` connection reads on later `start`/`migrate`
 			// runs). The web wizard writes it only to the in-container config
 			// volume, so without this the next host-side `neko` connection would
-			// fall back to the stale bootstrap default. The gateway itself is
-			// unaffected by the rotation — it runs on its dedicated `openshell`
-			// role (see ensureOpenShellGatewayRole), so no gateway restart is
-			// needed.
+			// fall back to the stale bootstrap default. This must happen even
+			// when a LATER wizard step failed — the remote rotation has already
+			// committed by then, and dropping it here locked the host CLI out.
+			// The gateway itself is unaffected by the rotation — it runs on its
+			// dedicated `openshell` role (see ensureOpenShellGatewayRole), so no
+			// gateway restart is needed.
 			if outcome.PasswordSet != "" {
 				if err := config.WriteLocalDatabasePasswords("", outcome.PasswordSet, outcome.PasswordSet); err != nil {
 					ui.Info(out, "warning: couldn't persist the DB password to the host config: %v", err)
 				}
+			}
+			if runErr != nil {
+				return runErr
 			}
 
 			if outcome.Configured {

--- a/apps/openneko/internal/cli/start.go
+++ b/apps/openneko/internal/cli/start.go
@@ -17,6 +17,7 @@ import (
 	"github.com/open-neko/neko/apps/openneko/internal/compose"
 	"github.com/open-neko/neko/apps/openneko/internal/config"
 	"github.com/open-neko/neko/apps/openneko/internal/db"
+	"github.com/open-neko/neko/apps/openneko/internal/setup"
 	"github.com/open-neko/neko/apps/openneko/internal/version"
 )
 
@@ -38,6 +39,15 @@ Modes:
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
+			// Same host checks setup runs; `start` used to skip them and race
+			// straight into an opaque compose failure (port conflict with a
+			// neighboring stack, docker gone away). A stack already answering
+			// legitimately holds the ports, so only a fresh bring-up checks.
+			if !setup.NewClient(webBaseURL()).Ready(ctx) {
+				if err := runPreflight(cmd.OutOrStdout()); err != nil {
+					return err
+				}
+			}
 			return bringUpStack(ctx, cmd, compose.Mode(mode), bringUpOptions{
 				detach:      detach,
 				skipMigrate: skipMigrate,
@@ -162,15 +172,22 @@ func bringUpStack(ctx context.Context, cmd *cobra.Command, mode compose.Mode, op
 		return WithExit(code, fmt.Errorf("database preparation failed"))
 	}
 
-	// Pre-pull the agent sandbox image at install time so the gateway's first
-	// sandbox-create (the user's first chat) never blocks on a large pull.
+	// Pre-pull the sandbox images at install time so the gateway's first
+	// sandbox-create (the user's first chat, or the first plugin RPC) never
+	// blocks on a large pull inside the create timeout. `upgrade` already
+	// pulled both; `start`/`setup` used to pull only the agent image, so a
+	// fresh install's first plugin call raced a lazy multi-GB pull.
 	// Best-effort: a failure just falls back to a lazy pull.
-	agentImg := agentImageRef(os.Getenv("OPENNEKO_AGENT_IMAGE"), os.Getenv("OPENNEKO_VERSION"))
-	if !opts.quiet {
-		fmt.Fprintf(os.Stderr, "Pre-pulling agent sandbox image %s ...\n", agentImg)
-	}
-	if err := sup.EnsureImage(ctx, agentImg, os.Stdout, os.Stderr); err != nil {
-		fmt.Fprintf(os.Stderr, "warning: agent image pre-pull failed (%v); it will pull on first use\n", err)
+	for _, img := range []string{
+		agentImageRef(os.Getenv("OPENNEKO_AGENT_IMAGE"), os.Getenv("OPENNEKO_VERSION")),
+		pluginBaseImageRef(os.Getenv("OPENNEKO_PLUGIN_BASE_IMAGE"), os.Getenv("OPENNEKO_VERSION")),
+	} {
+		if !opts.quiet {
+			fmt.Fprintf(os.Stderr, "Pre-pulling sandbox image %s ...\n", img)
+		}
+		if err := sup.EnsureImage(ctx, img, os.Stdout, os.Stderr); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: image pre-pull failed for %s (%v); it will pull on first use\n", img, err)
+		}
 	}
 
 	// Stage 2: bring up the rest.

--- a/apps/openneko/internal/config/crypt.go
+++ b/apps/openneko/internal/config/crypt.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Mirrors packages/llm/src/secrets.ts exactly: AES-256-GCM, key =
@@ -50,10 +51,44 @@ func loadOrCreateKey(overrideDir string) ([]byte, error) {
 		return nil, err
 	}
 	secret := base64.StdEncoding.EncodeToString(fresh)
-	if err := os.WriteFile(path, []byte(secret), 0o600); err != nil {
+	// Exclusive create: two overlapping CLI invocations (a deploy `upgrade`
+	// racing a cron `status`) must never mint different keys — the derived
+	// openshell DB role password and every enc:v1 value hang off this file.
+	// The loser of O_EXCL re-reads the winner's key.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+	if err == nil {
+		_, werr := f.WriteString(secret)
+		cerr := f.Close()
+		if werr != nil {
+			return nil, werr
+		}
+		if cerr != nil {
+			return nil, cerr
+		}
+		sum := sha256.Sum256([]byte(secret))
+		return sum[:], nil
+	}
+	if !errors.Is(err, fs.ErrExist) {
 		return nil, err
 	}
-	sum := sha256.Sum256([]byte(secret))
+	// The race winner created the file but may not have written it yet;
+	// give it a moment to land before declaring the file corrupt.
+	var existing string
+	for attempt := 0; attempt < 20; attempt++ {
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return nil, rerr
+		}
+		existing = strings.TrimSpace(string(raw))
+		if existing != "" {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if existing == "" {
+		return nil, fmt.Errorf("secret-key at %s exists but is empty; remove the file to let openneko generate a new key", path)
+	}
+	sum := sha256.Sum256([]byte(existing))
 	return sum[:], nil
 }
 

--- a/apps/openneko/internal/config/crypt_race_test.go
+++ b/apps/openneko/internal/config/crypt_race_test.go
@@ -1,0 +1,58 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// Two overlapping CLI invocations (a deploy `upgrade` racing a cron
+// `status`) must never mint different secret keys: the derived openshell
+// DB-role password and every enc:v1 value hang off this one file.
+func TestLoadOrCreateKeyConcurrent(t *testing.T) {
+	dir := t.TempDir()
+
+	const workers = 16
+	keys := make([][]byte, workers)
+	errs := make([]error, workers)
+	var start, done sync.WaitGroup
+	start.Add(1)
+	done.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func(i int) {
+			defer done.Done()
+			start.Wait()
+			keys[i], errs[i] = loadOrCreateKey(dir)
+		}(i)
+	}
+	start.Done()
+	done.Wait()
+
+	for i := 0; i < workers; i++ {
+		if errs[i] != nil {
+			t.Fatalf("worker %d: %v", i, errs[i])
+		}
+		if string(keys[i]) != string(keys[0]) {
+			t.Fatalf("worker %d derived a different key than worker 0", i)
+		}
+	}
+
+	info, err := os.Stat(filepath.Join(dir, "secret-key"))
+	if err != nil {
+		t.Fatalf("stat key file: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0o600 {
+		t.Fatalf("key file mode = %o, want 600", perm)
+	}
+}
+
+func TestLoadOrCreateKeyEmptyFileFails(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "secret-key"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := loadOrCreateKey(dir); err == nil {
+		t.Fatal("expected an error for an empty pre-existing key file")
+	}
+}

--- a/apps/openneko/internal/dockerproxy/proxy.go
+++ b/apps/openneko/internal/dockerproxy/proxy.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"sort"
 	"strings"
 
 	"golang.org/x/term"
@@ -27,7 +28,10 @@ const EnvMarker = "OPENNEKO_PROXIED"
 
 // FindRunningWorker returns the name of a running openneko-{prod,dev,demo}-
 // worker-1 container, or "" if none / docker unreachable / we are already
-// inside a proxied invocation.
+// inside a proxied invocation. With prod and demo both up, `docker ps`
+// order used to pick an arbitrary stack — plugin installs then landed in
+// the wrong install's config volume — so an ambiguous match now refuses
+// (falls back to the local implementation) and says why.
 func FindRunningWorker() string {
 	if os.Getenv(EnvMarker) == "1" {
 		return ""
@@ -40,13 +44,35 @@ func FindRunningWorker() string {
 	if err != nil {
 		return ""
 	}
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+	name, ambiguous := selectWorker(strings.Split(strings.TrimSpace(string(out)), "\n"))
+	if len(ambiguous) > 0 {
+		fmt.Fprintf(os.Stderr,
+			"[openneko] multiple running stacks found (%s); refusing to guess — stop the stack you don't mean, or pass --local\n",
+			strings.Join(ambiguous, ", "))
+	}
+	return name
+}
+
+// selectWorker picks the single matching worker container from `docker ps`
+// output lines. With more than one match it returns "" plus the sorted
+// candidates so the caller can explain the refusal.
+func selectWorker(lines []string) (string, []string) {
+	var workers []string
+	for _, line := range lines {
 		line = strings.TrimSpace(line)
 		if strings.HasPrefix(line, "openneko-") && strings.HasSuffix(line, "-worker-1") {
-			return line
+			workers = append(workers, line)
 		}
 	}
-	return ""
+	switch len(workers) {
+	case 0:
+		return "", nil
+	case 1:
+		return workers[0], nil
+	default:
+		sort.Strings(workers)
+		return "", workers
+	}
 }
 
 // ProxyToWorker re-executes `openneko <args>` inside the named container,

--- a/apps/openneko/internal/dockerproxy/proxy_test.go
+++ b/apps/openneko/internal/dockerproxy/proxy_test.go
@@ -93,3 +93,28 @@ func contains(s []string, v string) bool {
 	}
 	return false
 }
+
+// With prod and demo both running, `docker ps` order used to decide which
+// stack a plugin install landed in. Ambiguity must refuse, not guess.
+func TestSelectWorker(t *testing.T) {
+	if name, amb := selectWorker([]string{""}); name != "" || amb != nil {
+		t.Fatalf("empty input: got %q %v", name, amb)
+	}
+	if name, amb := selectWorker([]string{
+		"openneko-demo-web-1",
+		"openneko-demo-worker-1",
+		"unrelated-worker-1",
+	}); name != "openneko-demo-worker-1" || amb != nil {
+		t.Fatalf("single match: got %q %v", name, amb)
+	}
+	name, amb := selectWorker([]string{
+		"openneko-prod-worker-1",
+		"openneko-demo-worker-1",
+	})
+	if name != "" {
+		t.Fatalf("ambiguous match must refuse, got %q", name)
+	}
+	if len(amb) != 2 || amb[0] != "openneko-demo-worker-1" {
+		t.Fatalf("ambiguous candidates = %v", amb)
+	}
+}

--- a/apps/openneko/internal/setup/client.go
+++ b/apps/openneko/internal/setup/client.go
@@ -115,7 +115,11 @@ type ProviderDraft struct {
 // ----- readiness -----
 
 // Ready does one short-timeout probe (GET change-password is config-file
-// backed, so it answers as soon as the web process is serving).
+// backed, so it answers as soon as the web process is serving). 401/403
+// count as ready too: an SSO-gated install answers exactly that for an
+// unauthenticated CLI, and treating it as "down" made re-running setup
+// burn the whole WaitReady budget against a perfectly healthy stack and
+// then fail preflight with a misleading port-in-use error.
 func (c *Client) Ready(ctx context.Context) bool {
 	probe := &http.Client{Timeout: 2 * time.Second}
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, c.BaseURL+"/api/admin/change-password", nil)
@@ -125,7 +129,12 @@ func (c *Client) Ready(ctx context.Context) bool {
 	}
 	defer resp.Body.Close()
 	_, _ = io.Copy(io.Discard, resp.Body)
-	return resp.StatusCode == http.StatusOK
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusUnauthorized, http.StatusForbidden:
+		return true
+	default:
+		return false
+	}
 }
 
 // WaitReady polls Ready until the web app answers. Bring-up has already waited

--- a/apps/openneko/internal/setup/client_test.go
+++ b/apps/openneko/internal/setup/client_test.go
@@ -80,3 +80,28 @@ func TestClientReady(t *testing.T) {
 		t.Fatal("expected Ready=false for a down app")
 	}
 }
+
+// An SSO-gated install answers 401/403 to an unauthenticated CLI probe.
+// That is a SERVING stack: treating it as down made re-running setup burn
+// the whole WaitReady budget and then fail with a misleading port error.
+func TestReadyCountsAuthGatedResponses(t *testing.T) {
+	for _, tc := range []struct {
+		status int
+		ready  bool
+	}{
+		{http.StatusOK, true},
+		{http.StatusUnauthorized, true},
+		{http.StatusForbidden, true},
+		{http.StatusBadGateway, false},
+		{http.StatusNotFound, false},
+	} {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(tc.status)
+		}))
+		got := NewClient(srv.URL).Ready(context.Background())
+		srv.Close()
+		if got != tc.ready {
+			t.Errorf("status %d: Ready = %v, want %v", tc.status, got, tc.ready)
+		}
+	}
+}

--- a/apps/openneko/internal/setup/wizard.go
+++ b/apps/openneko/internal/setup/wizard.go
@@ -92,7 +92,9 @@ func runInteractive(ctx context.Context, c *Client, out io.Writer, cfg Config) (
 		return o, nil
 	}
 	if err != nil {
-		return Outcome{}, err
+		// A rotation that succeeded before the failing step must still reach
+		// the caller — the host config needs the new password either way.
+		return Outcome{PasswordSet: pw}, err
 	}
 	return Outcome{Configured: true, PasswordSet: pw}, nil
 }
@@ -354,40 +356,40 @@ func runHeadless(ctx context.Context, c *Client, cfg Config) (Outcome, error) {
 	passwordSet := ""
 	changed, err := c.PasswordChanged(ctx)
 	if err != nil {
-		return Outcome{}, err
+		return Outcome{PasswordSet: passwordSet}, err
 	}
 	if !changed {
 		if cfg.AdminPassword == "" {
-			return Outcome{}, errors.New("setup: --admin-password is required (database still has the bootstrap default)")
+			return Outcome{PasswordSet: passwordSet}, errors.New("setup: --admin-password is required (database still has the bootstrap default)")
 		}
 		if err := validatePassword(cfg.AdminPassword); err != nil {
-			return Outcome{}, err
+			return Outcome{PasswordSet: passwordSet}, err
 		}
 		if err := c.ChangePassword(ctx, cfg.AdminPassword); err != nil {
-			return Outcome{}, err
+			return Outcome{PasswordSet: passwordSet}, err
 		}
 		passwordSet = cfg.AdminPassword
 	}
 
 	ds, err := c.GetDataSource(ctx)
 	if err != nil {
-		return Outcome{}, err
+		return Outcome{PasswordSet: passwordSet}, err
 	}
 	gql, mcp := DeriveEndpoints(defaultDataURL(cfg, ds))
 	if _, err := c.TestDataSource(ctx, gql, mcp); err != nil {
-		return Outcome{}, fmt.Errorf("data source test failed: %w", err)
+		return Outcome{PasswordSet: passwordSet}, fmt.Errorf("data source test failed: %w", err)
 	}
 	if err := c.SaveDataSource(ctx, gql, mcp, "primary"); err != nil {
-		return Outcome{}, err
+		return Outcome{PasswordSet: passwordSet}, err
 	}
 
 	agent, err := c.GetAgent(ctx)
 	if err != nil {
-		return Outcome{}, err
+		return Outcome{PasswordSet: passwordSet}, err
 	}
 	prov, err := c.GetProvider(ctx)
 	if err != nil {
-		return Outcome{}, err
+		return Outcome{PasswordSet: passwordSet}, err
 	}
 	backend := cfg.Backend
 	if backend == "" {
@@ -398,10 +400,10 @@ func runHeadless(ctx context.Context, c *Client, cfg Config) (Outcome, error) {
 		provider = "anthropic"
 	}
 	if provider == "" {
-		return Outcome{}, errors.New("setup: --provider is required")
+		return Outcome{PasswordSet: passwordSet}, errors.New("setup: --provider is required")
 	}
 	if cfg.ProviderKey == "" {
-		return Outcome{}, errors.New("setup: --provider-key is required")
+		return Outcome{PasswordSet: passwordSet}, errors.New("setup: --provider-key is required")
 	}
 	model := cfg.Model
 	if model == "" {
@@ -420,10 +422,10 @@ func runHeadless(ctx context.Context, c *Client, cfg Config) (Outcome, error) {
 		return Outcome{}, fmt.Errorf("provider key test failed: %w", err)
 	}
 	if err := c.SaveAgent(ctx, backend, capJobs); err != nil {
-		return Outcome{}, err
+		return Outcome{PasswordSet: passwordSet}, err
 	}
 	if err := c.SaveProvider(ctx, draft); err != nil {
-		return Outcome{}, err
+		return Outcome{PasswordSet: passwordSet}, err
 	}
 
 	if !cfg.NoResearch && cfg.ResearchProvider != "" && cfg.ResearchKey != "" {
@@ -437,14 +439,14 @@ func runHeadless(ctx context.Context, c *Client, cfg Config) (Outcome, error) {
 			return Outcome{}, fmt.Errorf("research key test failed: %w", err)
 		}
 		if err := c.SaveProvider(ctx, rdraft); err != nil {
-			return Outcome{}, err
+			return Outcome{PasswordSet: passwordSet}, err
 		}
 	} else if err := c.SaveProvider(ctx, disabledResearch()); err != nil {
-		return Outcome{}, err
+		return Outcome{PasswordSet: passwordSet}, err
 	}
 
 	if err := c.Finish(ctx); err != nil {
-		return Outcome{}, err
+		return Outcome{PasswordSet: passwordSet}, err
 	}
 	return Outcome{Configured: true, PasswordSet: passwordSet}, nil
 }

--- a/apps/openneko/internal/setup/wizard_test.go
+++ b/apps/openneko/internal/setup/wizard_test.go
@@ -219,3 +219,41 @@ func TestPureHelpers(t *testing.T) {
 		t.Errorf("filterOut = %+v", got)
 	}
 }
+
+// A rotation that succeeded before a later step failed must still surface
+// through the Outcome — the CLI persists it to the host config either way.
+// Dropping it left the remote role rotated while the host kept the stale
+// bootstrap password: a lockout on the next host-side connection.
+func TestHeadlessErrorAfterPasswordRotationCarriesPasswordSet(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		enc := json.NewEncoder(w)
+		switch r.Method + " " + r.URL.Path {
+		case "GET /api/admin/change-password":
+			_ = enc.Encode(map[string]bool{"changed": false})
+		case "POST /api/admin/change-password":
+			_ = enc.Encode(map[string]bool{"ok": true})
+		case "GET /api/settings/data-source":
+			_ = enc.Encode(map[string]any{"source": "unset"})
+		case "POST /api/settings/data-source/test":
+			// The step after the rotation fails.
+			w.WriteHeader(http.StatusBadGateway)
+			_ = enc.Encode(map[string]string{"error": "graphjin still starting"})
+		default:
+			_ = enc.Encode(map[string]any{"ok": true})
+		}
+	}))
+	defer srv.Close()
+
+	out := &bytes.Buffer{}
+	cfg := Config{
+		Mode: "demo", BaseURL: srv.URL, Headless: true,
+		AdminPassword: "supersecret", Provider: "anthropic", ProviderKey: "sk-test", NoResearch: true,
+	}
+	outcome, err := Run(context.Background(), NewClient(srv.URL), out, cfg)
+	if err == nil {
+		t.Fatal("expected the data-source test failure to surface as an error")
+	}
+	if outcome.PasswordSet != "supersecret" {
+		t.Errorf("PasswordSet = %q, want supersecret carried through the error return", outcome.PasswordSet)
+	}
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,7 @@
     "@neko/interaction": "workspace:*",
     "@neko/llm": "workspace:*",
     "@neko/records": "workspace:*",
+    "@neko/secret-crypt": "workspace:*",
     "@neko/telemetry": "workspace:*",
     "clsx": "^2.1.1",
     "lucide-react": "^1.14.0",

--- a/apps/web/src/app/api/admin/change-password/route.ts
+++ b/apps/web/src/app/api/admin/change-password/route.ts
@@ -58,6 +58,14 @@ async function rotateDatabaseRoles(password: string): Promise<void> {
   const records = await getWebRecordsPool().connect();
   const recordsRole = roleIdentifier(buildRecordsPoolConfig().user, "records");
   try {
+    // Session-level advisory lock held across BOTH the role rotation and
+    // the config-file write below (released in the finally). Two
+    // concurrent rotations used to interleave: ALTER order A,B but
+    // config-write order B,A left the file holding one password and the
+    // role the other — a full-stack lockout recoverable only out-of-band.
+    await metadata.query(
+      "select pg_advisory_lock(hashtext('openneko.password-rotation'))",
+    );
     await metadata.query("begin");
     await records.query("begin");
     await metadata.query(`alter role neko with password '${password}'`);
@@ -68,6 +76,12 @@ async function rotateDatabaseRoles(password: string): Promise<void> {
     // connection.
     await records.query("commit");
     await metadata.query("commit");
+    // Persist while still inside the critical section, so the file always
+    // records the password of the LAST committed rotation.
+    writeLocalConfig({
+      pg: { password },
+      recordsPg: { password },
+    });
   } catch (error) {
     await Promise.allSettled([
       records.query("rollback"),
@@ -75,6 +89,9 @@ async function rotateDatabaseRoles(password: string): Promise<void> {
     ]);
     throw error;
   } finally {
+    await metadata
+      .query("select pg_advisory_unlock(hashtext('openneko.password-rotation'))")
+      .catch(() => {});
     records.release();
     metadata.release();
   }
@@ -107,37 +124,42 @@ export async function POST(request: NextRequest) {
     }
 
     // ALTER ROLE takes a literal; we vetted the string above because Postgres
-    // does not accept a bind parameter in this DDL position.
+    // does not accept a bind parameter in this DDL position. The rotation
+    // also persists the config file inside its critical section.
     await rotateDatabaseRoles(password);
-
-    writeLocalConfig({
-      pg: { password },
-      recordsPg: { password },
-    });
 
     // Drain both pools so subsequent queries use the new password.
     await reconnectWebRecordsRuntime();
     await reconnectPool();
 
     // Tell the worker process to restart so its pg-boss singleton
-    // (created at boot with old creds) gets rebuilt. Best-effort —
-    // the worker may not be running yet during /setup, and that's fine.
+    // (created at boot with old creds) gets rebuilt. The worker may
+    // legitimately not be running yet during /setup — but a SILENT drop
+    // here left pg-boss on stale credentials with jobs quietly stalled,
+    // so the outcome is reported to the caller and logged.
+    let workerNotified = false;
     try {
       const workerAdminUrl = (process.env.WORKER_ADMIN_URL ?? "http://127.0.0.1:4100")
         .replace(/\/+$/, "");
-      await fetch(`${workerAdminUrl}/admin/reconnect`, {
+      const res = await fetch(`${workerAdminUrl}/admin/reconnect`, {
         method: "POST",
-        signal: AbortSignal.timeout(2000),
+        signal: AbortSignal.timeout(5000),
       });
+      workerNotified = res.ok;
     } catch {
-      // worker down / not yet listening / network blip — non-fatal
+      workerNotified = false;
+    }
+    if (!workerNotified) {
+      console.warn(
+        "[change-password] worker reconnect notification failed; its job runner keeps the old credentials until it restarts",
+      );
     }
 
     if (process.env.OPENNEKO_RESTART_WEB_ON_PASSWORD_CHANGE === "1") {
       setTimeout(() => process.exit(0), 250).unref();
     }
 
-    return NextResponse.json({ ok: true });
+    return NextResponse.json({ ok: true, workerNotified });
   } catch (e) {
     const message = e instanceof Error ? e.message : String(e);
     return NextResponse.json({ error: message }, { status: 500 });

--- a/apps/web/src/app/api/admin/users/route.ts
+++ b/apps/web/src/app/api/admin/users/route.ts
@@ -68,14 +68,29 @@ export async function POST(request: NextRequest) {
   }
 
   const id = `usr_${randomBytes(9).toString("base64url")}`;
-  await db().insert(app_user).values({
-    id,
-    sub: null,
-    email,
-    name,
-    org_id: orgId,
-    role,
-  });
+  try {
+    await db().insert(app_user).values({
+      id,
+      sub: null,
+      email,
+      name,
+      org_id: orgId,
+      role,
+    });
+  } catch (e) {
+    // app_user_org_email_unique: a concurrent provision (double-click,
+    // second admin tab) won the race between our lookup and this insert.
+    const code =
+      (e as { code?: string })?.code ??
+      ((e as { cause?: { code?: string } })?.cause?.code);
+    if (code === "23505") {
+      return NextResponse.json(
+        { error: `a user with email ${email} already exists` },
+        { status: 409 },
+      );
+    }
+    throw e;
+  }
   return NextResponse.json(
     { user: { id, email, name, role } },
     { status: 201 },

--- a/apps/web/src/app/api/onboarding/submit/route.ts
+++ b/apps/web/src/app/api/onboarding/submit/route.ts
@@ -1,12 +1,16 @@
 import { NextRequest, NextResponse } from "next/server";
 import {
+  and,
   db,
   eq,
+  inArray,
   onboarding_wizard,
   organization,
   processing_job,
+  sql,
 } from "@neko/db";
 import { enqueue, QUEUE } from "@neko/db/jobs";
+import { isDenied, requireAdminActor } from "@/lib/admin-auth";
 import { getOrgId } from "@/lib/db";
 import {
   AGENT_RUNTIME_UNAVAILABLE_CODE,
@@ -16,6 +20,12 @@ import {
 import { hasPrimaryProviderSetup } from "@/lib/provider-settings";
 
 export async function POST(request: NextRequest) {
+  // Same gate as /settings/finish: onboarding writes org-level state and
+  // kicks off a profile build — not something an unauthenticated visitor
+  // may do once SSO is live.
+  const allowed = await requireAdminActor();
+  if (isDenied(allowed)) return allowed;
+
   const body = await request.json();
   const {
     companyName,
@@ -64,32 +74,62 @@ export async function POST(request: NextRequest) {
     throw error;
   }
 
-  await db()
-    .update(organization)
-    .set({ name: trimmedName, updated_at: new Date() })
-    .where(eq(organization.id, orgId));
+  // One transaction for the whole submit: the wizard-row replace was a
+  // delete + insert in separate statements (org_id is the PK — two
+  // concurrent submits hit a duplicate-key 500 or lost the row), and
+  // nothing stopped a second submit from stacking a second profile-build
+  // chain. The advisory lock serializes double-clicks and client retries;
+  // the in-flight check makes the second one a no-op.
+  const outcome = await db().transaction(async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtext(${"openneko.onboarding:" + orgId}))`,
+    );
+    const inflight = await tx
+      .select({ id: processing_job.id })
+      .from(processing_job)
+      .where(
+        and(
+          eq(processing_job.org_id, orgId),
+          eq(processing_job.kind, "business_profile_build"),
+          inArray(processing_job.status, ["queued", "running"]),
+        ),
+      )
+      .limit(1);
+    if (inflight[0]) return { inflightJobId: inflight[0].id };
 
-  await db().delete(onboarding_wizard).where(eq(onboarding_wizard.org_id, orgId));
-  await db().insert(onboarding_wizard).values({
-    org_id: orgId,
-    company_note: companyNote,
-    fiscal_year_start_month: fiscalYearStartMonth,
-    active_seats: activeSeats,
-    priorities,
-    step: "submitting",
-    submitted_at: new Date(),
+    await tx
+      .update(organization)
+      .set({ name: trimmedName, updated_at: new Date() })
+      .where(eq(organization.id, orgId));
+
+    await tx.delete(onboarding_wizard).where(eq(onboarding_wizard.org_id, orgId));
+    await tx.insert(onboarding_wizard).values({
+      org_id: orgId,
+      company_note: companyNote,
+      fiscal_year_start_month: fiscalYearStartMonth,
+      active_seats: activeSeats,
+      priorities,
+      step: "submitting",
+      submitted_at: new Date(),
+    });
+
+    const inserted = await tx
+      .insert(processing_job)
+      .values({
+        org_id: orgId,
+        kind: "business_profile_build",
+        status: "queued",
+        trigger: "wizard_submit",
+      })
+      .returning({ id: processing_job.id });
+    return { jobId: inserted[0]?.id };
   });
 
-  const inserted = await db()
-    .insert(processing_job)
-    .values({
-      org_id: orgId,
-      kind: "business_profile_build",
-      status: "queued",
-      trigger: "wizard_submit",
-    })
-    .returning({ id: processing_job.id });
-  const jobId = inserted[0]?.id;
+  if ("inflightJobId" in outcome) {
+    // A concurrent submit already queued the build; report it as ours.
+    return NextResponse.json({ ok: true, jobId: outcome.inflightJobId });
+  }
+  const jobId = outcome.jobId;
   if (!jobId) {
     return NextResponse.json(
       { error: "failed to record job" },

--- a/apps/web/src/lib/auth-gate-marker.ts
+++ b/apps/web/src/lib/auth-gate-marker.ts
@@ -1,0 +1,84 @@
+/**
+ * Durable memory of the auth gate, shared by the proxy and lib/auth.
+ *
+ * Both ask the worker whether an SSO plugin is installed, and both used to
+ * treat "worker unreachable" as "no plugin" — which meant every worker boot
+ * or restart window silently dropped the sign-in gate and admitted
+ * unauthenticated requests as the solo operator. The fix: whenever a live
+ * answer arrives, persist it next to the deployment config. When the worker
+ * is unreachable, the last persisted answer decides — an install that has
+ * ever seen SSO live fails CLOSED (sessions keep verifying locally; new
+ * sign-ins wait for the worker), while an install that never configured SSO
+ * keeps the solo-operator behavior.
+ *
+ * The two callers also kept independent 1s caches, only one of which was
+ * invalidated when SSO settings changed; they both register their reset
+ * here so one invalidation clears everything.
+ */
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type PersistedAuthProvider = {
+  pluginName: string;
+  [key: string]: unknown;
+};
+
+export type AuthGateMarker = { provider: PersistedAuthProvider | null };
+
+function markerPath(): string {
+  const xdg = process.env.XDG_CONFIG_HOME?.trim();
+  const base = xdg && xdg.length > 0 ? xdg : join(process.env.HOME || homedir(), ".config");
+  return join(base, "openneko", "auth-gate.json");
+}
+
+let cachedMarker: AuthGateMarker | null | undefined;
+
+/** Last persisted gate answer; null when no answer was ever persisted. */
+export function readAuthGateMarker(): AuthGateMarker | null {
+  if (cachedMarker !== undefined) return cachedMarker;
+  try {
+    const parsed = JSON.parse(readFileSync(markerPath(), "utf8")) as AuthGateMarker;
+    cachedMarker =
+      parsed && typeof parsed === "object" && "provider" in parsed ? parsed : null;
+  } catch {
+    cachedMarker = null;
+  }
+  return cachedMarker;
+}
+
+/**
+ * Persist a live gate answer. Best-effort: a read-only config volume must
+ * never break the request path — the marker then just stays stale.
+ */
+export function writeAuthGateMarker(marker: AuthGateMarker): void {
+  const previous = readAuthGateMarker();
+  const unchanged =
+    previous !== null &&
+    (previous.provider?.pluginName ?? null) === (marker.provider?.pluginName ?? null);
+  cachedMarker = marker;
+  if (unchanged) return;
+  try {
+    const path = markerPath();
+    mkdirSync(join(path, ".."), { recursive: true });
+    const tmp = `${path}.tmp-${process.pid}`;
+    writeFileSync(tmp, JSON.stringify(marker), { encoding: "utf8", mode: 0o600 });
+    renameSync(tmp, path);
+  } catch {
+    // Best-effort by design.
+  }
+}
+
+const cacheResets: Array<() => void> = [];
+
+/** Callers with an in-memory gate cache register its reset here. */
+export function registerAuthGateCacheReset(reset: () => void): void {
+  cacheResets.push(reset);
+}
+
+/** Clear every registered gate cache plus the marker's in-process copy. */
+export function resetAuthGateCaches(): void {
+  cachedMarker = undefined;
+  for (const reset of cacheResets) reset();
+}

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -23,6 +23,14 @@
  */
 
 import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { deriveSigningSecret } from "@neko/secret-crypt";
+import {
+  readAuthGateMarker,
+  registerAuthGateCacheReset,
+  resetAuthGateCaches,
+  writeAuthGateMarker,
+  type PersistedAuthProvider,
+} from "./auth-gate-marker";
 import { cookies } from "next/headers";
 import {
   and,
@@ -100,17 +108,21 @@ function workerAdminBase(): string {
 }
 
 function sessionSecret(): string {
-  // OPENNEKO_SESSION_SECRET is the HMAC key for session cookies. We
-  // refuse to start an SSO flow without one — silently falling back to
-  // a process-random secret would invalidate sessions on every restart
-  // and (worse) let a misconfigured deployment look like it's working.
+  // OPENNEKO_SESSION_SECRET is the HMAC key for session cookies. When it
+  // is not set (no compose file sets it), derive a stable per-install
+  // secret from the deployment secret-key: consistent across restarts and
+  // across web instances sharing the config volume — a process-random
+  // fallback would invalidate sessions on every restart. An explicitly
+  // set but too-short value is still a hard error: that is a
+  // misconfiguration, not an absence.
   const secret = process.env.OPENNEKO_SESSION_SECRET;
-  if (!secret || secret.length < 32) {
+  if (secret !== undefined && secret.length < 32) {
     throw new Error(
-      "OPENNEKO_SESSION_SECRET must be set to a value at least 32 characters long for SSO sessions",
+      "OPENNEKO_SESSION_SECRET must be at least 32 characters long for SSO sessions",
     );
   }
-  return secret;
+  if (secret) return secret;
+  return deriveSigningSecret("session-cookie:v1").toString("base64");
 }
 
 /**
@@ -141,30 +153,57 @@ export async function getAuthGateStatus(): Promise<AuthGateStatus> {
       signal: AbortSignal.timeout(2000),
     });
     if (!res.ok) {
-      providerCache = { value: NO_GATE, at: now };
-      return NO_GATE;
+      providerCache = { value: gateWhileWorkerUnavailable(), at: now };
+      return providerCache.value;
     }
     const body = (await res.json()) as AuthGateStatus;
     providerCache = {
       value: { provider: body.provider ?? null, pending: body.pending ?? null },
       at: now,
     };
+    writeAuthGateMarker({
+      provider: (body.provider as PersistedAuthProvider | null) ?? null,
+    });
     return providerCache.value;
   } catch {
-    // Worker unreachable — treat as "no provider". The dashboard
-    // gracefully degrades to local auth in that case.
-    providerCache = { value: NO_GATE, at: now };
-    return NO_GATE;
+    providerCache = { value: gateWhileWorkerUnavailable(), at: now };
+    return providerCache.value;
   }
+}
+
+/**
+ * Worker unreachable (booting, restarting, or slow): the last persisted
+ * live answer decides. An install where SSO was ever live fails CLOSED —
+ * synthesizing the persisted provider keeps requireAdminActor denying
+ * session-less requests while valid session cookies verify locally. An
+ * install that never configured SSO keeps the solo-operator behavior.
+ */
+function gateWhileWorkerUnavailable(): AuthGateStatus {
+  const marker = readAuthGateMarker();
+  if (marker?.provider) {
+    return {
+      provider: marker.provider as unknown as AuthProviderInfo,
+      pending: null,
+    };
+  }
+  return NO_GATE;
 }
 
 export async function getAuthProvider(): Promise<AuthProviderInfo | null> {
   return (await getAuthGateStatus()).provider;
 }
 
-/** Test seam — clears the provider cache between tests. */
-export function _resetAuthProviderCache() {
+registerAuthGateCacheReset(() => {
   providerCache = null;
+});
+
+/**
+ * Clears every auth-gate cache (this module's, the proxy's, and the
+ * persisted-marker copy) — SSO settings changes must be visible on the
+ * very next request in all of them.
+ */
+export function _resetAuthProviderCache() {
+  resetAuthGateCaches();
 }
 
 /**
@@ -349,98 +388,94 @@ export async function upsertUserFromIdentity(
   const providerInfo = gate.provider ?? gate.pending;
   const provider = providerInfo?.pluginName ?? "oidc";
   const mapped = await resolveGroupRole(orgId, provider, identity.groups ?? []);
-  // Primary lookup: sub. Anything matching wins, regardless of email
-  // changes (people get married, change addresses — sub doesn't).
-  const bySub = await db()
-    .select({
-      id: app_user.id,
-      email: app_user.email,
-      name: app_user.name,
-      role: app_user.role,
-    })
-    .from(app_user)
-    .where(and(eq(app_user.org_id, orgId), eq(app_user.sub, identity.sub)))
-    .limit(1);
-  if (bySub[0]) {
-    // A configured group mapping is authoritative on every sign-in; when
-    // none is configured, leave the existing role untouched.
-    const role = mapped.role ?? bySub[0].role;
-    await db()
-      .update(app_user)
-      .set({
-        email: identity.email,
-        name: identity.name ?? null,
-        role,
-        last_login_at: new Date(),
-        updated_at: new Date(),
-      })
-      .where(eq(app_user.id, bySub[0].id));
-    await syncSsoGroups({ orgId, userId: bySub[0].id, identity });
-    await provisionPersona({ orgId, userId: bySub[0].id, identity, mapped });
-    return {
-      id: bySub[0].id,
-      email: identity.email,
-      name: identity.name ?? null,
-    };
-  }
-  // Migration lookup: same email, no sub yet. Attach the sub.
-  const byEmail = await db()
-    .select({
-      id: app_user.id,
-      email: app_user.email,
-      name: app_user.name,
-      sub: app_user.sub,
-      role: app_user.role,
-    })
-    .from(app_user)
-    .where(and(eq(app_user.org_id, orgId), eq(app_user.email, identity.email)))
-    .limit(1);
-  if (byEmail[0] && !byEmail[0].sub) {
-    const role = mapped.role ?? byEmail[0].role;
-    await db()
-      .update(app_user)
-      .set({
-        sub: identity.sub,
-        name: identity.name ?? byEmail[0].name ?? null,
-        role,
-        last_login_at: new Date(),
-        updated_at: new Date(),
-      })
-      .where(eq(app_user.id, byEmail[0].id));
-    await syncSsoGroups({ orgId, userId: byEmail[0].id, identity });
-    await provisionPersona({ orgId, userId: byEmail[0].id, identity, mapped });
-    return {
-      id: byEmail[0].id,
-      email: identity.email,
-      name: identity.name ?? byEmail[0].name ?? null,
-    };
-  }
-  if (byEmail[0]) {
-    // Same email, *different* sub already on file. Refuse rather than
-    // silently take over — the operator should resolve this manually
-    // (likely two IdP accounts pointing at the same mailbox).
-    throw new Error(
-      `app_user.email ${identity.email} is already bound to a different SSO subject; remove the row or update sub manually before re-attempting`,
+  // Serialize sign-ins per org. Two concurrent first sign-ins (two tabs,
+  // an IdP callback retry) could each miss both lookups AND both pass the
+  // has-admin check — minting duplicate identities and duplicate admins,
+  // after which later sign-ins threw permanently. Under the lock the
+  // second caller simply finds the first's row; the unique indexes from
+  // migration 0061 are the loud backstop should the lock ever be bypassed.
+  const resolved = await db().transaction(async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtext(${"openneko.app_user:" + orgId}))`,
     );
-  }
-  if (providerInfo?.provisioning === "manual") {
-    // Self-asserted identity (e.g. magic link) with no pre-provisioned
-    // user. The begin route already drops unknown emails silently; this
-    // is the defense-in-depth backstop.
-    throw new Error(
-      `no user is provisioned for ${identity.email} — ask an administrator to add you`,
-    );
-  }
-  // Brand new user. Bootstrap the first active admin so installing an SSO
-  // plugin cannot leave an org with no administrator.
-  const newId = `usr_${randomBytes(9).toString("base64url")}`;
-  const fallbackRole = heuristicRoleForGroups(identity.groups ?? []);
-  const role = (await orgHasActiveAdmin(orgId))
-    ? (mapped.role ?? fallbackRole)
-    : "admin";
-  await db()
-    .insert(app_user)
-    .values({
+    // Primary lookup: sub. Anything matching wins, regardless of email
+    // changes (people get married, change addresses — sub doesn't).
+    const bySub = await tx
+      .select({
+        id: app_user.id,
+        email: app_user.email,
+        name: app_user.name,
+        role: app_user.role,
+      })
+      .from(app_user)
+      .where(and(eq(app_user.org_id, orgId), eq(app_user.sub, identity.sub)))
+      .limit(1);
+    if (bySub[0]) {
+      // A configured group mapping is authoritative on every sign-in; when
+      // none is configured, leave the existing role untouched.
+      const role = mapped.role ?? bySub[0].role;
+      await tx
+        .update(app_user)
+        .set({
+          email: identity.email,
+          name: identity.name ?? null,
+          role,
+          last_login_at: new Date(),
+          updated_at: new Date(),
+        })
+        .where(eq(app_user.id, bySub[0].id));
+      return { id: bySub[0].id, name: identity.name ?? null };
+    }
+    // Migration lookup: same email, no sub yet. Attach the sub.
+    const byEmail = await tx
+      .select({
+        id: app_user.id,
+        email: app_user.email,
+        name: app_user.name,
+        sub: app_user.sub,
+        role: app_user.role,
+      })
+      .from(app_user)
+      .where(and(eq(app_user.org_id, orgId), eq(app_user.email, identity.email)))
+      .limit(1);
+    if (byEmail[0] && !byEmail[0].sub) {
+      const role = mapped.role ?? byEmail[0].role;
+      await tx
+        .update(app_user)
+        .set({
+          sub: identity.sub,
+          name: identity.name ?? byEmail[0].name ?? null,
+          role,
+          last_login_at: new Date(),
+          updated_at: new Date(),
+        })
+        .where(eq(app_user.id, byEmail[0].id));
+      return { id: byEmail[0].id, name: identity.name ?? byEmail[0].name ?? null };
+    }
+    if (byEmail[0]) {
+      // Same email, *different* sub already on file. Refuse rather than
+      // silently take over — the operator should resolve this manually
+      // (likely two IdP accounts pointing at the same mailbox).
+      throw new Error(
+        `app_user.email ${identity.email} is already bound to a different SSO subject; remove the row or update sub manually before re-attempting`,
+      );
+    }
+    if (providerInfo?.provisioning === "manual") {
+      // Self-asserted identity (e.g. magic link) with no pre-provisioned
+      // user. The begin route already drops unknown emails silently; this
+      // is the defense-in-depth backstop.
+      throw new Error(
+        `no user is provisioned for ${identity.email} — ask an administrator to add you`,
+      );
+    }
+    // Brand new user. Bootstrap the first active admin so installing an SSO
+    // plugin cannot leave an org with no administrator.
+    const newId = `usr_${randomBytes(9).toString("base64url")}`;
+    const fallbackRole = heuristicRoleForGroups(identity.groups ?? []);
+    const role = (await orgHasActiveAdmin(orgId, tx))
+      ? (mapped.role ?? fallbackRole)
+      : "admin";
+    await tx.insert(app_user).values({
       id: newId,
       sub: identity.sub,
       email: identity.email,
@@ -449,17 +484,22 @@ export async function upsertUserFromIdentity(
       role,
       last_login_at: new Date(),
     });
-  await syncSsoGroups({ orgId, userId: newId, identity });
-  await provisionPersona({ orgId, userId: newId, identity, mapped });
+    return { id: newId, name: identity.name ?? null };
+  });
+  await syncSsoGroups({ orgId, userId: resolved.id, identity });
+  await provisionPersona({ orgId, userId: resolved.id, identity, mapped });
   return {
-    id: newId,
+    id: resolved.id,
     email: identity.email,
-    name: identity.name ?? null,
+    name: resolved.name,
   };
 }
 
-async function orgHasActiveAdmin(orgId: string): Promise<boolean> {
-  const [admin] = await db()
+async function orgHasActiveAdmin(
+  orgId: string,
+  runner: Pick<ReturnType<typeof db>, "select"> = db(),
+): Promise<boolean> {
+  const [admin] = await runner
     .select({ id: app_user.id })
     .from(app_user)
     .where(

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -39,6 +39,13 @@ import { NextResponse, type NextRequest } from "next/server";
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { get as httpGet } from "node:http";
 import { get as httpsGet } from "node:https";
+import { deriveSigningSecret } from "@neko/secret-crypt";
+import {
+  readAuthGateMarker,
+  registerAuthGateCacheReset,
+  resetAuthGateCaches,
+  writeAuthGateMarker,
+} from "./lib/auth-gate-marker";
 
 const SESSION_COOKIE_NAME = "openneko_session";
 const PROVIDER_CACHE_TTL_MS = 1_000;
@@ -112,10 +119,12 @@ function workerAdminBase(): string {
  * second to keep proxy overhead negligible under load while still
  * picking up `openneko install` within a second of the manifest write.
  *
- * Fails OPEN (treats as "no plugin") when the worker is unreachable —
- * a dev environment with no worker running shouldn't be locked out.
- * If an operator has actually configured SSO and their worker is down,
- * action execution is already broken and that's where they'll notice.
+ * When the worker is unreachable, the persisted auth-gate marker decides:
+ * an install where SSO was ever live fails CLOSED (valid session cookies
+ * still verify locally below; everything else goes to /signin), because
+ * "worker restarting" must not drop the gate. An install that never
+ * configured SSO keeps failing open — a dev environment with no worker
+ * running shouldn't be locked out.
  */
 export async function isAuthPluginInstalled(): Promise<boolean> {
   const now = Date.now();
@@ -127,22 +136,31 @@ export async function isAuthPluginInstalled(): Promise<boolean> {
       `${workerAdminBase()}/admin/auth/status`,
     );
     if (!res.ok) {
-      providerCache = { installed: false, at: now };
-      return false;
+      providerCache = { installed: installedWhileWorkerUnavailable(), at: now };
+      return providerCache.installed;
     }
     const body = (await res.json()) as { provider: { pluginName: string } | null };
     const installed = body.provider != null;
     providerCache = { installed, at: now };
+    writeAuthGateMarker({ provider: body.provider ?? null });
     return installed;
   } catch {
-    providerCache = { installed: false, at: now };
-    return false;
+    providerCache = { installed: installedWhileWorkerUnavailable(), at: now };
+    return providerCache.installed;
   }
 }
 
-/** Test seam — clears the provider cache between tests. */
-export function _resetProviderCache(): void {
+function installedWhileWorkerUnavailable(): boolean {
+  return readAuthGateMarker()?.provider != null;
+}
+
+registerAuthGateCacheReset(() => {
   providerCache = null;
+});
+
+/** Test seam — clears this cache, lib/auth's, and the marker copy. */
+export function _resetProviderCache(): void {
+  resetAuthGateCaches();
 }
 
 /**
@@ -153,8 +171,19 @@ export function _resetProviderCache(): void {
  */
 export function verifySessionCookie(value: string | undefined): boolean {
   if (!value) return false;
-  const secret = process.env.OPENNEKO_SESSION_SECRET;
-  if (!secret || secret.length < 32) return false;
+  // Same resolution as lib/auth's sessionSecret(): explicit env wins;
+  // otherwise a stable secret derived from the deployment secret-key.
+  // (This copy still never throws — the proxy treats any failure as "no
+  // valid session".)
+  let secret = process.env.OPENNEKO_SESSION_SECRET;
+  if (!secret) {
+    try {
+      secret = deriveSigningSecret("session-cookie:v1").toString("base64");
+    } catch {
+      return false;
+    }
+  }
+  if (secret.length < 32) return false;
   const parts = value.split(".");
   if (parts.length !== 3) return false;
   const [userId, expiresAtRaw, mac] = parts;

--- a/apps/web/test/_helpers/setup-config-isolation.ts
+++ b/apps/web/test/_helpers/setup-config-isolation.ts
@@ -1,0 +1,14 @@
+/**
+ * Per-file config-dir isolation for the whole suite.
+ *
+ * Modules persist state next to the deployment config (the secret-key,
+ * the auth-gate marker) via XDG_CONFIG_HOME. Tests must never read the
+ * machine's real ~/.config nor leak such state between test files — a
+ * marker written by one file's live-gate test would flip another file's
+ * requireAdminActor to fail closed.
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.XDG_CONFIG_HOME = mkdtempSync(join(tmpdir(), "neko-test-config-"));

--- a/apps/web/test/api/admin-change-password.test.ts
+++ b/apps/web/test/api/admin-change-password.test.ts
@@ -67,9 +67,13 @@ describe("admin database password rotation", () => {
 
     expect(response.status).toBe(200);
     expect(mocks.metadata.query.mock.calls.map(([sql]) => sql)).toEqual([
+      // The advisory lock brackets rotation AND config persistence, so two
+      // concurrent rotations can't leave the file and the role divergent.
+      "select pg_advisory_lock(hashtext('openneko.password-rotation'))",
       "begin",
       "alter role neko with password 'A-safe-passphrase-2026'",
       "commit",
+      "select pg_advisory_unlock(hashtext('openneko.password-rotation'))",
     ]);
     expect(mocks.records.query.mock.calls.map(([sql]) => sql)).toEqual([
       "begin",

--- a/apps/web/test/api/onboarding-submit.test.ts
+++ b/apps/web/test/api/onboarding-submit.test.ts
@@ -20,6 +20,7 @@ import {
   uniqueOrgId,
 } from "@neko/db/test-helpers";
 import {
+  and,
   db,
   eq,
   onboarding_wizard,
@@ -167,6 +168,12 @@ describeIfDb("/api/onboarding/submit", () => {
         },
       });
     await submit("first");
+    // The first submit's build must have settled before a re-submit takes
+    // effect; an in-flight build suppresses re-submits (tested below).
+    await db()
+      .update(processing_job)
+      .set({ status: "completed" })
+      .where(eq(processing_job.org_id, orgId));
     await submit("second");
 
     const rows = await db()
@@ -175,6 +182,46 @@ describeIfDb("/api/onboarding/submit", () => {
       .where(eq(onboarding_wizard.org_id, orgId));
     expect(rows).toHaveLength(1);
     expect(rows[0].note).toBe("second");
+  });
+
+  it("suppresses a concurrent submit while a build is in flight", async () => {
+    const submit = (note: string) =>
+      callRoute(POST, {
+        method: "POST",
+        body: {
+          companyName: "AdventureWorks Cycles",
+          companyNote: note,
+          fiscalYearStartMonth: 1,
+          activeSeats: ["CEO"],
+          priorities: [],
+        },
+      });
+    const first = await submit("first");
+    const firstBody = first.body as { jobId?: string };
+    // Double-click / client retry while the first build is still queued:
+    // no second chain, no wizard-row churn, same job reported back.
+    const second = await submit("second");
+    const secondBody = second.body as { jobId?: string };
+    expect(second.status).toBe(200);
+    expect(secondBody.jobId).toBe(firstBody.jobId);
+
+    const rows = await db()
+      .select({ note: onboarding_wizard.company_note })
+      .from(onboarding_wizard)
+      .where(eq(onboarding_wizard.org_id, orgId));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].note).toBe("first");
+
+    const jobs = await db()
+      .select({ id: processing_job.id })
+      .from(processing_job)
+      .where(
+        and(
+          eq(processing_job.org_id, orgId),
+          eq(processing_job.kind, "business_profile_build"),
+        ),
+      );
+    expect(jobs).toHaveLength(1);
   });
 
   it("rejects an empty companyName with 400", async () => {

--- a/apps/web/test/auth-gate-failclosed.test.ts
+++ b/apps/web/test/auth-gate-failclosed.test.ts
@@ -1,0 +1,95 @@
+/**
+ * The auth gate must fail CLOSED while the worker is unreachable on any
+ * install where SSO has been seen live — a worker boot or restart window
+ * previously dropped the gate entirely and admitted unauthenticated
+ * requests as the solo-operator admin.
+ */
+
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  _resetProviderCache,
+  _setProviderStatusRequestForTest,
+  isAuthPluginInstalled,
+} from "../src/proxy";
+import {
+  readAuthGateMarker,
+  resetAuthGateCaches,
+  writeAuthGateMarker,
+} from "../src/lib/auth-gate-marker";
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const failing = () => Promise.reject(new Error("connect ECONNREFUSED"));
+
+beforeEach(() => {
+  process.env.XDG_CONFIG_HOME = mkdtempSync(join(tmpdir(), "auth-gate-"));
+  resetAuthGateCaches();
+});
+
+afterEach(() => {
+  delete process.env.XDG_CONFIG_HOME;
+  _setProviderStatusRequestForTest(null);
+  resetAuthGateCaches();
+});
+
+describe("auth gate while the worker is unreachable", () => {
+  it("stays open when SSO was never seen live", async () => {
+    _setProviderStatusRequestForTest(failing);
+    expect(await isAuthPluginInstalled()).toBe(false);
+  });
+
+  it("fails closed once a live answer reported a provider", async () => {
+    _setProviderStatusRequestForTest(() =>
+      Promise.resolve(jsonResponse({ provider: { pluginName: "scalekit" } })),
+    );
+    expect(await isAuthPluginInstalled()).toBe(true);
+    expect(readAuthGateMarker()?.provider?.pluginName).toBe("scalekit");
+
+    // Worker goes away (restart window). The gate must hold.
+    _setProviderStatusRequestForTest(failing);
+    resetAuthGateCaches();
+    expect(await isAuthPluginInstalled()).toBe(true);
+  });
+
+  it("re-opens after a live answer reports SSO removed", async () => {
+    writeAuthGateMarker({ provider: { pluginName: "scalekit" } });
+    _setProviderStatusRequestForTest(() =>
+      Promise.resolve(jsonResponse({ provider: null })),
+    );
+    expect(await isAuthPluginInstalled()).toBe(false);
+
+    _setProviderStatusRequestForTest(failing);
+    resetAuthGateCaches();
+    expect(await isAuthPluginInstalled()).toBe(false);
+  });
+
+  it("marker survives a fresh process (persisted, not just cached)", async () => {
+    writeAuthGateMarker({ provider: { pluginName: "scalekit" } });
+    // Simulate a fresh process: drop every in-memory copy, keep the file.
+    resetAuthGateCaches();
+    _setProviderStatusRequestForTest(failing);
+    expect(await isAuthPluginInstalled()).toBe(true);
+  });
+
+  it("_resetProviderCache clears the proxy cache too (single invalidation)", async () => {
+    _setProviderStatusRequestForTest(() =>
+      Promise.resolve(jsonResponse({ provider: null })),
+    );
+    expect(await isAuthPluginInstalled()).toBe(false);
+
+    // SSO becomes live; without invalidation the 1s cache would lag.
+    _setProviderStatusRequestForTest(() =>
+      Promise.resolve(jsonResponse({ provider: { pluginName: "scalekit" } })),
+    );
+    _resetProviderCache();
+    expect(await isAuthPluginInstalled()).toBe(true);
+  });
+});

--- a/apps/web/test/lib/auth.test.ts
+++ b/apps/web/test/lib/auth.test.ts
@@ -71,16 +71,22 @@ describe("session encode/decode", () => {
     expect(decodeSession("a.b.c.d")).toBeNull();
   });
 
-  it("throws when the session secret is missing or too short", () => {
+  it("derives a stable per-install secret when the env var is unset", () => {
+    // No compose file sets OPENNEKO_SESSION_SECRET; falling back to a
+    // secret derived from the deployment secret-key keeps sessions valid
+    // across restarts instead of throwing on every SSO deployment.
     delete process.env.OPENNEKO_SESSION_SECRET;
-    expect(() =>
-      encodeSession({
-        userId: "u",
-        email: "",
-        name: null,
-        expiresAt: Math.floor(Date.now() / 1000) + 60,
-      }),
-    ).toThrow(/OPENNEKO_SESSION_SECRET/);
+    const session = {
+      userId: "u",
+      email: "",
+      name: null,
+      expiresAt: Math.floor(Date.now() / 1000) + 60,
+    };
+    const encoded = encodeSession(session);
+    expect(decodeSession(encoded)?.userId).toBe("u");
+  });
+
+  it("throws when the session secret is explicitly set but too short", () => {
     process.env.OPENNEKO_SESSION_SECRET = "tooshort";
     expect(() =>
       encodeSession({

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -6,6 +6,7 @@ const here = (rel: string) => fileURLToPath(new URL(rel, import.meta.url));
 export default defineConfig({
   test: {
     include: ["test/**/*.test.ts"],
+    setupFiles: [here("./test/_helpers/setup-config-isolation.ts")],
     // One fork per test file: each file gets a fresh module graph, a fresh
     // @neko/db pool, and a fresh vi.mock registry. Without this, files
     // sharing a fork inherited a singleton pool that earlier files'

--- a/apps/worker/scripts/load-adventureworks.ts
+++ b/apps/worker/scripts/load-adventureworks.ts
@@ -13,8 +13,9 @@
  *      with cwd set to the CSV dir so install.sql's relative \copy paths
  *      resolve
  *
- * Idempotent: if the database already has 50+ tables in the AdventureWorks
- * schemas, exits without doing anything.
+ * Idempotent: a completion marker table (stamped only after install.sql
+ * finishes) short-circuits re-runs; pre-marker installs are recognized by
+ * schema+data presence and back-stamped.
  *
  * Env:
  *   PGHOST, PGPORT, PGUSER, PGPASSWORD     — adventureworks-db connection
@@ -29,6 +30,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  renameSync,
   writeFileSync,
 } from "node:fs";
 import { dirname, join, resolve } from "node:path";
@@ -101,17 +103,45 @@ async function isAlreadyLoaded(): Promise<boolean> {
   }
   const client = await connect(ADVENTUREWORKS_DB);
   try {
+    // Authoritative: the marker written after install.sql completed. A raw
+    // table count turned true as soon as the DDL committed — an interrupted
+    // load (container kill, upgrade --force-recreate mid-\copy) then skipped
+    // forever, leaving AdventureWorks structurally present but empty.
+    const marker = await client.query<{ exists: boolean }>(
+      `select exists(
+         select 1 from information_schema.tables
+          where table_schema = 'public' and table_name = '_openneko_aw_load_complete'
+       ) as exists`,
+    );
+    if (marker.rows[0]?.exists) return true;
+    // Pre-marker installs: only a schema WITH data counts as loaded (and
+    // gets the marker backfilled so the next run takes the fast path).
     const res = await client.query<{ count: string }>(
       `select count(*)::text as count
          from information_schema.tables
         where table_schema in ('person','humanresources','production','purchasing','sales')`,
     );
-    return Number(res.rows[0]?.count ?? "0") >= 50;
+    if (Number(res.rows[0]?.count ?? "0") < 50) return false;
+    const data = await client.query<{ count: string }>(
+      "select count(*)::text as count from sales.salesorderheader",
+    );
+    if (Number(data.rows[0]?.count ?? "0") === 0) return false;
+    await markLoadComplete(client);
+    return true;
   } catch {
     return false;
   } finally {
     await client.end();
   }
+}
+
+async function markLoadComplete(client: Client): Promise<void> {
+  await client.query(
+    `create table if not exists public._openneko_aw_load_complete (
+       loaded_at timestamptz not null default now()
+     )`,
+  );
+  await client.query("insert into public._openneko_aw_load_complete default values");
 }
 
 async function createDatabase(): Promise<void> {
@@ -136,7 +166,21 @@ function ensureMsZip(): void {
   }
   mkdirSync(WORK_DIR, { recursive: true });
   log(`downloading ${MS_ZIP_URL}`);
-  run("curl", ["-sSL", "--fail", "-o", ZIP_PATH, MS_ZIP_URL]);
+  // The whole demo stack (worker and web included) gates on this one-shot,
+  // so a transient network blip must not take the product down with it.
+  // Download to a temp name and rename only on success, so an interrupted
+  // transfer can never be mistaken for a cached zip on the next run.
+  const partial = `${ZIP_PATH}.partial`;
+  run("curl", [
+    "-sSL",
+    "--fail",
+    "--retry", "5",
+    "--retry-delay", "3",
+    "--retry-all-errors",
+    "-o", partial,
+    MS_ZIP_URL,
+  ]);
+  renameSync(partial, ZIP_PATH);
 }
 
 function ensureExtracted(): void {
@@ -293,6 +337,15 @@ async function main(): Promise<void> {
   convertAllCsvs();
   await createDatabase();
   runInstallSql();
+  {
+    // Stamp completion only after install.sql (DDL + \copy data) finished.
+    const client = await connect(ADVENTUREWORKS_DB);
+    try {
+      await markLoadComplete(client);
+    } finally {
+      await client.end();
+    }
+  }
   log("done");
 }
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -645,15 +645,45 @@ if (!recordsWatchWebhookUrl) {
 console.log(
   `[worker] records schema runtime ready (reconciled=${recordsSchemaRuntime.reconciliation.projected.length}, failed=${recordsSchemaRuntime.reconciliation.failed.length})`,
 );
-const reboundRecordsWatches = await reconcileRecordsNativeWatchDeliveries({
-  graphjin: recordsWatchGraphjin,
-  token: recordsWatchServiceToken,
-  webhookUrl: recordsWatchWebhookUrl,
-});
-if (reboundRecordsWatches > 0) {
-  console.log(
-    `[worker] rebound ${reboundRecordsWatches} durable records watch delivery target(s)`,
+// records-watch-graphjin deliberately exits until its generated config
+// exists and can still be mid-restart during an upgrade. This reconcile is
+// idempotent and only matters for installs with active bindings, so it must
+// never kill boot: an unguarded throw here crash-looped the whole worker
+// (with Docker's growing restart backoff) whenever the watch plane was a
+// few seconds behind. Failures retry in the background instead.
+const reconcileWatchDeliveries = async (): Promise<void> => {
+  const rebound = await reconcileRecordsNativeWatchDeliveries({
+    graphjin: recordsWatchGraphjin,
+    token: recordsWatchServiceToken,
+    webhookUrl: recordsWatchWebhookUrl,
+  });
+  if (rebound > 0) {
+    console.log(
+      `[worker] rebound ${rebound} durable records watch delivery target(s)`,
+    );
+  }
+};
+try {
+  await reconcileWatchDeliveries();
+} catch (e) {
+  console.warn(
+    `[worker] records watch delivery reconcile failed at boot; retrying in background: ${e instanceof Error ? e.message : e}`,
   );
+  void (async () => {
+    for (let attempt = 1; attempt <= 5; attempt++) {
+      await new Promise((resolve) => setTimeout(resolve, attempt * 5_000));
+      try {
+        await reconcileWatchDeliveries();
+        console.log("[worker] records watch delivery reconcile recovered");
+        return;
+      } catch {
+        // next attempt
+      }
+    }
+    console.warn(
+      "[worker] records watch delivery reconcile did not recover; existing deliveries keep their previous targets until the next restart",
+    );
+  })();
 }
 
 await seedDefaultActionPolicies(ADMIN_ORG_ID);

--- a/apps/worker/src/jobs/work-run.ts
+++ b/apps/worker/src/jobs/work-run.ts
@@ -1,4 +1,4 @@
-import type { AgentEvent } from "@neko/llm";
+import { ensureHostConfigProvisioned, type AgentEvent } from "@neko/llm";
 import {
   agentRuntimeDepsFromEnv,
   appendWorkRunEvent,
@@ -84,6 +84,12 @@ export async function runWorkRun(
   const pluginActions = includeRecordActionDescriptors(
     getPluginRegistryInstance()?.getRegisteredActionDescriptors() ?? [],
   );
+
+  // Same gate the workflow job runs: if the boot-time provider sync lost a
+  // race with a gateway restart, this is the retry — memoized on success, so
+  // the healthy path costs nothing. Without it, channel-triggered runs
+  // stayed broken until a settings save or a worker restart.
+  await ensureHostConfigProvisioned(orgId);
 
   const broker = await ensureAgentBroker();
   const unregisterBrokerEvents = registerAgentBrokerEventSink(runId, emit);

--- a/apps/worker/test/records/starter-watches.integration.test.ts
+++ b/apps/worker/test/records/starter-watches.integration.test.ts
@@ -146,6 +146,21 @@ describeIfDb("records starter watch lifecycle", () => {
         token: "watch-service-token",
       }),
     );
+
+    // Transport failures must REJECT (not resolve partially): the worker's
+    // boot path relies on that contract to catch, warn, and retry in the
+    // background instead of crash-looping while records-watch-graphjin is
+    // still coming up.
+    const down = vi.fn(async () => {
+      throw new Error("connect ECONNREFUSED records-watch-graphjin:8090");
+    });
+    await expect(
+      reconcileRecordsNativeWatchDeliveries({
+        graphjin: { execute: down },
+        token: () => "watch-service-token",
+        webhookUrl: "http://172.19.0.8:4100/admin/events/records-watch",
+      }),
+    ).rejects.toThrow(/ECONNREFUSED/);
   });
 
   it("runs the same deterministic evaluator for native and scheduled triggers", async () => {

--- a/compose.adventureworks.yml
+++ b/compose.adventureworks.yml
@@ -57,6 +57,13 @@ services:
         chmod -R a+rwX /config
     restart: "no"
 
+  # Legacy anonymous dev config — no JWT secret to reconcile. The one-shot
+  # still runs (core wires graphjin/worker/web behind it) so org-row
+  # creation stays serialized for host dev processes.
+  graphjin-secret-init:
+    environment:
+      GRAPHJIN_SOURCES_CONFIG: ""
+
   graphjin:
     image: dosco/graphjin:3.18.42
     restart: unless-stopped

--- a/compose.adventureworks.yml
+++ b/compose.adventureworks.yml
@@ -174,6 +174,11 @@ services:
         condition: service_completed_successfully
       adventureworks-init:
         condition: service_completed_successfully
+      # openneko-config-init repairs the config volume's ownership; reading
+      # config.json / the secret-key before that chown returned EACCES, which
+      # older secret-crypt turned into a destructive key regeneration.
+      openneko-config-init:
+        condition: service_completed_successfully
     environment:
       XDG_CONFIG_HOME: /config
       NEKO_PG_HOST: neko-db

--- a/compose.graphjin-agent.yml
+++ b/compose.graphjin-agent.yml
@@ -7,6 +7,14 @@
 #     -f compose.yml -f compose.adventureworks.yml \
 #     -f compose.graphjin-agent.yml up -d --build
 services:
+  # This overlay switches the demo back to sources (agentic) mode, so the
+  # per-org JWT secret must again be reconciled before GraphJin starts.
+  graphjin-secret-init:
+    environment:
+      GRAPHJIN_SOURCES_CONFIG: /config/graphjin/agentic.yml
+    volumes:
+      - graphjin-config:/config/graphjin
+
   graphjin-config-init:
     volumes:
       - graphjin-config:/config

--- a/compose.openshell.yml
+++ b/compose.openshell.yml
@@ -52,9 +52,12 @@ services:
     restart: "no"
     user: "0:0"
     command:
+      # Generates into a STAGING dir; openshell-reg promotes it to pki/ only
+      # when no complete PKI is active. certgen re-runs on every `up`, and
+      # rewriting the CA under a live gateway broke every issued client cert.
       - generate-certs
       - --output-dir
-      - ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/pki
+      - ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/pki-staging
       - --server-san
       - host.openshell.internal
       - --server-san
@@ -80,29 +83,62 @@ services:
       - |
         set -e
         PKI=${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/pki
+        STAGING=${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/pki-staging
+        # Promote certgen's staged PKI only when no complete set is active:
+        # an existing CA always wins, so a hand-run `compose up` (which
+        # re-runs the one-shots but not the unchanged gateway) can never
+        # invalidate the material a live gateway already loaded.
+        if [ ! -f "$$PKI/ca.crt" ] || [ ! -f "$$PKI/server/tls.key" ] || [ ! -f "$$PKI/client/tls.key" ]; then
+          rm -rf "$$PKI"
+          mv "$$STAGING" "$$PKI"
+        elif [ -d "$$STAGING" ]; then
+          rm -rf "$$STAGING"
+        fi
         # web + worker have XDG_CONFIG_HOME=/config and the CLI reads gateway
         # registrations from $$XDG_CONFIG_HOME/openshell — so write to
         # /config/openshell (the shared openshell-config volume), NOT under the
         # openneko-config volume (which mounts at /config/openneko).
         REG=/config/openshell/gateways/openneko
         mkdir -p "$$REG/mtls"
-        cp "$$PKI/ca.crt"         "$$REG/mtls/ca.crt"
-        cp "$$PKI/client/tls.crt" "$$REG/mtls/tls.crt"
-        cp "$$PKI/client/tls.key" "$$REG/mtls/tls.key"
+        chmod a+rx /config/openshell /config/openshell/gateways "$$REG" "$$REG/mtls"
+        # Per-file atomic publish: stage next to the destination with final
+        # permissions, then rename(2) into place — every `openshell` CLI
+        # spawn re-reads these files, and an in-place truncate-and-write
+        # handed concurrent spawns truncated keys and half-written JSON.
+        # active_gateway goes LAST: it is the pointer that makes the
+        # registration live.
+        pub() {
+          tmp="$$2.tmp.$$$$"
+          cp "$$1" "$$tmp"
+          chmod a+r "$$tmp"
+          mv "$$tmp" "$$2"
+        }
+        pub "$$PKI/ca.crt"         "$$REG/mtls/ca.crt"
+        pub "$$PKI/client/tls.crt" "$$REG/mtls/tls.crt"
+        pub "$$PKI/client/tls.key" "$$REG/mtls/tls.key"
+        tmp="$$REG/metadata.json.tmp.$$$$"
         printf '{"name":"openneko","gateway_endpoint":"https://openshell-gateway:%s","is_remote":false,"gateway_port":0,"auth_mode":"mtls"}\n' "${OPENSHELL_PORT:-18080}" \
-          > "$$REG/metadata.json"
-        printf 'openneko' > /config/openshell/active_gateway
+          > "$$tmp"
+        chmod a+r "$$tmp"
+        mv "$$tmp" "$$REG/metadata.json"
+        tmp="/config/openshell/gateway.toml.tmp.$$$$"
         printf '[openshell]\nversion = 1\n\n[openshell.drivers.docker]\nnetwork_name = "%s"\ngrpc_endpoint = "https://openshell-gateway:%s"\nhost_gateway_ip = "%s"\n' \
           "$$OPENNEKO_COMPOSE_NETWORK" "${OPENSHELL_PORT:-18080}" "$$OPENSHELL_GATEWAY_IP" \
-          > /config/openshell/gateway.toml
-        chmod -R a+rX /config/openshell
+          > "$$tmp"
+        chmod a+r "$$tmp"
+        mv "$$tmp" /config/openshell/gateway.toml
+        tmp="/config/openshell/active_gateway.tmp.$$$$"
+        printf 'openneko' > "$$tmp"
+        chmod a+r "$$tmp"
+        mv "$$tmp" /config/openshell/active_gateway
     environment:
       # `docker compose -p ...` supplies COMPOSE_PROJECT_NAME during
       # interpolation; the explicit name must match the runtime network below.
       OPENNEKO_COMPOSE_NETWORK: "${COMPOSE_PROJECT_NAME}_runtime"
       OPENSHELL_GATEWAY_IP: "${OPENSHELL_GATEWAY_IP:-172.29.3.2}"
     volumes:
-      - ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/pki:${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}/pki:ro
+      # Whole state dir read-write: reg promotes pki-staging -> pki.
+      - ${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}:${OPENSHELL_STATE_DIR:-/var/lib/openneko/openshell}
       - openshell-config:/config/openshell
 
   openshell-gateway:
@@ -195,6 +231,11 @@ services:
     depends_on:
       openshell-ready:
         condition: service_completed_successfully
+      # openshell-ready's exit-0 is a historical fact; the direct edge keeps
+      # `up -d worker`/`up -d web` from starting an app process with no
+      # gateway container at all.
+      openshell-gateway:
+        condition: service_started
 
   # Web: interactive chat launches the agent in a sandbox too (the Next.js server
   # is the control plane; the agent never runs in-process). Same flags; egress
@@ -213,6 +254,11 @@ services:
     depends_on:
       openshell-ready:
         condition: service_completed_successfully
+      # openshell-ready's exit-0 is a historical fact; the direct edge keeps
+      # `up -d worker`/`up -d web` from starting an app process with no
+      # gateway container at all.
+      openshell-gateway:
+        condition: service_started
 
 volumes:
   # Holds the worker/web CLI's gateway registration at /config/openshell (the

--- a/compose.yml
+++ b/compose.yml
@@ -356,17 +356,46 @@ services:
       - ./db/graphjin/customer.sources.example.yml:/seed/customer.sources.yml:ro
     restart: "no"
 
+  # One-shot: resolves (or creates, under an advisory lock) the single org
+  # row and reconciles the per-org JWT secret into the customer GraphJin
+  # sources config BEFORE the server's first start. GraphJin 3.18 does not
+  # hot-reload auth keys; expressing that as `graphjin -> worker` cycled
+  # against the adventureworks overlay's `worker -> graphjin` edge, so this
+  # one-shot carries the ordering instead. Reconciles unconditionally, so
+  # key rotation, restores, and partial volume wipes self-heal on the next
+  # stack start.
+  graphjin-secret-init:
+    build:
+      context: .
+      target: worker
+    working_dir: /app
+    command: ["node", "--import", "tsx/esm", "node_modules/@neko/llm/src/graphjin/init-secret.mjs"]
+    depends_on:
+      neko-migrate:
+        condition: service_completed_successfully
+      openneko-config-init:
+        condition: service_completed_successfully
+      graphjin-config-init:
+        condition: service_completed_successfully
+    environment:
+      <<: *neko-app-env
+      GRAPHJIN_SOURCES_CONFIG: /config/graphjin/agentic.yml
+    volumes:
+      - ${OPENNEKO_CONFIG_VOLUME:-openneko-config}:/config/openneko
+      - openneko-graphjin-cli:/config/graphjin
+    restart: "no"
+
   graphjin:
     image: ${OPENNEKO_GRAPHJIN_IMAGE:-dosco/graphjin:3.18.42}
     restart: unless-stopped
     depends_on:
       graphjin-config-init:
         condition: service_completed_successfully
-      # The worker reconciles the per-org JWT secret into agentic.yml during
-      # startup. GraphJin 3.18 does not hot-reload auth keys, so start it only
-      # after that reconciliation has completed.
-      worker:
-        condition: service_healthy
+      # The per-org JWT secret is reconciled into agentic.yml by the
+      # graphjin-secret-init one-shot. GraphJin 3.18 does not hot-reload
+      # auth keys, so start only after that reconciliation has completed.
+      graphjin-secret-init:
+        condition: service_completed_successfully
     ports:
       - "127.0.0.1:${GRAPHJIN_PORT:-8080}:8080"
     environment:
@@ -429,7 +458,7 @@ services:
       neko-migrate:
         condition: service_completed_successfully
     volumes:
-      - openneko-config:/config/openneko
+      - ${OPENNEKO_CONFIG_VOLUME:-openneko-config}:/config/openneko
     restart: "no"
 
   neko-graphjin:
@@ -484,6 +513,8 @@ services:
         condition: service_started
       graphjin:
         condition: service_started
+      graphjin-secret-init:
+        condition: service_completed_successfully
       # Web is the user-facing readiness boundary. Do not serve the temporary
       # recovery screen while the control plane is still starting.
       worker:
@@ -497,7 +528,10 @@ services:
     ports:
       - "${OPENNEKO_WEB_BIND_ADDRESS:-0.0.0.0}:${OPENNEKO_PORT:-3000}:8080"
     volumes:
-      - openneko-config:/config/openneko
+      # Honors OPENNEKO_CONFIG_VOLUME like neko-migrate/neko-graphjin, so the
+      # host-hybrid dev layout shares one physical config dir (and one
+      # secret-key) instead of splitting it across a named volume.
+      - ${OPENNEKO_CONFIG_VOLUME:-openneko-config}:/config/openneko
       - openneko-graphjin-cli:/config/graphjin
       - openneko-agent-home:/tmp/openneko-home
       - openneko-agent-tmp:/tmp/openneko-tmp
@@ -521,9 +555,12 @@ services:
         condition: service_started
       records-watch-graphjin:
         condition: service_started
-      # The worker must patch the per-org JWT secret before customer GraphJin
-      # starts; depending on the one-shot seed avoids a startup cycle.
+      # The per-org JWT secret is seeded by graphjin-secret-init before
+      # either GraphJin or the worker starts; the worker's own boot pass is
+      # a re-verify. Depending on the one-shots avoids a startup cycle.
       graphjin-config-init:
+        condition: service_completed_successfully
+      graphjin-secret-init:
         condition: service_completed_successfully
     environment:
       <<: *neko-app-env
@@ -549,7 +586,7 @@ services:
     expose:
       - "4100"
     volumes:
-      - openneko-config:/config/openneko
+      - ${OPENNEKO_CONFIG_VOLUME:-openneko-config}:/config/openneko
       - openneko-graphjin-cli:/config/graphjin
       - openneko-records-graphjin:/config/records-graphjin
       - openneko-agent-home:/tmp/openneko-home

--- a/db/migrations/0061_app_user_identity_unique.sql
+++ b/db/migrations/0061_app_user_identity_unique.sql
@@ -1,0 +1,48 @@
+-- The concurrent first-sign-in race could insert two app_user rows for one
+-- identity (same sub, or same email), after which every later sign-in threw
+-- "already bound to a different SSO subject" until an operator did manual
+-- SQL. Repair existing duplicates, then add the unique indexes that make
+-- the race lose loudly instead of persisting.
+--
+-- Duplicate repair keeps the OLDEST row (the one later sign-ins would have
+-- matched first) and neutralizes newer ones in place rather than deleting
+-- them: rows may be referenced by runs/personas, so they are detached from
+-- the identity (sub cleared, email made unique) and disabled.
+
+with ranked_sub as (
+  select id,
+         row_number() over (
+           partition by org_id, sub
+           order by created_at asc, id asc
+         ) as rn
+  from app_user
+  where sub is not null
+)
+update app_user u
+set sub = null,
+    disabled_at = coalesce(u.disabled_at, now()),
+    updated_at = now()
+from ranked_sub r
+where u.id = r.id and r.rn > 1;
+
+with ranked_email as (
+  select id,
+         row_number() over (
+           partition by org_id, lower(email)
+           order by created_at asc, id asc
+         ) as rn
+  from app_user
+)
+update app_user u
+set email = u.email || '+duplicate-' || u.id,
+    disabled_at = coalesce(u.disabled_at, now()),
+    updated_at = now()
+from ranked_email r
+where u.id = r.id and r.rn > 1;
+
+create unique index if not exists app_user_org_sub_unique
+  on app_user (org_id, sub)
+  where sub is not null;
+
+create unique index if not exists app_user_org_email_unique
+  on app_user (org_id, lower(email));

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -56,6 +56,7 @@ export {
   inArray,
   isNull,
   isNotNull,
+  like,
   lt,
   lte,
   ne,

--- a/packages/db/src/org.ts
+++ b/packages/db/src/org.ts
@@ -8,30 +8,60 @@
  * regardless of which side of the app is running. When SSO/multi-tenant
  * lands the web side switches to session-derived org ids; the worker stays
  * single-tenant per process or gets refactored to per-job.
+ *
+ * Nothing in the schema forbids a second organization row, and on a fresh
+ * database web, worker, the graphjin-secret-init one-shot, and the demo
+ * seed can all arrive here at once — so creation is serialized under a
+ * transaction-scoped advisory lock, and every reader picks the same row
+ * via a stable ORDER BY. (Compose ordering usually prevents the race, but
+ * `pnpm dev` and non-Compose topologies have no such ordering.)
  */
 
 import { randomUUID } from "node:crypto";
+import { sql } from "drizzle-orm";
 import { db } from "./index";
 import { organization } from "./schema";
 
+export const ORG_BOOTSTRAP_LOCK_KEY = "openneko.organization.bootstrap";
+
 let _cachedOrgId: string | null = null;
+
+async function selectFirstOrgId(
+  runner: Pick<ReturnType<typeof db>, "select">,
+): Promise<string | null> {
+  const rows = await runner
+    .select({ id: organization.id })
+    .from(organization)
+    .orderBy(organization.created_at, organization.id)
+    .limit(1);
+  return rows[0]?.id ?? null;
+}
 
 export async function getOrgId(): Promise<string> {
   if (_cachedOrgId) return _cachedOrgId;
-  const rows = await db()
-    .select({ id: organization.id })
-    .from(organization)
-    .limit(1);
-  if (rows[0]?.id) {
-    _cachedOrgId = rows[0].id;
+
+  // Steady state: the org exists, one ordered select, no lock traffic.
+  const existing = await selectFirstOrgId(db());
+  if (existing) {
+    _cachedOrgId = existing;
     return _cachedOrgId;
   }
-  const newId = randomUUID();
-  await db().insert(organization).values({
-    id: newId,
-    name: "My Workspace",
+
+  const resolved = await db().transaction(async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtext(${ORG_BOOTSTRAP_LOCK_KEY}))`,
+    );
+    // Re-check under the lock: whoever held it before us created the row.
+    const raced = await selectFirstOrgId(tx);
+    if (raced) return raced;
+    const newId = randomUUID();
+    await tx.insert(organization).values({
+      id: newId,
+      name: "My Workspace",
+    });
+    return newId;
   });
-  _cachedOrgId = newId;
+  _cachedOrgId = resolved;
   return _cachedOrgId;
 }
 

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -69,6 +69,16 @@ export const app_user = pgTable(
   },
   (t) => ({
     org_idx: index("app_user_org_idx").on(t.org_id),
+    // One row per SSO subject and per mailbox within an org — the backstop
+    // that makes the concurrent first-sign-in race fail loudly instead of
+    // leaving duplicate identities behind (migration 0061).
+    org_sub_unique: uniqueIndex("app_user_org_sub_unique")
+      .on(t.org_id, t.sub)
+      .where(sql`${t.sub} is not null`),
+    org_email_unique: uniqueIndex("app_user_org_email_unique").on(
+      t.org_id,
+      sql`lower(${t.email})`,
+    ),
   }),
 );
 

--- a/packages/db/src/seed-adventureworks.mjs
+++ b/packages/db/src/seed-adventureworks.mjs
@@ -67,8 +67,15 @@ const client = new pg.Client({
 
 await client.connect();
 
+// Same advisory lock as getOrgId() and graphjin-secret-init: on a fresh
+// database several processes can race to create the single org row, and
+// nothing in the schema forbids a second one.
+await client.query("begin");
+await client.query(
+  "select pg_advisory_xact_lock(hashtext('openneko.organization.bootstrap'))",
+);
 const existingOrg = await client.query(
-  "select id, name from organization order by created_at asc limit 1",
+  "select id, name from organization order by created_at asc, id asc limit 1",
 );
 let orgId = existingOrg.rows[0]?.id;
 if (!orgId) {
@@ -87,6 +94,7 @@ if (!orgId) {
 } else {
   console.log(`[seed-adventureworks] keeping existing organization ${orgId}`);
 }
+await client.query("commit");
 
 const sourceRows = await client.query(
   `select id, label
@@ -105,7 +113,8 @@ if (sourceRows.rowCount === 0) {
   await client.query(
     `insert into data_source (
        org_id, kind, graphql_url, subscription_url, mcp_url, label, auth_mode
-     ) values ($1, 'graphjin', $2, $3, $4, 'AdventureWorks', $5)`,
+     ) values ($1, 'graphjin', $2, $3, $4, 'AdventureWorks', $5)
+     on conflict (org_id, name) do nothing`,
     [orgId, ...graphjinUrls, AUTH_MODE],
   );
   console.log(
@@ -159,7 +168,8 @@ if (wizardRows.rowCount === 0) {
        priorities,
        step
      )
-     values ($1, $2, $3, $4, $5, 'company')`,
+     values ($1, $2, $3, $4, $5, 'company')
+     on conflict (org_id) do nothing`,
     [
       orgId,
       DEFAULT_COMPANY_NOTE,
@@ -178,8 +188,11 @@ if (wizardRows.rowCount === 0) {
 // produces real outputs against the AdventureWorks data within minutes
 // of first run. Idempotent: only inserts when no workflows exist yet
 // for the org, so a re-seed never clobbers operator-authored workflows.
+// Guard on operator/seed workflows only: the worker upserts its own
+// 'OpenNeko operations' system workflow on every boot, and counting it
+// here made a partially-failed first seed permanently skip the trial set.
 const wfRows = await client.query(
-  "select id from workflow_definition where org_id = $1 limit 1",
+  "select id from workflow_definition where org_id = $1 and name <> 'OpenNeko operations' limit 1",
   [orgId],
 );
 if (wfRows.rowCount === 0) {
@@ -233,13 +246,24 @@ if (wfRows.rowCount === 0) {
     );
   }
   console.log(`[seed-adventureworks] inserted ${trialWorkflows.length} trial workflows`);
+} else {
+  console.log("[seed-adventureworks] workflows already exist; leaving them unchanged");
+}
 
-  const stockWatchRows = await client.query(
-    "select id from workflow_definition where org_id = $1 and name = 'Stock Reorder Watch' limit 1",
-    [orgId],
+// Wired outside the workflow guard and self-guarded, so a first run that
+// died between the workflow insert and this point heals on the next run
+// instead of skipping forever.
+const stockWatchRows = await client.query(
+  "select id from workflow_definition where org_id = $1 and name = 'Stock Reorder Watch' limit 1",
+  [orgId],
+);
+const stockWatchWorkflowId = stockWatchRows.rows[0]?.id;
+if (stockWatchWorkflowId) {
+  const existingSub = await client.query(
+    "select id from subscription where org_id = $1 and workflow_id = $2 and source_kind = 'source_change' limit 1",
+    [orgId, stockWatchWorkflowId],
   );
-  const stockWatchWorkflowId = stockWatchRows.rows[0]?.id;
-  if (stockWatchWorkflowId) {
+  if (existingSub.rowCount === 0) {
     await client.query(
       `insert into subscription (
          org_id, workflow_id, source_kind, filter, enabled,
@@ -260,8 +284,6 @@ if (wfRows.rowCount === 0) {
     );
     console.log("[seed-adventureworks] wired Stock Reorder Watch subscription");
   }
-} else {
-  console.log("[seed-adventureworks] workflows already exist; leaving them unchanged");
 }
 
 const policyRows = await client.query(

--- a/packages/db/test/integration/app-user-identity.test.ts
+++ b/packages/db/test/integration/app-user-identity.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Migration 0061: app_user identity uniqueness.
+ *
+ * The concurrent first-sign-in race could persist duplicate rows for one
+ * identity. The migration must repair existing duplicates (keeping the
+ * oldest, neutralizing the newer in place — never deleting, rows may be
+ * referenced) and leave unique indexes that make any future race lose
+ * loudly.
+ */
+
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import pg from "pg";
+import { afterAll, describe, expect, it } from "vitest";
+import { dbReachable } from "./_helpers";
+import { pool } from "../../src";
+
+const reachable = await dbReachable();
+const describeIfDb = reachable ? describe : describe.skip;
+
+if (!reachable) {
+  console.warn("[app-user-identity] skipping: Postgres unreachable.");
+}
+
+const REPO_ROOT = join(__dirname, "..", "..", "..", "..");
+const M_0061 = join(REPO_ROOT, "db", "migrations", "0061_app_user_identity_unique.sql");
+
+const TEMP_DB = `vitest_appuser_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
+
+afterAll(async () => {
+  if (!reachable) return;
+  await pool().query(`drop database if exists ${TEMP_DB} with (force)`);
+});
+
+describeIfDb("0061 app_user identity uniqueness", () => {
+  it("repairs duplicates and blocks new ones", async () => {
+    await pool().query(`create database ${TEMP_DB}`);
+    const client = new pg.Client({
+      host: process.env.NEKO_PG_HOST ?? "localhost",
+      port: Number(process.env.NEKO_PG_PORT ?? 5432),
+      user: process.env.NEKO_PG_USER ?? "neko",
+      password: process.env.NEKO_PG_PASSWORD ?? "secret",
+      database: TEMP_DB,
+    });
+    await client.connect();
+    try {
+      await client.query(`
+        create table app_user (
+          id text primary key,
+          sub text,
+          email text not null,
+          name text,
+          org_id text not null,
+          role text not null,
+          disabled_at timestamptz,
+          created_at timestamptz not null default now(),
+          updated_at timestamptz not null default now(),
+          last_login_at timestamptz
+        )`);
+      // Race artifacts: two rows claimed the same sub, two the same mailbox
+      // (case-insensitively).
+      await client.query(`
+        insert into app_user (id, sub, email, org_id, role, created_at) values
+          ('u1', 'sub-1', 'alice@example.com',  'org', 'admin',  now() - interval '2 hours'),
+          ('u2', 'sub-1', 'alice2@example.com', 'org', 'admin',  now() - interval '1 hour'),
+          ('u3', null,    'Bob@Example.com',    'org', 'member', now() - interval '2 hours'),
+          ('u4', null,    'bob@example.com',    'org', 'member', now() - interval '1 hour')`);
+
+      await client.query(await readFile(M_0061, "utf8"));
+
+      const u1 = (await client.query("select sub, disabled_at from app_user where id='u1'")).rows[0];
+      const u2 = (await client.query("select sub, disabled_at from app_user where id='u2'")).rows[0];
+      expect(u1.sub).toBe("sub-1");
+      expect(u1.disabled_at).toBeNull();
+      expect(u2.sub).toBeNull();
+      expect(u2.disabled_at).not.toBeNull();
+
+      const u3 = (await client.query("select email, disabled_at from app_user where id='u3'")).rows[0];
+      const u4 = (await client.query("select email, disabled_at from app_user where id='u4'")).rows[0];
+      expect(u3.email).toBe("Bob@Example.com");
+      expect(u3.disabled_at).toBeNull();
+      expect(u4.email).toBe("bob@example.com+duplicate-u4");
+      expect(u4.disabled_at).not.toBeNull();
+
+      // The indexes now block fresh duplicates loudly.
+      await expect(
+        client.query(
+          "insert into app_user (id, sub, email, org_id, role) values ('u5','sub-1','carol@example.com','org','member')",
+        ),
+      ).rejects.toMatchObject({ code: "23505" });
+      await expect(
+        client.query(
+          "insert into app_user (id, sub, email, org_id, role) values ('u6',null,'ALICE@example.com','org','member')",
+        ),
+      ).rejects.toMatchObject({ code: "23505" });
+
+      // Re-running the migration is a no-op (idempotent for upgrades).
+      await client.query(await readFile(M_0061, "utf8"));
+    } finally {
+      await client.end();
+    }
+  }, 30_000);
+});

--- a/packages/db/test/integration/org-bootstrap.test.ts
+++ b/packages/db/test/integration/org-bootstrap.test.ts
@@ -1,0 +1,102 @@
+/**
+ * getOrgId() bootstrap race, against a real Postgres.
+ *
+ * On an empty organization table, web, worker, the graphjin-secret-init
+ * one-shot, and the demo seed can all resolve the org concurrently, and
+ * nothing in the schema forbids a second row. Creation must therefore be
+ * serialized (advisory lock) and reads made deterministic (stable ORDER BY).
+ */
+
+import pg from "pg";
+import { afterAll, describe, expect, it } from "vitest";
+import { dbReachable } from "./_helpers";
+import { pool } from "../../src";
+import { getOrgId, _resetOrgIdCacheForTesting } from "../../src/org";
+
+const reachable = await dbReachable();
+const describeIfDb = reachable ? describe : describe.skip;
+
+if (!reachable) {
+  console.warn("[org-bootstrap] skipping: Postgres unreachable.");
+}
+
+const TEMP_DB = `vitest_org_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
+const savedDatabase = process.env.NEKO_PG_DATABASE;
+
+afterAll(async () => {
+  if (!reachable) return;
+  if (savedDatabase === undefined) delete process.env.NEKO_PG_DATABASE;
+  else process.env.NEKO_PG_DATABASE = savedDatabase;
+  _resetOrgIdCacheForTesting();
+  // Touch the pool so the signature change retires the temp-db pool before
+  // the force-drop terminates its backends (avoids a stray 'error' event).
+  await pool().query("select 1");
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  await pool().query(`drop database if exists ${TEMP_DB} with (force)`);
+});
+
+describeIfDb("getOrgId bootstrap", () => {
+  it("many concurrent first calls create exactly one organization", async () => {
+    await pool().query(`create database ${TEMP_DB}`);
+    const admin = new pg.Client({
+      host: process.env.NEKO_PG_HOST ?? "localhost",
+      port: Number(process.env.NEKO_PG_PORT ?? 5432),
+      user: process.env.NEKO_PG_USER ?? "neko",
+      password: process.env.NEKO_PG_PASSWORD ?? "secret",
+      database: TEMP_DB,
+    });
+    await admin.connect();
+    await admin.query(`
+      create table organization (
+        id text primary key,
+        scalekit_org_id text,
+        name text not null,
+        domain text,
+        status text not null default 'active',
+        setup_complete_at timestamptz,
+        created_at timestamptz not null default now(),
+        updated_at timestamptz not null default now()
+      )`);
+
+    // Point the shared pool at the temp database; db() rebuilds on config
+    // signature change. Reset the cache so every call takes the cold path.
+    process.env.NEKO_PG_DATABASE = TEMP_DB;
+    _resetOrgIdCacheForTesting();
+
+    const ids = await Promise.all(
+      Array.from({ length: 12 }, async () => {
+        // Each caller behaves like a separate cold process.
+        _resetOrgIdCacheForTesting();
+        return getOrgId();
+      }),
+    );
+
+    const rows = await admin.query("select id, name from organization");
+    await admin.end();
+
+    expect(rows.rowCount).toBe(1);
+    expect(new Set(ids).size).toBe(1);
+    expect(ids[0]).toBe(rows.rows[0].id);
+    expect(rows.rows[0].name).toBe("My Workspace");
+  }, 30_000);
+
+  it("returns the oldest org when two rows exist (deterministic tie-break)", async () => {
+    const admin = new pg.Client({
+      host: process.env.NEKO_PG_HOST ?? "localhost",
+      port: Number(process.env.NEKO_PG_PORT ?? 5432),
+      user: process.env.NEKO_PG_USER ?? "neko",
+      password: process.env.NEKO_PG_PASSWORD ?? "secret",
+      database: TEMP_DB,
+    });
+    await admin.connect();
+    await admin.query(`
+      insert into organization (id, name, created_at)
+      values ('older-org', 'Older', now() - interval '1 hour')`);
+    await admin.end();
+
+    for (let i = 0; i < 3; i++) {
+      _resetOrgIdCacheForTesting();
+      expect(await getOrgId()).toBe("older-org");
+    }
+  });
+});

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -16,6 +16,7 @@
     "./workflows/fences": "./src/workflows/fence-parsers.ts",
     "./workflows/fence-schemas": "./src/workflows/fence-schemas.ts",
     "./graphjin": "./src/graphjin/index.ts",
+    "./graphjin/sources-config": "./src/graphjin/sources-config.ts",
     "./graphjin/client": "./src/graphjin/client.ts",
     "./graphjin/file-source-assets": "./src/graphjin/file-source-assets.ts",
     "./graphjin/openapi-assets": "./src/graphjin/openapi-assets.ts",

--- a/packages/llm/src/graphjin/init-secret.mjs
+++ b/packages/llm/src/graphjin/init-secret.mjs
@@ -1,0 +1,130 @@
+import pg from "pg";
+import { readFile } from "node:fs/promises";
+import { randomUUID } from "node:crypto";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import {
+  atomicWriteFile,
+  patchGraphjinSourcesJwtSecret,
+} from "./sources-config.ts";
+
+// One-shot entrypoint for the graphjin-secret-init compose service.
+//
+// GraphJin sources mode signs actor tokens with a per-org secret derived as
+// HMAC(deployment secret-key, "graphjin:<orgId>"). GraphJin 3.18 cannot be
+// relied on to hot-reload auth keys, so the secret must be correct in
+// agentic.yml BEFORE the server's first start — which previously forced
+// `graphjin` to wait on a healthy worker and created a dependency cycle with
+// the demo/dev overlays' `worker -> graphjin` edge. This script needs only
+// the migrated database (for the org row) and the config volume (for the
+// secret-key), so it runs right after neko-migrate, ahead of both sides.
+//
+// It reconciles UNCONDITIONALLY on every run — placeholder or stale concrete
+// secret alike — so partial volume wipes, secret-key rotation, and restores
+// self-heal on the next stack start. The worker's own boot pass stays as a
+// second line of defense and normally finds nothing to do.
+
+// Empty (explicitly set to "") means the stack runs an anonymous GraphJin
+// config with no JWT secret to reconcile — the one-shot then only
+// serializes org-row creation. Unset falls back to the packaged default.
+const CONFIG_PATH =
+  process.env.GRAPHJIN_SOURCES_CONFIG !== undefined
+    ? process.env.GRAPHJIN_SOURCES_CONFIG.trim()
+    : "/config/graphjin/agentic.yml";
+
+function configBase() {
+  const xdg = process.env.XDG_CONFIG_HOME?.trim();
+  return xdg && xdg.length > 0
+    ? xdg
+    : join(process.env.HOME || homedir(), ".config");
+}
+
+async function readLocalConfig() {
+  const paths = [
+    join(configBase(), "openneko", "config.json"),
+    join(configBase(), "neko", "config.json"),
+  ];
+  for (const path of paths) {
+    try {
+      const parsed = JSON.parse(await readFile(path, "utf8"));
+      if (parsed && typeof parsed === "object") return parsed;
+    } catch {
+      // Missing or malformed local config; try the next path.
+    }
+  }
+  return {};
+}
+
+const localConfig = await readLocalConfig();
+const localPg =
+  localConfig.pg && typeof localConfig.pg === "object" ? localConfig.pg : {};
+if (typeof localPg.password === "string" && localPg.password.startsWith("enc:")) {
+  const { maybeDecryptSecret } = await import("@neko/secret-crypt");
+  localPg.password = maybeDecryptSecret(localPg.password);
+}
+const sslmode = localPg.sslmode ?? process.env.NEKO_PG_SSLMODE;
+const client = new pg.Client({
+  host: localPg.host ?? process.env.NEKO_PG_HOST ?? "localhost",
+  port: Number(localPg.port ?? process.env.NEKO_PG_PORT ?? 5432),
+  user: localPg.user ?? process.env.NEKO_PG_USER ?? "neko",
+  password: localPg.password ?? process.env.NEKO_PG_PASSWORD ?? "secret",
+  database: localPg.database ?? process.env.NEKO_PG_DATABASE ?? "neko",
+  ssl: sslmode === "require" ? { rejectUnauthorized: false } : undefined,
+});
+
+await client.connect();
+
+let orgId;
+try {
+  // Same transaction-scoped advisory lock as getOrgId(); whichever process
+  // takes it first creates the single org row, everyone else re-reads it.
+  await client.query("begin");
+  await client.query(
+    "select pg_advisory_xact_lock(hashtext('openneko.organization.bootstrap'))",
+  );
+  const existing = await client.query(
+    "select id from organization order by created_at asc, id asc limit 1",
+  );
+  if (existing.rows[0]?.id) {
+    orgId = existing.rows[0].id;
+  } else {
+    orgId = randomUUID();
+    await client.query(
+      "insert into organization (id, name) values ($1, $2)",
+      [orgId, "My Workspace"],
+    );
+    console.log(`[graphjin-secret-init] created organization ${orgId}`);
+  }
+  await client.query("commit");
+} catch (e) {
+  await client.query("rollback").catch(() => {});
+  throw e;
+} finally {
+  await client.end();
+}
+
+if (!CONFIG_PATH) {
+  console.log(
+    `[graphjin-secret-init] no sources config for this stack; org ${orgId} ready, nothing to patch`,
+  );
+  process.exit(0);
+}
+
+// token.ts is dependency-light (node:crypto + @neko/secret-crypt); importing
+// it here keeps the secret derivation single-sourced with the worker's.
+const { graphjinSigningSecretB64 } = await import("./token.ts");
+const secret = graphjinSigningSecretB64(orgId);
+
+const raw = await readFile(CONFIG_PATH, "utf8");
+const patched = patchGraphjinSourcesJwtSecret(raw, secret);
+if (patched.changed) {
+  await atomicWriteFile(CONFIG_PATH, patched.content);
+  console.log(
+    `[graphjin-secret-init] reconciled per-org JWT secret in ${CONFIG_PATH} (org ${orgId})`,
+  );
+} else {
+  console.log(
+    `[graphjin-secret-init] per-org JWT secret already current in ${CONFIG_PATH} (org ${orgId})`,
+  );
+}

--- a/packages/llm/src/graphjin/sources-config.ts
+++ b/packages/llm/src/graphjin/sources-config.ts
@@ -1,0 +1,67 @@
+import { rename, writeFile } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+
+/**
+ * Pure helpers for the GraphJin sources-mode (agentic) config file.
+ *
+ * Kept dependency-free on purpose: the one-shot graphjin-secret-init
+ * container patches the per-org JWT secret with these BEFORE GraphJin's
+ * first start, and must not drag the worker's whole dependency graph
+ * (drizzle, the app schema, …) into that boot path. host-provision.ts
+ * re-exports them so existing imports keep working.
+ */
+
+export const SOURCES_SECRET_PLACEHOLDER = "REPLACE_WITH_PER_ORG_SECRET_B64";
+export const SOURCES_JWT_SECRET_RE =
+  /(^auth:\s*\n\s+type:\s*jwt\s*\n\s+jwt:\s*\n(?:\s+#.*\n)*\s+secret:\s*")([^"]*)(")/m;
+export const LEGACY_PACKAGED_DEMO_GRAPHJIN_CONFIG = "/graphjin-config/agentic.yml";
+
+export function patchGraphjinSourcesJwtSecret(
+  raw: string,
+  secret: string,
+): { content: string; changed: boolean } {
+  let content = raw.replaceAll(SOURCES_SECRET_PLACEHOLDER, secret);
+  if (content !== raw) return { content, changed: true };
+
+  const match = SOURCES_JWT_SECRET_RE.exec(raw);
+  if (!match || match[2] === secret) return { content: raw, changed: false };
+
+  content = raw.replace(SOURCES_JWT_SECRET_RE, `$1${secret}$3`);
+  return { content, changed: content !== raw };
+}
+
+/**
+ * Existing v2.25 demo installs do not carry OPENNEKO_STACK_MODE because their
+ * compose file is embedded in the older host CLI. The dedicated demo mount is
+ * therefore retained as a backward-compatible discriminator. Production uses
+ * /config/graphjin/agentic.yml and must keep its capability-probe behavior.
+ */
+export function shouldReconcileDemoSourceAuthMode(
+  configPath: string | undefined,
+  configContent: string,
+  stackMode?: string,
+): boolean {
+  const isDemo =
+    stackMode === "demo" || configPath === LEGACY_PACKAGED_DEMO_GRAPHJIN_CONFIG;
+  return isDemo && SOURCES_JWT_SECRET_RE.test(configContent);
+}
+
+/**
+ * Write-then-rename within the target directory. GraphJin watches these
+ * files (reload_on_config_change) and other processes read them on their
+ * own schedule; an in-place truncate-and-write exposes a partial file to
+ * both. rename(2) within one volume is atomic, so readers see either the
+ * old content or the new — never a truncated intermediate.
+ */
+export async function atomicWriteFile(
+  path: string,
+  content: string,
+  opts?: { mode?: number },
+): Promise<void> {
+  const tmp = join(
+    dirname(path),
+    `.${basename(path)}.tmp-${process.pid}-${Date.now().toString(36)}`,
+  );
+  await writeFile(tmp, content, { encoding: "utf8", mode: opts?.mode ?? 0o664 });
+  await rename(tmp, path);
+}

--- a/packages/llm/src/host-provision.ts
+++ b/packages/llm/src/host-provision.ts
@@ -1,5 +1,5 @@
 import { realpathSync } from "node:fs";
-import { mkdir, writeFile, chmod } from "node:fs/promises";
+import { mkdir, chmod } from "node:fs/promises";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 
@@ -95,51 +95,28 @@ async function provisionGraphJin(orgId: string): Promise<void> {
 
   const path = graphjinConfigPath();
   await mkdir(join(path, ".."), { recursive: true });
-  await writeFile(
+  await atomicWriteFile(
     path,
     JSON.stringify(
       { server, token: "", expires_at: "0001-01-01T00:00:00Z" },
       null,
       2,
     ),
-    "utf8",
   );
 }
 
-const SOURCES_SECRET_PLACEHOLDER = "REPLACE_WITH_PER_ORG_SECRET_B64";
-const SOURCES_JWT_SECRET_RE =
-  /(^auth:\s*\n\s+type:\s*jwt\s*\n\s+jwt:\s*\n(?:\s+#.*\n)*\s+secret:\s*")([^"]*)(")/m;
-const LEGACY_PACKAGED_DEMO_GRAPHJIN_CONFIG = "/graphjin-config/agentic.yml";
-
-export function patchGraphjinSourcesJwtSecret(
-  raw: string,
-  secret: string,
-): { content: string; changed: boolean } {
-  let content = raw.replaceAll(SOURCES_SECRET_PLACEHOLDER, secret);
-  if (content !== raw) return { content, changed: true };
-
-  const match = SOURCES_JWT_SECRET_RE.exec(raw);
-  if (!match || match[2] === secret) return { content: raw, changed: false };
-
-  content = raw.replace(SOURCES_JWT_SECRET_RE, `$1${secret}$3`);
-  return { content, changed: content !== raw };
-}
-
-/**
- * Existing v2.25 demo installs do not carry OPENNEKO_STACK_MODE because their
- * compose file is embedded in the older host CLI. The dedicated demo mount is
- * therefore retained as a backward-compatible discriminator. Production uses
- * /config/graphjin/agentic.yml and must keep its capability-probe behavior.
- */
-export function shouldReconcileDemoSourceAuthMode(
-  configPath: string | undefined,
-  configContent: string,
-  stackMode?: string,
-): boolean {
-  const isDemo =
-    stackMode === "demo" || configPath === LEGACY_PACKAGED_DEMO_GRAPHJIN_CONFIG;
-  return isDemo && SOURCES_JWT_SECRET_RE.test(configContent);
-}
+export {
+  SOURCES_SECRET_PLACEHOLDER,
+  SOURCES_JWT_SECRET_RE,
+  LEGACY_PACKAGED_DEMO_GRAPHJIN_CONFIG,
+  patchGraphjinSourcesJwtSecret,
+  shouldReconcileDemoSourceAuthMode,
+} from "./graphjin/sources-config";
+import {
+  atomicWriteFile,
+  patchGraphjinSourcesJwtSecret,
+  shouldReconcileDemoSourceAuthMode,
+} from "./graphjin/sources-config";
 
 /**
  * Sources-mode (agentic) bootstrap. Two halves, both idempotent:
@@ -175,7 +152,7 @@ async function provisionGraphjinSourcesMode(orgId: string): Promise<void> {
         process.env.OPENNEKO_STACK_MODE,
       );
       if (patched.changed) {
-        await writeFile(cfgPath, patched.content, "utf8");
+        await atomicWriteFile(cfgPath, patched.content);
         wroteSecret = true;
         console.log(
           `[host-provision] reconciled per-org JWT secret in ${cfgPath} (sources mode)`,
@@ -222,10 +199,14 @@ async function provisionGraphjinSourcesMode(orgId: string): Promise<void> {
   const { mintGraphjinToken } = await import("./graphjin/token");
   const token = mintGraphjinToken({ orgId, userId: null, role: "service" });
   // Only when WE just wrote the secret does the server need a reload
-  // window (reload_on_config_change, observed ~10s on 3.18.37). For an
-  // unmanaged source a single quick probe is enough — an unreachable or
-  // legacy endpoint must not stall boot.
-  const maxAttempts = wroteSecret ? 6 : 1;
+  // window (reload_on_config_change, observed ~10s on 3.18.37). An
+  // in-stack GraphJin may simply still be starting alongside us, so give
+  // it a few short attempts; an unmanaged external or legacy endpoint
+  // gets a single quick probe — an unreachable one must not stall boot.
+  const inStackGraphjin = /^https?:\/\/(graphjin|neko-graphjin|records-graphjin)[:/]/.test(
+    src.graphqlUrl,
+  );
+  const maxAttempts = wroteSecret ? 6 : inStackGraphjin ? 4 : 1;
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       const res = await fetch(src.graphqlUrl, {
@@ -430,10 +411,10 @@ async function provisionHermes(orgId: string): Promise<void> {
   yamlLines.push(...hermesDelegationConfigLines());
   yamlLines.push("");
 
-  await writeFile(join(hermesHome, "config.yaml"), yamlLines.join("\n"), "utf8");
+  await atomicWriteFile(join(hermesHome, "config.yaml"), yamlLines.join("\n"));
 
   const envContent = apiKey ? `${keyVar}=${apiKey}\n` : "";
-  await writeFile(join(hermesHome, ".env"), envContent, { encoding: "utf8", mode: 0o600 });
+  await atomicWriteFile(join(hermesHome, ".env"), envContent, { mode: 0o600 });
   await chmod(join(hermesHome, ".env"), 0o600);
 }
 

--- a/packages/llm/src/host-provision.ts
+++ b/packages/llm/src/host-provision.ts
@@ -478,17 +478,35 @@ function deriveAgentEgress(
  * wire (the key never enters the box). Replaces the manual `openshell
  * provider create` + hand-set egress env.
  */
+// Operator-supplied values (compose env) win permanently; empty or unset
+// means "derive from the org's provider config". Snapshotted at module load,
+// BEFORE any provisioning pass mutates process.env — the previous `||=`
+// writes made the FIRST pass's derived values permanent, so a provider
+// switch left the sandbox egress allowlist and key env var pinned to the old
+// provider until the process restarted.
+const OPERATOR_AGENT_ENV = {
+  provider: process.env.OPENNEKO_AGENT_MODEL_PROVIDER || "",
+  host: process.env.OPENNEKO_AGENT_MODEL_HOST || "",
+  binary: process.env.OPENNEKO_AGENT_MODEL_BINARY || "",
+  keyEnv: process.env.OPENNEKO_AGENT_MODEL_KEY_ENV || "",
+  hermesHome: process.env.OPENNEKO_AGENT_HERMES_HOME || "",
+};
+
+function setAgentEnv(key: string, operator: string, derived: string): void {
+  const value = operator || derived;
+  if (value) process.env[key] = value;
+  else delete process.env[key];
+}
+
 async function provisionOpenShellRuntime(orgId: string, backend: string): Promise<void> {
   const row = await loadProviderRow(orgId, "primary");
   if (!row || !row.enabled) return;
 
   const { hosts, binary, keyEnv } = deriveAgentEgress(row, backend);
-  process.env.OPENNEKO_AGENT_MODEL_PROVIDER ||= "openneko-agent";
-  if (!process.env.OPENNEKO_AGENT_MODEL_HOST && hosts.length > 0) {
-    process.env.OPENNEKO_AGENT_MODEL_HOST = hosts.join(",");
-  }
-  process.env.OPENNEKO_AGENT_MODEL_BINARY ||= binary;
-  process.env.OPENNEKO_AGENT_MODEL_KEY_ENV ||= keyEnv;
+  setAgentEnv("OPENNEKO_AGENT_MODEL_PROVIDER", OPERATOR_AGENT_ENV.provider, "openneko-agent");
+  setAgentEnv("OPENNEKO_AGENT_MODEL_HOST", OPERATOR_AGENT_ENV.host, hosts.join(","));
+  setAgentEnv("OPENNEKO_AGENT_MODEL_BINARY", OPERATOR_AGENT_ENV.binary, binary);
+  setAgentEnv("OPENNEKO_AGENT_MODEL_KEY_ENV", OPERATOR_AGENT_ENV.keyEnv, keyEnv);
   // hermes reads its model + provider from config.yaml under HERMES_HOME. In the
   // sandbox that config must be MIRRORED in — the launcher does so when
   // OPENNEKO_AGENT_HERMES_HOME points at the host home provisionHermes writes.
@@ -496,17 +514,42 @@ async function provisionOpenShellRuntime(orgId: string, backend: string): Promis
   // default model that 404s. (claude takes the model via its backend args, so
   // it needs no hermes home.)
   if (backend !== "claude-agent") {
-    process.env.OPENNEKO_AGENT_HERMES_HOME ||= hermesHomeForOrg(orgId);
+    setAgentEnv(
+      "OPENNEKO_AGENT_HERMES_HOME",
+      OPERATOR_AGENT_ENV.hermesHome,
+      hermesHomeForOrg(orgId),
+    );
   }
 
   const apiKey = decryptSecrets(row.secrets).apiKey;
   if (!apiKey) return;
-  await ensureOpenShellProvider({
-    providerName: process.env.OPENNEKO_AGENT_MODEL_PROVIDER,
-    apiKey,
-    gatewayName: process.env.OPENSHELL_GATEWAY || undefined,
-    gatewayEndpoint: process.env.OPENSHELL_GATEWAY_ENDPOINT || undefined,
-  });
+  // The gateway can be restarting exactly while we register the provider
+  // (deploys recreate it alongside the worker). A single failed attempt
+  // used to be swallowed upstream, leaving a healthy worker with no
+  // provider on the gateway and every channel run broken until a restart.
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 3; attempt++) {
+    try {
+      await ensureOpenShellProvider({
+        providerName: process.env.OPENNEKO_AGENT_MODEL_PROVIDER ?? "openneko-agent",
+        apiKey,
+        gatewayName: process.env.OPENSHELL_GATEWAY || undefined,
+        gatewayEndpoint: process.env.OPENSHELL_GATEWAY_ENDPOINT || undefined,
+      });
+      lastError = undefined;
+      break;
+    } catch (e) {
+      lastError = e;
+      if (attempt < 3) {
+        console.warn(
+          `[host-provision] OpenShell provider sync attempt ${attempt} failed; retrying: ${e instanceof Error ? e.message : e}`,
+        );
+        const base = Number(process.env.OPENNEKO_PROVISION_RETRY_BASE_MS ?? 2_000);
+        await new Promise((resolve) => setTimeout(resolve, attempt * base));
+      }
+    }
+  }
+  if (lastError !== undefined) throw lastError;
   console.log(
     `[host-provision] OpenShell agent runtime self-configured: provider="${process.env.OPENNEKO_AGENT_MODEL_PROVIDER}" egress="${hosts.join(",")}" binary="${process.env.OPENNEKO_AGENT_MODEL_BINARY}" keyEnv=${keyEnv}`,
   );

--- a/packages/llm/src/host-provision.ts
+++ b/packages/llm/src/host-provision.ts
@@ -3,7 +3,7 @@ import { mkdir, chmod } from "node:fs/promises";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 
-import { and, data_source, db, desc, eq, llm_provider_config } from "@neko/db";
+import { and, data_source, db, desc, eq, like, llm_provider_config, or } from "@neko/db";
 import { isAgentBackendId } from "./agent-backend";
 import { maybeDecryptSecret } from "./secrets";
 import {
@@ -176,7 +176,14 @@ async function provisionGraphjinSourcesMode(orgId: string): Promise<void> {
       reconcileDemoAuthMode
         ? and(
             eq(data_source.org_id, orgId),
-            eq(data_source.label, "AdventureWorks"),
+            // The seeded label ("AdventureWorks") is renamed by the setup
+            // wizard's data-source save, which permanently disabled this
+            // reconcile. The in-stack customer GraphJin URL is the stable
+            // identity of the packaged demo's source, so match either.
+            or(
+              eq(data_source.label, "AdventureWorks"),
+              like(data_source.graphql_url, "http://graphjin:8080/%"),
+            ),
           )
         : eq(data_source.org_id, orgId),
     )

--- a/packages/llm/src/work/sandbox-launcher.ts
+++ b/packages/llm/src/work/sandbox-launcher.ts
@@ -648,12 +648,7 @@ function makeSandboxCore(
         "node",
         "--version",
       ];
-      try {
-        await run(createArgs, 180_000);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        if (!message.includes("already exists")) throw error;
-
+      const reclaimAndCreate = async () => {
         // Run names are deterministic so a durable queue retry can collide
         // with an OpenShell sandbox orphaned by a worker restart or deploy.
         // Replace only that exact run sandbox, then let the normal finally
@@ -661,6 +656,33 @@ function makeSandboxCore(
         log(`replacing stale agent sandbox after name collision: ${name}`);
         await runCleanup(["sandbox", "delete", name], 60_000);
         await run(createArgs, 180_000);
+      };
+      try {
+        await run(createArgs, 180_000);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (message.includes("already exists")) {
+          await reclaimAndCreate();
+        } else {
+          // Not a name collision: a transient gateway hiccup (restart mid
+          // deploy) or a first-use image pull that outran the timeout — the
+          // gateway-side pull keeps going, so a second attempt usually rides
+          // its cache. Retry once before surfacing the real error; a timed-out
+          // first attempt may have half-registered the name, which the retry
+          // then reclaims.
+          log(
+            `agent sandbox create failed (${message.slice(0, 200)}); retrying once`,
+          );
+          await new Promise((resolve) => setTimeout(resolve, 3_000));
+          try {
+            await run(createArgs, 180_000);
+          } catch (retryError) {
+            const retryMessage =
+              retryError instanceof Error ? retryError.message : String(retryError);
+            if (!retryMessage.includes("already exists")) throw retryError;
+            await reclaimAndCreate();
+          }
+        }
       }
       sandboxCreated = true;
 
@@ -978,27 +1000,45 @@ export async function ensureOpenShellProvider(opts: {
     runProcessOnce(cli, [...gatewayArgs, ...args], 60_000);
 
   const dir = await mkdtemp(path.join(tmpdir(), "oss-profile-"));
+  let profileImportError: unknown;
   try {
     const file = path.join(dir, `${OPENNEKO_AGENT_PROFILE_ID}.yaml`);
     await writeFile(file, OPENNEKO_AGENT_PROFILE_YAML);
-    // Import is upsert-ish; tolerate "already registered".
-    await run(["provider", "profile", "import", "--file", file]).catch(() => {});
+    // Import is upsert-ish; "already registered" is fine. But a swallowed
+    // TRANSPORT failure (gateway restarting) means the profile type the
+    // create below references may not exist — remember the failure so the
+    // create's error path can surface the real cause instead of a cryptic
+    // unknown-profile error.
+    await run(["provider", "profile", "import", "--file", file]).catch((e) => {
+      profileImportError = e;
+    });
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
 
   const credential = `api_key=${opts.apiKey}`;
   // create on first run; update (refresh key) when it already exists.
-  await run([
-    "provider",
-    "create",
-    "--name",
-    opts.providerName,
-    "--type",
-    OPENNEKO_AGENT_PROFILE_ID,
-    "--credential",
-    credential,
-  ]).catch(() => run(["provider", "update", opts.providerName, "--credential", credential]));
+  try {
+    await run([
+      "provider",
+      "create",
+      "--name",
+      opts.providerName,
+      "--type",
+      OPENNEKO_AGENT_PROFILE_ID,
+      "--credential",
+      credential,
+    ]);
+  } catch (createError) {
+    try {
+      await run(["provider", "update", opts.providerName, "--credential", credential]);
+    } catch (updateError) {
+      // Neither path landed: prefer the profile-import failure as the root
+      // cause when there was one (the create's unknown-profile error is a
+      // symptom of it).
+      throw profileImportError ?? updateError ?? createError;
+    }
+  }
 }
 
 /**

--- a/packages/llm/test/host-provision.test.ts
+++ b/packages/llm/test/host-provision.test.ts
@@ -450,6 +450,45 @@ describeIfDb("provisionHostConfig", () => {
     expect(source?.authMode).toBe("jwt");
   });
 
+  it("still reconciles the demo source after the wizard renamed its label", async () => {
+    const configPath = join(tempHome, "agentic.yml");
+    await writeFile(
+      configPath,
+      `auth:
+  type: jwt
+  jwt:
+    secret: "${graphjinSigningSecretB64(orgId)}"
+`,
+      "utf8",
+    );
+    // The setup wizard saves the data source with label "primary", renaming
+    // the seeded AdventureWorks row in place. The in-stack GraphJin URL is
+    // the stable identity the reconcile must key on.
+    await seedDataSource(orgId, {
+      label: "primary",
+      graphqlUrl: "http://graphjin:8080/api/v1/graphql",
+    });
+
+    const previousPath = process.env.OPENNEKO_GRAPHJIN_CONFIG;
+    const previousMode = process.env.OPENNEKO_STACK_MODE;
+    process.env.OPENNEKO_GRAPHJIN_CONFIG = configPath;
+    process.env.OPENNEKO_STACK_MODE = "demo";
+    try {
+      await provisionHostConfig(orgId);
+    } finally {
+      if (previousPath === undefined) delete process.env.OPENNEKO_GRAPHJIN_CONFIG;
+      else process.env.OPENNEKO_GRAPHJIN_CONFIG = previousPath;
+      if (previousMode === undefined) delete process.env.OPENNEKO_STACK_MODE;
+      else process.env.OPENNEKO_STACK_MODE = previousMode;
+    }
+
+    const [source] = await db()
+      .select({ authMode: data_source.auth_mode })
+      .from(data_source)
+      .where(eq(data_source.org_id, orgId));
+    expect(source?.authMode).toBe("jwt");
+  });
+
   it("writes hermes config under ~/.config/openneko/hermes/{orgId} when HERMES_HOME is unset", async () => {
     delete process.env.HERMES_HOME;
     await seedDataSource(orgId);

--- a/packages/llm/test/host-provision.test.ts
+++ b/packages/llm/test/host-provision.test.ts
@@ -539,8 +539,44 @@ describeIfDb("provisionHostConfig", () => {
     expect(env).toBe("");
   });
 
+  it("re-derives the sandbox egress env on a provider switch", async () => {
+    await seedDataSource(orgId);
+    await seedProvider(orgId, {
+      scope: "agent",
+      provider: "hermes",
+      config: { backend: "hermes" },
+    });
+    await seedProvider(orgId, {
+      scope: "primary",
+      provider: "google-gemini",
+      model: "gemini-pro-latest",
+      secrets: { apiKey: "key-a" },
+    });
+    await provisionHostConfig(orgId);
+    const firstHost = process.env.OPENNEKO_AGENT_MODEL_HOST;
+    expect(firstHost).toBeTruthy();
+
+    // Operator switches provider; the old `||=` writes pinned the first
+    // pass's derived values for the process lifetime, leaving the egress
+    // allowlist and key env var on the previous provider.
+    await clearProvider(orgId, "primary");
+    await seedProvider(orgId, {
+      scope: "primary",
+      provider: "anthropic",
+      model: "claude-opus-4-7",
+      secrets: { apiKey: "key-b" },
+    });
+    await provisionHostConfig(orgId);
+    expect(process.env.OPENNEKO_AGENT_MODEL_HOST).toBeTruthy();
+    expect(process.env.OPENNEKO_AGENT_MODEL_HOST).not.toBe(firstHost);
+    expect(process.env.OPENNEKO_AGENT_MODEL_KEY_ENV).toContain("ANTHROPIC");
+  });
+
   it("keeps direct provisioning best-effort when OpenShell provider sync fails", async () => {
-    ensureOpenShellProviderMock.mockRejectedValueOnce(new Error("gateway unavailable"));
+    // Persistent failure: the sync now retries in place (3 attempts) before
+    // giving up, so a single rejection would be healed by the retry.
+    process.env.OPENNEKO_PROVISION_RETRY_BASE_MS = "10";
+    ensureOpenShellProviderMock.mockRejectedValue(new Error("gateway unavailable"));
     await seedDataSource(orgId);
     await seedProvider(orgId, {
       scope: "agent",
@@ -555,10 +591,11 @@ describeIfDb("provisionHostConfig", () => {
     });
 
     await expect(provisionHostConfig(orgId)).resolves.toBeUndefined();
-    expect(ensureOpenShellProviderMock).toHaveBeenCalledTimes(1);
+    expect(ensureOpenShellProviderMock).toHaveBeenCalledTimes(3);
 
     const yaml = await readFile(join(hermesHome, "config.yaml"), "utf8");
     expect(yaml).toContain('provider: "gemini"');
+    delete process.env.OPENNEKO_PROVISION_RETRY_BASE_MS;
   });
 
   it("verifies the gateway and syncs the provider before an agent job", async () => {
@@ -610,16 +647,19 @@ describeIfDb("provisionHostConfig", () => {
         model: "gemini-pro-latest",
         secrets: { apiKey: "test-gemini-key" },
       });
-      ensureOpenShellProviderMock
-        .mockRejectedValueOnce(new Error("gateway unavailable"))
-        .mockResolvedValueOnce(undefined);
+      // Persistently down first (all 3 in-place retries fail), then back.
+      process.env.OPENNEKO_PROVISION_RETRY_BASE_MS = "10";
+      ensureOpenShellProviderMock.mockRejectedValue(new Error("gateway unavailable"));
 
       await expect(ensureHostConfigProvisioned(retryOrgId)).rejects.toThrow(
         "gateway unavailable",
       );
-      await expect(ensureHostConfigProvisioned(retryOrgId)).resolves.toBeUndefined();
+      expect(ensureOpenShellProviderMock).toHaveBeenCalledTimes(3);
 
-      expect(ensureOpenShellProviderMock).toHaveBeenCalledTimes(2);
+      ensureOpenShellProviderMock.mockResolvedValue(undefined);
+      await expect(ensureHostConfigProvisioned(retryOrgId)).resolves.toBeUndefined();
+      expect(ensureOpenShellProviderMock).toHaveBeenCalledTimes(4);
+      delete process.env.OPENNEKO_PROVISION_RETRY_BASE_MS;
     } finally {
       await deleteTestOrg(retryOrgId);
     }

--- a/packages/llm/test/sources-config.test.ts
+++ b/packages/llm/test/sources-config.test.ts
@@ -1,0 +1,107 @@
+import { mkdtemp, readFile, readdir, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  SOURCES_SECRET_PLACEHOLDER,
+  atomicWriteFile,
+  patchGraphjinSourcesJwtSecret,
+  shouldReconcileDemoSourceAuthMode,
+} from "../src/graphjin/sources-config";
+import * as hostProvision from "../src/host-provision";
+
+const SOURCES_CONFIG = `# sources mode
+auth:
+  type: jwt
+  jwt:
+    # per-org actor-token secret
+    secret: "${SOURCES_SECRET_PLACEHOLDER}"
+`;
+
+describe("patchGraphjinSourcesJwtSecret", () => {
+  it("replaces the placeholder", () => {
+    const patched = patchGraphjinSourcesJwtSecret(SOURCES_CONFIG, "s3cret==");
+    expect(patched.changed).toBe(true);
+    expect(patched.content).toContain('secret: "s3cret=="');
+    expect(patched.content).not.toContain(SOURCES_SECRET_PLACEHOLDER);
+  });
+
+  it("repairs a stale concrete secret", () => {
+    const seeded = patchGraphjinSourcesJwtSecret(SOURCES_CONFIG, "old==").content;
+    const repaired = patchGraphjinSourcesJwtSecret(seeded, "new==");
+    expect(repaired.changed).toBe(true);
+    expect(repaired.content).toContain('secret: "new=="');
+  });
+
+  it("is a no-op when the secret is already current", () => {
+    const seeded = patchGraphjinSourcesJwtSecret(SOURCES_CONFIG, "same==").content;
+    const again = patchGraphjinSourcesJwtSecret(seeded, "same==");
+    expect(again.changed).toBe(false);
+    expect(again.content).toBe(seeded);
+  });
+
+  it("leaves configs without a jwt auth block untouched", () => {
+    const anonymous = "auth:\n  type: none\n";
+    const patched = patchGraphjinSourcesJwtSecret(anonymous, "s==");
+    expect(patched.changed).toBe(false);
+    expect(patched.content).toBe(anonymous);
+  });
+});
+
+describe("shouldReconcileDemoSourceAuthMode", () => {
+  const jwtConfig = patchGraphjinSourcesJwtSecret(SOURCES_CONFIG, "k==").content;
+
+  it("recognises demo stack mode with a jwt template", () => {
+    expect(shouldReconcileDemoSourceAuthMode("/any/path.yml", jwtConfig, "demo")).toBe(true);
+  });
+
+  it("recognises the legacy packaged demo mount", () => {
+    expect(
+      shouldReconcileDemoSourceAuthMode("/graphjin-config/agentic.yml", jwtConfig, undefined),
+    ).toBe(true);
+  });
+
+  it("stays off for prod paths and anonymous configs", () => {
+    expect(
+      shouldReconcileDemoSourceAuthMode("/config/graphjin/agentic.yml", jwtConfig, undefined),
+    ).toBe(false);
+    expect(shouldReconcileDemoSourceAuthMode("/x.yml", "auth:\n  type: none\n", "demo")).toBe(
+      false,
+    );
+  });
+});
+
+describe("atomicWriteFile", () => {
+  it("replaces content without leaving a temp file behind", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sources-config-"));
+    const target = join(dir, "agentic.yml");
+    await writeFile(target, "before", "utf8");
+
+    await atomicWriteFile(target, "after");
+
+    expect(await readFile(target, "utf8")).toBe("after");
+    expect(await readdir(dir)).toEqual(["agentic.yml"]);
+  });
+
+  it("honours an explicit mode", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "sources-config-"));
+    const target = join(dir, ".env");
+    await atomicWriteFile(target, "KEY=v\n", { mode: 0o600 });
+    const info = await stat(target);
+    expect(info.mode & 0o777).toBe(0o600);
+  });
+});
+
+// host-provision must keep re-exporting the canonical implementations —
+// the graphjin-secret-init one-shot and the worker's boot pass patch the
+// same file and must agree byte-for-byte.
+describe("host-provision re-exports", () => {
+  it("exposes the same functions as sources-config", () => {
+    expect(hostProvision.patchGraphjinSourcesJwtSecret).toBe(patchGraphjinSourcesJwtSecret);
+    expect(hostProvision.shouldReconcileDemoSourceAuthMode).toBe(
+      shouldReconcileDemoSourceAuthMode,
+    );
+    expect(hostProvision.SOURCES_SECRET_PLACEHOLDER).toBe(SOURCES_SECRET_PLACEHOLDER);
+  });
+});

--- a/packages/secret-crypt/src/index.ts
+++ b/packages/secret-crypt/src/index.ts
@@ -5,7 +5,7 @@ import {
   createHmac,
   randomBytes,
 } from "node:crypto";
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { linkSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -42,18 +42,67 @@ function generateAndPersist(): string {
   const path = appSecretKeyPath();
   mkdirSync(join(path, ".."), { recursive: true });
   const value = randomBytes(32).toString("base64");
-  writeFileSync(path, value, { encoding: "utf8" });
-  chmodSync(path, 0o600);
-  return value;
+  // Exclusive publish: write the complete key to a private temp file, then
+  // link(2) it into place. link fails with EEXIST when a concurrent process
+  // won the race — their key is then THE deployment key and ours is
+  // discarded. A plain truncate-and-write here let two processes cache
+  // different keys, and exposed an empty/partial file to concurrent readers.
+  const tmp = `${path}.tmp-${process.pid}-${randomBytes(4).toString("hex")}`;
+  writeFileSync(tmp, value, { encoding: "utf8", mode: 0o600 });
+  try {
+    linkSync(tmp, path);
+  } catch (e) {
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code === "EPERM" || code === "ENOSYS" || code === "EXDEV") {
+      // Filesystem without hardlink support: fall back to exclusive create.
+      try {
+        writeFileSync(path, value, { encoding: "utf8", mode: 0o600, flag: "wx" });
+      } catch (e2) {
+        if ((e2 as NodeJS.ErrnoException).code !== "EEXIST") {
+          rmSync(tmp, { force: true });
+          throw e2;
+        }
+      }
+    } else if (code !== "EEXIST") {
+      rmSync(tmp, { force: true });
+      throw e;
+    }
+  }
+  rmSync(tmp, { force: true });
+  // Re-read whatever actually landed — ours, or the race winner's.
+  const stored = readFileSync(path, "utf8").trim();
+  if (!stored) {
+    throw new Error(
+      `secret-key at ${path} exists but is empty; remove the file to let OpenNeko generate a new key`,
+    );
+  }
+  return stored;
 }
 
 function readSecret(): string {
   const path = appSecretKeyPath();
+  let raw: string | null = null;
   try {
-    const stored = readFileSync(path, "utf8").trim();
+    raw = readFileSync(path, "utf8");
+  } catch (e) {
+    // ONLY a missing file may trigger generation. Every stored secret —
+    // LLM API keys, plugin secrets, the rotated DB password — and every
+    // derived signing secret is keyed by this file, so regenerating on a
+    // transient read failure (EACCES during an init chown, EISDIR from a
+    // bad mount, ...) would silently orphan all of them.
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw new Error(
+        `secret-key unreadable at ${path} (${(e as NodeJS.ErrnoException).code}); refusing to regenerate — fix access to the existing key file`,
+        { cause: e },
+      );
+    }
+  }
+  if (raw !== null) {
+    const stored = raw.trim();
     if (stored) return stored;
-  } catch {
-    // file missing or unreadable — fall through to generate.
+    throw new Error(
+      `secret-key at ${path} exists but is empty; remove the file to let OpenNeko generate a new key`,
+    );
   }
   return generateAndPersist();
 }

--- a/packages/secret-crypt/test/key-file.test.ts
+++ b/packages/secret-crypt/test/key-file.test.ts
@@ -1,0 +1,103 @@
+import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
+import { mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  _resetSecretKeyCacheForTesting,
+  maybeDecryptSecret,
+  maybeEncryptSecret,
+} from "../src/index";
+
+const execFileAsync = promisify(execFile);
+const require = createRequire(import.meta.url);
+const here = fileURLToPath(new URL(".", import.meta.url));
+
+function freshConfigHome(): string {
+  const dir = mkdtempSync(join(tmpdir(), "secret-crypt-"));
+  process.env.XDG_CONFIG_HOME = dir;
+  _resetSecretKeyCacheForTesting();
+  return dir;
+}
+
+afterEach(() => {
+  delete process.env.XDG_CONFIG_HOME;
+  _resetSecretKeyCacheForTesting();
+});
+
+describe("secret-key creation", () => {
+  it("generates a 0600 key on first use and reuses it", () => {
+    const dir = freshConfigHome();
+    const round = maybeDecryptSecret(maybeEncryptSecret("hello"));
+    expect(round).toBe("hello");
+    const keyPath = join(dir, "openneko", "secret-key");
+    const info = statSync(keyPath);
+    expect(info.mode & 0o777).toBe(0o600);
+    expect(readFileSync(keyPath, "utf8").trim().length).toBeGreaterThan(0);
+  });
+
+  it("adopts an existing key instead of overwriting it", () => {
+    const dir = freshConfigHome();
+    const keyPath = join(dir, "openneko", "secret-key");
+    mkdirSync(join(dir, "openneko"), { recursive: true, mode: 0o700 });
+    writeFileSync(keyPath, "pre-existing-key-material\n", { mode: 0o600 });
+
+    const encrypted = maybeEncryptSecret("hello");
+    expect(readFileSync(keyPath, "utf8")).toBe("pre-existing-key-material\n");
+    expect(maybeDecryptSecret(encrypted)).toBe("hello");
+  });
+
+  it("throws instead of regenerating when the key file is unreadable", () => {
+    const dir = freshConfigHome();
+    // A directory at the key path yields EISDIR — a non-ENOENT failure that
+    // previously triggered a silent, destructive regeneration.
+    mkdirSync(join(dir, "openneko", "secret-key"), { recursive: true });
+    expect(() => maybeEncryptSecret("hello")).toThrow(/refusing to regenerate/);
+  });
+
+  it("throws on an empty key file rather than replacing it", () => {
+    const dir = freshConfigHome();
+    mkdirSync(join(dir, "openneko"), { recursive: true, mode: 0o700 });
+    writeFileSync(join(dir, "openneko", "secret-key"), "", { mode: 0o600 });
+    expect(() => maybeEncryptSecret("hello")).toThrow(/exists but is empty/);
+    expect(readFileSync(join(dir, "openneko", "secret-key"), "utf8")).toBe("");
+  });
+});
+
+describe("concurrent first-use across processes", () => {
+  it("every process converges on one key", async () => {
+    const dir = freshConfigHome();
+    // tsx is a dependency of the worker app; resolve its loader from there so
+    // child node processes can import the TS source directly, like the
+    // packaged one-shots do.
+    const tsxLoader = require.resolve("tsx/esm", {
+      paths: [join(here, "..", "..", "..", "apps", "worker")],
+    });
+    const entry = join(here, "..", "src", "index.ts");
+    const script = `
+      const { maybeEncryptSecret } = await import(${JSON.stringify(entry)});
+      process.stdout.write(maybeEncryptSecret("probe"));
+    `;
+
+    const children = Array.from({ length: 6 }, () =>
+      execFileAsync(
+        process.execPath,
+        ["--import", tsxLoader, "--input-type=module", "-e", script],
+        { env: { ...process.env, XDG_CONFIG_HOME: dir } },
+      ),
+    );
+    const outputs = await Promise.all(children);
+
+    // The parent process reads whichever key won; every child's ciphertext
+    // must decrypt under it — divergent cached keys would fail GCM auth.
+    _resetSecretKeyCacheForTesting();
+    for (const { stdout } of outputs) {
+      expect(stdout.startsWith("enc:v1:")).toBe(true);
+      expect(maybeDecryptSecret(stdout)).toBe("probe");
+    }
+  }, 30_000);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ importers:
       '@neko/records':
         specifier: workspace:*
         version: link:../../packages/records
+      '@neko/secret-crypt':
+        specifier: workspace:*
+        version: link:../../packages/secret-crypt
       '@neko/telemetry':
         specifier: workspace:*
         version: link:../../packages/telemetry


### PR DESCRIPTION
## Summary

The "Deploy to VM" failure on run #274 (`dependency cycle detected: graphjin -> worker -> graphjin`) turned out to be the tip of a larger set of startup/onboarding ordering hazards. A full race audit of stack bring-up and onboarding (web boot, setup wizard, demo seeding, OpenShell chain) surfaced ~30 findings; this PR implements every fix from that audit's recommended fix order, one commit per group, each with tests. It also documents the stack modes in the README.

## What's fixed

**Compose / GraphJin secret ordering** — a new `graphjin-secret-init` one-shot resolves (or creates, under an advisory lock) the org row and reconciles the per-org JWT secret into the sources config *before* GraphJin's first start, in every mode. This replaces the `graphjin -> worker(healthy)` edge that cycled against the demo/adventureworks overlays' `worker -> graphjin` edge and broke every demo and dev bring-up (including `pnpm dev:up`). Reconciliation is unconditional, so secret-key rotation, restores, and partial volume wipes self-heal. Also: atomic tmp+rename writes for the GraphJin/hermes config files, a short probe retry for the in-stack GraphJin, and merged-graph **acyclicity tests over all 8 shipped compose file combinations** (the parity test only ever parsed `demo.yml` in isolation, which is why the cycle shipped).

**Org & secret-key bootstrap** — `getOrgId()` creation is serialized under a transaction-scoped advisory lock with a stable ORDER BY (nothing in the schema forbids two org rows, and web/worker/seed/one-shots can all race an empty table outside Compose ordering). The TS secret-key loader regenerates **only on ENOENT** — any other read failure (e.g. EACCES during an init chown) previously overwrote the live key and orphaned every `enc:v1` secret — and creation publishes atomically via link(2); the Go CLI's loader gets the same O_EXCL treatment.

**Auth** — the sign-in gate now **fails closed** while the worker is unreachable on any install where SSO has been seen live (last live answer persisted next to the deployment config; both the proxy's and lib/auth's caches reset through one invalidation). Previously every worker boot/restart window dropped the gate and admitted unauthenticated requests as the solo-operator admin. Session cookies fall back to a stable secret derived from the deployment key when `OPENNEKO_SESSION_SECRET` is unset (no compose file ever set it). Migration `0061` repairs duplicate SSO identities in place and adds unique indexes on `app_user (org_id, sub)` / `(org_id, lower(email))`; `upsertUserFromIdentity` runs in one locked transaction so two concurrent first sign-ins can no longer both become admin and permanently break sign-in.

**Password rotation & onboarding submit** — rotation holds an advisory lock across both the `ALTER ROLE`s and the config-file write (two concurrent rotations could leave `config.json` and the Postgres role holding different passwords: a full-stack lockout), and the worker-reconnect notification is no longer silently dropped. The onboarding submit route gains the admin gate, one locked transaction for its delete+insert, and in-flight build dedupe. The Go wizard persists a successfully rotated password through every error path.

**Demo pipeline** — the AdventureWorks download retries and can't mistake a partial file for a cached zip; the "already loaded" check is a completion marker stamped after `install.sql` finishes instead of "≥50 tables exist" (which went true at DDL commit, so an interrupted load skipped forever with empty tables). The seed serializes org creation, tolerates a concurrently racing settings wizard, no longer counts the worker's own system workflow when deciding whether the trial set was seeded, self-heals partial runs, and waits for `openneko-config-init`. The demo `auth_mode` reconcile keys on the in-stack GraphJin URL as well as the label the setup wizard renames.

**OpenShell chain** — certgen generates into a staging dir and `openshell-reg` promotes it only when no complete PKI is active, so a hand-run `compose up` can no longer rewrite the CA under a live gateway; the registration publish is per-file atomic with `active_gateway` written last. worker/web gain a direct gateway dependency. The boot-time provider sync retries in place, surfaces the profile-import failure it used to swallow, and channel-triggered runs re-provision like the workflow job does. Sandbox creation retries once on non-collision failures, and the agent egress env is re-derived on every provisioning pass instead of first-writer-wins pinning (operator-set compose values still win).

**Worker boot** — the records-watch delivery reconcile can no longer crash-loop the whole worker while `records-watch-graphjin` is still coming up; failures warn and retry in the background.

**CLI contract** — `Ready()` counts 401/403 as "web serving" (an SSO-gated install answers exactly that), setup refuses to configure a running stack whose mode doesn't match `--mode`, plugin-op proxying refuses to guess between multiple running stacks, and `openneko start` runs preflight and pre-pulls `plugin-base` alongside the agent image.

## Validation

- All 8 compose file combinations (packaged prod/dev/demo, source base/adventureworks/graphjin-agent/openshell/openshell-host) validated with the real Compose binary; new Go tests enforce acyclicity and the secret-init gating.
- `graphjin-secret-init` exercised end-to-end against a real Postgres 16: concurrent first-boot runs converge on one org, re-runs are idempotent, secret-key rotation self-heals the config.
- The rendered `openshell-reg` script executed in both scenarios: fresh install promotes the staged PKI; re-run under a live gateway preserves the active CA and refreshes registrations from it.
- Full `go test ./...` green; workspace typecheck clean; TS suites green against a live Postgres (secret-crypt 11, db 49, web 380, worker 482, llm 822 — the two pre-existing `graphjin CLI is not installed` integration failures reproduce identically on unmodified `main` and are environmental).

## Notes for review

- The demo's `graphjin-secret-init` runs after `neko-adventureworks-seed` so the demo keeps its `adventureworks` org identity; in prod it runs right after migrate.
- `web`/`worker`/`openneko-config-init` in the source compose now honor `OPENNEKO_CONFIG_VOLUME` like `neko-migrate`/`neko-graphjin` already did, so the host-hybrid dev layout shares one config dir (and one secret-key).
- Migration `0061` neutralizes duplicate rows in place (clears `sub`, uniquifies `email`, sets `disabled_at`) rather than deleting them — rows may be referenced by runs/personas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBiMm2PoXxch4TQc8JRNPy

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBiMm2PoXxch4TQc8JRNPy)_