### PR TITLE
fix(ci): avoid GraphJin release API rate limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,14 +151,12 @@ COPY --from=openshell-bin /usr/local/bin/openshell /usr/local/bin/openshell
 # this lineage: all agent GraphJin reads cross the authenticated host broker.
 FROM debian:bookworm-slim AS graphjin-bin
 ARG GRAPHJIN_VERSION=3.20.47
-ARG GRAPHJIN_ASSET_AMD64=527162704
-ARG GRAPHJIN_ASSET_ARM64=527162707
 ARG TARGETARCH
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
-    && GRAPHJIN_ASSET_ID="$(case "${TARGETARCH}" in amd64) echo "${GRAPHJIN_ASSET_AMD64}" ;; arm64) echo "${GRAPHJIN_ASSET_ARM64}" ;; *) exit 1 ;; esac)" \
+    && case "${TARGETARCH}" in amd64|arm64) ;; *) exit 1 ;; esac \
     && curl -fsSL --retry 10 --retry-delay 5 --retry-all-errors \
-      -H 'Accept: application/octet-stream' -o /tmp/graphjin.tgz \
-      "https://api.github.com/repos/dosco/graphjin/releases/assets/${GRAPHJIN_ASSET_ID}" \
+      -o /tmp/graphjin.tgz \
+      "https://github.com/dosco/graphjin/releases/download/v${GRAPHJIN_VERSION}/graphjin_${GRAPHJIN_VERSION}_linux_${TARGETARCH}.tar.gz" \
     && tar -xzf /tmp/graphjin.tgz -C /usr/local/bin graphjin \
     && rm /tmp/graphjin.tgz \
     && rm -rf /var/lib/apt/lists/* \

--- a/scripts/check-release-recovery-contract.sh
+++ b/scripts/check-release-recovery-contract.sh
@@ -23,4 +23,13 @@ grep -Fq -- "--prerelease=false --latest" "$smoke_workflow"
 grep -Fq "failure() && steps.ctx.outputs.stable == 'true' && steps.ctx.outputs.tag != ''" "$smoke_workflow"
 grep -Fq -- "--prerelease --latest=false" "$smoke_workflow"
 
+# Release builds must use the immutable versioned GraphJin asset URL. The API
+# asset-ID endpoint is rate limited for unauthenticated Docker build steps and
+# can return 403 even while the release asset itself remains healthy.
+if grep -Fq "api.github.com/repos/dosco/graphjin/releases/assets" Dockerfile; then
+  echo "GraphJin build still depends on the rate-limited GitHub API asset endpoint" >&2
+  exit 1
+fi
+grep -Fq 'releases/download/v${GRAPHJIN_VERSION}/graphjin_${GRAPHJIN_VERSION}_linux_${TARGETARCH}.tar.gz' Dockerfile
+
 echo "release recovery contract is intact"


### PR DESCRIPTION
## Summary

- download pinned GraphJin 3.20.47 from its immutable versioned release URL instead of the unauthenticated GitHub API asset-ID endpoint
- retain architecture validation for amd64 and arm64
- extend the release recovery contract check to reject the rate-limited API endpoint

## Failure addressed

Recovery run 32868339771 received HTTP 403 from `api.github.com/repos/dosco/graphjin/releases/assets/...` for all ten retries in `records-graphjin (linux/amd64)`. The public versioned assets remained healthy.

## Verification

- direct amd64 asset: HTTP 200, 45,353,698 bytes
- direct arm64 asset: HTTP 200, 41,374,200 bytes
- local Docker `graphjin-bin` build on linux/amd64: GraphJin 3.20.47
- local Docker `graphjin-bin` build on linux/arm64: GraphJin 3.20.47
- `bash scripts/check-release-recovery-contract.sh`
- `git diff --check`