### PR TITLE
fix(deploy): verify ghcr images exist before main-supervisor deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,9 +47,47 @@ jobs:
         working-directory: apps/openneko
         run: |
           set -euo pipefail
-          tag=$(curl -fsSL https://api.github.com/repos/open-neko/openneko/releases/latest \
-            | jq -r .tag_name)
-          test -n "$tag"
+          # The GitHub release becomes releases/latest the moment release-please
+          # publishes it — ~15 minutes before release-binaries has pushed that
+          # tag's images to ghcr. Deploying inside that window failed run #279
+          # with "records-graphjin:v2.28.1: not found". Walk stable releases
+          # newest-first and deploy the first tag whose release-versioned images
+          # (from the packaged compose files, plus the agent image the deploy's
+          # sandbox smoke pulls) all have ghcr manifests.
+          # shellcheck disable=SC2016
+          mapfile -t images < <(
+            {
+              sed -n 's/^[[:space:]]*image:[[:space:]]*//p' \
+                assets/compose/core.yml assets/compose/openshell.yml \
+              | grep -F '${OPENNEKO_VERSION' \
+              | sed 's/:\${OPENNEKO_VERSION.*//'
+              echo ghcr.io/open-neko/agent
+            } | sort -u
+          )
+          mapfile -t candidates < <(
+            curl -fsSL "https://api.github.com/repos/open-neko/openneko/releases?per_page=10" \
+            | jq -r '[.[] | select(.prerelease == false and .draft == false)][:5] | .[].tag_name'
+          )
+          tag=""
+          for cand in "${candidates[@]}"; do
+            complete=true
+            for img in "${images[@]}"; do
+              if ! docker manifest inspect "${img}:${cand}" >/dev/null 2>&1; then
+                echo "::notice::${img}:${cand} is not on ghcr yet — skipping ${cand} (images still publishing)"
+                complete=false
+                break
+              fi
+            done
+            if [ "$complete" = true ]; then
+              tag="$cand"
+              break
+            fi
+          done
+          if [ -z "$tag" ]; then
+            echo "::error::no stable release has a complete ghcr image set (checked: ${candidates[*]:-none})"
+            exit 1
+          fi
+          echo "deploying application images at $tag"
           version="${tag#v}"
           go build -trimpath \
             -ldflags "-s -w -X github.com/open-neko/neko/apps/openneko/internal/version.Version=$version -X github.com/open-neko/neko/apps/openneko/internal/version.Commit=${{ github.event.workflow_run.head_sha }}" \


### PR DESCRIPTION
## Problem

The main-supervisor deploy path resolves its application image tag from `releases/latest`, but release-please publishes the GitHub release ~15 minutes before `release-binaries` finishes pushing that tag's images to ghcr. A main push landing in that window deploys a tag whose images don't exist yet — deploy run #279 failed exactly this way with `ghcr.io/open-neko/records-graphjin:v2.28.1: not found`.

The release-triggered path doesn't have this race: it only runs after post-release smoke, which has already pulled every image.

## Fix

Instead of trusting `releases/latest`, the tag-resolution step now:

1. Derives the release-versioned image list from the packaged compose files (`core.yml` + `openshell.yml`, everything pinned to `${OPENNEKO_VERSION}`), plus `ghcr.io/open-neko/agent` which the deploy's sandbox smoke pulls — 9 images total, so a newly added image is covered automatically.
2. Walks stable releases newest-first (prerelease/draft excluded, so smoke-demoted releases are skipped — same semantics as `releases/latest`).
3. Deploys the first tag for which **all** images have ghcr manifests (`docker manifest inspect`). A release whose images are still publishing is skipped with a `::notice::` and the deploy falls back to the previous complete release instead of failing.

If no candidate has a complete image set, the step fails with a clear error listing what was checked.

## Validation

- Workflow YAML parses.
- Guard logic exercised locally with mocked `curl`/`docker`: it derives the 9-image list from the real compose files, skips a newest release with one missing manifest, excludes a demoted (prerelease) release, and resolves the newest complete tag; the empty-candidate path exits 1.

Closes the last known deploy-chain race after #224 (compose cycle), #226 (secret-init image skew), and #228 (smoke pre-pull sed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBiMm2PoXxch4TQc8JRNPy)_