### PR TITLE
fix(compose): tolerate release images that predate the secret-init script

### DIFF
--- a/apps/openneko/assets/compose/core.yml
+++ b/apps/openneko/assets/compose/core.yml
@@ -298,7 +298,21 @@ services:
   graphjin-secret-init:
     image: ghcr.io/open-neko/neko-worker:${OPENNEKO_VERSION:-latest}
     working_dir: /app
-    command: ["node", "--import", "tsx/esm", "node_modules/@neko/llm/src/graphjin/init-secret.mjs"]
+    # Guarded for supervisor/image version skew: the main-supervisor deploy
+    # path pairs a supervisor (and this embedded compose) built from main
+    # with application images from the latest smoked RELEASE, which may
+    # predate the init script. Older images fall back to the worker's
+    # boot-time reconcile — the pre-secret-init behavior every released
+    # worker still carries — instead of failing the whole bring-up.
+    command:
+      - /bin/sh
+      - -c
+      - |
+        SCRIPT=node_modules/@neko/llm/src/graphjin/init-secret.mjs
+        if [ -f "$$SCRIPT" ]; then
+          exec node --import tsx/esm "$$SCRIPT"
+        fi
+        echo "[graphjin-secret-init] image predates the embedded secret-init script; the worker reconciles the per-org JWT secret at boot instead"
     depends_on:
       neko-migrate:
         condition: service_completed_successfully

--- a/compose.yml
+++ b/compose.yml
@@ -369,7 +369,21 @@ services:
       context: .
       target: worker
     working_dir: /app
-    command: ["node", "--import", "tsx/esm", "node_modules/@neko/llm/src/graphjin/init-secret.mjs"]
+    # Guarded for supervisor/image version skew: the main-supervisor deploy
+    # path pairs a supervisor (and this embedded compose) built from main
+    # with application images from the latest smoked RELEASE, which may
+    # predate the init script. Older images fall back to the worker's
+    # boot-time reconcile — the pre-secret-init behavior every released
+    # worker still carries — instead of failing the whole bring-up.
+    command:
+      - /bin/sh
+      - -c
+      - |
+        SCRIPT=node_modules/@neko/llm/src/graphjin/init-secret.mjs
+        if [ -f "$$SCRIPT" ]; then
+          exec node --import tsx/esm "$$SCRIPT"
+        fi
+        echo "[graphjin-secret-init] image predates the embedded secret-init script; the worker reconciles the per-org JWT secret at boot instead"
     depends_on:
       neko-migrate:
         condition: service_completed_successfully


### PR DESCRIPTION
## Summary

Deploy to VM run #277 (main-supervisor path, after #224 merged) failed with:

```
service "graphjin-secret-init" didn't complete successfully: exit 1
```

The cycle fix itself worked — the demo compose graph resolved and the whole stack came up, which is further than run #274 ever got. The failure is **supervisor/image version skew**: the main-supervisor deploy path pairs a supervisor (and its embedded compose) built from `main` with application images from the latest smoked **release**, and the new `graphjin-secret-init` one-shot execs `node_modules/@neko/llm/src/graphjin/init-secret.mjs` inside the worker image — which the v2.28.0 images don't carry yet.

## Fix

Guard the one-shot's command in both the embedded `core.yml` and the source `compose.yml`:

- image has the script → run it (full seed-before-GraphJin ordering, unchanged);
- image predates it → log the skew and exit 0, so the stack falls back to the worker's boot-time JWT reconcile — the pre-secret-init behavior every released worker still ships.

This is structural hardening, not just a one-off: the supervisor built from `main` will always be ahead of the released images on this deploy path, so the embedded compose must never hard-depend on brand-new in-image assets.

## Validation

- All packaged mode combinations still resolve with the real Compose binary; Go assets tests (acyclicity + parity) green.
- Executed the rendered guard script both ways: missing script → exits 0 with the skew message; present script → execs node on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBiMm2PoXxch4TQc8JRNPy

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBiMm2PoXxch4TQc8JRNPy)_