### PR TITLE
fix: restore required GraphJin CLI to worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,8 +135,9 @@ COPY --from=openshell-bin /usr/local/bin/openshell /usr/local/bin/openshell
 CMD ["openshell", "--version"]
 
 # ─── 2. control-plane runtime: sandbox launcher only ───────────────────
-# Web and worker are trusted control planes. They launch OpenShell sandboxes
-# but never contain an agent runtime, GraphJin CLI, or document toolchain.
+# Web is a trusted control plane that launches OpenShell sandboxes but never
+# contains an agent runtime, GraphJin CLI, or document toolchain. The worker
+# uses the narrower shared GraphJin/npm runtime defined below.
 FROM node-runtime AS runtime-base
 # Git supports trusted config VCS and git-backed installs. openssh-client is
 # required by `openshell sandbox exec`.
@@ -145,7 +146,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=openshell-bin /usr/local/bin/openshell /usr/local/bin/openshell
 
-# Pinned GraphJin binary, downloaded once and copied into both the sandbox and
+# Pinned GraphJin binary shared by the Records-aware worker, sandbox agent, and
 # the two dedicated GraphJin runtimes.
 FROM debian:bookworm-slim AS graphjin-bin
 ARG GRAPHJIN_VERSION=3.18.42
@@ -162,13 +163,18 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
     && rm -rf /var/lib/apt/lists/* \
     && graphjin version
 
+# The worker and sandbox agent both require npm plus the pinned GraphJin CLI.
+# Keeping those payloads in one common parent makes their large GraphJin layer
+# byte-identical, so the worker reuses the payload already required by the agent.
+FROM npm-runtime AS graphjin-node-runtime
+COPY --from=graphjin-bin /usr/local/bin/graphjin /usr/local/bin/graphjin
+
 # ─── 2b. agent runtime: Hermes + GraphJin (sandbox only) ───────────────
-FROM npm-runtime AS agent-base
+FROM graphjin-node-runtime AS agent-base
 ARG HERMES_AGENT_REF=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git python3 python3-pip \
     && rm -rf /var/lib/apt/lists/*
-COPY --from=graphjin-bin /usr/local/bin/graphjin /usr/local/bin/graphjin
 # Hermes uses Debian's system Python instead of downloading a second Python
 # distribution. It remains pinned while its Gemini/MCP compatibility patches
 # are required.
@@ -392,12 +398,15 @@ CMD ["node", "apps/web/server.js"]
 FROM source AS worker-deploy
 ARG TARGETARCH
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
-    pnpm --filter @neko/worker deploy --prod /out/worker-app \
+    ONNXRUNTIME_NODE_INSTALL=skip \
+      pnpm --filter @neko/worker deploy --prod /out/worker-app \
     && sh scripts/prune-node-runtime.sh /out/worker-app "$TARGETARCH"
 
 # The worker runs from source via tsx (not a build step). It serves /health +
-# admin endpoints on port 4100 for liveness probes.
-FROM runtime-base AS worker
+# admin endpoints on port 4100 for liveness probes. Records config validation
+# and approved schema diff/sync require the shared pinned GraphJin CLI; this
+# parent supplies it without inheriting Hermes or the document toolchain.
+FROM graphjin-node-runtime AS worker
 WORKDIR /app
 # Minimal extraction toolchain for the library distiller ("the librarian"),
 # which shells out to the bundled document-extraction script on this host:
@@ -409,15 +418,11 @@ WORKDIR /app
 # worker resolve the agent's exact /proc/<pid>/exe identity for OpenShell
 # egress without reinstalling the Hermes tool or virtual environment here.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      python3 poppler-utils unzip postgresql-client \
+      git openssh-client python3 poppler-utils unzip postgresql-client \
     && rm -rf /var/lib/apt/lists/* \
     && install -d /usr/local/uv/tools/hermes-agent/bin \
     && ln -s /usr/bin/python3 /usr/local/uv/tools/hermes-agent/bin/python
-# `openneko install` deliberately invokes npm in this container. Add the same
-# pruned runtime payload used by the agent, without Corepack or Yarn.
-COPY --from=npm-payload /usr/local/lib/node_modules/npm /usr/local/lib/node_modules/npm
-RUN ln -s ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
-    && ln -s ../lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+COPY --from=openshell-bin /usr/local/bin/openshell /usr/local/bin/openshell
 ENV NODE_ENV=production \
     PORT=4100 \
     HOSTNAME=0.0.0.0 \

--- a/packages/llm/test/hermes-install-contract.test.ts
+++ b/packages/llm/test/hermes-install-contract.test.ts
@@ -44,17 +44,31 @@ describe("Hermes install contract", () => {
     expect(dockerfile).toContain("HERMES_DISABLE_LAZY_INSTALLS=1");
   });
 
-  it("keeps Hermes out of the worker while preserving its egress identity", async () => {
+  it("keeps Hermes out of the worker while preserving its required runtime contracts", async () => {
     const dockerfile = await readFile(`${REPO_ROOT}Dockerfile`, "utf8");
+    const sharedRuntime = dockerfile.slice(
+      dockerfile.indexOf("FROM npm-runtime AS graphjin-node-runtime"),
+      dockerfile.indexOf("FROM graphjin-node-runtime AS agent-base"),
+    );
+    const workerDeployStage = dockerfile.slice(
+      dockerfile.indexOf("FROM source AS worker-deploy"),
+      dockerfile.indexOf("FROM graphjin-node-runtime AS worker"),
+    );
     const workerStage = dockerfile.slice(
-      dockerfile.indexOf("FROM runtime-base AS worker"),
+      dockerfile.indexOf("FROM graphjin-node-runtime AS worker"),
       dockerfile.indexOf("FROM source AS agent-deploy"),
     );
 
+    expect(sharedRuntime).toContain(
+      "COPY --from=graphjin-bin /usr/local/bin/graphjin /usr/local/bin/graphjin",
+    );
+    expect(workerDeployStage).toContain("ONNXRUNTIME_NODE_INSTALL=skip");
     expect(workerStage).toContain(
       "ln -s /usr/bin/python3 /usr/local/uv/tools/hermes-agent/bin/python",
     );
+    expect(workerStage).toContain("COPY --from=openshell-bin");
     expect(workerStage).not.toContain("uv tool install");
     expect(workerStage).not.toContain("COPY --from=agent-base");
+    expect(workerStage).not.toContain("COPY --from=npm-payload");
   });
 });

--- a/packages/llm/test/node-runtime-prune-contract.test.ts
+++ b/packages/llm/test/node-runtime-prune-contract.test.ts
@@ -1,0 +1,61 @@
+import { execFile } from "node:child_process";
+import { access, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
+const PRUNE_SCRIPT = `${REPO_ROOT}scripts/prune-node-runtime.sh`;
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe("production Node runtime pruning", () => {
+  it("keeps ONNX CPU runtime files but removes GPU providers and install scripts", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openneko-node-runtime-"));
+    const onnxRoot = join(
+      root,
+      "node_modules/.pnpm/onnxruntime-node@1.24.3/node_modules/onnxruntime-node",
+    );
+    const nativeRoot = join(onnxRoot, "bin/napi-v6/linux/x64");
+    const scriptRoot = join(onnxRoot, "script");
+    const files = {
+      cpu: join(nativeRoot, "libonnxruntime.so.1"),
+      shared: join(nativeRoot, "libonnxruntime_providers_shared.so"),
+      cuda: join(nativeRoot, "libonnxruntime_providers_cuda.so"),
+      tensorrt: join(nativeRoot, "libonnxruntime_providers_tensorrt.so"),
+      metadata: join(scriptRoot, "install-metadata.js"),
+      installer: join(scriptRoot, "install.js"),
+    };
+
+    try {
+      await Promise.all([
+        mkdir(nativeRoot, { recursive: true }),
+        mkdir(scriptRoot, { recursive: true }),
+      ]);
+      await Promise.all(
+        Object.values(files).map((path) => writeFile(path, "fixture")),
+      );
+
+      await execFileAsync("sh", [PRUNE_SCRIPT, root, "amd64"]);
+
+      await expect(exists(files.cpu)).resolves.toBe(true);
+      await expect(exists(files.shared)).resolves.toBe(true);
+      await expect(exists(files.cuda)).resolves.toBe(false);
+      await expect(exists(files.tensorrt)).resolves.toBe(false);
+      await expect(exists(files.metadata)).resolves.toBe(false);
+      await expect(exists(files.installer)).resolves.toBe(false);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/prune-node-runtime.sh
+++ b/scripts/prune-node-runtime.sh
@@ -40,6 +40,15 @@ find "$runtime_root/node_modules" -type f \
      -o -name 'libonnxruntime_providers_tensorrt.so' \) \
   -delete 2>/dev/null || true
 
+# The package's script directory is only for install/build/prepack. Production
+# loads dist/index.js and the retained native CPU runtime; keeping Microsoft's
+# download metadata and postinstall implementation serves no runtime purpose.
+find "$runtime_root/node_modules" -type d \
+  -path '*/node_modules/onnxruntime-node/script' -print 2>/dev/null |
+while IFS= read -r install_scripts; do
+  rm -rf "$install_scripts"
+done
+
 # Transformers.js imports the WebGPU entry module even on Node, but selects
 # onnxruntime-node for execution. Preserve that entry module and remove its
 # browser-only WASM engines and duplicate browser bundles from server images.


