### PR TITLE
fix(ci): unwrap parametrized image refs in post-release smoke pre-pull

### DIFF
--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -103,6 +103,10 @@ jobs:
           # `--mode prod` actually runs instead of hand-maintaining it
           # (busybox:latest for openshell-reg was the second one missed).
           # OPENSHELL_VERSION is intentionally literal in the second sed expression.
+          # The final expression unwraps ANY other ${VAR:-default} to its
+          # default (e.g. ${OPENNEKO_GRAPHJIN_IMAGE:-dosco/graphjin:X}) — an
+          # uninterpolated ref reaches `docker pull` as a literal and fails
+          # smoke with "invalid reference format", demoting a good release.
           # shellcheck disable=SC2016
           mapfile -t refs < <(
             sed -n 's/^[[:space:]]*image:[[:space:]]*//p' \
@@ -110,6 +114,7 @@ jobs:
               apps/openneko/assets/compose/openshell.yml \
             | sed -e "s/\${OPENNEKO_VERSION:-latest}/${tag}/" \
                   -e 's/\${OPENSHELL_VERSION:-\([0-9.][0-9.]*\)}/\1/' \
+                  -e 's/\${[A-Za-z_][A-Za-z_0-9]*:-\([^}]*\)}/\1/g' \
             | sort -u
           )
           echo "pre-pulling: ${refs[*]}"


### PR DESCRIPTION
## Summary

Post-release smoke has failed for every release since v2.28.0 — in ~1 minute, before any real smoke testing — and each failure **demoted the release off "Latest"** (v2.28.0 this morning, v2.28.1 at 13:51). That demotion is what has been blocking the release-path Deploy to VM.

Root cause: smoke derives its `--pull never` pre-pull list from the embedded compose files, but its `sed` only interpolates `${OPENNEKO_VERSION}` and `${OPENSHELL_VERSION}`. PR #222 parametrized the customer GraphJin image as `${OPENNEKO_GRAPHJIN_IMAGE:-dosco/graphjin:3.18.42}`, so smoke passed the literal `${OPENNEKO_GRAPHJIN_IMAGE:-…}` to `docker pull`:

```
docker pull '${OPENNEKO_GRAPHJIN_IMAGE:-dosco/graphjin:3.18.42}'
invalid reference format
…
pull of ${OPENNEKO_GRAPHJIN_IMAGE:-dosco/graphjin:3.18.42} failed after 5 attempts
::error::v2.28.1 failed post-release smoke — demoting off 'Latest'
```

## Fix

One added `sed` expression that unwraps **any** remaining `${VAR:-default}` to its default, after the version substitutions — covering `OPENNEKO_GRAPHJIN_IMAGE` and any future parametrized image, so the next one can't silently break smoke and demote a good release. Comment updated to explain why.

Validated by running the exact extraction pipeline against the current compose files — every ref is now a pullable literal:

```
busybox:latest
dosco/graphjin:3.18.42
ghcr.io/nvidia/openshell/gateway:0.0.54
ghcr.io/open-neko/neko-backup:v9.9.9
… (all ghcr refs at the substituted tag)
```

## Timing note

v2.28.2's binaries finish around 13:58 and its smoke run executes this workflow **from main** — if this merges first, that smoke passes on its own and the release-path Deploy to VM fires with tag and images consistent. If we miss the window, smoke can be re-dispatched for v2.28.2 after merge (and the release re-promoted to Latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBiMm2PoXxch4TQc8JRNPy

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBiMm2PoXxch4TQc8JRNPy)_