### PR TITLE
fix: enforce agent runtime turn delivery contract

### DIFF
--- a/AGENT_RUNTIME.md
+++ b/AGENT_RUNTIME.md
@@ -45,6 +45,21 @@ Docker stage runs it during the image build, and PR CI builds the final agent
 image and runs it again. Release smoke tests therefore exercise the same
 contract used by OpenShell sandbox creation.
 
+## Turn protocol guarantees
+
+The tagged stdout protocol is ordered and lossless at the process boundary:
+
+1. Agent events are delivered to the host serially in marker order.
+2. The launcher drains every event handler before accepting the result marker.
+3. A `completed` result must contain assistant output or be accompanied by a
+   user-visible surface event. A content-free ACP `end_turn` is retried only
+   when no tool activity occurred; if it repeats, the run fails with an
+   explicit diagnostic instead of persisting an empty success.
+
+These guarantees are behavioral parts of the runtime artifact contract. Keep
+the delayed-event, empty-completion, and surface-only regression tests when
+changing the bundle, launcher, backend, or stdout protocol.
+
 ## Changing runtime dependencies
 
 When sandbox code starts reading a new filesystem resource, add it to

--- a/apps/web/src/lib/coalescing-emit.ts
+++ b/apps/web/src/lib/coalescing-emit.ts
@@ -63,6 +63,8 @@ export function createCoalescingEmit(
 
   let buffer: { role: "assistant" | "user"; content: string } | null = null;
   let bufferTimer: ReturnType<typeof setTimeout> | null = null;
+  let persistQueue = Promise.resolve();
+  let persistError: Error | undefined;
 
   const clearTimer = () => {
     if (bufferTimer) {
@@ -71,9 +73,19 @@ export function createCoalescingEmit(
     }
   };
 
-  const persist = async (event: AgentEvent): Promise<void> => {
-    const id = await persistEvent({ orgId, threadId, runId, event });
-    notify(runId, event, id);
+  const persist = (event: AgentEvent): Promise<void> => {
+    const pending = persistQueue.then(async () => {
+      const id = await persistEvent({ orgId, threadId, runId, event });
+      notify(runId, event, id);
+    });
+    // Idle-timer flushes and explicit emits can overlap. Keep persistence and
+    // subscriber notification in one ordered queue so a slow earlier write
+    // can never be overtaken by a later event.
+    persistQueue = pending.catch((error: unknown) => {
+      persistError ??=
+        error instanceof Error ? error : new Error(String(error));
+    });
+    return pending;
   };
 
   const flushBuffer = async (): Promise<void> => {
@@ -108,7 +120,9 @@ export function createCoalescingEmit(
       }
       clearTimer();
       bufferTimer = setTimeout(() => {
-        void flushBuffer();
+        void flushBuffer().catch(() => {
+          // persistQueue records the error; finalize() reports it to the run.
+        });
       }, flushIdleMs);
       return;
     }
@@ -122,6 +136,8 @@ export function createCoalescingEmit(
   const finalize = async (): Promise<void> => {
     clearTimer();
     if (buffer) await flushBuffer();
+    await persistQueue;
+    if (persistError) throw persistError;
   };
 
   return { emit, finalize };

--- a/apps/web/test/coalescing-emit.test.ts
+++ b/apps/web/test/coalescing-emit.test.ts
@@ -101,6 +101,50 @@ describe("createCoalescingEmit", () => {
     expect(h.persisted[1].event).toMatchObject({ content: "second burst." });
   });
 
+  it("does not let a later event overtake a slow idle flush", async () => {
+    const persisted: AgentEvent[] = [];
+    let releaseFirstPersist: (() => void) | undefined;
+    let firstPersistStarted: (() => void) | undefined;
+    const started = new Promise<void>((resolve) => {
+      firstPersistStarted = resolve;
+    });
+    const gate = new Promise<void>((resolve) => {
+      releaseFirstPersist = resolve;
+    });
+    const { emit, finalize } = createCoalescingEmit(
+      {
+        orgId: "org_test",
+        threadId: "thr_test",
+        runId: "run_test",
+        flushIdleMs: 100,
+      },
+      {
+        persistEvent: (async (args: { event: AgentEvent }) => {
+          if (args.event.type === "message") {
+            firstPersistStarted?.();
+            await gate;
+          }
+          persisted.push(args.event);
+          return persisted.length;
+        }) as CoalescingEmitDeps["persistEvent"],
+        notify: () => {},
+      },
+    );
+
+    await emit({ type: "message", role: "assistant", content: "answer" });
+    vi.advanceTimersByTime(100);
+    await started;
+    const laterEmit = emit({ type: "done", result: { status: "completed" } });
+    await Promise.resolve();
+    expect(persisted).toEqual([]);
+
+    releaseFirstPersist?.();
+    await laterEmit;
+    await finalize();
+
+    expect(persisted.map((event) => event.type)).toEqual(["message", "done"]);
+  });
+
   it("flushes prior buffer when role flips", async () => {
     const h = makeHarness();
 

--- a/packages/llm/src/agent-backends/hermes.ts
+++ b/packages/llm/src/agent-backends/hermes.ts
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import {
   agentTurnTimeoutMs,
   type AgentBackend,
+  type AgentEvent,
   type AgentRunOptions,
   type AgentRunResult,
   type AgentTokenUsage,
@@ -261,7 +262,11 @@ export class HermesBackend implements AgentBackend {
       await onEvent({ type: "status", message: "Hermes is working…" });
     }
 
-    const maxAttempts = onEvent ? 1 : retries + 1;
+    // Streaming turns normally cannot be retried because replaying tool and
+    // message events would duplicate visible work. A completely empty ACP
+    // turn is the exception: runOnce marks it retryable only when Hermes
+    // emitted neither content nor tool activity.
+    const maxAttempts = retries + 1;
     let lastErr: Error | undefined;
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
@@ -286,6 +291,13 @@ export class HermesBackend implements AgentBackend {
               `[hermes] attempt ${attempt + 1}/${maxAttempts} failed: ${out.error}`,
             );
           }
+          if (onEvent && !out.retryable) break;
+          if (onEvent && attempt + 1 < maxAttempts) {
+            await onEvent({
+              type: "status",
+              message: "Hermes returned no output; retrying…",
+            });
+          }
           continue;
         }
         return {
@@ -301,6 +313,7 @@ export class HermesBackend implements AgentBackend {
             `[hermes] attempt ${attempt + 1}/${maxAttempts} failed: ${lastErr.message}`,
           );
         }
+        if (onEvent) break;
       }
     }
 
@@ -333,6 +346,7 @@ type RunOnceOutcome = {
   finalText: string;
   rawText?: string;
   error?: string;
+  retryable?: boolean;
 };
 
 async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
@@ -529,6 +543,19 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
     let accumulatedText = "";
     let emittedOutsideLen = 0;
     let surfaceEmittedDuringStream = false;
+    let toolActivityObserved = false;
+    let eventQueue = Promise.resolve();
+    let eventError: Error | undefined;
+    const emitQueued = (event: AgentEvent): void => {
+      if (!onEvent) return;
+      eventQueue = eventQueue.then(async () => {
+        try {
+          await onEvent(event);
+        } catch (error) {
+          eventError ??= error instanceof Error ? error : new Error(String(error));
+        }
+      });
+    };
 
     client.onNotification((notif) => {
       const update = notif.update;
@@ -542,7 +569,7 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
             const delta = outside.slice(emittedOutsideLen);
             if (delta) {
               emittedOutsideLen = outside.length;
-              void onEvent({ type: "message", role: "assistant", content: delta });
+              emitQueued({ type: "message", role: "assistant", content: delta });
             }
             // Streaming surface emit: the fence regex requires a closing ```,
             // so a partial fence returns no messages and we wait for the next chunk.
@@ -550,17 +577,18 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
               const parsed = extractSurfaceMessages(accumulatedText);
               if (parsed.messages.length > 0) {
                 surfaceEmittedDuringStream = true;
-                void onEvent({ type: "surface", messages: parsed.messages });
+                emitQueued({ type: "surface", messages: parsed.messages });
               }
             }
           }
           return;
         }
         case "agent_thought_chunk": {
-          if (debug && onEvent) void onEvent({ type: "status", message: "Thinking…" });
+          if (debug) emitQueued({ type: "status", message: "Thinking…" });
           return;
         }
         case "tool_call": {
+          toolActivityObserved = true;
           if (!onEvent) return;
           // A render_cards call IS the answer surface, not a tool step: pull the
           // a2ui messages from the call input and emit them, skipping the pill.
@@ -570,11 +598,11 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
             );
             if (messages.length > 0) {
               surfaceEmittedDuringStream = true;
-              void onEvent({ type: "surface", messages });
+              emitQueued({ type: "surface", messages });
             }
             return;
           }
-          void onEvent({
+          emitQueued({
             type: "tool_start",
             id: update.toolCallId,
             name: update.kind || "tool",
@@ -587,18 +615,19 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
           return;
         }
         case "tool_call_update": {
+          toolActivityObserved = true;
           if (!onEvent) return;
           const id = update.toolCallId;
           const status = update.status;
           if (status === "completed" || status === "failed") {
-            void onEvent({
+            emitQueued({
               type: "tool_end",
               id,
               result: status === "completed" ? update.rawOutput ?? update.content : undefined,
               error: status === "failed" ? extractErrorText(update.content ?? update.rawOutput) : undefined,
             });
           } else {
-            void onEvent({
+            emitQueued({
               type: "tool_delta",
               id,
               delta: { status: status ?? "in_progress", content: update.content, rawOutput: update.rawOutput },
@@ -609,7 +638,7 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
         case "plan": {
           if (!onEvent) return;
           const next = update.entries.find((e) => e.status !== "completed");
-          if (next) void onEvent({ type: "status", message: next.content });
+          if (next) emitQueued({ type: "status", message: next.content });
           return;
         }
         default:
@@ -618,15 +647,18 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
     });
 
     let promptError: string | undefined;
+    let promptStopReason: string | undefined;
+    let promptUsage: ReturnType<typeof normalizeHermesUsage>;
     try {
-      const promptResponse = await client.request<{ usage?: unknown }>("session/prompt", {
+      const promptResponse = await client.request<{
+        usage?: unknown;
+        stopReason?: string;
+      }>("session/prompt", {
         sessionId,
         prompt: [{ type: "text", text: prompt }],
       });
-      const usage = normalizeHermesUsage(promptResponse.usage);
-      if (onEvent && usage) {
-        await onEvent({ type: "usage", source: "outer", usage });
-      }
+      promptStopReason = promptResponse.stopReason;
+      promptUsage = normalizeHermesUsage(promptResponse.usage);
     } catch (e) {
       if (e instanceof AcpProtocolError) {
         promptError = `hermes: ${e.message}`;
@@ -641,6 +673,28 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
     if (promptError) {
       return { finalText: "", error: promptError };
     }
+    await eventQueue;
+    if (eventError) throw eventError;
+
+    // ACP considers `end_turn` with no chunks a valid protocol response. It is
+    // not a valid OpenNeko answer: accepting it used to persist a green run
+    // with no assistant message, leaving the UI apparently dead. Retry only
+    // when no tool ran, then fail with an explicit diagnostic.
+    if (!accumulatedText.trim() && !surfaceEmittedDuringStream) {
+      return {
+        finalText: "",
+        error:
+          `hermes completed without assistant output or surface` +
+          ` (stopReason=${promptStopReason ?? "unknown"})`,
+        retryable: !toolActivityObserved,
+      };
+    }
+
+    if (promptUsage) {
+      emitQueued({ type: "usage", source: "outer", usage: promptUsage });
+      await eventQueue;
+      if (eventError) throw eventError;
+    }
 
     let finalText = accumulatedText;
     if (onEvent) {
@@ -648,7 +702,9 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
       const markdownText = extractMarkdownText(parsed.messages);
       finalText = (markdownText || parsed.text).trim();
       if (parsed.messages.length > 0 && !surfaceEmittedDuringStream) {
-        await onEvent({ type: "surface", messages: parsed.messages });
+        emitQueued({ type: "surface", messages: parsed.messages });
+        await eventQueue;
+        if (eventError) throw eventError;
       }
     }
 

--- a/packages/llm/src/work/sandbox-launcher.ts
+++ b/packages/llm/src/work/sandbox-launcher.ts
@@ -1193,6 +1193,9 @@ function execAndStream(
     let result: AgentRunResult | undefined;
     let stderr = "";
     let settled = false;
+    let sawAnswerEvent = false;
+    let eventError: Error | undefined;
+    let eventQueue = Promise.resolve();
     let timer: ReturnType<typeof setTimeout>;
     const cleanup = () => {
       clearTimeout(timer);
@@ -1211,7 +1214,28 @@ function execAndStream(
       const ev = line.indexOf(EVENT_MARKER);
       if (ev >= 0) {
         try {
-          void emit(JSON.parse(line.slice(ev + EVENT_MARKER.length)) as AgentEvent);
+          const event = JSON.parse(
+            line.slice(ev + EVENT_MARKER.length),
+          ) as AgentEvent;
+          sawAnswerEvent ||=
+            (event.type === "message" &&
+              event.role === "assistant" &&
+              event.content.trim().length > 0) ||
+            (event.type === "surface" && event.messages.length > 0) ||
+            event.type === "action_request_emit" ||
+            event.type === "needs_input" ||
+            event.type === "output_emit";
+          // The bundled runtime can exit immediately after its result marker.
+          // Serialize and drain host-side handlers so a fast process cannot
+          // overtake message persistence or reorder streamed deltas.
+          eventQueue = eventQueue.then(async () => {
+            try {
+              await emit(event);
+            } catch (error) {
+              eventError ??=
+                error instanceof Error ? error : new Error(String(error));
+            }
+          });
         } catch {
           /* ignore a partial/garbled event line */
         }
@@ -1238,14 +1262,42 @@ function execAndStream(
     });
     child.on("close", (code) => {
       if (settled) return;
-      settled = true;
-      cleanup();
-      if (result) return resolve(result);
-      reject(
-        new Error(
-          `agent sandbox exited ${code} without a result line; stderr=${stderr.slice(0, 500)}`,
-        ),
-      );
+      void (async () => {
+        await eventQueue;
+        if (settled) return;
+        settled = true;
+        cleanup();
+        if (eventError) {
+          reject(new Error(`agent event delivery failed: ${eventError.message}`));
+          return;
+        }
+        if (result) {
+          const hasResultOutput =
+            (typeof result.finalText === "string" &&
+              result.finalText.trim().length > 0) ||
+            (typeof result.rawText === "string" &&
+              result.rawText.trim().length > 0);
+          if (
+            result.status === "completed" &&
+            !hasResultOutput &&
+            !sawAnswerEvent
+          ) {
+            reject(
+              new Error(
+                "agent runtime contract violation: completed without assistant output or surface",
+              ),
+            );
+            return;
+          }
+          resolve(result);
+          return;
+        }
+        reject(
+          new Error(
+            `agent sandbox exited ${code} without a result line; stderr=${stderr.slice(0, 500)}`,
+          ),
+        );
+      })();
     });
   });
 }

--- a/packages/llm/test/hermes-backend-acp.test.ts
+++ b/packages/llm/test/hermes-backend-acp.test.ts
@@ -138,6 +138,72 @@ describe("HermesBackend ACP behavior", () => {
     expect(result.finalText).toBe("abc");
   });
 
+  it("retries a content-free end_turn, then fails instead of completing empty", async () => {
+    let promptCalls = 0;
+    controller.setScript({
+      responders: {
+        "session/new": () => ({ sessionId: `sess-empty-${promptCalls}` }),
+        "session/prompt": () => {
+          promptCalls += 1;
+          return { stopReason: "end_turn" };
+        },
+      },
+    });
+    const events: Array<{ type: string; message?: string }> = [];
+    const backend = new HermesBackend();
+
+    const result = await backend.run({
+      prompt: "p",
+      workspace: FAKE_WORKSPACE,
+      retries: 1,
+      onEvent: (event) => {
+        events.push(event as { type: string; message?: string });
+      },
+    });
+
+    expect(promptCalls).toBe(2);
+    expect(result).toMatchObject({
+      status: "failed",
+      finalText: "",
+      error: expect.stringContaining("completed without assistant output"),
+    });
+    expect(events.filter((event) => event.type === "error")).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining("stopReason=end_turn"),
+      }),
+    ]);
+  });
+
+  it("awaits async event handlers in chunk order before returning", async () => {
+    const sessionId = "sess-ordered-events";
+    controller.setScript({
+      responders: {
+        "session/new": () => ({ sessionId }),
+        "session/prompt": (_p, ctx) => {
+          ctx.emitNotification(chunkNotification(sessionId, "first"));
+          ctx.emitNotification(chunkNotification(sessionId, "second"));
+          return { stopReason: "end_turn" };
+        },
+      },
+    });
+    const contents: string[] = [];
+    const backend = new HermesBackend();
+
+    await backend.run({
+      prompt: "p",
+      workspace: FAKE_WORKSPACE,
+      onEvent: async (event) => {
+        if (event.type !== "message") return;
+        if (event.content === "first") {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+        contents.push(event.content);
+      },
+    });
+
+    expect(contents).toEqual(["first", "second"]);
+  });
+
   it("emits tool_start then tool_end with matching toolCallId", async () => {
     const sessionId = "sess-tool";
     controller.setScript({

--- a/packages/llm/test/hermes-backend-spawn.test.ts
+++ b/packages/llm/test/hermes-backend-spawn.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { createMockSpawn, makeController } from "./helpers/fake-acp-process";
+import {
+  chunkNotification,
+  createMockSpawn,
+  makeController,
+} from "./helpers/fake-acp-process";
 
 const controller = makeController();
 
@@ -15,7 +19,11 @@ vi.mock("node:child_process", async () => {
 
 beforeEach(() => {
   controller.spawnCalls.length = 0;
-  controller.setScript({});
+  controller.setScript({
+    notificationsByMethod: {
+      "session/prompt": [chunkNotification("sess-1", "OK")],
+    },
+  });
 });
 
 afterEach(() => {

--- a/packages/llm/test/sandbox-launcher.test.ts
+++ b/packages/llm/test/sandbox-launcher.test.ts
@@ -23,7 +23,11 @@ import type { RunWorkflowAgentBackendInput } from "../src/workflows/agent-core";
  */
 const h = vi.hoisted(() => {
   const calls: { args: string[] }[] = [];
-  const state = { holdExec: false, collideOnNextCreate: false };
+  const state = {
+    holdExec: false,
+    collideOnNextCreate: false,
+    execLines: undefined as string[] | undefined,
+  };
   function spawn(_cmd: string, args: string[]) {
     calls.push({ args });
     const isExec = args.includes("exec");
@@ -46,7 +50,7 @@ const h = vi.hoisted(() => {
         : [],
     );
     const lines = isExec
-      ? [
+      ? state.execLines ?? [
           'noise before\n',
           `\n__openneko_event__${JSON.stringify({ type: "message", role: "assistant", content: "hi" })}\n`,
           `\n__openneko_agent_result__${JSON.stringify({ status: "completed", finalText: "hi there", backendState: { t: 1 } })}\n`,
@@ -367,6 +371,7 @@ describe("makeSandboxRunCore", () => {
     h.calls.length = 0;
     h.state.holdExec = false;
     h.state.collideOnNextCreate = false;
+    h.state.execLines = undefined;
     jobCapture.jobs.length = 0;
     jobCapture.policies.length = 0;
   });
@@ -436,6 +441,88 @@ describe("makeSandboxRunCore", () => {
     expect(execCommand).not.toContain("HERMES_DISABLE_LAZY_INSTALLS");
     // the credential alias references the OpenShell-injected var at runtime, never a value:
     expect(execCommand).toContain('export GEMINI_API_KEY="$api_key"');
+  });
+
+  it("serializes and drains streamed events before accepting the result", async () => {
+    h.state.execLines = [
+      `__openneko_event__${JSON.stringify({ type: "message", role: "assistant", content: "first" })}\n`,
+      `__openneko_event__${JSON.stringify({ type: "message", role: "assistant", content: "second" })}\n`,
+      `__openneko_agent_result__${JSON.stringify({ status: "completed", finalText: "firstsecond" })}\n`,
+    ];
+    const events: string[] = [];
+    let activeEmits = 0;
+    let maxActiveEmits = 0;
+    const runCore = makeSandboxRunCore({
+      agentImage: "ghcr.io/open-neko/agent:test",
+      onLog: () => {},
+    });
+
+    const result = await runCore(
+      fakeInput(async (event) => {
+        if (event.type !== "message") return;
+        activeEmits += 1;
+        maxActiveEmits = Math.max(maxActiveEmits, activeEmits);
+        if (event.content === "first") {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+        }
+        events.push(event.content);
+        activeEmits -= 1;
+      }),
+    );
+
+    expect(result.status).toBe("completed");
+    expect(events).toEqual(["first", "second"]);
+    expect(maxActiveEmits).toBe(1);
+  });
+
+  it("rejects an empty completed result with no answer event", async () => {
+    h.state.execLines = [
+      `__openneko_agent_result__${JSON.stringify({ status: "completed", finalText: "", rawText: "" })}\n`,
+    ];
+    const runCore = makeSandboxRunCore({
+      agentImage: "ghcr.io/open-neko/agent:test",
+      onLog: () => {},
+    });
+
+    await expect(runCore(fakeInput(async () => {}))).rejects.toThrow(
+      /completed without assistant output or surface/,
+    );
+  });
+
+  it("rejects the run when ordered event delivery fails", async () => {
+    const runCore = makeSandboxRunCore({
+      agentImage: "ghcr.io/open-neko/agent:test",
+      onLog: () => {},
+    });
+
+    await expect(
+      runCore(
+        fakeInput(async (event) => {
+          if (event.type === "message") throw new Error("database unavailable");
+        }),
+      ),
+    ).rejects.toThrow(/agent event delivery failed: database unavailable/);
+  });
+
+  it("accepts a surface-only completed result", async () => {
+    h.state.execLines = [
+      `__openneko_event__${JSON.stringify({ type: "surface", messages: [{ version: "v1.0" }] })}\n`,
+      `__openneko_agent_result__${JSON.stringify({ status: "completed", finalText: "", rawText: "" })}\n`,
+    ];
+    const events: AgentEvent[] = [];
+    const runCore = makeSandboxRunCore({
+      agentImage: "ghcr.io/open-neko/agent:test",
+      onLog: () => {},
+    });
+
+    const result = await runCore(
+      fakeInput(async (event) => void events.push(event)),
+    );
+
+    expect(result.status).toBe("completed");
+    expect(events.filter((event) => event.type === "surface")).toEqual([
+      expect.objectContaining({ type: "surface" }),
+    ]);
   });
 
   it("replaces an orphaned sandbox when a durable retry collides on the run name", async () => {


### PR DESCRIPTION
## What broke

v2.29's fast standalone agent bundle exposed two missing behavioral guarantees that the heavier v2.28 workspace runtime had masked:

- OpenShell stdout events were relayed with `void emit(...)`, so result/process completion could overtake async message persistence and reorder chunks. The local Magento run persisted a correct final assistant message but its streamed event was rotated.
- Hermes/ACP can return `end_turn` without any content chunks. OpenNeko accepted that as `completed`, producing the two demo runs with no assistant message, usage, tool, surface, or error event.

The web coalescer also allowed an idle-timer flush to persist concurrently with a later event, leaving one more ordering hole.

## Fix

- serialize Hermes notification delivery and drain it before returning
- retry a content-free turn once only when no tool activity occurred
- fail repeated empty completion with a visible diagnostic
- serialize and drain sandbox event handlers before accepting the result
- reject `completed` runtime results with neither answer content nor a user-visible surface
- preserve valid surface-only completions
- serialize coalescer persistence and subscriber notifications, including idle flushes
- document the behavioral turn protocol contract

## Regression coverage

- async Hermes chunk handlers retain order
- content-free `end_turn` retries then fails explicitly
- sandbox host delivery drains in order before result acceptance
- event delivery failures fail the run
- empty completed result is rejected
- surface-only completed result is accepted
- slow idle flush cannot be overtaken

## Validation

- `@neko/llm`: 664 passed, 135 skipped (integration services unavailable)
- `@neko/web`: 277 passed, 101 skipped (integration services unavailable)
- `@neko/agent-runtime`: build/preflight + 8 passed
- web, worker, and agent-runtime type checks passed
- web ESLint passed