### PR DESCRIPTION
## Summary

- restore the pinned GraphJin 3.18.42 CLI required by worker Records config validation and approved schema diff/sync
- put npm plus GraphJin in a common parent shared by worker and agent, so full installs reuse the same GraphJin layer while Hermes remains agent-only
- skip ONNX Runtime network postinstall during worker deployment and remove install/build metadata together with CUDA and TensorRT providers
- add regression coverage for the Docker stage contract and production ONNX pruning behavior

## Root cause

The v2.29.2 worker image no longer contained GraphJin. Worker startup failed closed at graphjin version before becoming healthy, so post-release smoke correctly prevented the production VM upgrade.

## Upgrade and runtime proof

- exact final AMD64 image upgraded an isolated persistent stack from v2.28.4 to patched v2.29.2
- config and database sentinels survived
- schema migrations advanced exactly once from 61 to 62
- worker and both Records GraphJin services were healthy with zero restarts
- worker logged records schema runtime ready and pg-boss running
- GraphJin 3.18.42, npm 11.17.0, and OpenShell 0.0.54 are present
- Hermes runtime is absent; the zero-payload interpreter marker resolves to /usr/bin/python3.11
- offline embedding inference produced a 384-dimensional vector
- CUDA, TensorRT, and install-metadata.js are absent from the final worker filesystem

## Size

The final gzip OCI payload is 251.6 MiB against the 270 MiB worker budget, leaving 18.4 MiB headroom. GraphJin is a shared parent layer with the agent, so a full install does not download that payload twice.

## Validation

- pnpm -r build
- pnpm -r lint
- pnpm -r --if-present typecheck
- pnpm -r --workspace-concurrency=1 test
- bash scripts/check-hermes-only.sh
- go vet ./...
- go test ./... -count=1
- go build ./...
- scripts/test-records-recovery.sh
- two full isolated v2.28.4 to patched v2.29.2 upgrade smokes