### PR TITLE
fix(ci): recover v2.30.4 workspace-runtime release

### DIFF
--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -4,7 +4,8 @@ name: post-release smoke
 # published artifacts and asks `openneko status` whether the stack serves. If
 # the build FAILED, or the smoke fails, it demotes that release off "Latest"
 # (gh release edit --prerelease) so `releases/latest` falls back to the last
-# good version — a broken release never becomes the one users download.
+# good version. A successful recovery promotes the stable release again before
+# Deploy-to-VM resolves `releases/latest`.
 
 on:
   workflow_run:
@@ -196,6 +197,18 @@ jobs:
             --gateway openneko \
             --from "ghcr.io/open-neko/agent:$OPENNEKO_VERSION" \
             --no-keep --no-tty -- /bin/true
+
+      # Failed releases are demoted to prerelease by the failure path below.
+      # A manual recovery must reverse that state before this workflow ends:
+      # Deploy-to-VM is triggered by our completion and resolves releases/latest.
+      - name: Promote recovered stable release to "Latest" after smoke
+        if: ${{ success() && steps.ctx.outputs.stable == 'true' && steps.ctx.outputs.tag != '' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release edit "${{ steps.ctx.outputs.tag }}" \
+            --prerelease=false --latest \
+            --repo "${{ github.repository }}"
 
       # Any failure above — build incomplete OR the stack never served — demotes
       # the release so installers fall back to the last good version.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,6 +10,16 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  release-recovery-contract:
+    name: Release recovery contract
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify failed-to-recovered release transitions
+        run: bash scripts/check-release-recovery-contract.sh
+
   records-recovery:
     name: Records recovery
     runs-on: ubuntu-latest

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -161,6 +161,9 @@ jobs:
           IMAGE_DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           set -euo pipefail
+          # The restored workspace agent measured 764.3 MiB on linux/amd64 in
+          # v2.30.4. Keep a narrow ceiling rather than the obsolete 575 MiB
+          # bundled-runtime limit so architecture changes remain intentional.
           MAX_MIB=$(jq -er --arg image "${{ matrix.image }}" '.[$image]' scripts/image-size-budgets.json)
           bash scripts/check-image-size.sh \
             "ghcr.io/open-neko/${{ matrix.image }}@${IMAGE_DIGEST}" \
@@ -265,6 +268,9 @@ jobs:
       - name: Enforce aggregate unique-layer budget
         run: |
           set -euo pipefail
+          # v2.30.4 measured 1459.5 MiB on linux/amd64 after deduplicating
+          # shared layers (1235.7 MiB on arm64). The budget retains enforcement
+          # while admitting the deliberately restored workspace runtime.
           MAX_MIB=$(jq -er '.uniqueStack' scripts/image-size-budgets.json)
           bash scripts/check-image-stack-size.sh \
             "${{ steps.tag.outputs.value }}" \

--- a/scripts/check-release-recovery-contract.sh
+++ b/scripts/check-release-recovery-contract.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Fast static guard for the release recovery state machine. GitHub owns the
+# workflow runtime, so this check ensures the source keeps the transitions that
+# a failed-then-recovered stable release needs before Deploy-to-VM runs.
+set -euo pipefail
+
+release_workflow=".github/workflows/release-binaries.yml"
+smoke_workflow=".github/workflows/post-release-smoke.yml"
+budgets="scripts/image-size-budgets.json"
+
+jq -e '
+  .agent == 800
+  and .uniqueStack == 1500
+  and (.agent | type) == "number"
+  and (.uniqueStack | type) == "number"
+' "$budgets" >/dev/null
+
+grep -Fq "Manual recovery runs may contain CI hardening newer than the tag" "$release_workflow"
+grep -Fq "github.event_name == 'workflow_dispatch' && github.ref" "$release_workflow"
+grep -Fq "Promote recovered stable release to \"Latest\" after smoke" "$smoke_workflow"
+grep -Fq "success() && steps.ctx.outputs.stable == 'true' && steps.ctx.outputs.tag != ''" "$smoke_workflow"
+grep -Fq -- "--prerelease=false --latest" "$smoke_workflow"
+grep -Fq "failure() && steps.ctx.outputs.stable == 'true' && steps.ctx.outputs.tag != ''" "$smoke_workflow"
+grep -Fq -- "--prerelease --latest=false" "$smoke_workflow"
+
+echo "release recovery contract is intact"

--- a/scripts/image-size-budgets.json
+++ b/scripts/image-size-budgets.json
@@ -7,7 +7,7 @@
   "neko-db": 140,
   "records-db": 140,
   "neko-backup": 45,
-  "agent": 575,
+  "agent": 800,
   "plugin-base": 100,
-  "uniqueStack": 1200
+  "uniqueStack": 1500
 }


### PR DESCRIPTION
## Summary

- raise the agent and deduplicated install-stack budgets to narrow ceilings above the measured v2.30.4 workspace-runtime artifacts
- promote a recovered stable release back from prerelease to Latest after smoke succeeds, before Deploy-to-VM resolves `releases/latest`
- add a fast CI contract check covering branch-source recovery, promotion, and failure demotion

## Measured artifacts

- agent linux/amd64: 764.3 MiB compressed (new ceiling: 800 MiB)
- agent linux/arm64: 569.4 MiB compressed
- unique stack linux/amd64: 1459.5 MiB (new ceiling: 1500 MiB)
- unique stack linux/arm64: 1235.7 MiB

## Verification

- `bash scripts/check-release-recovery-contract.sh`
- `bash -n scripts/check-release-recovery-contract.sh`
- `actionlint v1.7.7` on the three changed workflows (ignoring the pre-existing intentional SC2086 latest-tag argument split)
- `git diff --check`

After merge, the release workflow can be dispatched from this recovery revision for the existing `v2.30.4` tag; successful post-release smoke will re-promote it and trigger deployment of the v2.30.4 images.