### PR TITLE
feat: upgrade GraphJin, add live CI, and align CLI upgrades

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,6 +21,87 @@ jobs:
       - name: Verify backup and database crash recovery
         run: ./scripts/test-records-recovery.sh
 
+  graphjin-integration:
+    name: GraphJin integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    services:
+      records-postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: records
+          POSTGRES_PASSWORD: records-secret
+          POSTGRES_DB: records
+        ports:
+          - 5434:5432
+        options: >-
+          --health-cmd "pg_isready -U records"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      GRAPHJIN_VERSION: "3.20.47"
+      RECORDS_GRAPHJIN_IMAGE: openneko/graphjin-integration:3.20.47
+      REQUIRE_GRAPHJIN_INTEGRATION: "1"
+      OPENNEKO_PG_ENV_OVERRIDE: "1"
+      RECORDS_PG_HOST: localhost
+      RECORDS_PG_PORT: "5434"
+      RECORDS_PG_USER: records
+      RECORDS_PG_PASSWORD: records-secret
+      RECORDS_PG_DATABASE: records
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 9.14.1
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install
+        run: AX_SKIP_SKILL_INSTALL=1 pnpm install --frozen-lockfile
+
+      - name: Build the pinned GraphJin runtime
+        run: |
+          docker buildx build \
+            --load \
+            --platform linux/amd64 \
+            --target graphjin-runtime \
+            --tag "$RECORDS_GRAPHJIN_IMAGE" \
+            .
+          docker run --rm --entrypoint graphjin \
+            "$RECORDS_GRAPHJIN_IMAGE" version | grep -F "$GRAPHJIN_VERSION"
+
+      - name: Validate shipped source-mode configs
+        run: |
+          for config in customer.sources.example.yml dev.sources.example.yml; do
+            docker run --rm --entrypoint graphjin \
+              --volume "$PWD/db/graphjin:/config:ro" \
+              "$RECORDS_GRAPHJIN_IMAGE" \
+              config --file "/config/$config" validate
+          done
+
+      - name: Configure GraphJin-to-Postgres routing
+        run: |
+          gateway="$(docker network inspect bridge --format '{{(index .IPAM.Config 0).Gateway}}')"
+          test -n "$gateway"
+          echo "RECORDS_GRAPHJIN_DB_HOST=$gateway" >> "$GITHUB_ENV"
+
+      - name: Run live GraphJin compatibility tests
+        run: |
+          pnpm --filter @neko/records exec vitest run \
+            test/policy-graphjin.integration.test.ts \
+            test/schema-graphjin.integration.test.ts \
+            test/write-executor.integration.test.ts \
+            test/import-executor.integration.test.ts \
+            --no-file-parallelism
+
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -65,7 +146,7 @@ jobs:
 
       - name: Install graphjin CLI
         env:
-          GRAPHJIN_VERSION: "3.18.42"
+          GRAPHJIN_VERSION: "3.20.47"
         run: |
           curl -fsSL -o /tmp/graphjin.tgz \
             "https://github.com/dosco/graphjin/releases/download/v${GRAPHJIN_VERSION}/graphjin_${GRAPHJIN_VERSION}_linux_amd64.tar.gz"

--- a/Dockerfile
+++ b/Dockerfile
@@ -149,9 +149,9 @@ COPY --from=openshell-bin /usr/local/bin/openshell /usr/local/bin/openshell
 # Pinned GraphJin binary shared by the Records-aware worker, sandbox agent, and
 # the two dedicated GraphJin runtimes.
 FROM debian:bookworm-slim AS graphjin-bin
-ARG GRAPHJIN_VERSION=3.18.42
-ARG GRAPHJIN_ASSET_AMD64=470534811
-ARG GRAPHJIN_ASSET_ARM64=470534772
+ARG GRAPHJIN_VERSION=3.20.47
+ARG GRAPHJIN_ASSET_AMD64=527162704
+ARG GRAPHJIN_ASSET_ARM64=527162707
 ARG TARGETARCH
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
     && GRAPHJIN_ASSET_ID="$(case "${TARGETARCH}" in amd64) echo "${GRAPHJIN_ASSET_AMD64}" ;; arm64) echo "${GRAPHJIN_ASSET_ARM64}" ;; *) exit 1 ;; esac)" \

