### PR TITLE
fix(agent): broker GraphJin reads through runtime contract

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -30,9 +30,14 @@ jobs:
       - name: Re-run preflight from the final image
         run: |
           docker run --rm \
+            --user 1000660000:1000660000 \
             --entrypoint node \
             openneko/agent:pr-check \
             /app/agent-entry.js --preflight
+          docker run --rm \
+            --entrypoint /bin/sh \
+            openneko/agent:pr-check \
+            -c 'test ! -e /usr/local/bin/graphjin'
 
   records-recovery:
     name: Records recovery
@@ -89,7 +94,10 @@ jobs:
           cache: pnpm
 
       - name: Install
-        run: AX_SKIP_SKILL_INSTALL=1 pnpm install --frozen-lockfile
+        run: >-
+          AX_SKIP_SKILL_INSTALL=1
+          ONNXRUNTIME_NODE_INSTALL=skip
+          pnpm install --frozen-lockfile
 
       - name: Build the pinned GraphJin runtime
         run: |

--- a/AGENT_RUNTIME.md
+++ b/AGENT_RUNTIME.md
@@ -35,15 +35,19 @@ layout.
 `node /app/agent-entry.js --preflight` verifies:
 
 1. The artifact contains exactly the files declared by the manifest.
-2. Every file matches its declared digest and every role exists.
+2. Every file matches its declared digest and every role exists. Artifact
+   directories are normalized to read-only, world-traversable permissions and
+   files to read-only, world-readable permissions.
 3. Built-in skills can be materialized into a run workspace.
 4. Every supported logical MCP server can be constructed by the shipped bridge.
-5. The GraphJin guard can stage the manifest-owned compact CLI.
+5. The GraphJin guard can stage the manifest-owned compact CLI and rejects
+   direct data-source access inside the sandbox.
 
 The package test suite runs this preflight with a clean environment. The final
-Docker stage runs it during the image build, and PR CI builds the final agent
-image and runs it again. Release smoke tests therefore exercise the same
-contract used by OpenShell sandbox creation.
+Docker stage runs it as the unprivileged `sandbox` user during the image build,
+and PR CI builds the final agent image and runs it again. Release smoke tests
+therefore exercise the same filesystem identity and contract used by OpenShell
+sandbox creation.
 
 ## Turn protocol guarantees
 
@@ -59,6 +63,22 @@ The tagged stdout protocol is ordered and lossless at the process boundary:
 These guarantees are behavioral parts of the runtime artifact contract. Keep
 the delayed-event, empty-completion, and surface-only regression tests when
 changing the bundle, launcher, backend, or stdout protocol.
+
+## GraphJin protocol contract
+
+Sandboxed chat, workflow, profiler, metric, and job agents read customer data
+through `mcp__neko_graphjin__execute_graphql`. The packaged MCP bridge sends the
+request to the run-bound host broker. The host selects the source, resolves the
+work-run actor, mints a short-lived actor token for that call, rejects mutations
+and subscriptions, and performs the GraphQL request.
+
+The source URL, actor token, signing material, native GraphJin binary, and direct
+data-source egress never enter the sandbox. A manifest-owned deny shim gives
+legacy skill instructions an explicit migration error, so an obsolete
+independently versioned client initialization state machine cannot break ask
+runs or become a policy bypass. Tests cover prompt routing, chat/workflow server
+mounting, bridge construction, broker org/run binding, and the image preflight
+denial.
 
 ## Changing runtime dependencies
 
@@ -79,6 +99,7 @@ control-plane dependencies across the boundary.
 pnpm --filter @neko/agent-runtime typecheck
 pnpm --filter @neko/agent-runtime test
 docker build --target agent -t openneko/agent:contract-test .
-docker run --rm --entrypoint node openneko/agent:contract-test \
+docker run --rm --user 1000660000:1000660000 --entrypoint node \
+  openneko/agent:contract-test \
   /app/agent-entry.js --preflight
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -146,8 +146,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=openshell-bin /usr/local/bin/openshell /usr/local/bin/openshell
 
-# Pinned GraphJin binary shared by the Records-aware worker, sandbox agent, and
-# the two dedicated GraphJin runtimes.
+# Pinned GraphJin binary used by the Records-aware worker and dedicated
+# GraphJin runtimes. The sandbox agent deliberately does not inherit it.
 FROM debian:bookworm-slim AS graphjin-bin
 ARG GRAPHJIN_VERSION=3.20.47
 ARG GRAPHJIN_ASSET_AMD64=527162704
