### PR TITLE
fix: unblock amd64 image release and VM deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
             {
               sed -n 's/^[[:space:]]*image:[[:space:]]*//p' \
                 assets/compose/core.yml assets/compose/openshell.yml \
-              | grep -F '${OPENNEKO_VERSION' \
+              | grep -oE 'ghcr\.io/open-neko/[[:alnum:]_.-]+:\$\{OPENNEKO_VERSION[^}]*\}' \
               | sed 's/:\${OPENNEKO_VERSION.*//'
               echo ghcr.io/open-neko/agent
             } | sort -u

--- a/Dockerfile
+++ b/Dockerfile
@@ -230,8 +230,11 @@ COPY packages/plugin-types/package.json packages/plugin-types/package.json
 COPY packages/records/package.json packages/records/package.json
 COPY packages/secret-crypt/package.json packages/secret-crypt/package.json
 COPY packages/telemetry/package.json packages/telemetry/package.json
+# onnxruntime-node defaults Linux x64 installs to its 300+ MiB CUDA provider.
+# Control-plane images use the bundled CPU runtime and ship no NVIDIA stack.
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm install --frozen-lockfile
+    ONNXRUNTIME_NODE_INSTALL=skip \
+      pnpm install --frozen-lockfile --side-effects-cache=false
 
 # ─── 4. source + web build ─────────────────────────────────────────────
 # Keep source assembly separate from the expensive Next.js build. Worker,

--- a/scripts/prune-node-runtime.sh
+++ b/scripts/prune-node-runtime.sh
@@ -31,6 +31,15 @@ while IFS= read -r napi_root; do
     ! -name "$node_arch" -exec rm -rf '{}' +
 done
 
+# The Linux x64 onnxruntime-node postinstall also downloads CUDA and TensorRT
+# providers. These control-plane images do not ship the NVIDIA runtime and run
+# embeddings on CPU, so the providers are unusable; the CUDA library alone is
+# over 300 MiB uncompressed. Keep the CPU runtime and shared provider shim.
+find "$runtime_root/node_modules" -type f \
+  \( -name 'libonnxruntime_providers_cuda.so' \
+     -o -name 'libonnxruntime_providers_tensorrt.so' \) \
+  -delete 2>/dev/null || true
+
 # Transformers.js imports the WebGPU entry module even on Node, but selects
 # onnxruntime-node for execution. Preserve that entry module and remove its
 # browser-only WASM engines and duplicate browser bundles from server images.


### PR DESCRIPTION
## Summary

- prevent `onnxruntime-node` from downloading its default Linux/x64 CUDA provider and disable pnpm side-effects cache replay for this install
- defensively prune CUDA and TensorRT provider libraries while retaining the CPU ONNX runtime used by local MiniLM embeddings
- correctly extract nested OpenNeko image references when selecting the latest complete release for a main-supervisor VM deploy

## Why

`@neko/llm` uses `@huggingface/transformers`, which depends on Microsoft's cross-platform `onnxruntime-node`. Its Linux/x64 install metadata defaults to the CUDA package, adding a 302 MiB uncompressed provider to CPU-only images. This is unrelated to Windows or GraphJin and is unused by the deployed control-plane containers.

The main deploy parser also captured the outer `${OPENNEKO_GRAPHJIN_IMAGE:-...}` expression instead of its nested GHCR image, so it rejected every otherwise-complete stable release before contacting the VM.

## Validation

- `neko-web` amd64 conservative compressed archive: 195.1 MiB (budget: 225 MiB)
- `neko-worker` amd64 conservative compressed archive: 235.0 MiB (budget: 270 MiB)
- CPU-only offline MiniLM embedding smoke passed with 384 dimensions in both images
- CUDA and TensorRT provider libraries are absent from final amd64 images
- parser identifies all 9 owned deploy images; every `v2.28.4` manifest resolves
- workflow YAML parses, prune script passes `sh -n`, and `git diff --check` passes

`v2.29.0` was already demoted to prerelease after its post-release smoke failed, so the VM remains on the last known-good release until this recovery path succeeds.