--- a/apps/openneko/README.md
+++ b/apps/openneko/README.md
@@ -32,7 +32,7 @@ You also need Docker (Docker Desktop on macOS, Docker Engine on Linux).
 ```bash
 openneko setup [--mode prod|dev|demo]   # guided install: preflight + bring-up + configure
 openneko start [--mode prod|dev|demo] [--detach]
-openneko upgrade [--version vX.Y.Z] [--mode auto|prod|dev|demo]
+openneko upgrade [--version vX.Y.Z] [--mode auto|prod|dev|demo] [--stack-only|--cli-only]
 openneko stop [--volumes]
 openneko status
 openneko logs [service…] [-f]
@@ -54,11 +54,24 @@ in the current working directory before invoking `docker compose`. A
 project- or user-level override at `~/.config/openneko/compose.override.yml`
 is appended automatically when present.
 
-`openneko upgrade` pulls newer service images plus the agent/plugin-base
-images, recreates the recorded stack mode, runs migrations, prunes old
-OpenNeko image tags, and persists the selected image tag for later starts.
-Older installs without a recorded mode are inferred from existing Docker
-Compose projects; pass `--mode` only when multiple OpenNeko stacks exist.
+`openneko upgrade` resolves the latest stable release (or the exact
+`--version`), updates the local CLI first, and re-executes that new binary
+before it pulls service and agent/plugin-base images at the same tag. Keeping
+the CLI and stack together matters because the CLI embeds the Compose topology
+used to recreate the stack. Homebrew-owned CLIs are updated through Homebrew;
+standalone CLIs use the release archive and `checksums.txt` before atomic
+replacement. The command then recreates the recorded stack mode, runs
+migrations, prunes old OpenNeko image tags, and persists the selected tag for
+later starts.
+
+Use `--stack-only` for a deliberately independent image upgrade (including a
+custom non-release image tag), or `--cli-only` to update the operator binary
+without touching Docker. A source-built `0.0.0-dev` CLI cannot self-update and
+must use `--stack-only` or be replaced with a released CLI. Installations from
+before this behavior need one final manual CLI update; subsequent
+`openneko upgrade` invocations keep both sides aligned. Older installs without
+a recorded mode are inferred from existing Docker Compose projects; pass
+`--mode` only when multiple OpenNeko stacks exist.
 
 ### Backup encryption keys
 

--- a/apps/openneko/internal/cli/self_update.go
+++ b/apps/openneko/internal/cli/self_update.go
@@ -1,0 +1,480 @@
+package cli
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"syscall"
+	"time"
+
+	opennekoversion "github.com/open-neko/neko/apps/openneko/internal/version"
+)
+
+const maxReleaseAssetBytes = 128 << 20
+
+var (
+	latestOpenNekoReleaseURL = "https://github.com/open-neko/openneko/releases/latest"
+	openNekoReleaseBaseURL   = "https://github.com/open-neko/openneko/releases/download"
+	releaseTagPattern        = regexp.MustCompile(`^v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$`)
+	upgradeHTTPClient        = &http.Client{Timeout: 2 * time.Minute}
+	upgradeExecutable        = os.Executable
+	upgradeExec              = syscall.Exec
+)
+
+func resolveUpgradeTarget(ctx context.Context, requested string, stackOnly bool) (string, error) {
+	target := normalizeUpgradeImageVersion(requested)
+	if target == "latest" {
+		resolved, err := resolveLatestReleaseTag(ctx)
+		if err != nil {
+			return "", err
+		}
+		target = resolved
+	}
+	if !stackOnly && !releaseTagPattern.MatchString(target) {
+		return "", fmt.Errorf(
+			"CLI upgrades require a released semantic version, got %q; use --stack-only for a custom image tag",
+			target,
+		)
+	}
+	return target, nil
+}
+
+func resolveLatestReleaseTag(ctx context.Context) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, latestOpenNekoReleaseURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("User-Agent", "openneko-upgrade")
+	res, err := upgradeHTTPClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("resolve latest OpenNeko release: %w", err)
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return "", fmt.Errorf("resolve latest OpenNeko release: unexpected HTTP status %s", res.Status)
+	}
+	parts := strings.Split(strings.Trim(res.Request.URL.Path, "/"), "/")
+	if len(parts) < 2 || parts[len(parts)-2] != "tag" {
+		return "", fmt.Errorf("resolve latest OpenNeko release: unexpected redirect %q", res.Request.URL.String())
+	}
+	tag := parts[len(parts)-1]
+	if !releaseTagPattern.MatchString(tag) {
+		return "", fmt.Errorf("resolve latest OpenNeko release: invalid tag %q", tag)
+	}
+	return tag, nil
+}
+
+func cliVersionMatchesTarget(current, target string) bool {
+	return strings.TrimPrefix(strings.TrimSpace(current), "v") ==
+		strings.TrimPrefix(strings.TrimSpace(target), "v")
+}
+
+func upgradeReexecArgs(args []string, target string) []string {
+	out := make([]string, 0, len(args)+2)
+	replaced := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--version" && i+1 < len(args) {
+			out = append(out, arg, target)
+			i++
+			replaced = true
+			continue
+		}
+		if strings.HasPrefix(arg, "--version=") {
+			out = append(out, "--version="+target)
+			replaced = true
+			continue
+		}
+		out = append(out, arg)
+	}
+	if !replaced {
+		out = append(out, "--version", target)
+	}
+	return out
+}
+
+func upgradeCLIAndReexec(
+	ctx context.Context,
+	target string,
+	args []string,
+	stdout io.Writer,
+	stderr io.Writer,
+) error {
+	if cliVersionMatchesTarget(opennekoversion.Version, target) {
+		fmt.Fprintf(stdout, "OpenNeko CLI already at %s.\n", target)
+		return nil
+	}
+	if opennekoversion.Version == "0.0.0-dev" {
+		return errors.New("a development-build CLI cannot self-update; install a released CLI or re-run with --stack-only")
+	}
+
+	executable, err := upgradeExecutable()
+	if err != nil {
+		return fmt.Errorf("locate current OpenNeko CLI: %w", err)
+	}
+	executable, err = filepath.EvalSymlinks(executable)
+	if err != nil {
+		return fmt.Errorf("resolve current OpenNeko CLI path: %w", err)
+	}
+
+	fmt.Fprintf(stdout, "Upgrading OpenNeko CLI %s -> %s...\n", opennekoversion.Version, target)
+	nextExecutable := executable
+	brew, managed, err := homebrewManagedCLI(ctx, executable)
+	if err != nil {
+		return err
+	}
+	if managed {
+		nextExecutable, err = upgradeHomebrewCLI(ctx, brew, target, stdout, stderr)
+	} else {
+		err = installStandaloneCLI(ctx, target, executable, stdout, stderr)
+	}
+	if err != nil {
+		return err
+	}
+
+	reexecArgs := upgradeReexecArgs(args, target)
+	argv := append([]string{nextExecutable}, reexecArgs...)
+	fmt.Fprintf(stdout, "Re-running upgrade with OpenNeko CLI %s...\n", target)
+	if err := upgradeExec(nextExecutable, argv, os.Environ()); err != nil {
+		return fmt.Errorf("re-execute upgraded OpenNeko CLI: %w", err)
+	}
+	return nil
+}
+
+func homebrewManagedCLI(ctx context.Context, executable string) (string, bool, error) {
+	looksManaged := strings.Contains(filepath.ToSlash(executable), "/Caskroom/openneko/")
+	brew, err := exec.LookPath("brew")
+	if err != nil {
+		if looksManaged {
+			return "", false, errors.New("current CLI is Homebrew-managed, but brew is unavailable")
+		}
+		return "", false, nil
+	}
+	candidates, err := homebrewCLIExecutables(ctx, brew)
+	if err != nil {
+		if looksManaged {
+			return "", false, fmt.Errorf("inspect Homebrew OpenNeko cask: %w", err)
+		}
+		return "", false, nil
+	}
+	executableInfo, err := os.Stat(executable)
+	if err != nil {
+		return "", false, err
+	}
+	for _, candidate := range candidates {
+		candidateInfo, err := os.Stat(candidate)
+		if err == nil && os.SameFile(executableInfo, candidateInfo) {
+			return brew, true, nil
+		}
+	}
+	if looksManaged {
+		return "", false, errors.New("current CLI is inside Homebrew Caskroom but is not owned by the installed openneko cask")
+	}
+	return "", false, nil
+}
+
+func upgradeHomebrewCLI(
+	ctx context.Context,
+	brew string,
+	target string,
+	stdout io.Writer,
+	stderr io.Writer,
+) (string, error) {
+	cmd := exec.CommandContext(ctx, brew, "upgrade", "--cask", "openneko")
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("upgrade Homebrew OpenNeko CLI: %w", err)
+	}
+	executables, err := homebrewCLIExecutables(ctx, brew)
+	if err != nil {
+		return "", fmt.Errorf("locate Homebrew OpenNeko CLI after upgrade: %w", err)
+	}
+	if len(executables) == 0 {
+		return "", errors.New("locate Homebrew OpenNeko CLI after upgrade: cask contains no executable")
+	}
+	executable := executables[0]
+	if err := verifyCLIExecutable(ctx, executable, target); err != nil {
+		return "", fmt.Errorf("Homebrew did not install requested OpenNeko release: %w", err)
+	}
+	return executable, nil
+}
+
+func homebrewCLIExecutables(ctx context.Context, brew string) ([]string, error) {
+	cmd := exec.CommandContext(ctx, brew, "list", "--cask", "openneko")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	var executables []string
+	for _, candidate := range strings.Split(string(out), "\n") {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || filepath.Base(candidate) != "openneko" {
+			continue
+		}
+		info, err := os.Stat(candidate)
+		if err == nil && info.Mode().IsRegular() && info.Mode()&0o111 != 0 {
+			executables = append(executables, candidate)
+		}
+	}
+	return executables, nil
+}
+
+func installStandaloneCLI(
+	ctx context.Context,
+	target string,
+	executable string,
+	stdout io.Writer,
+	stderr io.Writer,
+) error {
+	if runtime.GOOS != "linux" && runtime.GOOS != "darwin" {
+		return fmt.Errorf("self-update is unsupported on %s; update the CLI with its package manager", runtime.GOOS)
+	}
+	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
+		return fmt.Errorf("self-update is unsupported on %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+	versionNumber := strings.TrimPrefix(target, "v")
+	archiveName := fmt.Sprintf("openneko_%s_%s_%s.tar.gz", versionNumber, runtime.GOOS, runtime.GOARCH)
+	base := strings.TrimSuffix(openNekoReleaseBaseURL, "/") + "/" + target
+
+	checksums, err := downloadReleaseAsset(ctx, base+"/checksums.txt")
+	if err != nil {
+		return fmt.Errorf("download OpenNeko checksums: %w", err)
+	}
+	expected, err := checksumForAsset(checksums, archiveName)
+	if err != nil {
+		return err
+	}
+	archive, err := downloadReleaseAsset(ctx, base+"/"+archiveName)
+	if err != nil {
+		return fmt.Errorf("download OpenNeko CLI archive: %w", err)
+	}
+	actual := sha256.Sum256(archive)
+	if !bytes.Equal(actual[:], expected) {
+		return fmt.Errorf("checksum mismatch for %s", archiveName)
+	}
+	binary, err := openNekoBinaryFromArchive(archive)
+	if err != nil {
+		return err
+	}
+
+	directory := filepath.Dir(executable)
+	candidate, err := os.CreateTemp(directory, ".openneko-upgrade-*")
+	privilegedInstall := false
+	if errors.Is(err, os.ErrPermission) {
+		candidate, err = os.CreateTemp("", ".openneko-upgrade-*")
+		privilegedInstall = true
+	}
+	if err != nil {
+		return fmt.Errorf("prepare CLI update beside %s: %w; update it with the original installer or use --stack-only", executable, err)
+	}
+	candidatePath := candidate.Name()
+	defer os.Remove(candidatePath)
+	if err := candidate.Chmod(0o755); err != nil {
+		candidate.Close()
+		return err
+	}
+	if _, err := candidate.Write(binary); err != nil {
+		candidate.Close()
+		return fmt.Errorf("write upgraded OpenNeko CLI: %w", err)
+	}
+	if err := candidate.Sync(); err != nil {
+		candidate.Close()
+		return fmt.Errorf("sync upgraded OpenNeko CLI: %w", err)
+	}
+	if err := candidate.Close(); err != nil {
+		return fmt.Errorf("close upgraded OpenNeko CLI: %w", err)
+	}
+	if err := verifyCLIExecutable(ctx, candidatePath, target); err != nil {
+		return fmt.Errorf("verify downloaded OpenNeko CLI: %w", err)
+	}
+	if privilegedInstall {
+		if err := installStandaloneCLIWithSudo(ctx, candidatePath, executable, target, stdout, stderr); err != nil {
+			return err
+		}
+	} else if err := os.Rename(candidatePath, executable); err != nil {
+		if !errors.Is(err, os.ErrPermission) {
+			return fmt.Errorf("replace OpenNeko CLI at %s: %w; update it with the original installer or use --stack-only", executable, err)
+		}
+		if err := installStandaloneCLIWithSudo(ctx, candidatePath, executable, target, stdout, stderr); err != nil {
+			return err
+		}
+	}
+	if dir, err := os.Open(directory); err == nil {
+		_ = dir.Sync()
+		_ = dir.Close()
+	}
+	return nil
+}
+
+func installStandaloneCLIWithSudo(
+	ctx context.Context,
+	candidate string,
+	executable string,
+	target string,
+	stdout io.Writer,
+	stderr io.Writer,
+) error {
+	sudo, err := exec.LookPath("sudo")
+	if err != nil {
+		return fmt.Errorf("replace protected OpenNeko CLI at %s: sudo is unavailable; update it with the original installer or use --stack-only", executable)
+	}
+	installCommand, err := trustedSystemCommand("install")
+	if err != nil {
+		return err
+	}
+	moveCommand, err := trustedSystemCommand("mv")
+	if err != nil {
+		return err
+	}
+	removeCommand, err := trustedSystemCommand("rm")
+	if err != nil {
+		return err
+	}
+	privilegedCandidate := filepath.Join(
+		filepath.Dir(executable),
+		"."+filepath.Base(candidate),
+	)
+	fmt.Fprintf(stdout, "Elevating to replace protected CLI at %s...\n", executable)
+	install := exec.CommandContext(ctx, sudo, installCommand, "-m", "0755", candidate, privilegedCandidate)
+	install.Stdout = stdout
+	install.Stderr = stderr
+	if err := install.Run(); err != nil {
+		return fmt.Errorf("stage protected OpenNeko CLI update: %w", err)
+	}
+	cleanup := func() {
+		remove := exec.CommandContext(context.Background(), sudo, removeCommand, "-f", privilegedCandidate)
+		remove.Stdout = stdout
+		remove.Stderr = stderr
+		_ = remove.Run()
+	}
+	moved := false
+	defer func() {
+		if !moved {
+			cleanup()
+		}
+	}()
+	if err := verifyCLIExecutable(ctx, privilegedCandidate, target); err != nil {
+		return fmt.Errorf("verify staged protected OpenNeko CLI update: %w", err)
+	}
+	replace := exec.CommandContext(ctx, sudo, moveCommand, "-f", privilegedCandidate, executable)
+	replace.Stdout = stdout
+	replace.Stderr = stderr
+	if err := replace.Run(); err != nil {
+		return fmt.Errorf("replace protected OpenNeko CLI: %w", err)
+	}
+	moved = true
+	if err := verifyCLIExecutable(ctx, executable, target); err != nil {
+		return fmt.Errorf("verify protected OpenNeko CLI update: %w", err)
+	}
+	return nil
+}
+
+func trustedSystemCommand(name string) (string, error) {
+	for _, directory := range []string{"/usr/bin", "/bin"} {
+		candidate := filepath.Join(directory, name)
+		if info, err := os.Stat(candidate); err == nil && info.Mode().IsRegular() && info.Mode()&0o111 != 0 {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("required system command %s is unavailable", name)
+}
+
+func verifyCLIExecutable(ctx context.Context, executable, target string) error {
+	verifyCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(verifyCtx, executable, "version", "--short").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("run %s version --short: %w (%s)", executable, err, strings.TrimSpace(string(out)))
+	}
+	got := strings.TrimSpace(string(out))
+	if !cliVersionMatchesTarget(got, target) {
+		return fmt.Errorf("got CLI version %q, want %q", got, strings.TrimPrefix(target, "v"))
+	}
+	return nil
+}
+
+func downloadReleaseAsset(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", "openneko-upgrade")
+	res, err := upgradeHTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return nil, fmt.Errorf("unexpected HTTP status %s", res.Status)
+	}
+	data, err := io.ReadAll(io.LimitReader(res.Body, maxReleaseAssetBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxReleaseAssetBytes {
+		return nil, errors.New("release asset exceeds size limit")
+	}
+	return data, nil
+}
+
+func checksumForAsset(checksums []byte, asset string) ([]byte, error) {
+	for _, line := range strings.Split(string(checksums), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) != 2 || strings.TrimPrefix(fields[1], "*") != asset {
+			continue
+		}
+		checksum, err := hex.DecodeString(fields[0])
+		if err != nil || len(checksum) != sha256.Size {
+			return nil, fmt.Errorf("invalid checksum for %s", asset)
+		}
+		return checksum, nil
+	}
+	return nil, fmt.Errorf("checksums.txt does not contain %s", asset)
+}
+
+func openNekoBinaryFromArchive(archive []byte) ([]byte, error) {
+	gz, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return nil, fmt.Errorf("open OpenNeko CLI archive: %w", err)
+	}
+	defer gz.Close()
+	tarReader := tar.NewReader(gz)
+	for {
+		header, err := tarReader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read OpenNeko CLI archive: %w", err)
+		}
+		if header.Typeflag != tar.TypeReg || filepath.Base(header.Name) != "openneko" {
+			continue
+		}
+		if header.Size <= 0 || header.Size > maxReleaseAssetBytes {
+			return nil, errors.New("OpenNeko CLI archive contains an invalid binary size")
+		}
+		binary, err := io.ReadAll(io.LimitReader(tarReader, maxReleaseAssetBytes+1))
+		if err != nil {
+			return nil, fmt.Errorf("extract OpenNeko CLI: %w", err)
+		}
+		if int64(len(binary)) != header.Size {
+			return nil, errors.New("OpenNeko CLI archive contains a truncated binary")
+		}
+		return binary, nil
+	}
+	return nil, errors.New("OpenNeko CLI archive does not contain the openneko binary")
+}

--- a/apps/openneko/internal/cli/self_update_test.go
+++ b/apps/openneko/internal/cli/self_update_test.go
@@ -1,0 +1,325 @@
+package cli
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
+	"testing"
+
+	opennekoversion "github.com/open-neko/neko/apps/openneko/internal/version"
+)
+
+func TestResolveUpgradeTarget(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/latest" {
+			http.Redirect(w, r, "/open-neko/openneko/releases/tag/v9.8.7", http.StatusFound)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	stubUpgradeReleaseEndpoints(t, server.URL+"/latest", server.URL)
+
+	got, err := resolveUpgradeTarget(context.Background(), "", false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "v9.8.7" {
+		t.Fatalf("latest target = %q, want v9.8.7", got)
+	}
+	got, err = resolveUpgradeTarget(context.Background(), "9.7.6-rc.1", false)
+	if err != nil || got != "v9.7.6-rc.1" {
+		t.Fatalf("exact target = %q, %v", got, err)
+	}
+	if _, err := resolveUpgradeTarget(context.Background(), "sha-deadbeef", false); err == nil {
+		t.Fatal("expected custom image tag to require --stack-only")
+	}
+	got, err = resolveUpgradeTarget(context.Background(), "sha-deadbeef", true)
+	if err != nil || got != "sha-deadbeef" {
+		t.Fatalf("stack-only custom target = %q, %v", got, err)
+	}
+}
+
+func TestUpgradeReexecArgsPinsResolvedTarget(t *testing.T) {
+	tests := []struct {
+		in   []string
+		want []string
+	}{
+		{[]string{"upgrade"}, []string{"upgrade", "--version", "v9.8.7"}},
+		{[]string{"upgrade", "--version", "latest"}, []string{"upgrade", "--version", "v9.8.7"}},
+		{[]string{"upgrade", "--version=v9.7.0"}, []string{"upgrade", "--version=v9.8.7"}},
+	}
+	for _, test := range tests {
+		if got := upgradeReexecArgs(test.in, "v9.8.7"); !reflect.DeepEqual(got, test.want) {
+			t.Fatalf("upgradeReexecArgs(%v) = %v, want %v", test.in, got, test.want)
+		}
+	}
+}
+
+func TestInstallStandaloneCLIVerifiesAndAtomicallyReplaces(t *testing.T) {
+	archiveName, archive, checksums := fakeCLIRelease(t, "9.8.7")
+	server := releaseAssetServer(t, "v9.8.7", archiveName, archive, checksums)
+	defer server.Close()
+	stubUpgradeReleaseEndpoints(t, server.URL+"/latest", server.URL)
+
+	executable := filepath.Join(t.TempDir(), "openneko")
+	if err := os.WriteFile(executable, []byte("old-cli"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := installStandaloneCLI(
+		context.Background(), "v9.8.7", executable, &bytes.Buffer{}, &bytes.Buffer{},
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyCLIExecutable(context.Background(), executable, "v9.8.7"); err != nil {
+		t.Fatal(err)
+	}
+	if leftovers, err := filepath.Glob(filepath.Join(filepath.Dir(executable), ".openneko-upgrade-*")); err != nil {
+		t.Fatal(err)
+	} else if len(leftovers) != 0 {
+		t.Fatalf("temporary CLI files remain: %v", leftovers)
+	}
+}
+
+func TestInstallStandaloneCLIRejectsChecksumMismatchWithoutReplacing(t *testing.T) {
+	archiveName, archive, _ := fakeCLIRelease(t, "9.8.7")
+	badChecksums := []byte(fmt.Sprintf("%064x  %s\n", 0, archiveName))
+	server := releaseAssetServer(t, "v9.8.7", archiveName, archive, badChecksums)
+	defer server.Close()
+	stubUpgradeReleaseEndpoints(t, server.URL+"/latest", server.URL)
+
+	executable := filepath.Join(t.TempDir(), "openneko")
+	if err := os.WriteFile(executable, []byte("old-cli"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	err := installStandaloneCLI(
+		context.Background(), "v9.8.7", executable, &bytes.Buffer{}, &bytes.Buffer{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "checksum mismatch") {
+		t.Fatalf("error = %v, want checksum mismatch", err)
+	}
+	got, err := os.ReadFile(executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "old-cli" {
+		t.Fatalf("existing CLI changed after rejected update: %q", got)
+	}
+}
+
+func TestUpgradeCLIAndReexecStandalone(t *testing.T) {
+	archiveName, archive, checksums := fakeCLIRelease(t, "9.8.7")
+	server := releaseAssetServer(t, "v9.8.7", archiveName, archive, checksums)
+	defer server.Close()
+	stubUpgradeReleaseEndpoints(t, server.URL+"/latest", server.URL)
+
+	executable := filepath.Join(t.TempDir(), "openneko")
+	if err := os.WriteFile(executable, []byte("old-cli"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	previousVersion := opennekoversion.Version
+	previousExecutable := upgradeExecutable
+	previousExec := upgradeExec
+	t.Cleanup(func() {
+		opennekoversion.Version = previousVersion
+		upgradeExecutable = previousExecutable
+		upgradeExec = previousExec
+	})
+	opennekoversion.Version = "9.7.0"
+	upgradeExecutable = func() (string, error) { return executable, nil }
+	var reexecPath string
+	var reexecArgs []string
+	upgradeExec = func(path string, args []string, _ []string) error {
+		reexecPath = path
+		reexecArgs = append([]string(nil), args...)
+		return nil
+	}
+
+	var stdout bytes.Buffer
+	if err := upgradeCLIAndReexec(
+		context.Background(),
+		"v9.8.7",
+		[]string{"upgrade", "--cli-only"},
+		&stdout,
+		&stdout,
+	); err != nil {
+		t.Fatal(err)
+	}
+	resolvedExecutable, err := filepath.EvalSymlinks(executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reexecPath != resolvedExecutable {
+		t.Fatalf("reexec path = %q, want %q", reexecPath, resolvedExecutable)
+	}
+	wantArgs := []string{resolvedExecutable, "upgrade", "--cli-only", "--version", "v9.8.7"}
+	if !reflect.DeepEqual(reexecArgs, wantArgs) {
+		t.Fatalf("reexec args = %v, want %v", reexecArgs, wantArgs)
+	}
+	if err := verifyCLIExecutable(context.Background(), executable, "v9.8.7"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(stdout.String(), "9.7.0 -> v9.8.7") {
+		t.Fatalf("upgrade output = %q", stdout.String())
+	}
+}
+
+func TestUpgradeCLIRejectsDevelopmentBuild(t *testing.T) {
+	previousVersion := opennekoversion.Version
+	t.Cleanup(func() { opennekoversion.Version = previousVersion })
+	opennekoversion.Version = "0.0.0-dev"
+	err := upgradeCLIAndReexec(
+		context.Background(),
+		"v9.8.7",
+		[]string{"upgrade"},
+		&bytes.Buffer{},
+		&bytes.Buffer{},
+	)
+	if err == nil || !strings.Contains(err.Error(), "development-build") {
+		t.Fatalf("error = %v, want development-build guidance", err)
+	}
+}
+
+func TestHomebrewManagedCLIRequiresSameInstalledFile(t *testing.T) {
+	dir := t.TempDir()
+	executable := filepath.Join(dir, "openneko")
+	if err := os.WriteFile(executable, []byte("cli"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	brew := filepath.Join(dir, "brew")
+	script := fmt.Sprintf("#!/bin/sh\nif [ \"$1\" = list ]; then printf '%%s\\n' %q; fi\n", executable)
+	if err := os.WriteFile(brew, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	got, managed, err := homebrewManagedCLI(context.Background(), executable)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !managed || got != brew {
+		t.Fatalf("homebrewManagedCLI = %q, %v; want %q, true", got, managed, brew)
+	}
+}
+
+func TestHomebrewManagedCLIFailsClosedWhenBrewIsUnavailable(t *testing.T) {
+	executable := filepath.Join(t.TempDir(), "Caskroom", "openneko", "9.7.0", "openneko")
+	if err := os.MkdirAll(filepath.Dir(executable), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(executable, []byte("cli"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", t.TempDir())
+	_, managed, err := homebrewManagedCLI(context.Background(), executable)
+	if err == nil || managed || !strings.Contains(err.Error(), "Homebrew-managed") {
+		t.Fatalf("homebrewManagedCLI = managed %v, error %v", managed, err)
+	}
+}
+
+func TestInstallStandaloneCLIWithSudoStagesThenAtomicallyMoves(t *testing.T) {
+	dir := t.TempDir()
+	executable := filepath.Join(dir, "openneko")
+	if err := os.WriteFile(executable, []byte("old-cli"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	candidate := filepath.Join(t.TempDir(), "candidate")
+	binary := []byte("#!/bin/sh\nif [ \"$1\" = version ]; then printf '9.8.7\\n'; fi\n")
+	if err := os.WriteFile(candidate, binary, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	sudo := filepath.Join(binDir, "sudo")
+	if err := os.WriteFile(sudo, []byte("#!/bin/sh\nexec \"$@\"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	var output bytes.Buffer
+	if err := installStandaloneCLIWithSudo(
+		context.Background(), candidate, executable, "v9.8.7", &output, &output,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := verifyCLIExecutable(context.Background(), executable, "v9.8.7"); err != nil {
+		t.Fatal(err)
+	}
+	privilegedCandidate := filepath.Join(dir, "."+filepath.Base(candidate))
+	if _, err := os.Stat(privilegedCandidate); !os.IsNotExist(err) {
+		t.Fatalf("privileged staging file remains at %s", privilegedCandidate)
+	}
+}
+
+func fakeCLIRelease(t *testing.T, version string) (string, []byte, []byte) {
+	t.Helper()
+	binary := []byte(fmt.Sprintf(
+		"#!/bin/sh\nif [ \"$1\" = version ] && [ \"$2\" = --short ]; then printf '%%s\\n' %q; exit 0; fi\nexit 1\n",
+		version,
+	))
+	var archive bytes.Buffer
+	gz := gzip.NewWriter(&archive)
+	tw := tar.NewWriter(gz)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "openneko",
+		Mode: 0o755,
+		Size: int64(len(binary)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(binary); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	archiveName := fmt.Sprintf("openneko_%s_%s_%s.tar.gz", version, runtime.GOOS, runtime.GOARCH)
+	checksum := sha256.Sum256(archive.Bytes())
+	checksums := []byte(fmt.Sprintf("%x  %s\n", checksum, archiveName))
+	return archiveName, archive.Bytes(), checksums
+}
+
+func releaseAssetServer(
+	t *testing.T,
+	tag string,
+	archiveName string,
+	archive []byte,
+	checksums []byte,
+) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/" + tag + "/checksums.txt":
+			_, _ = w.Write(checksums)
+		case "/" + tag + "/" + archiveName:
+			_, _ = w.Write(archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+func stubUpgradeReleaseEndpoints(t *testing.T, latestURL, releaseBaseURL string) {
+	t.Helper()
+	previousLatest := latestOpenNekoReleaseURL
+	previousBase := openNekoReleaseBaseURL
+	previousClient := upgradeHTTPClient
+	t.Cleanup(func() {
+		latestOpenNekoReleaseURL = previousLatest
+		openNekoReleaseBaseURL = previousBase
+		upgradeHTTPClient = previousClient
+	})
+	latestOpenNekoReleaseURL = latestURL
+	openNekoReleaseBaseURL = releaseBaseURL
+	upgradeHTTPClient = http.DefaultClient
+}

--- a/apps/openneko/internal/cli/upgrade.go
+++ b/apps/openneko/internal/cli/upgrade.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -13,23 +14,27 @@ import (
 
 	"github.com/open-neko/neko/apps/openneko/assets"
 	"github.com/open-neko/neko/apps/openneko/internal/compose"
+	opennekoversion "github.com/open-neko/neko/apps/openneko/internal/version"
 )
 
 func newUpgradeCmd() *cobra.Command {
 	var mode string
 	var imageVersion string
 	var noPrune bool
+	var stackOnly bool
+	var cliOnly bool
 
 	cmd := &cobra.Command{
 		Use:   "upgrade",
-		Short: "Pull newer OpenNeko images and update the current stack",
-		Long: `Pull newer OpenNeko component images, recreate the current stack, and clean
-up old OpenNeko image tags.
+		Short: "Upgrade the OpenNeko CLI and stack together",
+		Long: `Resolve an exact OpenNeko release, update the local CLI, re-execute that
+new CLI, then pull and recreate the current stack from the same release. This
+keeps the CLI's embedded Compose definitions aligned with the service images.
 
-By default the command targets the latest image tag and upgrades the current
-stack mode. It first uses the mode recorded by the last setup/start, then falls
-back to existing Docker Compose project names for older installs. Use --version
-to pin a specific image tag, and --mode if multiple OpenNeko stacks exist.`,
+The CLI honors its installation owner: Homebrew installations are upgraded
+through Homebrew; standalone installations use checksum-verified release
+artifacts and atomic replacement. Use --stack-only or --cli-only for recovery
+and specialized deployment workflows.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx, cancel := context.WithCancel(cmd.Context())
@@ -38,12 +43,16 @@ to pin a specific image tag, and --mode if multiple OpenNeko stacks exist.`,
 				mode:         mode,
 				imageVersion: imageVersion,
 				noPrune:      noPrune,
+				stackOnly:    stackOnly,
+				cliOnly:      cliOnly,
 			})
 		},
 	}
 	cmd.Flags().StringVar(&mode, "mode", "auto", "Stack mode to upgrade: auto|prod|dev|demo")
-	cmd.Flags().StringVar(&imageVersion, "version", "", "OpenNeko image tag/version to install (default: latest; accepts 1.2.3 or v1.2.3)")
+	cmd.Flags().StringVar(&imageVersion, "version", "", "Exact OpenNeko release to install (default: latest stable; accepts 1.2.3 or v1.2.3)")
 	cmd.Flags().BoolVar(&noPrune, "no-prune", false, "Keep old OpenNeko image tags after the upgrade")
+	cmd.Flags().BoolVar(&stackOnly, "stack-only", false, "Upgrade only stack images; keep the current local CLI")
+	cmd.Flags().BoolVar(&cliOnly, "cli-only", false, "Upgrade only the local CLI; do not change the stack")
 	return cmd
 }
 
@@ -51,12 +60,30 @@ type upgradeOptions struct {
 	mode         string
 	imageVersion string
 	noPrune      bool
+	stackOnly    bool
+	cliOnly      bool
 }
 
 func runUpgrade(ctx context.Context, cmd *cobra.Command, opts upgradeOptions) error {
 	out := cmd.OutOrStdout()
 	errOut := cmd.ErrOrStderr()
-	target := normalizeUpgradeImageVersion(opts.imageVersion)
+	if opts.stackOnly && opts.cliOnly {
+		return errors.New("--stack-only and --cli-only are mutually exclusive")
+	}
+	target, err := resolveUpgradeTarget(ctx, opts.imageVersion, opts.stackOnly)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "Resolved OpenNeko upgrade target %s.\n", target)
+	if !opts.stackOnly {
+		if err := upgradeCLIAndReexec(ctx, target, os.Args[1:], out, errOut); err != nil {
+			return err
+		}
+		if opts.cliOnly {
+			fmt.Fprintf(out, "CLI upgrade complete at %s.\n", target)
+			return nil
+		}
+	}
 
 	sup := compose.New(assets.ComposeFS)
 	m, defaulted, err := resolveUpgradeMode(ctx, opts.mode, sup)
@@ -127,7 +154,16 @@ func runUpgrade(ctx context.Context, cmd *cobra.Command, opts upgradeOptions) er
 		}
 	}
 
-	fmt.Fprintf(out, "Upgrade complete. Future starts will use image tag %s.\n", target)
+	if opts.stackOnly {
+		fmt.Fprintf(
+			out,
+			"Stack upgrade complete at %s; local CLI remains %s.\n",
+			target,
+			opennekoversion.Version,
+		)
+	} else {
+		fmt.Fprintf(out, "Upgrade complete. OpenNeko CLI and stack now use %s.\n", target)
+	}
 	return nil
 }
 

--- a/apps/openneko/internal/cli/upgrade_test.go
+++ b/apps/openneko/internal/cli/upgrade_test.go
@@ -1,12 +1,41 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/open-neko/neko/apps/openneko/internal/compose"
+	opennekoversion "github.com/open-neko/neko/apps/openneko/internal/version"
 )
+
+func TestUpgradeCLIOnlyStopsBeforeStack(t *testing.T) {
+	previousVersion := opennekoversion.Version
+	t.Cleanup(func() { opennekoversion.Version = previousVersion })
+	opennekoversion.Version = "9.8.7"
+	cmd := newUpgradeCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{"--cli-only", "--version", "v9.8.7"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); !strings.Contains(got, "CLI upgrade complete at v9.8.7") {
+		t.Fatalf("output = %q", got)
+	}
+}
+
+func TestUpgradeRejectsConflictingScopes(t *testing.T) {
+	cmd := newUpgradeCmd()
+	cmd.SetArgs([]string{"--cli-only", "--stack-only", "--version", "v9.8.7"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "mutually exclusive") {
+		t.Fatalf("error = %v, want mutually exclusive", err)
+	}
+}
 
 func TestNormalizeUpgradeImageVersion(t *testing.T) {
 	tests := map[string]string{

--- a/apps/worker/test/plugins/source-config-admin-adapter.test.ts
+++ b/apps/worker/test/plugins/source-config-admin-adapter.test.ts
@@ -145,9 +145,10 @@ describeIfDb("source_config_admin adapter (OL5)", () => {
       configFile,
       [
         "production: true",
+        "system:",
+        "  capabilities:",
+        "    config.write: true",
         "sources:",
-        "  - name: graphjin",
-        "    kind: graphjin",
         "  - name: adventureworks",
         "    kind: database",
         "    access:",
@@ -310,7 +311,7 @@ describeIfDb("source_config_admin adapter (OL5)", () => {
     expect(result.ok, result.error).toBe(true);
     const preview = calls[1].body.query;
     expect(preview).toContain("update_sources");
-    // Must not wipe the meta-source via a full replace or a non-existent field.
+    // Must not wipe the top-level system config via a full source replace.
     expect(preview).not.toContain("source_add");
     expect(preview).not.toMatch(/[^_]sources:/);
     expect(await readFile(configFile, "utf8")).toContain("name: warehouse");
@@ -323,7 +324,7 @@ describeIfDb("source_config_admin adapter (OL5)", () => {
     process.env.OPENNEKO_GRAPHJIN_CONFIG = join(root, "agentic.yml");
     await writeFile(
       process.env.OPENNEKO_GRAPHJIN_CONFIG,
-      "production: true\nsources:\n  - name: graphjin\n    kind: graphjin\n",
+      "production: true\nsystem:\n  capabilities:\n    config.write: true\nsources: []\n",
     );
     const content = [
       "openapi: 3.0.3",

--- a/apps/worker/test/records/schema-runtime.integration.test.ts
+++ b/apps/worker/test/records/schema-runtime.integration.test.ts
@@ -71,7 +71,7 @@ describeIfLive("records schema worker runtime", () => {
     const cli = new RecordsGraphjinSchemaCli({
       command: async (_binary, args) => {
         if (args[0] === "version") {
-          return { stdout: "GraphJin 3.18.42\n", stderr: "" };
+          return { stdout: "GraphJin 3.20.47\n", stderr: "" };
         }
         if (args.includes("diff")) {
           return {

--- a/apps/worker/test/records/starter-watches.integration.test.ts
+++ b/apps/worker/test/records/starter-watches.integration.test.ts
@@ -56,9 +56,25 @@ describeIfDb("records starter watch lifecycle", () => {
               {
                 id: graphjinWatchId,
                 name: "watch",
+                status: "paused",
+                approval: "pending",
+                enabled: false,
+                action_hash: "b".repeat(64),
+                action_approval: "pending",
+              },
+            ],
+          } as T;
+        }
+        if (input.operationName === "ReviewRecordsNativeWatchAction") {
+          return {
+            gj_watch: [
+              {
+                id: graphjinWatchId,
                 status: "active",
                 approval: "approved",
                 enabled: true,
+                action_hash: "b".repeat(64),
+                action_approval: "approved",
               },
             ],
           } as T;
@@ -132,7 +148,22 @@ describeIfDb("records starter watch lifecycle", () => {
       expect.stringMatching(new RegExp(`^records-watch-schedule:${binding.id}:\\d+$`)),
     );
 
-    const rebind = vi.fn(async () => ({ gj_watch: [{ id: graphjinWatchId }] }));
+    const rebind = vi
+      .fn()
+      .mockResolvedValueOnce({
+        gj_watch: [{
+          id: graphjinWatchId,
+          action_hash: "c".repeat(64),
+          action_approval: "pending",
+        }],
+      })
+      .mockResolvedValueOnce({
+        gj_watch: [{
+          id: graphjinWatchId,
+          action_hash: "c".repeat(64),
+          action_approval: "approved",
+        }],
+      });
     await expect(
       reconcileRecordsNativeWatchDeliveries({
         graphjin: { execute: rebind },

--- a/apps/worker/test/records/starter-watches.integration.test.ts
+++ b/apps/worker/test/records/starter-watches.integration.test.ts
@@ -331,7 +331,32 @@ describeIfDb("records starter watch lifecycle", () => {
         }
         if (input.operationName === "UpsertRecordsNativeWatch") {
           watchNumber += 1;
-          return { gj_watch: [{ id: `golden-watch-${watchNumber}` }] } as T;
+          return {
+            gj_watch: [
+              {
+                id: `golden-watch-${watchNumber}`,
+                status: "paused",
+                approval: "pending",
+                enabled: false,
+                action_hash: watchNumber.toString(16).padStart(64, "0"),
+                action_approval: "pending",
+              },
+            ],
+          } as T;
+        }
+        if (input.operationName === "ReviewRecordsNativeWatchAction") {
+          return {
+            gj_watch: [
+              {
+                id: `golden-watch-${watchNumber}`,
+                status: "active",
+                approval: "approved",
+                enabled: true,
+                action_hash: watchNumber.toString(16).padStart(64, "0"),
+                action_approval: "approved",
+              },
+            ],
+          } as T;
         }
         evaluationQueries.push(input.query);
         if (input.operationName === "EvaluateRecordsStaleOpportunities") {

--- a/compose.adventureworks.yml
+++ b/compose.adventureworks.yml
@@ -64,7 +64,7 @@ services:
       GRAPHJIN_SOURCES_CONFIG: ""
 
   graphjin:
-    image: dosco/graphjin:3.18.42
+    image: dosco/graphjin:3.20.47
     restart: unless-stopped
     depends_on:
       adventureworks-init:

--- a/compose.yml
+++ b/compose.yml
@@ -398,7 +398,7 @@ services:
     restart: "no"
 
   graphjin:
-    image: ${OPENNEKO_GRAPHJIN_IMAGE:-dosco/graphjin:3.18.42}
+    image: ${OPENNEKO_GRAPHJIN_IMAGE:-dosco/graphjin:3.20.47}
     restart: unless-stopped
     depends_on:
       graphjin-config-init:

--- a/db/graphjin/customer.sources.example.yml
+++ b/db/graphjin/customer.sources.example.yml
@@ -74,6 +74,17 @@ agent:
 
 analytics_mode: true
 
+# Customer sources are read-only by default and may be absent on first boot.
+# Durable GraphJin artifacts and watches live in OpenNeko's dedicated Records
+# GraphJin plane, never in a customer database.
+artifacts:
+  enabled: false
+watches:
+  enabled: false
+  runner: off
+tasks:
+  enabled: false
+
 # Keep every JWT role explicit: GraphJin re-normalizes roles on config updates.
 roles:
   - name: user
@@ -94,17 +105,25 @@ blocklist:
   - encrypted
   - token
 
-sources:
-  - name: graphjin
-    kind: graphjin
-    metadata: true
-    catalog: true
-    control_plane: true
-    capabilities:
-      config.write: true
-    access:
-      roots:
-        gj_catalog: authenticated
-        gj_config: admin
-        gj_security: admin
-        gj_runtime: admin
+system:
+  capabilities:
+    catalog.read: true
+    security.read: true
+    config.read: true
+    config.write: true
+    runtime.read: true
+    raw_graphql.query: true
+    raw_graphql.mutate: false
+    schema.reload: false
+    schema.write: false
+    dev_tools.read: false
+    legacy_discovery.read: false
+  root_access:
+    gj_catalog: authenticated
+    gj_config: admin
+    gj_security: admin
+    gj_runtime: admin
+
+# Keep source mode explicit on a fresh install; admins add external database,
+# API, code, or file sources through OpenNeko's approved config workflow.
+sources: []

--- a/db/graphjin/dev.sources.example.yml
+++ b/db/graphjin/dev.sources.example.yml
@@ -115,6 +115,16 @@ agent:
 
 analytics_mode: true
 
+# The AdventureWorks source is read-only. Durable GraphJin artifacts and
+# watches live in OpenNeko's dedicated Records GraphJin plane instead.
+artifacts:
+  enabled: false
+watches:
+  enabled: false
+  runner: off
+tasks:
+  enabled: false
+
 # OL5 precondition 1: define every token role explicitly. gj_config
 # role/source updates re-normalize roles; without these the implicit admin
 # role is dropped on the first apply and all tokens break.
@@ -140,28 +150,33 @@ blocklist:
   - encrypted
   - token
 
-sources:
-  - name: graphjin
-    kind: graphjin
-    metadata: true
-    catalog: true
-    control_plane: true
-    # Makes gj_config structurally mutable for the approved OpenNeko worker.
-    # access.roots below still limits both reads and writes to admin JWTs, and
-    # agent.read_only keeps the server-side LLM itself unable to mutate it.
-    capabilities:
-      config.write: true
-    access:
-      roots:
-        # authenticated, NOT public — verified live: public leaks the
-        # whole schema catalog to anonymous callers.
-        gj_catalog: authenticated
-        # Native GraphJin admin roots are the second boundary behind
-        # OpenNeko's live role checks and approval workflow.
-        gj_config: admin
-        gj_security: admin
-        gj_runtime: admin
+system:
+  # Makes gj_config structurally mutable for the approved OpenNeko worker.
+  # root_access below still limits both reads and writes to admin JWTs, and
+  # agent.read_only keeps the server-side LLM itself unable to mutate it.
+  capabilities:
+    catalog.read: true
+    security.read: true
+    config.read: true
+    config.write: true
+    runtime.read: true
+    raw_graphql.query: true
+    raw_graphql.mutate: false
+    schema.reload: false
+    schema.write: false
+    dev_tools.read: false
+    legacy_discovery.read: false
+  root_access:
+    # authenticated, NOT public — verified live: public leaks the
+    # whole schema catalog to anonymous callers.
+    gj_catalog: authenticated
+    # Native GraphJin admin roots are the second boundary behind
+    # OpenNeko's live role checks and approval workflow.
+    gj_config: admin
+    gj_security: admin
+    gj_runtime: admin
 
+sources:
   - name: adventureworks
     kind: database
     default: true

--- a/packages/llm/src/graphjin/version.ts
+++ b/packages/llm/src/graphjin/version.ts
@@ -1,4 +1,4 @@
-// Bump together with the GRAPHJIN_VERSION pins in Dockerfile,
-// scripts/install-clis.sh, and the dosco/graphjin image tag in both
-// compose.adventureworks.yml and apps/openneko/assets/compose/demo.yml.
-export const GRAPHJIN_VERSION = "3.18.42";
+// Bump together with the GraphJin pins in Dockerfile, scripts/install-clis.sh,
+// packages/records/src/graphjin/config.ts, the source-checkout Compose files,
+// and .github/workflows/pr-checks.yml.
+export const GRAPHJIN_VERSION = "3.20.47";

--- a/packages/llm/test/persist-source-config.test.ts
+++ b/packages/llm/test/persist-source-config.test.ts
@@ -20,9 +20,10 @@ async function configFile(): Promise<string> {
     [
       "# keep this operator note",
       "production: true",
+      "system:",
+      "  capabilities:",
+      "    config.write: true",
       "sources:",
-      "  - name: graphjin",
-      "    kind: graphjin",
       "  - name: warehouse",
       "    kind: database",
       "    access:",
@@ -75,12 +76,8 @@ describe("persistGraphjinSourceConfigUpdate", () => {
     const raw = await readFile(file, "utf8");
     const parsed = parse(raw) as { sources: Array<Record<string, unknown>> };
     expect(raw).toContain("# keep this operator note");
-    expect(parsed.sources.map((source) => source.name)).toEqual([
-      "graphjin",
-      "warehouse",
-      "pets",
-    ]);
-    expect(parsed.sources[2]).toMatchObject({
+    expect(parsed.sources.map((source) => source.name)).toEqual(["warehouse", "pets"]);
+    expect(parsed.sources[1]).toMatchObject({
       kind: "api",
       specs_dir: "/config/specs",
     });
@@ -103,7 +100,7 @@ describe("persistGraphjinSourceConfigUpdate", () => {
     const parsed = parse(await readFile(file, "utf8")) as {
       sources: Array<{ name: string; access?: Record<string, string> }>;
     };
-    expect(parsed.sources[1]?.access).toEqual({
+    expect(parsed.sources[0]?.access).toEqual({
       read: "admin",
       write: "blocked",
       delete: "blocked",
@@ -119,7 +116,7 @@ describe("persistGraphjinSourceConfigUpdate", () => {
     const parsed = parse(await readFile(file, "utf8")) as {
       sources: Array<{ name: string }>;
     };
-    expect(parsed.sources.map((source) => source.name)).toEqual(["graphjin"]);
+    expect(parsed.sources).toEqual([]);
   });
 
   it("persists GraphJin's deterministic secret reference, not a password", async () => {

--- a/packages/records/src/graphjin/config.ts
+++ b/packages/records/src/graphjin/config.ts
@@ -17,7 +17,7 @@ import {
 } from "../policy/graphjin";
 import { validateRecordIdentifier } from "../naming";
 
-export const RECORDS_GRAPHJIN_VERSION = "3.18.42";
+export const RECORDS_GRAPHJIN_VERSION = "3.20.47";
 export const RECORDS_GRAPHJIN_CONFIG_FILENAME = "dev.yml";
 export const RECORDS_WATCH_WEBHOOK_SECRET_FILENAME = ".records-watch-webhook-secret";
 
@@ -243,6 +243,10 @@ export function buildRecordsGraphjinConfig(input: BuildRecordsGraphjinConfigInpu
     default_limit: defaultLimit,
     subs_poll_duration: "5s",
     db_schema_poll_duration: "0s",
+    // Records GraphJin mounts its generated config volume read-only. GraphJin
+    // 3.20's discovery cache writes immutable schema generations below the
+    // config path by default, so retain the prior live-discovery behavior.
+    discovery_cache: { enabled: false },
     secret_key: input.secretKey,
     rate_limiter: { rate, bucket },
     // Governed record writes may commit while GraphJin returns an empty
@@ -331,6 +335,9 @@ export function buildRecordsWatchGraphjinConfig(
     default_limit: 500,
     subs_poll_duration: "30s",
     db_schema_poll_duration: "0s",
+    // The isolated watch process shares the same read-only generated-config
+    // volume as the records query process.
+    discovery_cache: { enabled: false },
     secret_key: input.secretKey,
     rate_limiter: { rate: 10, bucket: 20 },
     caching: { disable: true },
@@ -372,6 +379,35 @@ export function buildRecordsWatchGraphjinConfig(
       snapshot_max_bytes: 32768,
       webhook_allow: input.watchWebhookAllow ?? [],
     },
+    system: {
+      capabilities: {
+        "catalog.read": false,
+        "security.read": false,
+        "config.read": false,
+        "config.write": false,
+        "runtime.read": false,
+        "raw_graphql.query": true,
+        "raw_graphql.mutate": true,
+        "schema.reload": false,
+        "schema.write": false,
+        "dev_tools.read": false,
+        "legacy_discovery.read": false,
+      },
+      root_access: {
+        gj_catalog: "blocked",
+        gj_security: "blocked",
+        gj_config: "blocked",
+        gj_runtime: "blocked",
+        gj_artifacts: "blocked",
+        // This process has its own signing key and is only reachable on
+        // the private network. Authenticated access lets the service own
+        // its watches without granting GraphJin's tenant-filter bypass.
+        gj_watch: "authenticated",
+        gj_watch_event: "authenticated",
+        gj_workflow: "blocked",
+        gj_workflow_execution: "blocked",
+      },
+    },
     sources: [
       {
         name: "records",
@@ -396,42 +432,6 @@ export function buildRecordsWatchGraphjinConfig(
           namespace_column: "org_id",
           owner_column: "owner_user_id",
           missing_namespace_column: "block",
-        },
-      },
-      {
-        name: "graphjin",
-        kind: "graphjin",
-        metadata: false,
-        catalog: false,
-        control_plane: true,
-        access: {
-          roots: {
-            gj_catalog: "blocked",
-            gj_security: "blocked",
-            gj_config: "blocked",
-            gj_runtime: "blocked",
-            gj_artifacts: "blocked",
-            // This process has its own signing key and is only reachable on
-            // the private network. Authenticated access lets the service own
-            // its watches without granting GraphJin's tenant-filter bypass.
-            gj_watch: "authenticated",
-            gj_watch_event: "authenticated",
-            gj_workflow: "blocked",
-            gj_workflow_execution: "blocked",
-          },
-        },
-        capabilities: {
-          "catalog.read": false,
-          "security.read": false,
-          "config.read": false,
-          "config.write": false,
-          "runtime.read": false,
-          "raw_graphql.query": true,
-          "raw_graphql.mutate": true,
-          "schema.reload": false,
-          "schema.write": false,
-          "dev_tools.read": false,
-          "legacy_discovery.read": false,
         },
       },
     ],

--- a/packages/records/src/watchers/starter.ts
+++ b/packages/records/src/watchers/starter.ts
@@ -131,6 +131,30 @@ function firstRow(value: unknown, root: string): Record<string, unknown> | null 
   return isObject(candidate) ? candidate : null;
 }
 
+async function approveRecordsNativeWatchAction(input: {
+  graphjin: RecordsGraphjinTransport;
+  token: string;
+  watch: Record<string, unknown>;
+}): Promise<Record<string, unknown>> {
+  if (input.watch.action_approval === "approved") return input.watch;
+  const watchId = typeof input.watch.id === "string" ? input.watch.id : "";
+  const actionHash =
+    typeof input.watch.action_hash === "string" ? input.watch.action_hash : "";
+  if (!watchId || !/^[0-9a-f]{64}$/.test(actionHash)) {
+    throw new Error("GraphJin did not return the native watch action hash");
+  }
+  const reviewed = await input.graphjin.execute<Record<string, unknown>>({
+    operationName: "ReviewRecordsNativeWatchAction",
+    query: `mutation ReviewRecordsNativeWatchAction { gj_watch(where: { id: { eq: ${JSON.stringify(watchId)} } }, update: { action_review_json: { decision: "approve", expected_action_hash: ${JSON.stringify(actionHash)} } }) { id action_hash action_approval status approval enabled } }`,
+    token: input.token,
+  });
+  const row = firstRow(reviewed, "gj_watch");
+  if (row?.id !== watchId || row.action_approval !== "approved") {
+    throw new Error("GraphJin did not approve the native watch action");
+  }
+  return row;
+}
+
 export async function upsertRecordsNativeWatch(input: {
   graphjin: RecordsGraphjinTransport;
   token: string;
@@ -156,7 +180,6 @@ export async function upsertRecordsNativeWatch(input: {
     },
     lifecycle: "durable",
     status: "active",
-    approval: "approved",
     enabled: true,
     ...(input.webhookUrl
       ? {
@@ -174,14 +197,22 @@ export async function upsertRecordsNativeWatch(input: {
       : `insert: ${gqlValue(watchInput)}`;
   const changed = await input.graphjin.execute<Record<string, unknown>>({
     operationName: "UpsertRecordsNativeWatch",
-    query: `mutation UpsertRecordsNativeWatch { gj_watch(${selector}) { id name status approval enabled } }`,
+    query: `mutation UpsertRecordsNativeWatch { gj_watch(${selector}) { id name status approval enabled action_hash action_approval } }`,
     token: input.token,
   });
-  const updated = firstRow(changed, "gj_watch");
+  let updated = firstRow(changed, "gj_watch");
   if (typeof updated?.id !== "string" || !updated.id) {
     throw new Error("GraphJin did not return the native watch id");
   }
-  return { id: updated.id, definitionHash: input.definition.definitionHash };
+  const watchId = updated.id;
+  if (input.webhookUrl) {
+    updated = await approveRecordsNativeWatchAction({
+      graphjin: input.graphjin,
+      token: input.token,
+      watch: updated,
+    });
+  }
+  return { id: watchId, definitionHash: input.definition.definitionHash };
 }
 
 /** Rebind a durable watch after worker/container addressing changes. */
@@ -201,11 +232,18 @@ export async function updateRecordsNativeWatchDelivery(input: {
     : { kind: "inbox" };
   const changed = await input.graphjin.execute<Record<string, unknown>>({
     operationName: "UpdateRecordsNativeWatchDelivery",
-    query: `mutation UpdateRecordsNativeWatchDelivery { gj_watch(where: { id: { eq: ${JSON.stringify(input.watchId)} } }, update: { delivery_json: ${gqlValue(delivery)} }) { id } }`,
+    query: `mutation UpdateRecordsNativeWatchDelivery { gj_watch(where: { id: { eq: ${JSON.stringify(input.watchId)} } }, update: { delivery_json: ${gqlValue(delivery)} }) { id action_hash action_approval } }`,
     token: input.token,
   });
-  const updated = firstRow(changed, "gj_watch");
+  let updated = firstRow(changed, "gj_watch");
   if (updated?.id !== input.watchId) {
     throw new Error("GraphJin did not confirm the native watch delivery update");
+  }
+  if (input.webhookUrl) {
+    updated = await approveRecordsNativeWatchAction({
+      graphjin: input.graphjin,
+      token: input.token,
+      watch: updated,
+    });
   }
 }

--- a/packages/records/test/graphjin-config.test.ts
+++ b/packages/records/test/graphjin-config.test.ts
@@ -44,6 +44,7 @@ describe("records GraphJin config", () => {
       disable_production_security: true,
       analytics_mode: true,
       db_schema_poll_duration: "0s",
+      discovery_cache: { enabled: false },
       caching: { disable: true },
       mcp: { disable: true, allow_mutations: false, allow_raw_queries: false },
       auth: { type: "jwt", development: false },
@@ -93,6 +94,7 @@ describe("records GraphJin config", () => {
     expect(config).toMatchObject({
       mode: "agentic",
       production: true,
+      discovery_cache: { enabled: false },
       mcp: { disable: true, allow_mutations: false },
       identity: {
         namespace_claim: "org_id",
@@ -100,6 +102,18 @@ describe("records GraphJin config", () => {
       },
       artifacts: { enabled: true, source: "records", schema: "_graphjin" },
       watches: { enabled: true, runner: "all", webhook_allow: allow },
+      system: {
+        capabilities: {
+          "raw_graphql.query": true,
+          "raw_graphql.mutate": true,
+          "config.write": false,
+        },
+        root_access: {
+          gj_watch: "authenticated",
+          gj_watch_event: "authenticated",
+          gj_artifacts: "blocked",
+        },
+      },
       sources: [
         {
           name: "records",
@@ -110,18 +124,6 @@ describe("records GraphJin config", () => {
             delete: "blocked",
             namespace_column: "org_id",
             missing_namespace_column: "block",
-          },
-        },
-        {
-          name: "graphjin",
-          kind: "graphjin",
-          control_plane: true,
-          access: {
-            roots: {
-              gj_watch: "authenticated",
-              gj_watch_event: "authenticated",
-              gj_artifacts: "blocked",
-            },
           },
         },
       ],

--- a/packages/records/test/graphjin-schema.test.ts
+++ b/packages/records/test/graphjin-schema.test.ts
@@ -65,7 +65,7 @@ describe("records GraphJin schema boundary", () => {
     const calls: string[][] = [];
     const command: RecordsGraphjinSchemaCommand = async (_binary, args) => {
       calls.push(args);
-      if (args[0] === "version") return { stdout: "GraphJin 3.18.42\n", stderr: "" };
+      if (args[0] === "version") return { stdout: "GraphJin 3.20.47\n", stderr: "" };
       if (args.includes("diff")) {
         return { stdout: "CREATE TABLE example (id TEXT PRIMARY KEY);\n", stderr: "" };
       }

--- a/packages/records/test/import-executor.integration.test.ts
+++ b/packages/records/test/import-executor.integration.test.ts
@@ -113,6 +113,11 @@ function runKilledImportWorker(env: NodeJS.ProcessEnv): Promise<void> {
 const reachable = await recordsDbReachable();
 const describeIfLive = reachable && graphjinImage ? describe : describe.skip;
 
+if (process.env.REQUIRE_GRAPHJIN_INTEGRATION === "1") {
+  if (!reachable) throw new Error("required records Postgres is unreachable");
+  if (!graphjinImage) throw new Error("required RECORDS_GRAPHJIN_IMAGE is not set");
+}
+
 if (!reachable || !graphjinImage) {
   console.warn(
     "[records-import-executor] skipping: records Postgres or RECORDS_GRAPHJIN_IMAGE unavailable",

--- a/packages/records/test/policy-graphjin.integration.test.ts
+++ b/packages/records/test/policy-graphjin.integration.test.ts
@@ -54,6 +54,11 @@ const itIfGraphjin = graphjinBinary || graphjinImage ? it : it.skip;
 const itIfGraphjinImage = graphjinImage ? it : it.skip;
 const LIVE_JWT_SECRET = "live-jwt-secret-that-is-at-least-thirty-two-bytes";
 
+if (process.env.REQUIRE_GRAPHJIN_INTEGRATION === "1") {
+  if (!reachable) throw new Error("required records Postgres is unreachable");
+  if (!graphjinImage) throw new Error("required RECORDS_GRAPHJIN_IMAGE is not set");
+}
+
 function runTestCommand(command: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
     execFile(
@@ -86,7 +91,7 @@ async function validateWithTestGraphjin(configDirectory: string): Promise<void> 
       graphjinImage,
       "version",
     ]);
-    expect(version.stdout).toContain("GraphJin 3.18.42");
+    expect(version.stdout).toContain("GraphJin 3.20.47");
     await runTestCommand("docker", [
       "run",
       "--rm",

--- a/packages/records/test/schema-graphjin.integration.test.ts
+++ b/packages/records/test/schema-graphjin.integration.test.ts
@@ -57,6 +57,11 @@ const reachable = await recordsDbReachable();
 const graphjinImage = process.env.RECORDS_GRAPHJIN_IMAGE;
 const describeIfLive = reachable && graphjinImage ? describe : describe.skip;
 
+if (process.env.REQUIRE_GRAPHJIN_INTEGRATION === "1") {
+  if (!reachable) throw new Error("required records Postgres is unreachable");
+  if (!graphjinImage) throw new Error("required RECORDS_GRAPHJIN_IMAGE is not set");
+}
+
 if (!reachable || !graphjinImage) {
   console.warn(
     "[records-schema-graphjin] skipping: records Postgres or RECORDS_GRAPHJIN_IMAGE unavailable.",

--- a/packages/records/test/schema-saga.integration.test.ts
+++ b/packages/records/test/schema-saga.integration.test.ts
@@ -156,7 +156,7 @@ describeIfRecordsDb("records schema saga integration", () => {
     let physicallyApplied = false;
     const cli = new RecordsGraphjinSchemaCli({
       command: async (_binary, args) => {
-        if (args[0] === "version") return { stdout: "GraphJin 3.18.42\n", stderr: "" };
+        if (args[0] === "version") return { stdout: "GraphJin 3.20.47\n", stderr: "" };
         if (args.includes("diff")) {
           return {
             stdout: physicallyApplied

--- a/packages/records/test/starter-watches.test.ts
+++ b/packages/records/test/starter-watches.test.ts
@@ -56,12 +56,27 @@ describe("records starter watches", () => {
     }
   });
 
-  it("creates an approved HMAC webhook watch and updates it idempotently", async () => {
+  it("creates and reviews an approved HMAC webhook watch idempotently", async () => {
     const execute = vi
       .fn()
       .mockResolvedValueOnce({ gj_watch: [] })
       .mockResolvedValueOnce({
-        gj_watch: [{ id: "native-watch-1", status: "active", approval: "approved" }],
+        gj_watch: [{
+          id: "native-watch-1",
+          status: "paused",
+          approval: "pending",
+          action_hash: "b".repeat(64),
+          action_approval: "pending",
+        }],
+      })
+      .mockResolvedValueOnce({
+        gj_watch: [{
+          id: "native-watch-1",
+          status: "active",
+          approval: "approved",
+          action_hash: "b".repeat(64),
+          action_approval: "approved",
+        }],
       });
     const definition = buildRecordsStarterWatchDefinition({
       orgId: "org-a",
@@ -82,15 +97,32 @@ describe("records starter watches", () => {
     });
     const mutation = execute.mock.calls[1]![0].query as string;
     expect(mutation).toContain("insert:");
-    expect(mutation).toContain('approval: "approved"');
+    expect(mutation).not.toContain('approval: "approved"');
     expect(mutation).toContain("OPENNEKO_RECORDS_WATCH_WEBHOOK_SECRET");
     expect(mutation).toContain("approved_action_hash");
+    expect(execute.mock.calls[2]?.[0]).toMatchObject({
+      operationName: "ReviewRecordsNativeWatchAction",
+      query: expect.stringContaining("action_review_json"),
+    });
   });
 
   it("rebinds a durable watch without changing its approved query", async () => {
-    const execute = vi.fn().mockResolvedValue({
-      gj_watch: [{ id: "native-watch-1" }],
-    });
+    const execute = vi
+      .fn()
+      .mockResolvedValueOnce({
+        gj_watch: [{
+          id: "native-watch-1",
+          action_hash: "c".repeat(64),
+          action_approval: "pending",
+        }],
+      })
+      .mockResolvedValueOnce({
+        gj_watch: [{
+          id: "native-watch-1",
+          action_hash: "c".repeat(64),
+          action_approval: "approved",
+        }],
+      });
     await updateRecordsNativeWatchDelivery({
       graphjin: { execute },
       token: "watch-service-token",
@@ -106,5 +138,8 @@ describe("records starter watches", () => {
       }),
     );
     expect(execute.mock.calls[0]?.[0].query).not.toContain("query:");
+    expect(execute.mock.calls[1]?.[0]).toMatchObject({
+      operationName: "ReviewRecordsNativeWatchAction",
+    });
   });
 });

--- a/packages/records/test/write-executor.integration.test.ts
+++ b/packages/records/test/write-executor.integration.test.ts
@@ -65,6 +65,11 @@ function runCommand(command: string, args: string[]): Promise<{ stdout: string; 
 const reachable = await recordsDbReachable();
 const describeIfLive = reachable && graphjinImage ? describe : describe.skip;
 
+if (process.env.REQUIRE_GRAPHJIN_INTEGRATION === "1") {
+  if (!reachable) throw new Error("required records Postgres is unreachable");
+  if (!graphjinImage) throw new Error("required RECORDS_GRAPHJIN_IMAGE is not set");
+}
+
 if (!reachable || !graphjinImage) {
   console.warn(
     "[records-write-executor] skipping: records Postgres or RECORDS_GRAPHJIN_IMAGE unavailable.",
@@ -157,8 +162,29 @@ describeIfLive("records write executor live integration", () => {
       values
         ('org-a', 'equipment', 'member', 'loan', true, true, true, true),
         ('org-a', 'equipment', 'admin', 'loan', true, true, true, true);
+      insert into engine.app_access_grant
+        (org_id, app_id, subject_type, subject_id)
+      values
+        ('org-a', 'equipment', 'role', 'member'),
+        ('org-a', 'equipment', 'role', 'admin');
+      insert into engine.object_access_grant
+        (org_id, app_id, subject_type, subject_id, object_api_name,
+         can_read, can_create, can_update, can_delete)
+      values
+        ('org-a', 'equipment', 'role', 'member', 'loan', true, true, true, true),
+        ('org-a', 'equipment', 'role', 'admin', 'loan', true, true, true, true);
+      insert into engine.field_access_grant
+        (org_id, app_id, subject_type, subject_id, object_api_name, field_id,
+         can_read, can_write)
+      select 'org-a', 'equipment', 'role', role_name, 'loan', field.id,
+             true, not field.read_only
+      from engine.record_field field
+      cross join (values ('member'), ('admin')) as roles(role_name)
+      where field.object_id = '00000000-0000-0000-0000-000000000701';
       insert into engine.actor (org_id, user_id, role)
-      values ('org-a', 'records-service', 'service');
+      values
+        ('org-a', 'records-service', 'service'),
+        ('org-a', 'admin-1', 'admin');
       insert into engine.identity_map
         (org_id, source_instance_id, app_id, source_user_id, source_email,
          source_name, source_is_active, app_user_id, status, linked_at)

--- a/scripts/install-clis.sh
+++ b/scripts/install-clis.sh
@@ -12,7 +12,7 @@
 #   ./scripts/install-clis.sh --skip-hermes  # graphjin only
 set -euo pipefail
 
-GRAPHJIN_VERSION="${GRAPHJIN_VERSION:-3.18.42}"
+GRAPHJIN_VERSION="${GRAPHJIN_VERSION:-3.20.47}"
 # Pin Hermes to the same ref baked into the Dockerfile so local-dev installs
 # match what ships in the container image. v2026.5.16 / v0.14.0.
 HERMES_AGENT_REF="${HERMES_AGENT_REF:-a91a57fa5a13d516c38b07a141a9ce8a3daabeb0}"


### PR DESCRIPTION
## Summary

- upgrade the vendored GraphJin runtime and source-checkout images to v3.20.47
- adapt OpenNeko configs and native watch approval handling for GraphJin 3.20
- add a fail-closed PR job that builds the pinned runtime, validates shipped source configs, and runs live PostgreSQL-backed GraphJin integration tests
- make `openneko upgrade` resolve one exact release, update the local CLI first, re-exec it, and then upgrade the stack at the same tag
- preserve installation ownership: Homebrew updates through Homebrew; standalone releases use checksum verification and atomic replacement, with protected paths staged through sudo
- add `--stack-only` and `--cli-only` recovery/deployment escape hatches

Customer data sources remain read-only by default. The dedicated Records plane continues to allow only governed worker/service mutations.

## Validation

- 11/11 live GraphJin integration tests
- 141 Records tests
- 656 LLM tests
- 397 Worker tests
- all OpenNeko Go tests and vet checks
- Linux amd64 CLI cross-compile
- live latest-release resolution smoke test
- workspace TypeScript typechecks
- Actionlint and Docker Compose validation
- amd64 and arm64 GraphJin runtime builds
- shipped GraphJin source-config validation