@@ -163,14 +163,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
     && rm -rf /var/lib/apt/lists/* \
     && graphjin version
 
-# The worker and sandbox agent both require npm plus the pinned GraphJin CLI.
-# Keeping those payloads in one common parent makes their large GraphJin layer
-# byte-identical, so the worker reuses the payload already required by the agent.
+# The worker requires npm plus the pinned GraphJin CLI.
 FROM npm-runtime AS graphjin-node-runtime
 COPY --from=graphjin-bin /usr/local/bin/graphjin /usr/local/bin/graphjin
 
-# ─── 2b. agent runtime: Hermes + GraphJin (sandbox only) ───────────────
-FROM graphjin-node-runtime AS agent-base
+# ─── 2b. agent runtime: Hermes (sandbox only) ─────────────────────────
+# Customer data is available only through the host broker, so this stage must
+# not inherit the native GraphJin client or its independently versioned state.
+FROM npm-runtime AS agent-base
 ARG HERMES_AGENT_REF=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
 RUN apt-get update && apt-get install -y --no-install-recommends \
       git python3 python3-pip \
@@ -490,7 +490,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends iproute2 nftabl
 RUN groupadd -g 1000660000 sandbox \
     && useradd -u 1000660000 -g sandbox -d /sandbox -M sandbox \
     && install -d -o sandbox -g sandbox /sandbox \
-    && rm -f /usr/local/bin/graphjin \
     && test ! -e /usr/local/bin/graphjin
 # Keep the runtime payload immutable; only /sandbox is writable by the agent.
 COPY --from=agent-deploy --chown=root:root /out/agent-app /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -489,12 +489,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends iproute2 nftabl
     && rm -rf /var/lib/apt/lists/*
 RUN groupadd -g 1000660000 sandbox \
     && useradd -u 1000660000 -g sandbox -d /sandbox -M sandbox \
-    && install -d -o sandbox -g sandbox /sandbox
+    && install -d -o sandbox -g sandbox /sandbox \
+    && rm -f /usr/local/bin/graphjin \
+    && test ! -e /usr/local/bin/graphjin
 # Keep the runtime payload immutable; only /sandbox is writable by the agent.
 COPY --from=agent-deploy --chown=root:root /out/agent-app /app
 # The build must fail if the final image loses a declared runtime file, if an
-# asset checksum drifts, or if skills/MCP/GraphJin guard construction breaks.
+# asset checksum drifts, if the sandbox user cannot traverse it, or if
+# skills/MCP/GraphJin guard construction breaks.
+USER sandbox
 RUN node /app/agent-entry.js --preflight
+USER root
 WORKDIR /sandbox
 # Supervisor-replaced; launcher runs:
 #   node /app/agent-entry.js

--- a/apps/worker/test/agent-sandbox/broker.test.ts
+++ b/apps/worker/test/agent-sandbox/broker.test.ts
@@ -250,7 +250,12 @@ describe("agent broker", () => {
     events = [];
     server = createAgentBroker({
       controlPlane: fake.cp,
-      resolveRun: (t) => (t === "good" ? { runId: "r1", orgId: "o1" } : undefined),
+      resolveRun: (token) =>
+        token === "good"
+          ? { runId: "r1", orgId: "o1", kind: "work" }
+          : token === "job"
+            ? { runId: "job-1", orgId: "o1", kind: "agent-job" }
+            : undefined,
       onEvents: async (binding, evs) => {
         events.push({ binding, evs });
       },
@@ -352,6 +357,35 @@ describe("agent broker", () => {
       runId: "r1",
       instruction: "Count all orders",
       maxSteps: 6,
+    });
+  });
+
+  it("binds GraphJin reads to the authenticated org and actor run", async () => {
+    const cp = new BrokerControlPlane(baseUrl, "good");
+    await cp.queryGraphjinRead({
+      orgId: "SPOOF",
+      runId: "SPOOF",
+      query: "query { orders { id } }",
+    });
+
+    expect(fake.calls.find((call) => call.method === "graphjin-read")?.input).toEqual({
+      orgId: "o1",
+      runId: "r1",
+      query: "query { orders { id } }",
+    });
+  });
+
+  it("uses service identity for GraphJin reads from non-interactive jobs", async () => {
+    const cp = new BrokerControlPlane(baseUrl, "job");
+    await cp.queryGraphjinRead({
+      orgId: "SPOOF",
+      runId: "SPOOF",
+      query: "query { orders { id } }",
+    });
+
+    expect(fake.calls.find((call) => call.method === "graphjin-read")?.input).toEqual({
+      orgId: "o1",
+      query: "query { orders { id } }",
     });
   });
 
@@ -478,7 +512,11 @@ describe("agent broker", () => {
       { type: "message", text: "hi" } as unknown as AgentEvent,
     ]);
     expect(events).toHaveLength(1);
-    expect(events[0]?.binding).toEqual({ runId: "r1", orgId: "o1" });
+    expect(events[0]?.binding).toEqual({
+      runId: "r1",
+      orgId: "o1",
+      kind: "work",
+    });
     expect(events[0]?.evs[0]).toMatchObject({ type: "message", text: "hi" });
   });
 

--- a/packages/agent-runtime/scripts/build.mjs
+++ b/packages/agent-runtime/scripts/build.mjs
@@ -1,5 +1,13 @@
 import { createHash } from "node:crypto";
-import { cp, mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  cp,
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { build } from "esbuild";
@@ -91,6 +99,7 @@ await writeFile(
   join(distRoot, manifestName),
   `${JSON.stringify(manifest, null, 2)}\n`,
 );
+await normalizeArtifactPermissions(distRoot);
 
 async function walkFiles(root) {
   const files = [];
@@ -101,4 +110,14 @@ async function walkFiles(root) {
     else throw new Error(`agent runtime artifact cannot contain ${entry.name}`);
   }
   return files;
+}
+
+async function normalizeArtifactPermissions(root) {
+  await chmod(root, 0o755);
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    const absolutePath = join(root, entry.name);
+    if (entry.isDirectory()) await normalizeArtifactPermissions(absolutePath);
+    else if (entry.isFile()) await chmod(absolutePath, 0o644);
+    else throw new Error(`agent runtime artifact cannot contain ${entry.name}`);
+  }
 }

--- a/packages/agent-runtime/src/entry.ts
+++ b/packages/agent-runtime/src/entry.ts
@@ -2,13 +2,10 @@ import { existsSync, readFileSync } from "node:fs";
 import { execFile } from "node:child_process";
 import {
   appendFile,
-  chmod,
   mkdir,
   mkdtemp,
-  rename,
   rm,
   symlink,
-  writeFile,
 } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
@@ -28,10 +25,8 @@ import {
   buildWorkMemoryServer,
   getBuiltinSkillsRoot,
   materializeBuiltinSkills,
-  resolveBinaryOnPath,
   runAgentBackend,
   runWorkflowAgentBackend,
-  sandboxReachableUrl,
   type RunAgentBackendInput,
 } from "@neko/llm/sandbox-runtime";
 import { BrokerControlPlane } from "./broker-client";
@@ -74,10 +69,6 @@ interface SandboxJob {
   mode?: "live" | "headless";
   triggeredByObservationId?: string | null;
   workspace: AgentWorkspace;
-  /** Whether the raw GraphJin binary is replaced with the guarded client. */
-  graphjinEnabled?: boolean;
-  /** Install a deny wrapper even though no customer GraphJin egress/token exists. */
-  graphjinDenied?: boolean;
   /** Explicit least-privilege envelope for non-interactive agent jobs. */
   agentAccess?: {
     graphjinRead?: boolean;
@@ -95,14 +86,6 @@ interface SandboxJob {
     | "backendState"
     | "wantsCards"
   >;
-  /** GJ5: policy write grants resolved host-side (the box has no DB). */
-  graphjinWriteGrants?: string[];
-  /** GJ6: the org's GraphJin MCP URL, resolved host-side. Lets the box
-   *  build a client.json even in legacy (token-less) mode. */
-  graphjinServerUrl?: string;
-  /** GJ6/GJ4: host-side per-run GraphJin client config ({server, token, ...}).
-   *  The sandbox rewrites only server reachability and preserves the actor token. */
-  graphjinClientConfig?: Record<string, unknown>;
 }
 
 function requireEnv(name: string): string {
@@ -156,75 +139,22 @@ export async function main(): Promise<void> {
     return Promise.resolve();
   };
 
-  // GJ6: the workspace's bin/graphjin wrapper was generated host-side with
-  // host paths baked in — rebuild it for the box, pinned at the uploaded
-  // per-run client.json (GJ4 token) and carrying the host-resolved policy
-  // grants (GJ5). Without a graphjin binary in the image this is a no-op.
-  const graphjinEnabled =
-    job.kind === "agent-job"
-      ? job.graphjinEnabled === true
-      : job.graphjinEnabled !== false;
-  const graphjinBinary = graphjinEnabled
-    || job.graphjinDenied === true
-    ? await resolveBinaryOnPath("graphjin")
-    : null;
-  if (graphjinBinary) {
-    const gjAuth = join(job.workspace.runRoot, "gj-auth");
-    const clientJsonPath = join(gjAuth, "graphjin", "client.json");
-    const uploadedConfig = existsSync(clientJsonPath)
-      ? JSON.parse(readFileSync(clientJsonPath, "utf8")) as Record<string, unknown>
-      : null;
-    const clientConfig = sandboxGraphjinClientConfig(
-      job.graphjinClientConfig ?? uploadedConfig,
-      job.graphjinServerUrl,
-    );
-    let hasRunAuth = false;
-    if (clientConfig) {
-      await mkdir(join(gjAuth, "graphjin"), { recursive: true });
-      await writeFile(clientJsonPath, JSON.stringify(clientConfig));
-      await chmod(clientJsonPath, 0o600).catch(() => {});
-      hasRunAuth = true;
-    }
-    await mkdir(job.workspace.binRoot, { recursive: true });
-    // Defense-in-depth: the model sometimes ignores the "query only via the
-    // shell tool" contract and shells out to `graphjin` from execute_code (a
-    // Python subprocess with a minimal PATH), hitting the raw binary at
-    // /usr/local/bin/graphjin with the wrong auth — which fails and sends it
-    // into a retry loop, and would bypass the mutation gate. Move the real
-    // binary aside and shadow the standard PATH entry with the guard wrapper, so
-    // ANY `graphjin` invocation (any PATH) gets the guarded, correctly-authed
-    // CLI (the wrapper exports the run's XDG_CONFIG_HOME regardless of caller).
-    let realBinary = graphjinBinary;
-    if (graphjinBinary === "/usr/local/bin/graphjin") {
-      try {
-        await rename("/usr/local/bin/graphjin", "/usr/local/bin/graphjin.real");
-        realBinary = "/usr/local/bin/graphjin.real";
-      } catch {
-        /* not writable / already shadowed — fall back to binRoot-only guard */
-      }
-    }
-    await ensureGraphjinGuard(job.workspace.binRoot, realBinary, {
-      ...(hasRunAuth ? { xdgConfigHome: gjAuth } : {}),
-      ...(job.graphjinWriteGrants?.length
-        ? { allowSubcommands: job.graphjinWriteGrants }
-        : {}),
-      ...(job.graphjinDenied ? { denyAll: true } : {}),
-    });
-    if (realBinary === "/usr/local/bin/graphjin.real") {
-      // The move vacated /usr/local/bin/graphjin — point it at the guard wrapper.
-      await symlink(
-        join(job.workspace.binRoot, "graphjin"),
-        "/usr/local/bin/graphjin",
-      ).catch(() => {});
-    }
-    // The backend prepends binRoot to PATH for its children, but hermes'
-    // terminal tool spawns LOGIN shells (`bash -lic`) and /etc/profile resets
-    // PATH — silently un-guarding `graphjin`. Login shells re-source these
-    // files after the reset, so the wrapper wins the lookup again.
-    const pathLine = `\nexport PATH="${job.workspace.binRoot}:$PATH"\n`;
-    for (const rc of [".bash_profile", ".profile", ".bashrc"]) {
-      await appendFile(join(homedir(), rc), pathLine).catch(() => {});
-    }
+  // Customer reads are brokered; no source URL, actor token, or GraphJin
+  // egress enters the sandbox. Shadow the legacy binary with an explicit deny
+  // wrapper so old skills fail closed with a useful migration instruction.
+  await mkdir(job.workspace.binRoot, { recursive: true });
+  await ensureGraphjinGuard(
+    job.workspace.binRoot,
+    "/usr/local/bin/graphjin.unavailable",
+    { denyAll: true },
+  );
+  // The backend prepends binRoot to PATH for its children, but hermes'
+  // terminal tool spawns LOGIN shells (`bash -lic`) and /etc/profile resets
+  // PATH. Login shells re-source these files after the reset, so the explicit
+  // broker-migration diagnostic still wins the lookup.
+  const pathLine = `\nexport PATH="${job.workspace.binRoot}:$PATH"\n`;
+  for (const rc of [".bash_profile", ".profile", ".bashrc"]) {
+    await appendFile(join(homedir(), rc), pathLine).catch(() => {});
   }
 
   const kind = job.kind ?? "work";
@@ -337,19 +267,6 @@ export async function main(): Promise<void> {
   emitLine(RESULT_MARKER, result);
 }
 
-function sandboxGraphjinClientConfig(
-  config: Record<string, unknown> | null | undefined,
-  fallbackServerUrl: string | undefined,
-): Record<string, unknown> | null {
-  const next = config ? { ...config } : {};
-  const server =
-    typeof next.server === "string" && next.server.trim()
-      ? next.server
-      : fallbackServerUrl;
-  if (!server) return null;
-  return { ...next, server: sandboxReachableUrl(server) };
-}
-
 async function run(): Promise<void> {
   const runtime = configureAgentRuntime({ entryUrl: import.meta.url });
   const skillsRoot = getBuiltinSkillsRoot();
@@ -381,6 +298,7 @@ async function run(): Promise<void> {
 async function runPreflight(runtime: AgentRuntimeContract): Promise<{
   skillsReady: boolean;
   graphjinGuardReady: boolean;
+  directGraphjinDenied: boolean;
   bridgeReady: boolean;
   bridgeServers: number;
 }> {
@@ -394,6 +312,18 @@ async function runPreflight(runtime: AgentRuntimeContract): Promise<{
     const graphjinGuard = await ensureGraphjinGuard(
       binRoot,
       "/usr/local/bin/graphjin",
+      { denyAll: true },
+    );
+    const directGraphjinDenied = await execFileAsync(
+      graphjinGuard,
+      ["cli", "execute_graphql", "--args", '{"query":"query { x }"}'],
+      { env: { PATH: process.env.PATH ?? "" }, timeout: 30_000 },
+    ).then(
+      () => false,
+      (error: unknown) =>
+        String((error as { stderr?: unknown }).stderr ?? "").includes(
+          "Direct GraphJin CLI access is unavailable",
+        ),
     );
     const bridgeResult = await execFileAsync(
       process.execPath,
@@ -412,6 +342,7 @@ async function runPreflight(runtime: AgentRuntimeContract): Promise<{
       graphjinGuardReady:
         existsSync(graphjinGuard) &&
         existsSync(join(binRoot, "compact-cli.mjs")),
+      directGraphjinDenied,
       bridgeReady: bridge.status === "ok",
       bridgeServers: bridge.servers ?? 0,
     };

--- a/packages/agent-runtime/src/mcp-bridge.ts
+++ b/packages/agent-runtime/src/mcp-bridge.ts
@@ -98,7 +98,7 @@ export function buildBridgeServer(
   const common = { orgId, runId, emit, controlPlane };
   switch (name) {
     case "neko_graphjin":
-      return buildGraphjinReadServer({ orgId, controlPlane });
+      return buildGraphjinReadServer({ orgId, runId, controlPlane });
     case "neko_graphjin_agent":
       return buildGraphjinAgentServer({ orgId, runId, controlPlane });
     case "neko_skills":

--- a/packages/agent-runtime/test/artifact.test.ts
+++ b/packages/agent-runtime/test/artifact.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile, readdir, stat } from "node:fs/promises";
 import { spawnSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -30,6 +30,20 @@ describe("built agent runtime artifact", () => {
     ).toBeGreaterThan(200);
   });
 
+  it("is immutable but readable and traversable by the sandbox user", async () => {
+    const paths = [distRoot];
+    while (paths.length > 0) {
+      const path = paths.pop()!;
+      const metadata = await stat(path);
+      if (metadata.isDirectory()) {
+        expect(metadata.mode & 0o777, path).toBe(0o755);
+        for (const entry of await readdir(path)) paths.push(join(path, entry));
+      } else {
+        expect(metadata.mode & 0o777, path).toBe(0o644);
+      }
+    }
+  });
+
   it("passes the complete preflight with a clean supervised environment", () => {
     const result = spawnSync(
       process.execPath,
@@ -47,6 +61,7 @@ describe("built agent runtime artifact", () => {
       lazyInstallsDisabled: true,
       skillsReady: true,
       graphjinGuardReady: true,
+      directGraphjinDenied: true,
       bridgeReady: true,
       bridgeServers: 17,
     });

--- a/packages/llm/src/agent-backends/hermes.ts
+++ b/packages/llm/src/agent-backends/hermes.ts
@@ -78,21 +78,26 @@ export function ensureRenderStub(): string {
 
 /** Last error-ish lines of hermes' own agent.log — the file dies with the
  *  sandbox, so a mid-turn death must read it NOW or never. */
-function hermesAgentLogTail(hermesHome: string | undefined): string {
+export function hermesAgentLogTail(hermesHome: string | undefined): string {
   if (!hermesHome) return "";
   try {
     const lines = readFileSync(join(hermesHome, "logs", "agent.log"), "utf8")
       .split("\n")
       .filter(
         (l) =>
-          l.trim() &&
+          /^\d{4}-\d{2}-\d{2}[ T]\d{2}:\d{2}:\d{2}(?:[,.]\d+)?\s+(?:DEBUG|INFO|WARNING|ERROR|CRITICAL)\s+/.test(
+            l,
+          ) &&
           !l.includes("Prompt on session") &&
           !l.includes("conversation turn:"),
       );
     const errs = lines.filter((l) =>
       /ERROR|CRITICAL|Traceback|Unhandled|fatal|Killed|Segmentation/i.test(l),
     );
-    return (errs.length ? errs : lines).slice(-8).join("\n").slice(-900);
+    const activity = lines.filter((l) =>
+      /provider|client created|API call|request|response|timeout|denied|failed|error/i.test(l),
+    );
+    return (errs.length ? errs : activity).slice(-8).join("\n").slice(-900);
   } catch {
     return "";
   }
@@ -681,11 +686,13 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
     // with no assistant message, leaving the UI apparently dead. Retry only
     // when no tool ran, then fail with an explicit diagnostic.
     if (!accumulatedText.trim() && !surfaceEmittedDuringStream) {
+      const activity = hermesAgentLogTail(env.HERMES_HOME);
       return {
         finalText: "",
         error:
           `hermes completed without assistant output or surface` +
-          ` (stopReason=${promptStopReason ?? "unknown"})`,
+          ` (stopReason=${promptStopReason ?? "unknown"})` +
+          (activity ? `; agent activity: ${activity}` : ""),
         retryable: !toolActivityObserved,
       };
     }

--- a/packages/llm/src/prompts/sections.ts
+++ b/packages/llm/src/prompts/sections.ts
@@ -121,8 +121,10 @@ ${application}${usage}
 
 export type DataAccessOptions = {
   shellTool: string;
-  /** Query-only broker tool used by isolated, non-interactive jobs. */
+  /** Query-only broker tool used by sandboxed chat, workflow, and job agents. */
   queryTool?: string;
+  /** Interactive runs preserve their work-run actor; jobs use service reads. */
+  queryIdentity?: "actor" | "service";
   /** Read-only GraphJin server-agent tool used by delegated jobs. */
   agentTool?: string;
   workspace: AgentWorkspace;
@@ -319,10 +321,11 @@ ${GRAPHJIN_AGGREGATE_RULE}
 function buildBrokeredDataAccessSection(opts: DataAccessOptions): string {
   const { queryTool, knowledge } = opts;
   if (!queryTool) throw new Error("brokered data access requires queryTool");
+  const actorBound = opts.queryIdentity === "actor";
   const agentic = knowledge.mode === "agentic";
   const knowledgeBlock = agentic
     ? `================================================================================
-Tables visible to the service role (deeper detail via gj_catalog):
+Tables visible to this run's role (deeper detail via gj_catalog):
 ================================================================================
 
 ${compactTableDigest(knowledge.tables)}
@@ -374,10 +377,14 @@ Execute every database read by calling \`${queryTool}\` with:
 
   { "query": "<your read-only GraphQL query>" }
 
-This tool is implemented by the trusted OpenNeko host. The source URL and
-short-lived service credential never enter your sandbox. The host rejects
-mutations and subscriptions before GraphJin sees them. No shell, raw HTTP,
-configuration, or write path is available for database access.
+This tool is implemented by the trusted OpenNeko host. ${
+  actorBound
+    ? `The source URL and short-lived actor credential never enter your sandbox;
+the broker binds each call to this org and work run.`
+    : `The source URL and short-lived service credential never enter your sandbox;
+the broker binds each call to this org's read-only job capability.`
+} The host rejects mutations and subscriptions before GraphJin sees them. No
+shell, raw HTTP, configuration, or write path is available for database access.
 
 ${
   agentic

--- a/packages/llm/src/work/agent-core.ts
+++ b/packages/llm/src/work/agent-core.ts
@@ -18,6 +18,7 @@ import {
   buildAuditViewerServer,
   buildChannelManagerServer,
   buildDataSourceManagerServer,
+  buildGraphjinReadServer,
   buildSourceConfigManagerServer,
   buildUserManagerServer,
   buildLibraryServer,
@@ -120,6 +121,13 @@ export async function runAgentBackend(
           }),
         }
       : {
+        // Customer reads cross the OpenShell boundary only through the
+        // run-bound broker. The source URL and actor token stay host-side.
+        neko_graphjin: buildGraphjinReadServer({
+          orgId,
+          runId,
+          controlPlane,
+        }),
         // Rendering is per-channel: the card server only ships to web turns.
         ...(wantsCards ? { neko_ui: buildRenderCardsServer(emit) } : {}),
         neko_skills: buildSkillBuilderServer(workspace.skillsRoot),

--- a/packages/llm/src/work/broker.ts
+++ b/packages/llm/src/work/broker.ts
@@ -13,6 +13,8 @@ import { sandboxBrokerHost } from "./sandbox-net";
 export interface RunBinding {
   runId: string;
   orgId: string;
+  /** Agent jobs have no work_run actor and intentionally use service reads. */
+  kind?: "work" | "workflow" | "agent-job";
   /** Present for chat/workflow runs so broker-emitted events can be persisted. */
   threadId?: string;
 }
@@ -168,6 +170,7 @@ async function handle(
             ? { operationName: body.operationName }
             : {}),
           orgId: binding.orgId,
+          ...(binding.kind === "agent-job" ? {} : { runId: binding.runId }),
         }),
       );
     case "/v1/graphjin/agent":

--- a/packages/llm/src/work/control-plane.ts
+++ b/packages/llm/src/work/control-plane.ts
@@ -111,11 +111,24 @@ export function assertReadOnlyGraphql(query: string): void {
   // can cause a harmless false positive, while accepting either operation
   // would turn the broker into a write bypass for legacy GraphJin sources.
   if (/\b(?:mutation|subscription)\b/i.test(text)) {
-    throw new Error("GraphJin job broker allows query operations only");
+    throw new Error("GraphJin agent broker allows query operations only");
   }
   if (!text.startsWith("{") && !/^query\b/i.test(text)) {
-    throw new Error("GraphJin job broker requires an explicit query operation");
+    throw new Error("GraphJin agent broker requires an explicit query operation");
   }
+}
+
+export function graphjinReadPrincipal(actor: {
+  userId: string | null;
+  role: string | null;
+}): { userId: string | null; role: "admin" | "member" | "service" } {
+  if (actor.role === "admin" || actor.role === "member") {
+    return { userId: actor.userId, role: actor.role };
+  }
+  if (actor.role === "service") {
+    return { userId: null, role: "service" };
+  }
+  throw new Error("GraphJin read actor has an invalid role");
 }
 
 async function requireSourceConfigAccess(input: {
@@ -411,6 +424,8 @@ export interface AgentControlPlane {
   searchLibraryForRun(args: LibrarySearchArgs): Promise<LibrarySearchResult[]>;
   queryGraphjinRead(input: {
     orgId: string;
+    /** Trusted work-run binding used to mint the same actor identity as chat. */
+    runId?: string | null;
     query: string;
     variables?: Record<string, unknown>;
     operationName?: string;
@@ -819,6 +834,7 @@ export class InProcessControlPlane implements AgentControlPlane {
 
   async queryGraphjinRead(input: {
     orgId: string;
+    runId?: string | null;
     query: string;
     variables?: Record<string, unknown>;
     operationName?: string;
@@ -840,11 +856,20 @@ export class InProcessControlPlane implements AgentControlPlane {
 
     const headers: Record<string, string> = {};
     if (source.authMode === "jwt") {
+      let principal: ReturnType<typeof graphjinReadPrincipal> = {
+        userId: null,
+        role: "service",
+      };
+      if (input.runId) {
+        const { getWorkRunActor } = await import("./personas");
+        const actor = await getWorkRunActor(input.runId, input.orgId);
+        principal = graphjinReadPrincipal(actor);
+      }
       const { mintGraphjinToken } = await import("../graphjin/token");
       headers.authorization = `Bearer ${mintGraphjinToken({
         orgId: input.orgId,
-        userId: null,
-        role: "service",
+        userId: principal.userId,
+        role: principal.role,
       })}`;
     }
     const { graphjinQuery } = await import("../graphjin/client");

--- a/packages/llm/src/work/graphjin-guard.ts
+++ b/packages/llm/src/work/graphjin-guard.ts
@@ -93,7 +93,7 @@ export async function ensureGraphjinGuard(
     xdgConfigHome?: string;
     /** GJ5: write subcommands this run's policy grants (admin actors only). */
     allowSubcommands?: string[];
-    /** Records-mode isolation: customer GraphJin is not a permitted data plane. */
+    /** Sandbox isolation: direct customer GraphJin access is not permitted. */
     denyAll?: boolean;
   } = {},
 ): Promise<string> {
@@ -118,7 +118,7 @@ export async function ensureGraphjinGuard(
     "",
     ...(opts.denyAll
       ? [
-          "echo \"Customer GraphJin is unavailable in a records-scoped turn. Use the native neko_records tools.\" >&2",
+          "echo \"Direct GraphJin CLI access is unavailable in this sandbox. Use mcp__neko_graphjin__execute_graphql for customer data or the native neko_records tools for generated apps.\" >&2",
           "exit 2",
           "",
         ]

--- a/packages/llm/src/work/personas.ts
+++ b/packages/llm/src/work/personas.ts
@@ -109,6 +109,7 @@ export async function upsertOperatorProfile(input: {
 /** The run's acting principal (K1 columns), for persona resolution. */
 export async function getWorkRunActor(
   runId: string,
+  orgId?: string,
 ): Promise<{ userId: string | null; role: string | null }> {
   const [row] = await db()
     .select({
@@ -116,7 +117,11 @@ export async function getWorkRunActor(
       role: work_run.actor_role,
     })
     .from(work_run)
-    .where(eq(work_run.id, runId))
+    .where(
+      orgId
+        ? and(eq(work_run.id, runId), eq(work_run.org_id, orgId))
+        : eq(work_run.id, runId),
+    )
     .limit(1);
   return row ?? { userId: null, role: null };
 }

--- a/packages/llm/src/work/prompt.ts
+++ b/packages/llm/src/work/prompt.ts
@@ -171,7 +171,18 @@ spawn depth allows it.
 function buildWorkflowToolsSection(
   supportsWorkflowTool: boolean,
   shellTool: string,
+  supportsGraphjinTool: boolean,
 ): string {
+  const introspection = supportsGraphjinTool
+    ? `Before setting \`triggers.when\`, query \`gj_catalog\` through
+  \`mcp__neko_graphjin__execute_graphql\` for table cards, columns, and
+  relationship edges. Confirm the table, columns, and \`primary_key\` from
+  those role-scoped results.`
+    : `Before setting \`triggers.when\`, introspect the data source with the
+  available GraphJin discovery surface. In source-mode, query \`gj_catalog\`
+  through \`graphjin cli execute_graphql\` for table cards, columns, and
+  relationship edges. Only use MCP dev tools such as \`list_tables\`,
+  \`describe_table\`, or \`get_table_sample\` when the server exposes them.`;
   if (supportsWorkflowTool) {
     return `<workflows>
 The operator can ask you to set up, modify, or look up workflows directly
@@ -213,11 +224,7 @@ A workflow can run on a schedule, when the data changes, or both:
   The workflow's \`steps\` are the response (e.g. "DM Amit on Slack with
   the low-stock details"); \`triggers.when\` is the condition.
 
-  Before setting \`triggers.when\`, introspect the data source with the
-  available GraphJin discovery surface. In source-mode, query \`gj_catalog\`
-  through \`graphjin cli execute_graphql\` for table cards, columns, and
-  relationship edges. Only use MCP dev tools such as \`list_tables\`,
-  \`describe_table\`, or \`get_table_sample\` when the server exposes them.
+  ${introspection}
 
   \`triggers.when\` shape:
   \`\`\`json
@@ -280,11 +287,8 @@ both:
   \`triggers.when\` is the condition. Omit \`triggers\` entirely for a
   manual workflow.
 
-Before writing \`triggers.when\`, introspect the data source with your
-\`${shellTool}\` tool. In source-mode, query \`gj_catalog\` through
-\`graphjin cli execute_graphql\`; in legacy/tool deployments, use available
-GraphJin CLI discovery commands. Confirm the table, columns, and
-\`primary_key\`. \`primary_key\` is
+${introspection.replace("Before setting", "Before writing")}
+\`primary_key\` is
 required and drives idempotency. If the workflow's steps write back to
 the watched table, add \`triggers.when.idempotency_key_template\` (e.g.
 \`"reorder-{primary_key}"\`).
@@ -687,6 +691,8 @@ export function buildWorkPrompt(args: {
   supportsPolicyTool: boolean;
   supportsSourceConfigTool: boolean;
   supportsPluginManagerTool?: boolean;
+  /** Customer GraphJin reads are brokered when the backend mounts MCP tools. */
+  supportsGraphjinTool?: boolean;
   pluginCatalog?: PluginCatalog;
   // True when prior turns must be inlined into the system prompt because the
   // backend can't reload them out-of-band (i.e. no session resume).
@@ -716,6 +722,7 @@ export function buildWorkPrompt(args: {
     supportsPolicyTool,
     supportsSourceConfigTool,
     supportsPluginManagerTool = false,
+    supportsGraphjinTool = false,
     pluginCatalog,
     inlineTranscript,
     pluginActions,
@@ -756,7 +763,11 @@ that flags churn risk every Monday."
         })
       : "",
     dataSurface === "customer"
-      ? buildWorkflowToolsSection(supportsWorkflowTool, shellTool)
+      ? buildWorkflowToolsSection(
+          supportsWorkflowTool,
+          shellTool,
+          supportsGraphjinTool,
+        )
       : "",
     dataSurface === "customer" ? buildPoliciesSection(supportsPolicyTool) : "",
     dataSurface === "customer"
@@ -770,6 +781,12 @@ that flags churn risk every Monday."
       ? buildRecordsAccessSection(appContext, recordContext)
       : buildDataAccessSection({
           shellTool,
+          ...(supportsGraphjinTool
+            ? {
+                queryTool: "mcp__neko_graphjin__execute_graphql",
+                queryIdentity: "actor" as const,
+              }
+            : {}),
           workspace,
           knowledge,
           inlineKnowledge: "syntax",

--- a/packages/llm/src/work/run-chat-turn.ts
+++ b/packages/llm/src/work/run-chat-turn.ts
@@ -404,11 +404,15 @@ export async function runChatTurn(
     }
   };
 
-  // Production resolves and guards GraphJin inside the OpenShell sandbox.
-  // The host path is retained only for the in-process test harness.
+  // Hermes reads customer data through the brokered MCP server. Keep the
+  // guarded CLI only for a legacy in-process backend without MCP support.
+  const directGraphjin =
+    dataSurface === "customer" && !backend.capabilities.mcpTools;
   const graphjinBinary =
-    runCore === runAgentBackend ? await resolveBinaryOnPath("graphjin") : null;
-  if (runCore === runAgentBackend && !graphjinBinary && dataSurface === "customer") {
+    runCore === runAgentBackend && directGraphjin
+      ? await resolveBinaryOnPath("graphjin")
+      : null;
+  if (runCore === runAgentBackend && directGraphjin && !graphjinBinary) {
     const errMsg = "graphjin CLI is not installed on PATH.";
     await wrappedEmit({ type: "error", message: errMsg });
     await finishWorkRun(runId, "failed", errMsg);
@@ -422,7 +426,7 @@ export async function runChatTurn(
   // run's CLI calls carry this run's actor token — a per-run client.json
   // the guard pins XDG_CONFIG_HOME at. Legacy mode is unchanged.
   let guardXdg: string | undefined;
-  if (dataSurface === "customer") {
+  if (directGraphjin) {
     const { data_source, db, desc, eq } = await import("@neko/db");
     const [src] = await db()
       .select({ authMode: data_source.auth_mode, mcpUrl: data_source.mcp_url })
@@ -450,14 +454,13 @@ export async function runChatTurn(
   // GJ5: an org policy may grant an admin actor specific write
   // subcommands; everyone else keeps the read-only guard.
   const { resolveGraphjinWriteGrants } = await import("./graphjin-actor-guard");
-  const writeGrants = dataSurface === "customer"
+  const writeGrants = directGraphjin
     ? await resolveGraphjinWriteGrants(orgId, actor)
     : [];
   if (graphjinBinary) {
     await ensureGraphjinGuard(workspace.binRoot, graphjinBinary, {
       ...(guardXdg ? { xdgConfigHome: guardXdg } : {}),
       ...(writeGrants.length > 0 ? { allowSubcommands: writeGrants } : {}),
-      ...(dataSurface === "records" ? { denyAll: true } : {}),
     });
   }
 
@@ -481,6 +484,8 @@ export async function runChatTurn(
     const supportsWorkflowTool = customerSurface && backend.capabilities.mcpTools;
     const supportsPolicyTool = customerSurface && backend.capabilities.mcpTools;
     const supportsPluginManagerTool =
+      customerSurface && backend.capabilities.mcpTools;
+    const supportsGraphjinTool =
       customerSurface && backend.capabilities.mcpTools;
     const sourceConfigSettings = dataSurface === "customer"
       ? await getGraphjinConfigSettingsForOrg(orgId)
@@ -586,6 +591,7 @@ export async function runChatTurn(
       supportsPolicyTool,
       supportsSourceConfigTool,
       supportsPluginManagerTool,
+      supportsGraphjinTool,
       pluginCatalog,
       inlineTranscript,
       pluginActions: customerSurface ? (opts.pluginActions ?? []) : [],

--- a/packages/llm/src/work/sandbox-launcher.ts
+++ b/packages/llm/src/work/sandbox-launcher.ts
@@ -14,8 +14,8 @@ import {
 import type { RunWorkflowAgentBackendInput } from "../workflows/agent-core";
 import type { RunWorkflowTurnDeps } from "../workflows/run-workflow-turn";
 import type { RunAgentBackendInput } from "./agent-core";
+import type { RunBinding } from "./broker";
 import type { RunChatTurnDeps } from "./run-chat-turn";
-import { resolveSandboxReachableUrl } from "./sandbox-net";
 import { copySkillOverrides } from "./workspace";
 
 // Wire protocol shared with the in-image entrypoint. The agent runs in a
@@ -61,21 +61,11 @@ export interface SandboxLauncherOptions {
    * keyAliases, process env) is what hermes uses. Set for the hermes backend.
    */
   hermesHomeHostPath?: string;
-  /**
-   * GJ6: path of the graphjin binary inside the agent image — the org's
-   * data-source host is allowed for this binary so `graphjin cli` can
-   * reach the GraphJin server from the box.
-   */
-  graphjinBinaryInBox?: string;
   /** Broker coordinates for Hermes MCP tools. */
   brokerUrl?: string;
   /** Mint a per-run bearer token bound to {runId, orgId, threadId} (the broker forces
    *  org/run from the binding, never the request body). */
-  brokerTokenFor?: (binding: {
-    runId: string;
-    orgId: string;
-    threadId?: string;
-  }) => string;
+  brokerTokenFor?: (binding: RunBinding) => string;
   /** Release the run's token after it finishes (called in the run's finally). */
   brokerRelease?: (runId: string) => void;
   execTimeoutMs?: number;
@@ -463,43 +453,13 @@ function makeSandboxCore(
       ]),
     ) as RunAgentBackendInput["workspace"];
 
-    // Non-interactive jobs never receive direct source egress or a GraphJin
-    // token. Their graphjinRead capability is a brokered query-only MCP tool.
-    const graphjinDenied =
+    // Every sandboxed path uses the brokered query-only MCP tool. The source
+    // URL and actor token remain on the trusted host; no data-source egress is
+    // granted to the sandbox's general-purpose binaries.
+    const recordsScoped =
       !isJob &&
       kind === "work" &&
       (input as RunAgentBackendInput).dataSurface === "records";
-    const graphjinEnabled = !isJob && !graphjinDenied;
-
-    // Job agents are always read-only. Interactive/workflow turns retain
-    // their existing actor-policy grant resolution.
-    const graphjinWriteGrants =
-      graphjinEnabled && !isJob
-        ? await resolveRunGraphjinGrants(input.orgId, input.runId)
-        : [];
-
-    // GJ6: the box must reach the org's GraphJin server — resolved here
-    // (host-side, where the DB lives) both for the egress rule and for the
-    // in-box client.json (entry.ts rewrites loopback to the host alias).
-    const dataEgress: Awaited<ReturnType<typeof resolveDataSourceEgress>> = graphjinEnabled
-      ? await resolveDataSourceEgress(
-          input.orgId,
-          (() => {
-            const binary =
-              opts.graphjinBinaryInBox ?? "/usr/local/bin/graphjin";
-            return binary.endsWith("/graphjin")
-              ? [binary, `${binary}.real`]
-              : [binary];
-          })(),
-        )
-      : { rules: [] };
-    const storedGraphjinClientConfig = graphjinEnabled
-      ? await readRunGraphjinClientConfig(input.workspace.runRoot)
-      : null;
-    const graphjinClientConfig =
-      storedGraphjinClientConfig && dataEgress.serverUrl
-        ? { ...storedGraphjinClientConfig, server: dataEgress.serverUrl }
-        : storedGraphjinClientConfig;
 
     const threadId = isJob
       ? `agent-job:${input.runId}`
@@ -518,8 +478,6 @@ function makeSandboxCore(
       backendId: input.backend.id,
       // Hermes reads its model from the staged config.yaml.
       workspace: boxWorkspace,
-      graphjinEnabled,
-      ...(graphjinDenied ? { graphjinDenied: true } : {}),
       ...(kind === "work"
         ? {
             backendState: (input as RunAgentBackendInput).backendState,
@@ -543,9 +501,6 @@ function makeSandboxCore(
               agentAccess: jobInput?.access ?? {},
               agentRun: serializableAgentRunOptions(jobInput?.run ?? { prompt: inputPrompt }),
             }),
-      ...(graphjinWriteGrants.length > 0 ? { graphjinWriteGrants } : {}),
-      ...(dataEgress.serverUrl ? { graphjinServerUrl: dataEgress.serverUrl } : {}),
-      ...(graphjinClientConfig ? { graphjinClientConfig } : {}),
     };
 
     // MCP tools reach the control plane via the broker — node's
@@ -566,7 +521,6 @@ function makeSandboxCore(
     const egressRules: SandboxEgressRule[] = [
       ...(opts.modelEgress ?? []),
       ...brokerEgress,
-      ...dataEgress.rules,
     ];
 
     const stageDir = await mkdtemp(path.join(tmpdir(), "oss-agent-"));
@@ -579,7 +533,7 @@ function makeSandboxCore(
       const staged = await stageSandboxWorkspace(input.workspace, stageDir, {
         // A records-scoped turn must remain functional during a rolling
         // upgrade even if the sandbox image predates the records skill.
-        requiredSkillNames: graphjinDenied ? ["records"] : [],
+        requiredSkillNames: recordsScoped ? ["records"] : [],
       });
       const stageRuntimeRoot = path.join(
         staged.workspace.runRoot,
@@ -675,7 +629,7 @@ function makeSandboxCore(
 
       log(
         `agent sandbox ready: ${name} (backend=${input.backend.id}, kind=${kind}, ` +
-          `graphjin=${graphjinEnabled}, skill_overrides=${staged.skillOverrides.length})`,
+          `graphjin=brokered, skill_overrides=${staged.skillOverrides.length})`,
       );
       await input.emit({ type: "status", message: "Launching agent…" });
       return await execAndStream(
@@ -692,6 +646,7 @@ function makeSandboxCore(
                     runId: input.runId,
                     orgId: input.orgId,
                     threadId,
+                    kind,
                   }),
                 }
               : {}),
@@ -742,88 +697,6 @@ function makeSandboxCore(
 }
 
 /** `policy update` adding the model endpoint(s) scoped to the backend binary. */
-/** GJ6: the org's GraphJin host as a per-run egress allow entry. Best-effort. */
-async function resolveDataSourceEgress(
-  orgId: string,
-  graphjinBinaries: readonly string[],
-): Promise<{
-  rules: Array<{ host: string; binary: string; port?: number }>;
-  serverUrl?: string;
-}> {
-  try {
-    const { data_source, db, desc, eq } = await import("@neko/db");
-    const [src] = await db()
-      .select({ mcpUrl: data_source.mcp_url })
-      .from(data_source)
-      .where(eq(data_source.org_id, orgId))
-      .orderBy(desc(data_source.is_default), data_source.created_at)
-      .limit(1);
-    if (!src?.mcpUrl) return { rules: [] };
-    const sandboxUrl = await resolveSandboxReachableUrl(src.mcpUrl);
-    const u = new URL(sandboxUrl);
-    const port = Number(u.port) || (u.protocol === "https:" ? 443 : 80);
-    return {
-      rules: graphjinBinaries.map((binary) => ({
-        host: u.hostname,
-        port,
-        binary,
-      })),
-      serverUrl: sandboxUrl,
-    };
-  } catch (err) {
-    console.warn(
-      `[agent-sandbox] data-source egress lookup failed: ${err instanceof Error ? err.message : err}`,
-    );
-    return { rules: [] };
-  }
-}
-
-async function readRunGraphjinClientConfig(
-  runRoot: string | undefined,
-): Promise<Record<string, unknown> | null> {
-  if (!runRoot) return null;
-  const candidates = [
-    path.join(runRoot, "gj-auth", "graphjin", "client.json"),
-    path.join(runRoot, "gj-auth", ".config", "graphjin", "client.json"),
-    path.join(
-      runRoot,
-      "gj-auth",
-      "Library",
-      "Application Support",
-      "graphjin",
-      "client.json",
-    ),
-  ];
-  for (const candidate of candidates) {
-    try {
-      const parsed = JSON.parse(await readFile(candidate, "utf8")) as unknown;
-      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-        return parsed as Record<string, unknown>;
-      }
-    } catch {
-      continue;
-    }
-  }
-  return null;
-}
-
-/** GJ5 host-side grant resolution for the in-box guard rebuild. Best-effort. */
-async function resolveRunGraphjinGrants(
-  orgId: string,
-  runId: string,
-): Promise<string[]> {
-  try {
-    const { getWorkRunActor } = await import("./personas");
-    const { resolveGraphjinWriteGrants } = await import(
-      "./graphjin-actor-guard"
-    );
-    const actor = await getWorkRunActor(runId);
-    return await resolveGraphjinWriteGrants(orgId, actor);
-  } catch {
-    return [];
-  }
-}
-
 export function buildModelEgressArgs(
   name: string,
   egress: ReadonlyArray<{ host: string; binary: string; port?: number }>,
@@ -869,43 +742,31 @@ export function buildScopedEgressArgs(
  * bound to its control plane and passes the handle so every backend can reach
  * policy-gated host capabilities and return their UI events mid-turn.
  */
-export function agentRuntimeDepsFromEnv(broker?: {
+type SandboxBrokerHandle = {
   url: string;
-  tokenFor: (binding: {
-    runId: string;
-    orgId: string;
-    threadId?: string;
-  }) => string;
+  tokenFor: (binding: RunBinding) => string;
   release?: (runId: string) => void;
-}): Pick<Partial<RunChatTurnDeps>, "runCore"> {
+};
+
+export function agentRuntimeDepsFromEnv(
+  broker?: SandboxBrokerHandle,
+): Pick<Partial<RunChatTurnDeps>, "runCore"> {
   return {
     runCore: makeSandboxRunCore(sandboxLauncherOptionsFromEnv(broker)),
   };
 }
 
-export function workflowRuntimeDepsFromEnv(broker?: {
-  url: string;
-  tokenFor: (binding: {
-    runId: string;
-    orgId: string;
-    threadId?: string;
-  }) => string;
-  release?: (runId: string) => void;
-}): Pick<Partial<RunWorkflowTurnDeps>, "runCore"> {
+export function workflowRuntimeDepsFromEnv(
+  broker?: SandboxBrokerHandle,
+): Pick<Partial<RunWorkflowTurnDeps>, "runCore"> {
   return {
     runCore: makeSandboxWorkflowRunCore(sandboxLauncherOptionsFromEnv(broker)),
   };
 }
 
-function sandboxLauncherOptionsFromEnv(broker?: {
-  url: string;
-  tokenFor: (binding: {
-    runId: string;
-    orgId: string;
-    threadId?: string;
-  }) => string;
-  release?: (runId: string) => void;
-}): SandboxLauncherOptions {
+function sandboxLauncherOptionsFromEnv(
+  broker?: SandboxBrokerHandle,
+): SandboxLauncherOptions {
   // Comma-separated: the model endpoint AND any resolution hosts (hermes needs
   // models.dev), all scoped to the backend's one connecting binary.
   const hosts = (process.env.OPENNEKO_AGENT_MODEL_HOST ?? "")
@@ -927,8 +788,6 @@ function sandboxLauncherOptionsFromEnv(broker?: {
     modelEgress: binary ? hosts.map((host) => ({ host, binary })) : [],
     keyAliases: keyEnv ? [{ from: credName, to: keyEnv }] : undefined,
     hermesHomeHostPath: process.env.OPENNEKO_AGENT_HERMES_HOME || undefined,
-    graphjinBinaryInBox:
-      process.env.OPENNEKO_AGENT_GRAPHJIN_BINARY || undefined,
     brokerUrl: broker?.url,
     brokerTokenFor: broker?.tokenFor,
     brokerRelease: broker?.release,

--- a/packages/llm/src/work/tools.ts
+++ b/packages/llm/src/work/tools.ts
@@ -970,11 +970,13 @@ export function buildSkillBuilderServer(skillsRoot: string) {
 }
 
 /**
- * Query-only GraphJin surface for non-interactive jobs. The broker owns the
- * source URL and short-lived service token; neither enters the sandbox.
+ * Query-only GraphJin surface for sandboxed agents. The broker owns the source
+ * URL and mints a short-lived token for the bound run actor on each call;
+ * neither enters the sandbox.
  */
 export function buildGraphjinReadServer(opts: {
   orgId: string;
+  runId?: string;
   controlPlane?: AgentControlPlane;
 }) {
   const controlPlane = requireControlPlane(opts.controlPlane);
@@ -993,6 +995,7 @@ export function buildGraphjinReadServer(opts: {
     async (args) => {
       const result = await controlPlane.queryGraphjinRead({
         orgId: opts.orgId,
+        ...(opts.runId ? { runId: opts.runId } : {}),
         query: args.query,
         ...(args.variables ? { variables: args.variables } : {}),
         ...(args.operationName ? { operationName: args.operationName } : {}),

--- a/packages/llm/src/workflows/agent-core.ts
+++ b/packages/llm/src/workflows/agent-core.ts
@@ -5,7 +5,11 @@ import type {
   AgentWorkspace,
 } from "../agent-backend";
 import type { AgentControlPlane } from "../work/control-plane";
-import { buildLibraryServer, buildWorkMemoryServer } from "../work/tools";
+import {
+  buildGraphjinReadServer,
+  buildLibraryServer,
+  buildWorkMemoryServer,
+} from "../work/tools";
 import { buildWorkflowActionServer } from "./action-tool-server";
 import { buildWorkflowOutputServer } from "./output-tool-server";
 
@@ -58,6 +62,11 @@ export async function runWorkflowAgentBackend(
   const mcp = backend.capabilities.mcpTools;
   const mcpServers = mcp
     ? {
+        neko_graphjin: buildGraphjinReadServer({
+          orgId,
+          runId,
+          controlPlane,
+        }),
         neko_workflow_output: buildWorkflowOutputServer({
           orgId,
           workflowRunId,

--- a/packages/llm/src/workflows/runner-prompt.ts
+++ b/packages/llm/src/workflows/runner-prompt.ts
@@ -224,6 +224,12 @@ export function buildWorkflowRunnerPrompt(
   const shellTool = shellToolName(backend);
   const dataAccessSection = buildDataAccessSection({
     shellTool,
+    ...(mcpTools
+      ? {
+          queryTool: "mcp__neko_graphjin__execute_graphql",
+          queryIdentity: "actor" as const,
+        }
+      : {}),
     workspace,
     knowledge,
     inlineKnowledge: "syntax",

--- a/packages/llm/test/graphjin-job-broker.test.ts
+++ b/packages/llm/test/graphjin-job-broker.test.ts
@@ -1,7 +1,71 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, it } from "vitest";
-import { assertReadOnlyGraphql } from "../src/work/control-plane";
+import type { AgentControlPlane } from "../src/work/control-plane";
+import {
+  assertReadOnlyGraphql,
+  graphjinReadPrincipal,
+} from "../src/work/control-plane";
+import { buildGraphjinReadServer } from "../src/work/tools";
 
-describe("GraphJin job broker read gate", () => {
+describe("GraphJin broker read gate", () => {
+  it("preserves explicit member/admin/service identities and rejects unknown roles", () => {
+    expect(graphjinReadPrincipal({ userId: "member-1", role: "member" })).toEqual({
+      userId: "member-1",
+      role: "member",
+    });
+    expect(graphjinReadPrincipal({ userId: "admin-1", role: "admin" })).toEqual({
+      userId: "admin-1",
+      role: "admin",
+    });
+    expect(graphjinReadPrincipal({ userId: "service-user", role: "service" })).toEqual({
+      userId: null,
+      role: "service",
+    });
+    expect(() =>
+      graphjinReadPrincipal({ userId: "unknown-1", role: null }),
+    ).toThrow(/invalid role/);
+    expect(() =>
+      graphjinReadPrincipal({ userId: "unknown-1", role: "owner" }),
+    ).toThrow(/invalid role/);
+  });
+
+  it("sends the agent-visible tool call with its trusted work-run identity", async () => {
+    let seen: Parameters<AgentControlPlane["queryGraphjinRead"]>[0] | undefined;
+    const controlPlane = {
+      async queryGraphjinRead(input) {
+        seen = input;
+        return { data: { orders: [{ id: "order-1" }] } };
+      },
+    } as AgentControlPlane;
+    const server = buildGraphjinReadServer({
+      orgId: "org-1",
+      runId: "run-1",
+      controlPlane,
+    });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.instance.connect(serverTransport);
+    const client = new Client({ name: "graphjin-broker-test", version: "1" });
+    await client.connect(clientTransport);
+    try {
+      const result = await client.callTool({
+        name: "execute_graphql",
+        arguments: { query: "query { orders { id } }" },
+      });
+      expect(result.isError).not.toBe(true);
+      expect(JSON.stringify(result.content)).toContain("order-1");
+      expect(seen).toEqual({
+        orgId: "org-1",
+        runId: "run-1",
+        query: "query { orders { id } }",
+      });
+    } finally {
+      await client.close();
+      await server.instance.close();
+    }
+  });
+
   it("accepts explicit and shorthand query operations", () => {
     expect(() =>
       assertReadOnlyGraphql("query { orders(limit: 1) { id } }"),

--- a/packages/llm/test/hermes-backend-acp.test.ts
+++ b/packages/llm/test/hermes-backend-acp.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   chunkNotification,
   createMockSpawn,
@@ -29,7 +32,9 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-const { HermesBackend } = await import("../src/agent-backends/hermes");
+const { HermesBackend, hermesAgentLogTail } = await import(
+  "../src/agent-backends/hermes"
+);
 
 const FAKE_WORKSPACE = {
   orgRoot: "/tmp/neko-test/org",
@@ -52,6 +57,29 @@ function captureRequests(): { seen: SeenRequest[]; record: (m: string, p: unknow
 }
 
 describe("HermesBackend ACP behavior", () => {
+  it("extracts safe provider activity from Hermes's timestamped agent log", async () => {
+    const home = await mkdtemp(join(tmpdir(), "hermes-agent-log-"));
+    try {
+      await mkdir(join(home, "logs"), { recursive: true });
+      await writeFile(
+        join(home, "logs", "agent.log"),
+        [
+          "2026-08-25 06:47:01,123 INFO Provider client created for google-gemini",
+          "Prompt on session: private system prompt",
+          "private multiline prompt continuation",
+          "2026-08-25 06:47:02,456 ERROR Provider request failed: connection reset",
+        ].join("\n"),
+      );
+
+      const tail = hermesAgentLogTail(home);
+      expect(tail).toContain("Provider request failed: connection reset");
+      expect(tail).not.toContain("private system prompt");
+      expect(tail).not.toContain("multiline prompt continuation");
+    } finally {
+      await rm(home, { recursive: true, force: true });
+    }
+  });
+
   it("always uses session/new — never session/load — even when backendState carries a sessionKey", async () => {
     // Hermes ACP session/load replays prior history as session/update events.
     // The worker already injects history into the prompt

--- a/packages/llm/test/sandbox-launcher.test.ts
+++ b/packages/llm/test/sandbox-launcher.test.ts
@@ -13,6 +13,7 @@ import { Readable } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentEvent, AgentWorkspace } from "../src/agent-backend";
 import type { RunAgentBackendInput } from "../src/work/agent-core";
+import type { RunBinding } from "../src/work/broker";
 import type { RunWorkflowAgentBackendInput } from "../src/workflows/agent-core";
 
 /**
@@ -383,7 +384,7 @@ describe("makeSandboxRunCore", () => {
     expect(jobCapture.jobs.at(-1)?.model).toBeUndefined();
   });
 
-  it("removes customer GraphJin egress and installs a deny guard for records turns", async () => {
+  it("never injects direct GraphJin credentials into records turns", async () => {
     const runCore = makeSandboxRunCore({
       agentImage: "ghcr.io/open-neko/agent:test",
       onLog: () => {},
@@ -395,9 +396,9 @@ describe("makeSandboxRunCore", () => {
     expect(jobCapture.jobs.at(-1)).toMatchObject({
       kind: "work",
       dataSurface: "records",
-      graphjinEnabled: false,
-      graphjinDenied: true,
     });
+    expect(jobCapture.jobs.at(-1)).not.toHaveProperty("graphjinEnabled");
+    expect(jobCapture.jobs.at(-1)).not.toHaveProperty("graphjinDenied");
     expect(jobCapture.jobs.at(-1)).not.toHaveProperty("graphjinServerUrl");
     expect(jobCapture.jobs.at(-1)).not.toHaveProperty("graphjinClientConfig");
   });
@@ -623,7 +624,7 @@ describe("makeSandboxRunCore", () => {
     expect(h.calls.filter((c) => c.args.includes("delete"))).toHaveLength(1);
   });
 
-  it("serializes the per-run GraphJin client config into workflow sandbox jobs", async () => {
+  it("does not serialize GraphJin credentials into workflow sandbox jobs", async () => {
     const orgRoot = await mkdtemp(join(tmpdir(), "ws-"));
     const workspace = fullWorkspace(orgRoot);
     const clientDir = join(workspace.runRoot, "gj-auth", "graphjin");
@@ -643,11 +644,8 @@ describe("makeSandboxRunCore", () => {
 
     await runCore(fakeWorkflowInput(async () => {}, undefined, workspace));
 
-    expect(jobCapture.jobs.at(-1)?.graphjinClientConfig).toMatchObject({
-      server: "http://localhost:8080/api/v1/mcp",
-      token: "run-token",
-      subject: "service",
-    });
+    expect(jobCapture.jobs.at(-1)).not.toHaveProperty("graphjinClientConfig");
+    expect(jobCapture.jobs.at(-1)).not.toHaveProperty("graphjinServerUrl");
   });
 
   it("gives model-only jobs no GraphJin capability or artifact persistence", async () => {
@@ -663,7 +661,6 @@ describe("makeSandboxRunCore", () => {
 
     expect(jobCapture.jobs.at(-1)).toMatchObject({
       kind: "agent-job",
-      graphjinEnabled: false,
       agentAccess: {},
       agentRun: {
         timeoutMs: 45_000,
@@ -699,7 +696,6 @@ describe("makeSandboxRunCore", () => {
     const job = jobCapture.jobs.at(-1);
     expect(job).toMatchObject({
       kind: "agent-job",
-      graphjinEnabled: false,
       agentAccess: { graphjinRead: true },
     });
     expect(job).not.toHaveProperty("graphjinWriteGrants");
@@ -709,17 +705,20 @@ describe("makeSandboxRunCore", () => {
     await runCore(fakeJobInput(workspace, { graphjinAgent: true }));
     expect(jobCapture.jobs.at(-1)).toMatchObject({
       kind: "agent-job",
-      graphjinEnabled: false,
       agentAccess: { graphjinAgent: true },
     });
   });
 
   it("scopes broker egress to node, injects url+token, and releases on finish", async () => {
     const released: string[] = [];
+    const bindings: RunBinding[] = [];
     const runCore = makeSandboxRunCore({
       agentImage: "ghcr.io/open-neko/agent:test",
       brokerUrl: "http://host.openshell.internal:4199",
-      brokerTokenFor: ({ runId, orgId }) => `tok-${orgId}-${runId}`,
+      brokerTokenFor: (binding) => {
+        bindings.push(binding);
+        return `tok-${binding.orgId}-${binding.runId}`;
+      },
       brokerRelease: (runId) => released.push(runId),
       onLog: () => {},
     });
@@ -745,6 +744,14 @@ describe("makeSandboxRunCore", () => {
       "OPENNEKO_BROKER_URL='http://host.openshell.internal:4199'",
     );
     expect(execCall?.args.join(" ")).toContain("OPENNEKO_BROKER_TOKEN='tok-org-1-run-1'");
+    expect(bindings).toEqual([
+      {
+        runId: "run-1",
+        orgId: "org-1",
+        threadId: "thr-1",
+        kind: "work",
+      },
+    ]);
     // the token is dropped when the run ends:
     expect(released).toEqual(["run-1"]);
   });

--- a/packages/llm/test/work-agent-core.test.ts
+++ b/packages/llm/test/work-agent-core.test.ts
@@ -53,7 +53,10 @@ describe("runAgentBackend", () => {
     });
 
     expect(captured?.mcpServers).toEqual(
-      expect.objectContaining({ neko_records: expect.anything() }),
+      expect.objectContaining({
+        neko_graphjin: expect.anything(),
+        neko_records: expect.anything(),
+      }),
     );
     expect(captured?.mcpBridgeEnv).toMatchObject({
       OPENNEKO_MCP_ORG_ID: "org-1",

--- a/packages/llm/test/work-graphjin-guard.test.ts
+++ b/packages/llm/test/work-graphjin-guard.test.ts
@@ -144,7 +144,7 @@ describe("ensureGraphjinGuard wrapper script", () => {
     }
   });
 
-  it("installs an explicit records-mode deny wrapper", async () => {
+  it("installs an explicit sandbox direct-access deny wrapper", async () => {
     const guardDir = await mkdtemp(join(tmpdir(), "neko-guard-records-"));
     try {
       const deniedWrapper = await ensureGraphjinGuard(guardDir, "/bin/echo", {
@@ -156,7 +156,8 @@ describe("ensureGraphjinGuard wrapper script", () => {
         { encoding: "utf8" },
       );
       expect(result.status).toBe(2);
-      expect(result.stderr).toContain("records-scoped turn");
+      expect(result.stderr).toContain("Direct GraphJin CLI access is unavailable");
+      expect(result.stderr).toContain("mcp__neko_graphjin__execute_graphql");
       expect(result.stdout).not.toContain("execute_graphql");
     } finally {
       await rm(guardDir, { recursive: true, force: true });

--- a/packages/llm/test/work-prompt.test.ts
+++ b/packages/llm/test/work-prompt.test.ts
@@ -35,6 +35,7 @@ function build(
     supportsPolicyTool?: boolean;
     supportsSourceConfigTool?: boolean;
     supportsPluginManagerTool?: boolean;
+    supportsGraphjinTool?: boolean;
     pluginCatalog?: PluginCatalog;
     installedSkills?: Array<{ name: string; description: string }>;
     pluginActions?: Array<{
@@ -60,6 +61,7 @@ function build(
     supportsPolicyTool: overrides.supportsPolicyTool ?? false,
     supportsSourceConfigTool: overrides.supportsSourceConfigTool ?? false,
     supportsPluginManagerTool: overrides.supportsPluginManagerTool ?? false,
+    supportsGraphjinTool: overrides.supportsGraphjinTool ?? false,
     pluginCatalog: overrides.pluginCatalog,
     installedSkills: overrides.installedSkills,
     pluginActions: overrides.pluginActions,
@@ -99,6 +101,15 @@ describe("buildWorkPrompt records data surface", () => {
     expect(prompt).not.toContain("<data_access>");
     expect(prompt).not.toContain("graphjin cli execute_graphql");
     expect(prompt).not.toContain("neko_source_config_manager");
+  });
+});
+
+describe("buildWorkPrompt customer data surface", () => {
+  it("routes GraphJin reads through the run-bound broker tool", () => {
+    const prompt = build("hermes", { supportsGraphjinTool: true });
+    expect(prompt).toContain("`mcp__neko_graphjin__execute_graphql`");
+    expect(prompt).toContain("trusted OpenNeko host");
+    expect(prompt).not.toContain("graphjin cli execute_graphql");
   });
 });
 

--- a/packages/llm/test/workflow-agent-core.test.ts
+++ b/packages/llm/test/workflow-agent-core.test.ts
@@ -62,6 +62,7 @@ describe("runWorkflowAgentBackend", () => {
     expect(captured?.mcpServers).toEqual(
       expect.objectContaining({
         neko_action: expect.anything(),
+        neko_graphjin: expect.anything(),
         neko_memory: expect.anything(),
         neko_workflow_output: expect.anything(),
       }),

--- a/packages/llm/test/workflow-prompts.test.ts
+++ b/packages/llm/test/workflow-prompts.test.ts
@@ -57,6 +57,8 @@ describe("buildWorkflowRunnerPrompt", () => {
     const prompt = buildWorkflowRunnerPrompt({ ...base, mcpTools: true });
     expect(prompt).toContain("mcp__neko_workflow_output__emit");
     expect(prompt).toContain("mcp__neko_action__request");
+    expect(prompt).toContain("mcp__neko_graphjin__execute_graphql");
+    expect(prompt).not.toContain("graphjin cli execute_graphql");
     expect(prompt).not.toContain("```neko_workflow_output");
     expect(prompt).not.toContain("```neko_action_request");
   });


### PR DESCRIPTION
## What changed

- route chat, workflow, profiler, metric, and agent-job customer reads through the run-bound host broker
- preserve admin/member actor identity for interactive runs and use service identity only for non-interactive jobs
- remove GraphJin URL, credentials, direct egress, and the native GraphJin binary from the OpenShell sandbox
- install an explicit migration deny shim for legacy CLI instructions
- preserve ordered Hermes output and turn empty completions into actionable failures
- normalize runtime artifact permissions and run image preflight as the unprivileged sandbox UID
- document the agent-runtime filesystem, turn, GraphJin, and security contracts

## Why

The slim v2.29 agent bundles accidentally coupled runtime behavior to an obsolete native GraphJin client initialization state machine. That exposed `tools/call is invalid during session initialization`, while missing filesystem permissions and content-free ACP completion could make Hermes disappear or truncate output. The host broker is the stable protocol boundary and keeps source credentials outside the sandbox.

## Verification

- `pnpm --filter @neko/agent-runtime test` — 9 passed
- impacted llm suites — 107 passed
- worker broker suite — 11 passed
- repository workspace typechecks — passed
- final `openneko/agent` image preflight passed as UID 1000660000
- final image has no `/usr/local/bin/graphjin`
- local exact-thread acceptance on `d9e40020-780c-49fa-95ad-144469f1a0d6` completed with 9 brokered GraphJin calls, zero initialization errors, a rendered order surface, persisted assistant text, and `done/completed`
