### PR TITLE
fix: preserve Hermes egress identity in lean worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -405,9 +405,14 @@ WORKDIR /app
 # (poppler-utils) covers PDFs. Deliberately no pip deps and no tesseract —
 # scanned-PDF OCR runs in the agent image; a worker-side extraction miss
 # fails the document row with a clear reason and is retryable from /library.
+# Hermes remains agent-only. The zero-payload interpreter marker lets the
+# worker resolve the agent's exact /proc/<pid>/exe identity for OpenShell
+# egress without reinstalling the Hermes tool or virtual environment here.
 RUN apt-get update && apt-get install -y --no-install-recommends \
       python3 poppler-utils unzip postgresql-client \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && install -d /usr/local/uv/tools/hermes-agent/bin \
+    && ln -s /usr/bin/python3 /usr/local/uv/tools/hermes-agent/bin/python
 # `openneko install` deliberately invokes npm in this container. Add the same
 # pruned runtime payload used by the agent, without Corepack or Yarn.
 COPY --from=npm-payload /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm

--- a/packages/llm/test/hermes-install-contract.test.ts
+++ b/packages/llm/test/hermes-install-contract.test.ts
@@ -43,4 +43,18 @@ describe("Hermes install contract", () => {
 
     expect(dockerfile).toContain("HERMES_DISABLE_LAZY_INSTALLS=1");
   });
+
+  it("keeps Hermes out of the worker while preserving its egress identity", async () => {
+    const dockerfile = await readFile(`${REPO_ROOT}Dockerfile`, "utf8");
+    const workerStage = dockerfile.slice(
+      dockerfile.indexOf("FROM runtime-base AS worker"),
+      dockerfile.indexOf("FROM source AS agent-deploy"),
+    );
+
+    expect(workerStage).toContain(
+      "ln -s /usr/bin/python3 /usr/local/uv/tools/hermes-agent/bin/python",
+    );
+    expect(workerStage).not.toContain("uv tool install");
+    expect(workerStage).not.toContain("COPY --from=agent-base");
+  });
 });


### PR DESCRIPTION
## Summary

- keep Hermes installed only in the sandbox `agent` image
- add a zero-payload worker interpreter marker so runtime provisioning resolves the same `/proc/<pid>/exe` identity used by the agent
- add a regression test that forbids `uv tool install` or `agent-base` from returning to the worker

## Why

The lean-image release correctly removed Hermes from `neko-worker`, but `resolveHermesModelBinary()` still resolves `/usr/local/uv/tools/hermes-agent/bin/python` inside that container when deriving OpenShell's executable-scoped model egress. Without the venv path present, it returned the unresolved path while the agent process actually runs as `/usr/bin/python3.11`. Post-release smoke caught the mismatch before deployment.

The marker is a symlink to the worker's already-installed `/usr/bin/python3`; `realpath` follows Debian's versioned interpreter symlink and produces `/usr/bin/python3.11` on both architectures. It installs no Hermes files or Python packages.

## Upgrade safety

- replaced a running `v2.28.4` worker with the candidate against the same named volume
- persistent sentinel state survived replacement
- container UID remained `1001`
- rolled back to `v2.28.4`; state remained intact
- candidate runtime config matches published `v2.29.1`
- no Compose, migration, port, environment, schema, or volume changes

## Validation

- amd64: worker-derived, policy-derived, and published-agent executable all equal `/usr/bin/python3.11`
- arm64: same three-way equality
- Hermes remains absent from the worker on both architectures
- worker runtime binaries present: Python, Node, OpenShell, OpenNeko
- offline CPU MiniLM embedding: 384 dimensions
- CUDA/TensorRT ONNX providers absent
- conservative amd64 compressed archive: 235.0 MiB (270 MiB budget)
- `@neko/llm`: 655 passed, 135 environment-gated integration tests skipped
- `git diff --check` passed

`v2.29.1` remains demoted and the VM remains on `v2.28.4` until a fully smoked recovery release deploys.
