### PR TITLE
feat(work): add clarification flow and secure artifact downloads

### DIFF
--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -197,6 +197,19 @@ export type WorkEvent =
       error?: string;
       rejection_reason?: string;
     }
+  | {
+      type: "needs_input";
+      question: string;
+      options?: string[];
+      questions?: Array<{
+        id: string;
+        header?: string;
+        question: string;
+        options?: Array<{ label: string; description?: string }>;
+      }>;
+      reason?: string;
+      surfaceId?: string;
+    }
   | { type: "followups"; items: string[] }
   | { type: "vitals"; items: AnswerVital[] }
   | { type: "done"; result?: unknown };
@@ -1768,6 +1781,10 @@ type TimelineItem =
       kind: "capability";
       denial: Extract<WorkEvent, { type: "capability_denied" }>;
     }
+  | {
+      kind: "needs_input";
+      request: Extract<WorkEvent, { type: "needs_input" }>;
+    }
   | { kind: "error"; message: string };
 
 type RunArtifact = Extract<WorkEvent, { type: "artifact" }>["artifact"];
@@ -2235,6 +2252,16 @@ export function buildRunTimeline(events: WorkEvent[], runId: string): {
         artifacts.push(event.artifact);
         break;
       }
+      case "needs_input": {
+        // The AskUserQuestion tool normally emits a deterministic A2UI form
+        // immediately before this event. Thin/historical channels have no
+        // surface, so retain a modality-free fallback in the timeline.
+        if (!event.surfaceId) {
+          flushTextSegment();
+          items.push({ kind: "needs_input", request: event });
+        }
+        break;
+      }
       case "vitals": {
         vitals = event.items;
         break;
@@ -2497,6 +2524,15 @@ function RunTimeline({
             />
           );
         }
+        if (item.kind === "needs_input") {
+          return (
+            <NeedsInputNotice
+              key={`needs-input-${index}`}
+              request={item.request}
+              onRespond={(text) => insertComposerRef.current?.(text)}
+            />
+          );
+        }
         return (
           <div key={`error-${index}`} className="border border-warn/40 bg-warn-soft text-warn-ink rounded-2xl px-3 py-2.5 text-ui-body-sm">
             {item.message}
@@ -2525,6 +2561,67 @@ function RunTimeline({
         />
       ) : null}
     </div>
+  );
+}
+
+function NeedsInputNotice({
+  request,
+  onRespond,
+}: {
+  request: Extract<WorkEvent, { type: "needs_input" }>;
+  onRespond: (text: string) => void;
+}) {
+  const questions: NonNullable<typeof request.questions> = request.questions?.length
+    ? request.questions
+    : [{
+        id: "q1",
+        header: undefined,
+        question: request.question,
+        options: request.options?.map((label) => ({ label })),
+      }];
+  return (
+    <section className="work-surface-frame" aria-label="Clarification needed">
+      <div className="work-surface">
+        <div className="work-surface-eyebrow">
+          <span className="work-surface-eyebrow-rule" aria-hidden="true" />
+          Clarification
+        </div>
+        <div className="work-surface-title">A detail before I continue</div>
+        {request.reason ? <div className="work-surface-sub">{request.reason}</div> : null}
+        <div className="work-a2ui-layout is-column">
+          {questions.map((question) => (
+            <div key={question.id} className="work-a2ui-field">
+              <span className="work-a2ui-label">
+                {question.header ? `${question.header}: ` : ""}{question.question}
+              </span>
+              {question.options?.length ? (
+                <div className="work-a2ui-chips">
+                  {question.options.map((option) => (
+                    <button
+                      key={option.label}
+                      type="button"
+                      className="work-choice-btn"
+                      onClick={() => onRespond(`${question.question}\n\n${option.label}`)}
+                    >
+                      <span>{option.label}</span>
+                      <span aria-hidden="true">→</span>
+                    </button>
+                  ))}
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  className="work-a2ui-button"
+                  onClick={() => onRespond(`${question.question}\n\n`)}
+                >
+                  Answer in composer
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
   );
 }
 
@@ -2628,6 +2725,7 @@ function AnswerRunFooter({
               key={artifact.path}
               href={artifactHref(artifact.path)}
               title={artifact.path}
+              download={artifact.label}
             >
               <span>Artifact</span>
               <strong>{artifact.label}</strong>

--- a/apps/web/src/app/api/work/files/[...path]/route.ts
+++ b/apps/web/src/app/api/work/files/[...path]/route.ts
@@ -1,16 +1,10 @@
 import { NextResponse } from "next/server";
-import { extname } from "node:path";
 import { getCurrentActor } from "@/lib/actor";
 import { getOrgId } from "@/lib/db";
-import {
-  FORCE_DOWNLOAD_EXTENSIONS,
-  libraryOwnerSegment,
-  readWorkFile,
-} from "@/lib/work-files";
-import {
-  getAuthorizedWorkRun,
-  getAuthorizedWorkThread,
-} from "@/lib/work-thread-auth";
+import { readRunArtifact } from "@/lib/work-files";
+import { getWorkRunEvents } from "@/lib/work-store";
+import { getAuthorizedWorkRun } from "@/lib/work-thread-auth";
+import { isEmittedRunArtifact } from "@/lib/work-artifacts";
 
 type RouteContext = {
   params: Promise<{ path: string[] }>;
@@ -24,45 +18,35 @@ export async function GET(_: Request, context: RouteContext) {
     const relativePath = (path ?? []).join("/");
     const orgId = await getOrgId();
     const actor = await getCurrentActor();
-    if (path?.[0] === "uploads") {
-      const threadId = path[1] ?? "";
-      if (!threadId || !(await getAuthorizedWorkThread(orgId, threadId, actor))) {
-        return NextResponse.json({ error: "not found" }, { status: 404 });
-      }
+    // This endpoint is a download boundary, not a workspace file browser.
+    // Only an artifact event from an authorized run can grant access.
+    const runId = path?.[0] === "runs" ? path[1] ?? "" : "";
+    if (
+      !runId ||
+      path?.[2] !== "artifacts" ||
+      path.length < 4 ||
+      !(await getAuthorizedWorkRun(orgId, runId, actor))
+    ) {
+      return NextResponse.json({ error: "not found" }, { status: 404 });
     }
-    if (path?.[0] === "runs") {
-      const runId = path[1] ?? "";
-      if (!runId || !(await getAuthorizedWorkRun(orgId, runId, actor))) {
-        return NextResponse.json({ error: "not found" }, { status: 404 });
-      }
+    const events = await getWorkRunEvents(orgId, runId);
+    if (!isEmittedRunArtifact(events, runId, relativePath)) {
+      return NextResponse.json({ error: "not found" }, { status: 404 });
     }
-    if (path?.[0] === "library") {
-      // library/uploads/<owner>/... — the owner or an admin only.
-      const owner = path[2] ?? "";
-      if (
-        path[1] !== "uploads" ||
-        (owner !== libraryOwnerSegment(actor.userId) && actor.role !== "admin")
-      ) {
-        return NextResponse.json({ error: "not found" }, { status: 404 });
-      }
-    }
-    const file = await readWorkFile(orgId, relativePath);
+    const file = await readRunArtifact(orgId, runId, path.slice(3).join("/"));
     const body = new Uint8Array(file.data);
-    const disposition = FORCE_DOWNLOAD_EXTENSIONS.has(extname(file.filename).toLowerCase())
-      ? "attachment"
-      : "inline";
     const safeName = file.filename.replace(/"/g, "");
     return new NextResponse(body, {
       status: 200,
       headers: {
         "content-type": file.mimeType,
-        "content-disposition": `${disposition}; filename="${safeName}"`,
+        "content-disposition": `attachment; filename="${safeName}"`,
+        "x-content-type-options": "nosniff",
       },
     });
-  } catch (error) {
-    return NextResponse.json(
-      { error: error instanceof Error ? error.message : String(error) },
-      { status: 404 },
-    );
+  } catch {
+    // Do not turn path-validation or filesystem errors into a workspace
+    // oracle. Every denied/missing download has the same response.
+    return NextResponse.json({ error: "not found" }, { status: 404 });
   }
 }

--- a/apps/web/src/app/api/work/threads/[threadId]/runs/[runId]/events/route.ts
+++ b/apps/web/src/app/api/work/threads/[threadId]/runs/[runId]/events/route.ts
@@ -142,7 +142,8 @@ export async function GET(request: NextRequest, context: RouteContext) {
             current &&
             (current.status === "completed" ||
               current.status === "failed" ||
-              current.status === "cancelled")
+              current.status === "cancelled" ||
+              current.status === "needs_input")
           ) {
             const tail = await getWorkRunEventsAfter(orgId, runId, lastSentId);
             for (const { id, event } of tail) {

--- a/apps/web/src/app/api/work/threads/[threadId]/runs/route.ts
+++ b/apps/web/src/app/api/work/threads/[threadId]/runs/route.ts
@@ -168,7 +168,10 @@ export async function POST(request: NextRequest, context: RouteContext) {
       await observeSafely(runTelemetry.observer, {
         kind: "run.end",
         operationId: telemetryOperationId,
-        status: result.status === "completed" ? "ok" : "error",
+        status:
+          result.status === "completed" || result.status === "needs_input"
+            ? "ok"
+            : "error",
         ...(result.error ? { errorType: "work_run_error" } : {}),
         attributes: { "openneko.outcome": result.status },
         measurements: {
@@ -197,7 +200,8 @@ export async function POST(request: NextRequest, context: RouteContext) {
         const terminal =
           current?.status === "completed" ||
           current?.status === "failed" ||
-          current?.status === "cancelled";
+          current?.status === "cancelled" ||
+          current?.status === "needs_input";
         if (terminal) return;
 
         const errMsg = err instanceof Error ? err.message : String(err);

--- a/apps/web/src/lib/work-artifacts.ts
+++ b/apps/web/src/lib/work-artifacts.ts
@@ -1,0 +1,49 @@
+import { posix } from "node:path";
+
+type ArtifactEvent = {
+  type: string;
+  artifact?: { path?: unknown };
+};
+
+/** Canonicalize only paths under this exact run's artifacts directory. */
+export function canonicalRunArtifactPath(
+  value: unknown,
+  runId: string,
+): string | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  const raw = value.replace(/\\/g, "/");
+  const prefix = `runs/${runId}/artifacts/`;
+  const absoluteMarker = `/${prefix}`;
+  const markerIndex = raw.lastIndexOf(absoluteMarker);
+  const candidate = raw.startsWith(prefix)
+    ? raw
+    : markerIndex >= 0
+      ? raw.slice(markerIndex + 1)
+      : null;
+  if (!candidate || !candidate.startsWith(prefix)) return null;
+  const suffix = candidate.slice(prefix.length);
+  if (
+    !suffix ||
+    suffix.includes("\0") ||
+    suffix.startsWith("/") ||
+    posix.normalize(suffix) !== suffix ||
+    suffix.split("/").some((part) => !part || part === "." || part === "..")
+  ) {
+    return null;
+  }
+  return `${prefix}${suffix}`;
+}
+
+export function isEmittedRunArtifact(
+  events: readonly ArtifactEvent[],
+  runId: string,
+  requestedPath: string,
+): boolean {
+  const requested = canonicalRunArtifactPath(requestedPath, runId);
+  if (!requested) return false;
+  return events.some(
+    (event) =>
+      event.type === "artifact" &&
+      canonicalRunArtifactPath(event.artifact?.path, runId) === requested,
+  );
+}

--- a/apps/web/src/lib/work-files.ts
+++ b/apps/web/src/lib/work-files.ts
@@ -1,7 +1,7 @@
 import "server-only";
 
-import { mkdir, readFile, readdir, rm, stat, writeFile } from "node:fs/promises";
-import { basename, extname, join, resolve } from "node:path";
+import { mkdir, readFile, readdir, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { basename, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { ensureOrgWorkspace } from "@neko/llm/work";
 
 export const MAX_UPLOAD_SIZE = 10 * 1024 * 1024;
@@ -139,6 +139,54 @@ export async function readWorkFile(orgId: string, relativePath: string): Promise
     data: buffer,
     mimeType: MIME_BY_EXT[ext] ?? "application/octet-stream",
     filename: basename(absolute),
+  };
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+/** Read a regular file physically contained by one run's artifact root. */
+export async function readRunArtifact(
+  orgId: string,
+  runId: string,
+  artifactPath: string,
+): Promise<{ data: Buffer; mimeType: string; filename: string }> {
+  if (basename(runId) !== runId || !runId) {
+    throw new Error("Invalid work run id.");
+  }
+  const normalized = artifactPath.replace(/\\/g, "/");
+  if (
+    !normalized ||
+    normalized.startsWith("/") ||
+    normalized.split("/").some((part) => !part || part === "." || part === "..")
+  ) {
+    throw new Error("Invalid artifact path.");
+  }
+  const roots = await ensureOrgWorkspace(orgId);
+  const declaredRoot = resolve(roots.runsRoot, runId, "artifacts");
+  const declaredFile = resolve(declaredRoot, normalized);
+  if (!isWithin(declaredRoot, declaredFile)) {
+    throw new Error("Artifact path escapes the run.");
+  }
+  const [physicalRoot, physicalFile] = await Promise.all([
+    realpath(declaredRoot),
+    realpath(declaredFile),
+  ]);
+  if (!isWithin(physicalRoot, physicalFile)) {
+    throw new Error("Artifact resolves outside the run.");
+  }
+  const [buffer, meta] = await Promise.all([
+    readFile(physicalFile),
+    stat(physicalFile),
+  ]);
+  if (!meta.isFile()) throw new Error("Artifact is not a regular file.");
+  const ext = extname(physicalFile).toLowerCase();
+  return {
+    data: buffer,
+    mimeType: MIME_BY_EXT[ext] ?? "application/octet-stream",
+    filename: basename(physicalFile),
   };
 }
 

--- a/apps/web/test/api/work-file-download.test.ts
+++ b/apps/web/test/api/work-file-download.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const {
+  mockGetOrgId,
+  mockGetCurrentActor,
+  mockGetAuthorizedWorkRun,
+  mockGetWorkRunEvents,
+  mockReadRunArtifact,
+} = vi.hoisted(() => ({
+  mockGetOrgId: vi.fn(),
+  mockGetCurrentActor: vi.fn(),
+  mockGetAuthorizedWorkRun: vi.fn(),
+  mockGetWorkRunEvents: vi.fn(),
+  mockReadRunArtifact: vi.fn(),
+}));
+
+vi.mock("@/lib/db", () => ({ getOrgId: mockGetOrgId }));
+vi.mock("@/lib/actor", () => ({ getCurrentActor: mockGetCurrentActor }));
+vi.mock("@/lib/work-thread-auth", () => ({
+  getAuthorizedWorkRun: mockGetAuthorizedWorkRun,
+}));
+vi.mock("@/lib/work-store", () => ({
+  getWorkRunEvents: mockGetWorkRunEvents,
+}));
+vi.mock("@/lib/work-files", () => ({ readRunArtifact: mockReadRunArtifact }));
+
+const runId = "11111111-1111-4111-8111-111111111111";
+
+async function download(path: string[]) {
+  const { GET } = await import("@/app/api/work/files/[...path]/route");
+  return GET(new NextRequest("http://localhost:3000/test"), {
+    params: Promise.resolve({ path }),
+  });
+}
+
+describe("GET /api/work/files/[...path]", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetOrgId.mockResolvedValue("org-1");
+    mockGetCurrentActor.mockResolvedValue({ userId: "user-1", role: "member" });
+    mockGetAuthorizedWorkRun.mockResolvedValue({ id: runId });
+    mockGetWorkRunEvents.mockResolvedValue([
+      {
+        type: "artifact",
+        artifact: { path: `runs/${runId}/artifacts/quote.xlsx` },
+      },
+    ]);
+    mockReadRunArtifact.mockResolvedValue({
+      data: Buffer.from("workbook"),
+      filename: "quote.xlsx",
+      mimeType:
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    });
+  });
+
+  it("downloads an explicitly emitted artifact as an attachment", async () => {
+    const response = await download([
+      "runs",
+      runId,
+      "artifacts",
+      "quote.xlsx",
+    ]);
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-disposition")).toBe(
+      'attachment; filename="quote.xlsx"',
+    );
+    expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+    expect(mockReadRunArtifact).toHaveBeenCalledWith(
+      "org-1",
+      runId,
+      "quote.xlsx",
+    );
+  });
+
+  it("blocks every non-artifact workspace path before reading a file", async () => {
+    for (const path of [
+      ["uploads", "thread-1", "input.csv"],
+      ["memory", "MEMORY.md"],
+      ["skills", "pdf", "SKILL.md"],
+      ["runs", runId, "not-artifacts", "quote.xlsx"],
+    ]) {
+      const response = await download(path);
+      expect(response.status, path.join("/")).toBe(404);
+    }
+    expect(mockReadRunArtifact).not.toHaveBeenCalled();
+  });
+
+  it("blocks a real run file that has no artifact event", async () => {
+    mockGetWorkRunEvents.mockResolvedValue([]);
+    const response = await download([
+      "runs",
+      runId,
+      "artifacts",
+      "unpublished.csv",
+    ]);
+    expect(response.status).toBe(404);
+    expect(mockReadRunArtifact).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/test/lib/work-artifacts.test.ts
+++ b/apps/web/test/lib/work-artifacts.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  canonicalRunArtifactPath,
+  isEmittedRunArtifact,
+} from "../../src/lib/work-artifacts";
+
+describe("work artifact download authorization", () => {
+  const runId = "11111111-1111-4111-8111-111111111111";
+
+  it("accepts only the exact artifact path emitted by the authorized run", () => {
+    const events = [
+      {
+        type: "artifact",
+        artifact: {
+          path: `/workspace/org/runs/${runId}/artifacts/quotes/final.xlsx`,
+        },
+      },
+    ];
+    expect(
+      isEmittedRunArtifact(
+        events,
+        runId,
+        `runs/${runId}/artifacts/quotes/final.xlsx`,
+      ),
+    ).toBe(true);
+    expect(
+      isEmittedRunArtifact(
+        events,
+        runId,
+        `runs/${runId}/artifacts/quotes/draft.xlsx`,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects uploads, memory, other runs, traversal, and prefix tricks", () => {
+    const rejected = [
+      `uploads/thread-1/input.csv`,
+      `memory/MEMORY.md`,
+      `runs/other/artifacts/final.xlsx`,
+      `runs/${runId}/artifacts/../secret.txt`,
+      `runs/${runId}/artifacts//final.xlsx`,
+      `runs/${runId}/artifacts`,
+      `/tmp/runs/${runId}/artifacts-evil/final.xlsx`,
+    ];
+    for (const path of rejected) {
+      expect(canonicalRunArtifactPath(path, runId), path).toBeNull();
+    }
+  });
+});

--- a/apps/web/test/lib/work-files.test.ts
+++ b/apps/web/test/lib/work-files.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -6,6 +6,7 @@ import {
   ALLOWED_UPLOAD_EXTENSIONS,
   MAX_UPLOAD_SIZE,
   joinMessageWithAttachments,
+  readRunArtifact,
   readWorkFile,
   safeFileName,
   saveWorkUpload,
@@ -144,5 +145,33 @@ describe("saveWorkUpload + readWorkFile round-trip", () => {
     expect(saved.name).not.toContain("..");
 
     await expect(readWorkFile("org-test", "secrets/foo.txt")).rejects.toThrow();
+  }, 30_000);
+});
+
+describe("readRunArtifact", () => {
+  it("reads a contained artifact and rejects traversal or symlink escapes", async () => {
+    const home = await mkdtemp(join(tmpdir(), "neko-work-artifact-"));
+    cleanupPaths.push(home);
+    process.env.HOME = home;
+    const upload = await saveWorkUpload(
+      "org-test",
+      "thread-1",
+      new File(["private"], "private.txt", { type: "text/plain" }),
+    );
+    const orgRoot = upload.absolutePath.split(`${join("uploads", "thread-1")}`)[0]!;
+    const runId = "11111111-1111-4111-8111-111111111111";
+    const artifactRoot = join(orgRoot, "runs", runId, "artifacts");
+    await mkdir(artifactRoot, { recursive: true });
+    await writeFile(join(artifactRoot, "report.csv"), "a,b\n1,2\n");
+    await symlink(upload.absolutePath, join(artifactRoot, "private-link.txt"));
+
+    const artifact = await readRunArtifact("org-test", runId, "report.csv");
+    expect(artifact.data.toString()).toContain("a,b");
+    await expect(
+      readRunArtifact("org-test", runId, "../private.txt"),
+    ).rejects.toThrow(/Invalid artifact path/);
+    await expect(
+      readRunArtifact("org-test", runId, "private-link.txt"),
+    ).rejects.toThrow(/outside the run/);
   }, 30_000);
 });

--- a/apps/web/test/work-run-timeline.test.ts
+++ b/apps/web/test/work-run-timeline.test.ts
@@ -96,4 +96,54 @@ describe("work run action timeline", () => {
       },
     });
   });
+
+  it("keeps a modality-free clarification fallback only when no A2UI form was emitted", () => {
+    const withoutSurface = buildRunTimeline(
+      [
+        {
+          type: "needs_input",
+          question: "Which destination?",
+          options: ["Mumbai", "London"],
+        },
+        { type: "done", result: { status: "needs_input" } },
+      ],
+      "run-1",
+    );
+    expect(withoutSurface.items).toEqual([
+      {
+        kind: "needs_input",
+        request: {
+          type: "needs_input",
+          question: "Which destination?",
+          options: ["Mumbai", "London"],
+        },
+      },
+    ]);
+
+    const withSurface = buildRunTimeline(
+      [
+        {
+          type: "surface",
+          messages: [
+            {
+              version: "v1.0",
+              createSurface: {
+                surfaceId: "clarification-run-1",
+                catalogId: "urn:openneko:catalog:work:v2",
+                components: [{ id: "root", component: "Answer", children: [] }],
+              },
+            },
+          ],
+        },
+        {
+          type: "needs_input",
+          question: "Which destination?",
+          surfaceId: "clarification-run-1",
+        },
+      ],
+      "run-1",
+    );
+    expect(withSurface.items.filter((item) => item.kind === "needs_input")).toEqual([]);
+    expect(withSurface.items.filter((item) => item.kind === "surface")).toHaveLength(1);
+  });
 });

--- a/apps/worker/src/agent-sandbox/mcp-bridge.ts
+++ b/apps/worker/src/agent-sandbox/mcp-bridge.ts
@@ -9,6 +9,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import type { AgentEvent } from "@neko/llm";
 import {
+  buildAskUserQuestionServer,
   buildAuditViewerServer,
   buildChannelManagerServer,
   buildDataSourceManagerServer,
@@ -64,6 +65,7 @@ export type BridgeServerContext = {
   workflowRunId?: string;
   triggeredByObservationId?: string | null;
   recordScope?: { appId: string; objectApiName: string };
+  wantsCards?: boolean;
 };
 
 export function buildBridgeServer(
@@ -78,6 +80,12 @@ export function buildBridgeServer(
       : () => {};
   const common = { orgId, runId, emit, controlPlane };
   switch (name) {
+    case "neko_interaction":
+      return buildAskUserQuestionServer({
+        runId,
+        wantsCards: ctx.wantsCards ?? false,
+        emit,
+      });
     case "neko_ui":
       return buildRenderCardsServer(emit);
     case "neko_graphjin":
@@ -353,6 +361,7 @@ async function main(): Promise<void> {
           objectApiName: string;
         })
       : undefined,
+    wantsCards: process.env.OPENNEKO_MCP_WANTS_CARDS === "1",
   });
   await server.instance.connect(new StdioServerTransport());
 }

--- a/apps/worker/src/jobs/work-run.ts
+++ b/apps/worker/src/jobs/work-run.ts
@@ -136,7 +136,10 @@ export async function runWorkRun(
   await observeSafely(runTelemetry.observer, {
     kind: "run.end",
     operationId,
-    status: result.status === "completed" ? "ok" : "error",
+    status:
+      result.status === "completed" || result.status === "needs_input"
+        ? "ok"
+        : "error",
     ...(result.error ? { errorType: "work_run_error" } : {}),
     attributes: { "openneko.outcome": result.status },
     measurements: {
@@ -155,7 +158,11 @@ export async function runWorkRun(
 
   // Channel-initiated runs have no other return path — send the reply back to
   // the sender. Web runs (no channelPlugin) stream over SSE instead.
-  if (channelPlugin && recipient && result.status === "completed") {
+  if (
+    channelPlugin &&
+    recipient &&
+    (result.status === "completed" || result.status === "needs_input")
+  ) {
     await deliverChatReply(orgId, channelPlugin, recipient, runId, result.finalText, surfaces, vitals);
   }
 }

--- a/apps/worker/test/agent-sandbox/mcp-bridge.test.ts
+++ b/apps/worker/test/agent-sandbox/mcp-bridge.test.ts
@@ -12,6 +12,7 @@ import {
 import { BrokerControlPlane } from "../../src/agent-sandbox/broker-client.js";
 
 const SERVERS = [
+  "neko_interaction",
   "neko_ui",
   "neko_graphjin",
   "neko_graphjin_agent",

--- a/apps/worker/test/jobs/work-run.test.ts
+++ b/apps/worker/test/jobs/work-run.test.ts
@@ -32,6 +32,7 @@ import {
   pool,
   work_run,
   work_run_event,
+  work_message,
   work_thread,
   workflow_definition,
 } from "@neko/db";
@@ -212,6 +213,84 @@ describeIfDb("runChatTurn", () => {
       .limit(1);
     expect(final[0]?.status).toBe("completed");
     expect(final[0]?.error).toBeNull();
+  });
+
+  it("AskUserQuestion pauses Work chat, persists the question, and suppresses trailing answer content", async () => {
+    const thread = await insertWorkThread(orgId);
+    const run = await insertWorkRun({ orgId, threadId: thread.id });
+
+    mockBackendRun.mockImplementation(async (opts: {
+      onEvent: (event: AgentEvent) => Promise<void>;
+    }) => {
+      await opts.onEvent({
+        type: "needs_input",
+        question: "Where should the order be delivered?",
+        reason: "Destination changes freight and delivery timing.",
+        questions: [
+          {
+            id: "q1",
+            header: "Destination",
+            question: "Where should the order be delivered?",
+          },
+        ],
+      });
+      // A backend that ignores the tool's stop instruction must not be able to
+      // append a decision-ready answer behind the clarification.
+      await opts.onEvent({
+        type: "message",
+        role: "assistant",
+        content: "Invented delivered total: $3.2M",
+      });
+      return {
+        finalText: "Invented delivered total: $3.2M",
+        status: "completed",
+        backendState: {},
+      };
+    });
+
+    const emit = buildEmit({ orgId, threadId: thread.id, runId: run.id });
+    const result = await runChatTurn(
+      {
+        orgId,
+        threadId: thread.id,
+        runId: run.id,
+        message: "Quote 500 bikes delivered",
+        emit,
+      },
+      makeDeps(),
+    );
+
+    expect(result).toMatchObject({
+      status: "needs_input",
+      finalText: expect.stringContaining("Where should the order be delivered?"),
+    });
+    expect(result.finalText).not.toContain("$3.2M");
+    const [storedRun] = await db()
+      .select({ status: work_run.status, error: work_run.error })
+      .from(work_run)
+      .where(eq(work_run.id, run.id));
+    expect(storedRun).toEqual({ status: "needs_input", error: null });
+    const messages = await db()
+      .select({ role: work_message.role, content: work_message.content })
+      .from(work_message)
+      .where(eq(work_message.run_id, run.id));
+    expect(messages).toEqual([
+      {
+        role: "assistant",
+        content: expect.stringContaining("Destination changes freight"),
+      },
+    ]);
+    const events = await db()
+      .select({ kind: work_run_event.kind, payload: work_run_event.payload })
+      .from(work_run_event)
+      .where(eq(work_run_event.run_id, run.id))
+      .orderBy(asc(work_run_event.id));
+    expect(events.map((event) => event.kind)).toEqual([
+      "status",
+      "status",
+      "needs_input",
+      "done",
+    ]);
   });
 
   it("emits content-free model, tool, latency, and normalized usage observations", async () => {

--- a/packages/llm/src/agent-backend.ts
+++ b/packages/llm/src/agent-backend.ts
@@ -36,6 +36,18 @@ export type AgentArtifact = {
   mimeType?: string;
 };
 
+export type AgentInputQuestion = {
+  /** Stable within one needs_input event; used to bind submitted answers. */
+  id: string;
+  /** Short UI label such as "Destination" or "Size mix". */
+  header?: string;
+  question: string;
+  options?: Array<{
+    label: string;
+    description?: string;
+  }>;
+};
+
 export type OutputMood = "good" | "watch" | "act";
 
 export type AgentVital = {
@@ -130,7 +142,18 @@ export type AgentEvent =
       /** Operator-supplied reason when the user rejected the request. */
       rejection_reason?: string;
     }
-  | { type: "needs_input"; question: string; options?: string[] }
+  | {
+      type: "needs_input";
+      /** Modality-free summary retained for older and thin channels. */
+      question: string;
+      options?: string[];
+      /** Structured questions used by rich channels. */
+      questions?: AgentInputQuestion[];
+      /** Why the run cannot safely continue without these answers. */
+      reason?: string;
+      /** Present when the tool also emitted a deterministic A2UI form. */
+      surfaceId?: string;
+    }
   // Suggested follow-up questions — channel-agnostic content emitted once at
   // the end of a /work run via a `neko_followups` fence. Any channel (the Ask
   // rail, Telegram, Slack) can surface these as "ask next" prompts.

--- a/packages/llm/src/interaction/from-agent-event.ts
+++ b/packages/llm/src/interaction/from-agent-event.ts
@@ -78,8 +78,21 @@ const mapOne = (event: AgentEvent, gen: IdGen): InteractionEvent[] => {
         : [];
     case "action_request_result":
       return [{ kind: "resolve", id: event.action_request_id, ref: event.action_request_id, status: event.status, summary: resultSummary(event) }];
-    case "needs_input":
-      return [{ kind: "ask", id: gen(), ask: event.options?.length ? "choice" : "freeform", prompt: event.question, decisionRef: gen(), ...(event.options?.length ? { options: event.options.map((label, i) => ({ id: `opt-${i}`, label })) } : {}) }];
+    case "needs_input": {
+      const id = gen();
+      const first = event.questions?.[0];
+      const optionLabels = first?.options?.map((option) => option.label) ?? event.options;
+      return [{
+        kind: "ask",
+        id,
+        ask: optionLabels?.length ? "choice" : "freeform",
+        prompt: first?.question ?? event.question,
+        decisionRef: id,
+        ...(optionLabels?.length
+          ? { options: optionLabels.map((label, i) => ({ id: `opt-${i}`, label })) }
+          : {}),
+      }];
+    }
     case "capability_denied":
       return [{
         kind: "inform",

--- a/packages/llm/src/sandbox-runtime.ts
+++ b/packages/llm/src/sandbox-runtime.ts
@@ -8,6 +8,14 @@ export {
   type RunWorkflowAgentBackendInput,
 } from "./workflows/agent-core";
 export {
+  ASK_USER_SERVER_NAME,
+  ASK_USER_TOOL_NAME,
+  ASK_USER_TOOL_TITLE,
+  buildAskUserQuestionServer,
+  clarificationSurface,
+  type AskUserQuestionArgs,
+} from "./work/interaction-server";
+export {
   buildAuditViewerServer,
   buildChannelManagerServer,
   buildDataSourceManagerServer,

--- a/packages/llm/src/work/agent-core.ts
+++ b/packages/llm/src/work/agent-core.ts
@@ -7,6 +7,7 @@ import type {
 import { buildWorkflowBuilderServer } from "../workflows/builder-server";
 import { buildRuleBuilderServer } from "../workflows/rule-builder-server";
 import type { AgentControlPlane } from "./control-plane";
+import { buildAskUserQuestionServer } from "./interaction-server";
 import {
   parseAppWorkContext,
   parseRecordWorkContext,
@@ -113,6 +114,11 @@ export async function runAgentBackend(
   const mcpServers = mcp
     ? recordsOnly
       ? {
+          neko_interaction: buildAskUserQuestionServer({
+            runId,
+            wantsCards,
+            emit,
+          }),
           neko_records: buildRecordsReadServer({
             orgId,
             runId,
@@ -121,6 +127,13 @@ export async function runAgentBackend(
           }),
         }
       : {
+        // Work chat is interactive. Material ambiguity pauses the turn and
+        // returns control to the operator through a deterministic form.
+        neko_interaction: buildAskUserQuestionServer({
+          runId,
+          wantsCards,
+          emit,
+        }),
         // GraphJin's complete caller-visible MCP surface is brokered through
         // the trusted host. No binary, source URL, or credential enters the box.
         neko_graphjin: buildGraphjinMcpServer({
@@ -205,6 +218,7 @@ export async function runAgentBackend(
           OPENNEKO_MCP_THREAD_ID: threadId,
           OPENNEKO_MCP_RUN_ID: runId,
           OPENNEKO_MCP_SKILLS_ROOT: workspace.skillsRoot,
+          OPENNEKO_MCP_WANTS_CARDS: wantsCards ? "1" : "0",
           OPENNEKO_MCP_PLUGIN_ACTIONS: JSON.stringify(
             recordsOnly ? [] : (pluginActions ?? []),
           ),

--- a/packages/llm/src/work/artifacts.ts
+++ b/packages/llm/src/work/artifacts.ts
@@ -1,0 +1,59 @@
+import { readdir, realpath } from "node:fs/promises";
+import { basename, isAbsolute, join, relative, resolve, sep } from "node:path";
+import type { AgentArtifact, AgentWorkspace } from "../agent-backend";
+
+function portable(path: string): string {
+  return path.split(sep).join("/");
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+/**
+ * Discover only regular files physically contained by this run's artifact
+ * directory. Symlinks are deliberately ignored: a generated link must never
+ * turn a different workspace file into a downloadable artifact.
+ */
+export async function discoverRunArtifacts(
+  workspace: AgentWorkspace,
+): Promise<AgentArtifact[]> {
+  const root = await realpath(workspace.artifactRoot).catch(() => null);
+  if (!root) return [];
+  const orgRoot = await realpath(resolve(workspace.orgRoot)).catch(() => null);
+  if (!orgRoot) return [];
+  const physicalArtifactRoot = root;
+  const physicalOrgRoot = orgRoot;
+  const artifacts: AgentArtifact[] = [];
+
+  async function walk(directory: string): Promise<void> {
+    const entries = await readdir(directory, { withFileTypes: true }).catch(
+      () => [],
+    );
+    for (const entry of entries) {
+      const candidate = join(directory, entry.name);
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        await walk(candidate);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      const physical = await realpath(candidate).catch(() => null);
+      if (
+        !physical ||
+        !isWithin(physicalArtifactRoot, physical) ||
+        !isWithin(physicalOrgRoot, physical)
+      ) {
+        continue;
+      }
+      artifacts.push({
+        path: portable(relative(physicalOrgRoot, physical)),
+        label: basename(physical),
+      });
+    }
+  }
+
+  await walk(physicalArtifactRoot);
+  return artifacts.sort((a, b) => a.path.localeCompare(b.path));
+}

--- a/packages/llm/src/work/index.ts
+++ b/packages/llm/src/work/index.ts
@@ -1,9 +1,18 @@
 export * from "./workspace";
+export * from "./artifacts";
 export * from "./sandbox-net";
 export * from "./behavior-monitor";
 export * from "./deployment-profile";
 export * from "./data-surface";
 export { buildWorkPrompt } from "./prompt";
+export {
+  ASK_USER_SERVER_NAME,
+  ASK_USER_TOOL_NAME,
+  ASK_USER_TOOL_TITLE,
+  buildAskUserQuestionServer,
+  clarificationSurface,
+  type AskUserQuestionArgs,
+} from "./interaction-server";
 export {
   buildAuditViewerServer,
   buildChannelManagerServer,

--- a/packages/llm/src/work/interaction-server.ts
+++ b/packages/llm/src/work/interaction-server.ts
@@ -1,0 +1,209 @@
+import { createMcpServer, defineMcpTool } from "../mcp-server";
+import type {
+  AgentEvent,
+  AgentInputQuestion,
+  AgentSurfaceMessage,
+} from "../agent-backend";
+import { z } from "zod";
+import { A2UI_CATALOG_ID, A2UI_VERSION } from "./a2ui-contract";
+
+export const ASK_USER_SERVER_NAME = "neko_interaction" as const;
+export const ASK_USER_TOOL_NAME = "ask_user_question" as const;
+export const ASK_USER_TOOL_TITLE =
+  "mcp_neko_interaction_ask_user_question" as const;
+
+const optionSchema = z
+  .object({
+    label: z.string().trim().min(1).max(80),
+    description: z.string().trim().min(1).max(240).optional(),
+  })
+  .strict();
+
+const questionSchema = z
+  .object({
+    header: z.string().trim().min(1).max(40).optional(),
+    question: z.string().trim().min(1).max(500),
+    options: z.array(optionSchema).min(2).max(5).optional(),
+  })
+  .strict();
+
+export const ASK_USER_INPUT_SHAPE = {
+  reason: z.string().trim().min(1).max(500).optional(),
+  questions: z.array(questionSchema).min(1).max(3),
+};
+
+export type AskUserQuestionArgs = z.infer<
+  z.ZodObject<typeof ASK_USER_INPUT_SHAPE>
+>;
+
+function normalizedQuestions(
+  questions: AskUserQuestionArgs["questions"],
+): AgentInputQuestion[] {
+  return questions.map((question, index) => ({
+    id: `q${index + 1}`,
+    ...(question.header ? { header: question.header } : {}),
+    question: question.question,
+    ...(question.options ? { options: question.options } : {}),
+  }));
+}
+
+/**
+ * Build the deterministic clarification form. The model supplies meaning; the
+ * host owns protocol shape and the submit action, so asking a question cannot
+ * degrade into malformed or non-submittable generated UI.
+ */
+export function clarificationSurface(
+  runId: string,
+  questions: AgentInputQuestion[],
+  reason?: string,
+): AgentSurfaceMessage[] {
+  const surfaceId = `clarification-${runId}`;
+  const components: Array<Record<string, unknown>> = [];
+  const children: string[] = [];
+  const answers: Record<string, unknown> = {};
+  const requirements: Array<{ path: string }> = [];
+
+  for (const question of questions) {
+    const inputId = `${question.id}-input`;
+    children.push(inputId);
+    if (question.options?.length) {
+      answers[question.id] = [];
+      requirements.push({ path: `/answers/${question.id}/0` });
+      components.push({
+        id: inputId,
+        component: "ChoicePicker",
+        label: question.header
+          ? `${question.header}: ${question.question}`
+          : question.question,
+        options: question.options.map((option) => ({
+          label: option.description
+            ? `${option.label} — ${option.description}`
+            : option.label,
+          value: option.label,
+        })),
+        value: { path: `/answers/${question.id}` },
+        variant: "mutuallyExclusive",
+      });
+    } else {
+      answers[question.id] = "";
+      requirements.push({ path: `/answers/${question.id}` });
+      components.push({
+        id: inputId,
+        component: "TextField",
+        label: question.header
+          ? `${question.header}: ${question.question}`
+          : question.question,
+        value: { path: `/answers/${question.id}` },
+        variant: "longText",
+      });
+    }
+  }
+
+  children.push("submit");
+  components.unshift({
+    id: "root",
+    component: "Answer",
+    eyebrow: "Clarification",
+    title:
+      questions.length === 1
+        ? "One detail before I continue"
+        : "A few details before I continue",
+    ...(reason ? { subtitle: reason } : {}),
+    children,
+  });
+  components.push(
+    { id: "submit-label", component: "Text", text: "Continue", variant: "body" },
+    {
+      id: "submit",
+      component: "Button",
+      child: "submit-label",
+      variant: "primary",
+      requires: requirements,
+      action: {
+        event: {
+          name: "submit_clarification",
+          context: {
+            prompt:
+              "Continue the previous request using these operator-supplied answers. Re-check any remaining external facts and do not infer omitted values.",
+            questions: questions.map(({ id, header, question }) => ({
+              id,
+              ...(header ? { header } : {}),
+              question,
+            })),
+            answers: { path: "/answers" },
+          },
+        },
+      },
+    },
+  );
+
+  return [
+    {
+      version: A2UI_VERSION,
+      createSurface: {
+        surfaceId,
+        catalogId: A2UI_CATALOG_ID,
+        components,
+        dataModel: { answers },
+      },
+    },
+  ];
+}
+
+export function buildAskUserQuestionServer(opts: {
+  runId: string;
+  wantsCards: boolean;
+  emit: (event: AgentEvent) => Promise<void> | void;
+}) {
+  const askUserQuestion = defineMcpTool(
+    ASK_USER_TOOL_NAME,
+    [
+      "Pause this Work-chat turn and ask the operator for missing information.",
+      "Use only when uncertainty is material to correctness, scope, cost, timing, authorization, or an irreversible decision and available tools cannot resolve it.",
+      "Ask one to three focused questions. After this call, stop: do not render an answer, provide totals or recommendations, emit vitals/follow-ups, or call another tool.",
+    ].join(" "),
+    ASK_USER_INPUT_SHAPE,
+    async (args: AskUserQuestionArgs) => {
+      const questions = normalizedQuestions(args.questions);
+      const surfaceId = `clarification-${opts.runId}`;
+      if (opts.wantsCards) {
+        await opts.emit({
+          type: "surface",
+          messages: clarificationSurface(opts.runId, questions, args.reason),
+        });
+      }
+      await opts.emit({
+        type: "needs_input",
+        question:
+          questions.length === 1
+            ? questions[0].question
+            : `I need ${questions.length} details before I can continue.`,
+        ...(questions.length === 1 && questions[0].options
+          ? { options: questions[0].options.map((option) => option.label) }
+          : {}),
+        questions,
+        ...(args.reason ? { reason: args.reason } : {}),
+        ...(opts.wantsCards ? { surfaceId } : {}),
+      });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({
+              ok: true,
+              status: "needs_input",
+              instruction:
+                "The clarification was presented to the operator. End this turn now without any further tools, answer content, vitals, or follow-ups.",
+            }),
+          },
+        ],
+      };
+    },
+  );
+
+  return createMcpServer({
+    name: ASK_USER_SERVER_NAME,
+    version: "1.0.0",
+    tools: [askUserQuestion],
+  });
+}

--- a/packages/llm/src/work/prompt.ts
+++ b/packages/llm/src/work/prompt.ts
@@ -21,6 +21,7 @@ import {
   A2UI_RENDER_ACP_TITLE,
   A2UI_RENDER_TOOL_NAME,
 } from "./a2ui-contract";
+import { ASK_USER_TOOL_TITLE } from "./interaction-server";
 
 // Re-export so external callers (and tests) that import GRAPHJIN_DATE_RULE
 // from "@neko/llm/work" don't break.
@@ -110,6 +111,39 @@ prose-only answer may skip the tool. Check the render tool result: if it rejects
 the surface, correct the envelope and retry. Never say a surface was rendered
 unless the tool accepted it.
 </rendering>`;
+}
+
+function buildClarificationSection(supportsClarificationTool: boolean): string {
+  if (!supportsClarificationTool) {
+    return `<clarification>
+When you are unsure about something material to correctness, scope, cost,
+timing, authorization, or an irreversible decision, ask the operator a focused
+clarifying question instead of guessing. First use available read tools when
+they can resolve the uncertainty. If the uncertainty is minor and a useful,
+safe answer remains possible, state the limitation and continue.
+</clarification>`;
+  }
+  return `<clarification>
+This is an interactive Work-chat turn. When you are unsure about something
+material to correctness, scope, cost, timing, authorization, or an irreversible
+decision, clarify with the operator instead of guessing.
+
+- First use available read tools when they can resolve the uncertainty.
+- If material uncertainty remains, call \`${ASK_USER_TOOL_TITLE}\` with one to
+  three focused questions. Explain briefly why the answers are needed.
+- The clarification tool is the FINAL action of the turn. After calling it,
+  stop: do not call another tool, render an answer, provide totals or a
+  recommendation, or emit value, vitals, or follow-up blocks.
+- If uncertainty is minor and a useful, safe answer remains possible, state
+  the limitation and continue instead of interrupting the operator.
+- An explicit request for an estimate permits clearly labelled scenario
+  assumptions; it never permits invented sources or assumptions presented as
+  observed facts. Ask for approval of any assumption that could materially
+  change a decision-ready commercial total, commitment, or delivery date.
+- If the missing fact must come from an external authority, ask the operator
+  for that source or permission to proceed with a labelled scenario. A user
+  answer does not turn an unsupported external claim into an observed fact.
+</clarification>`;
 }
 
 function buildPluginManagementSection(
@@ -479,7 +513,11 @@ Your cwd is ${workspace.orgRoot}. Shared directories:
 - Artifacts for this run: ${workspace.artifactRoot}
 
 Read and write within those directories when needed. Save generated
-reports or files under the run artifact directory.
+reports or files under the run artifact directory. Regular files saved there
+are published as downloadable artifacts after a successful turn. Do not offer
+downloads from uploads, skills, memory, knowledge, or any other workspace path;
+the download boundary rejects every file that was not emitted as a run
+artifact.
 
 <attachments>
 When the user attaches files, their message will end with lines like:
@@ -543,10 +581,12 @@ ${GRAPHJIN_DATE_RULE}
   one, and label every estimated figure as estimated.
 </conduct>`;
 
-// Closing contract shared by both backends: two JSON blocks the runtime parses
-// from the final output (hours-saved value + suggested follow-ups).
+// Closing contract shared by both backends: three JSON blocks parsed by the
+// runtime (hours-saved value, vitals, and suggested follow-ups).
 const CLOSING_SECTION = `<closing>
-Always end your turn with these three JSON blocks, in this order. The
+Except when you call the clarification tool, always end your turn with these
+three JSON blocks, in this order. A clarification-tool call is the end of that
+turn and emits none of these blocks. Otherwise, the
 \`neko_value\` block is MANDATORY on every answer — emit it even when the
 turn ran long; never drop it.
 
@@ -562,7 +602,9 @@ turn ran long; never drop it.
 
    Anchors: a single metric lookup 15-30 · a multi-table breakdown or
    drill-down 45-120 · a multi-step diagnostic like "why did revenue drop"
-   120-300. Use 0 for a clarifying question or a check that surfaced nothing.
+   120-300. Use 0 for a check that surfaced nothing. If the clarification tool
+   is unavailable and you must ask in prose, use 0; a clarification-tool turn
+   emits no value block at all.
    An action you propose (an email, a purchase order) carries its own
    \`minutes_saved\`.
 
@@ -703,6 +745,7 @@ export function buildWorkPrompt(args: {
   supportsWorkflowTool: boolean;
   supportsPolicyTool: boolean;
   supportsSourceConfigTool: boolean;
+  supportsClarificationTool?: boolean;
   supportsPluginManagerTool?: boolean;
   pluginCatalog?: PluginCatalog;
   // True when prior turns must be inlined into the system prompt because the
@@ -732,6 +775,7 @@ export function buildWorkPrompt(args: {
     supportsWorkflowTool,
     supportsPolicyTool,
     supportsSourceConfigTool,
+    supportsClarificationTool = false,
     supportsPluginManagerTool = false,
     pluginCatalog,
     inlineTranscript,
@@ -756,6 +800,7 @@ everything, from "what was last week's revenue?" to "set up a workflow
 that flags churn risk every Monday."
 </role>`,
     operatorProfile ?? "",
+    buildClarificationSection(supportsClarificationTool),
     dataSurface === "customer" && wantsCards
       ? buildRenderingSection(supportsCardTool)
       : "",

--- a/packages/llm/src/work/run-chat-turn.ts
+++ b/packages/llm/src/work/run-chat-turn.ts
@@ -40,6 +40,7 @@ import {
 } from "./personas";
 import { buildWorkPrompt } from "./prompt";
 import { compactIfNeeded, type ThreadCompaction } from "./compact-transcript";
+import { discoverRunArtifacts } from "./artifacts";
 import {
   finishWorkRun,
   getWorkThreadBundle,
@@ -117,10 +118,35 @@ export type RunChatTurnDeps = {
 };
 
 export type RunChatTurnResult = {
-  status: "completed" | "failed" | "cancelled";
+  status: "completed" | "failed" | "cancelled" | "needs_input";
   finalText: string;
   error?: string;
 };
+
+function needsInputText(
+  event: Extract<AgentEvent, { type: "needs_input" }>,
+): string {
+  const questions = event.questions?.length
+    ? event.questions
+    : [
+        {
+          id: "q1",
+          question: event.question,
+          options: event.options?.map((label) => ({ label })),
+        },
+      ];
+  const lines = [
+    ...(event.reason ? [event.reason, ""] : []),
+    ...questions.flatMap((question, index) => [
+      `${questions.length > 1 ? `${index + 1}. ` : ""}${question.question}`,
+      ...(question.options?.length
+        ? question.options.map((option) => `- ${option.label}`)
+        : []),
+      ...(index < questions.length - 1 ? [""] : []),
+    ]),
+  ];
+  return lines.join("\n").trim();
+}
 
 function backendLabel(id: string): string {
   void id;
@@ -237,6 +263,11 @@ export async function runChatTurn(
     : await readKnowledgePack(knowledgePackPaths(workspace.knowledgeRoot));
 
   let assistantText = "";
+  let needsInputEvent: Extract<
+    AgentEvent,
+    { type: "needs_input" }
+  > | null = null;
+  let needsInputFinished = false;
   const operationId = `work:${runId}`;
   const stageOperationId = `${operationId}:agent`;
   const modelOperationId = `${operationId}:model:1`;
@@ -257,8 +288,23 @@ export async function runChatTurn(
   const toolRecorder = createToolOutputRecorder();
   const emittedCapabilityDenials = new Set<string>();
   const wrappedEmit = async (event: AgentEvent): Promise<void> => {
+    if (
+      needsInputEvent &&
+      (event.type === "message" ||
+        event.type === "surface" ||
+        event.type === "vitals" ||
+        event.type === "followups" ||
+        event.type === "needs_input")
+    ) {
+      // The clarification is now the canonical output. A model that ignores
+      // the tool's stop instruction cannot append an answer behind the form.
+      return;
+    }
     if (event.type === "message" && event.role === "assistant") {
       assistantText += event.content;
+    }
+    if (event.type === "needs_input" && !needsInputEvent) {
+      needsInputEvent = event;
     }
     toolRecorder.observe(event);
     if (
@@ -390,6 +436,27 @@ export async function runChatTurn(
     }
   };
 
+  const finishNeedsInput = async (): Promise<RunChatTurnResult> => {
+    if (!needsInputEvent) {
+      throw new Error(
+        "Cannot finish needs_input without a clarification event",
+      );
+    }
+    const finalText = needsInputText(needsInputEvent);
+    if (!needsInputFinished) {
+      needsInputFinished = true;
+      await saveAssistantWorkMessage({
+        orgId,
+        threadId,
+        runId,
+        content: finalText,
+      });
+      await finishWorkRun(runId, "needs_input", null);
+      await emit({ type: "done", result: { status: "needs_input" } });
+    }
+    return { status: "needs_input", finalText };
+  };
+
   // K1 actor drives the brokered GraphJin identity, persona (CV3), and
   // memory layer (CV2). GraphJin credentials never enter the agent sandbox.
   const actor = await getWorkRunActor(runId);
@@ -411,9 +478,10 @@ export async function runChatTurn(
     // vocabulary in their prompt. See docs/PER_CHANNEL_RENDERING.md.
     const RENDERING_CHANNELS = new Set(["web", "telegram"]);
     const customerSurface = dataSurface === "customer";
-    const wantsCards =
-      customerSurface && RENDERING_CHANNELS.has(opts.channel ?? "web");
+    const channelWantsCards = RENDERING_CHANNELS.has(opts.channel ?? "web");
+    const wantsCards = customerSurface && channelWantsCards;
     const supportsCardTool = customerSurface && backend.capabilities.mcpTools;
+    const supportsClarificationTool = backend.capabilities.mcpTools;
     const supportsSkillTool = customerSurface && backend.capabilities.mcpTools;
     const supportsMemoryTool = customerSurface && backend.capabilities.mcpTools;
     const supportsWorkflowTool = customerSurface && backend.capabilities.mcpTools;
@@ -523,6 +591,7 @@ export async function runChatTurn(
       supportsWorkflowTool,
       supportsPolicyTool,
       supportsSourceConfigTool,
+      supportsClarificationTool,
       supportsPluginManagerTool,
       pluginCatalog,
       inlineTranscript,
@@ -564,7 +633,10 @@ export async function runChatTurn(
       sourceConfigEnabled: supportsSourceConfigTool,
       dataSurface,
       controlPlane: opts.controlPlane ?? inProcessControlPlane,
-      wantsCards,
+      // The clarification server can render its deterministic form in any web
+      // Work chat, including records-scoped app chat. Generated answer-card
+      // vocabulary remains gated separately in the prompt above.
+      wantsCards: channelWantsCards,
       emit: wrappedEmit,
       signal,
     });
@@ -620,6 +692,24 @@ export async function runChatTurn(
           ? { ...protectedBase, compaction: newCompaction }
           : protectedBase,
       );
+    }
+
+    // Asking is a terminal outcome for this run. The next operator message is
+    // a new run in the same thread, with the persisted question + submitted
+    // answer in its transcript. Do not parse or emit answer fences after the
+    // model has handed control back to the operator.
+    if (needsInputEvent) {
+      return await finishNeedsInput();
+    }
+
+    // OpenShell has pulled the run artifact directory back to the host before
+    // runCore resolves. Publish every regular, non-symlink file from that
+    // directory as an explicit event; the web download route authorizes only
+    // these emitted paths.
+    if (result.status === "completed") {
+      for (const artifact of await discoverRunArtifacts(workspace)) {
+        await wrappedEmit({ type: "artifact", artifact });
+      }
     }
 
     await finishWorkRun(runId, result.status, result.error ?? null);
@@ -853,6 +943,54 @@ export async function runChatTurn(
       error: result.error,
     };
   } catch (error) {
+    if (needsInputEvent) {
+      for (const [toolId, tool] of toolStarts) {
+        await observe({
+          kind: "tool.end",
+          operationId: `${operationId}:tool:${toolId}`,
+          parentOperationId: modelOperationId,
+          status: "ok",
+          attributes: { "gen_ai.tool.name": tool.name },
+          measurements: {
+            durationMs: Date.now() - tool.startedAt,
+            coverage: "unavailable",
+          },
+        });
+      }
+      toolStarts.clear();
+      if (modelOpen) {
+        await observe({
+          kind: "model.response",
+          operationId: modelOperationId,
+          parentOperationId: stageOperationId,
+          status: "ok",
+          attributes: { "openneko.outcome": "needs_input" },
+          measurements: outerUsage?.usage ?? {
+            coverage: "unavailable",
+            missingReasons: ["turn paused for operator input"],
+          },
+        });
+        modelOpen = false;
+      }
+      if (stageOpen) {
+        await observe({
+          kind: "stage.end",
+          operationId: stageOperationId,
+          parentOperationId: operationId,
+          status: "ok",
+          attributes: {
+            "openneko.stage": "agent",
+            "openneko.outcome": "needs_input",
+          },
+          measurements: {
+            durationMs: Date.now() - agentStartedAt,
+            coverage: "unavailable",
+          },
+        });
+        stageOpen = false;
+      }
+      return await finishNeedsInput();
+    }
     const aborted =
       signal?.aborted ||
       (error instanceof Error &&

--- a/packages/llm/src/work/secret-scrubber.ts
+++ b/packages/llm/src/work/secret-scrubber.ts
@@ -147,6 +147,11 @@ export function scrubAgentEvent<T>(scrubber: Scrubber, event: T): T {
         options: Array.isArray(e.options)
           ? e.options.map((o) => (typeof o === "string" ? scrubber(o) : o))
           : e.options,
+        questions: Array.isArray(e.questions)
+          ? scrubJson(scrubber, e.questions)
+          : e.questions,
+        reason:
+          typeof e.reason === "string" ? scrubber(e.reason) : e.reason,
       } as T;
     case "output_emit":
       // Just identifiers + kind names, no user-supplied content.

--- a/packages/llm/src/work/store.ts
+++ b/packages/llm/src/work/store.ts
@@ -339,7 +339,7 @@ export async function markWorkRunRunning(runId: string) {
 
 export async function finishWorkRun(
   runId: string,
-  status: "completed" | "failed" | "cancelled",
+  status: "completed" | "failed" | "cancelled" | "needs_input",
   error: string | null,
 ) {
   const rows = await db()

--- a/packages/llm/test/ask-user-question-tool.test.ts
+++ b/packages/llm/test/ask-user-question-tool.test.ts
@@ -1,0 +1,117 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ASK_USER_TOOL_NAME,
+  buildAskUserQuestionServer,
+} from "../src/work/interaction-server";
+
+describe("Work-chat AskUserQuestion MCP server", () => {
+  it("emits a deterministic A2UI form followed by needs_input", async () => {
+    const emit = vi.fn(async () => {});
+    const server = buildAskUserQuestionServer({
+      runId: "run-1",
+      wantsCards: true,
+      emit,
+    });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.instance.connect(serverTransport);
+    const client = new Client({ name: "ask-user-test", version: "1.0.0" });
+    await client.connect(clientTransport);
+    try {
+      const result = await client.callTool({
+        name: ASK_USER_TOOL_NAME,
+        arguments: {
+          reason: "The destination changes freight and delivery timing.",
+          questions: [
+            {
+              header: "Destination",
+              question: "Where should the order be delivered?",
+            },
+            {
+              header: "Terms",
+              question: "Which shipping terms should I use?",
+              options: [
+                { label: "EXW", description: "Buyer arranges freight" },
+                { label: "CIF", description: "Seller includes freight" },
+              ],
+            },
+          ],
+        },
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(emit).toHaveBeenCalledTimes(2);
+      const surface = emit.mock.calls[0]?.[0];
+      expect(surface).toMatchObject({
+        type: "surface",
+        messages: [
+          {
+            version: "v1.0",
+            createSurface: {
+              surfaceId: "clarification-run-1",
+              catalogId: "urn:openneko:catalog:work:v2",
+              dataModel: { answers: { q1: "", q2: [] } },
+            },
+          },
+        ],
+      });
+      const components = (
+        surface as {
+          messages: Array<{
+            createSurface: { components: Array<Record<string, unknown>> };
+          }>;
+        }
+      ).messages[0].createSurface.components;
+      expect(components).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: "q1-input", component: "TextField" }),
+          expect.objectContaining({ id: "q2-input", component: "ChoicePicker" }),
+          expect.objectContaining({ id: "submit", component: "Button" }),
+        ]),
+      );
+      expect(emit.mock.calls[1]?.[0]).toMatchObject({
+        type: "needs_input",
+        surfaceId: "clarification-run-1",
+        questions: [
+          { id: "q1", question: "Where should the order be delivered?" },
+          { id: "q2", question: "Which shipping terms should I use?" },
+        ],
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it("rejects empty or over-broad question batches", async () => {
+    const server = buildAskUserQuestionServer({
+      runId: "run-2",
+      wantsCards: false,
+      emit: async () => {},
+    });
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.instance.connect(serverTransport);
+    const client = new Client({ name: "ask-user-test", version: "1.0.0" });
+    await client.connect(clientTransport);
+    try {
+      const empty = await client.callTool({
+        name: ASK_USER_TOOL_NAME,
+        arguments: { questions: [] },
+      });
+      expect(empty.isError).toBe(true);
+      const tooMany = await client.callTool({
+        name: ASK_USER_TOOL_NAME,
+        arguments: {
+          questions: ["one", "two", "three", "four"].map((question) => ({
+            question,
+          })),
+        },
+      });
+      expect(tooMany.isError).toBe(true);
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/packages/llm/test/interaction-from-agent-event.test.ts
+++ b/packages/llm/test/interaction-from-agent-event.test.ts
@@ -112,11 +112,19 @@ describe("toInteractionEvents", () => {
     const [choice, free] = toInteractionEvents([withOptions, freeform]);
     expect(choice).toMatchObject({
       kind: "ask",
+      id: "ie-1",
+      decisionRef: "ie-1",
       ask: "choice",
       prompt: "Which region?",
       options: [{ id: "opt-0", label: "NA" }, { id: "opt-1", label: "EU" }],
     });
-    expect(free).toMatchObject({ kind: "ask", ask: "freeform", prompt: "What's the budget?" });
+    expect(free).toMatchObject({
+      kind: "ask",
+      id: "ie-2",
+      decisionRef: "ie-2",
+      ask: "freeform",
+      prompt: "What's the budget?",
+    });
   });
 
   it("maps error to an act-mood inform and drops done", () => {

--- a/packages/llm/test/work-agent-core.test.ts
+++ b/packages/llm/test/work-agent-core.test.ts
@@ -54,6 +54,7 @@ describe("runAgentBackend", () => {
 
     expect(captured?.mcpServers).toEqual(
       expect.objectContaining({
+        neko_interaction: expect.anything(),
         neko_graphjin: expect.anything(),
         neko_records: expect.anything(),
       }),
@@ -62,6 +63,7 @@ describe("runAgentBackend", () => {
       OPENNEKO_MCP_MODE: "work",
       OPENNEKO_MCP_ORG_ID: "org-1",
       OPENNEKO_MCP_RUN_ID: "run-1",
+      OPENNEKO_MCP_WANTS_CARDS: "1",
     });
   });
 
@@ -104,7 +106,10 @@ describe("runAgentBackend", () => {
       emit: async () => {},
     });
 
-    expect(Object.keys(captured?.mcpServers ?? {})).toEqual(["neko_records"]);
+    expect(Object.keys(captured?.mcpServers ?? {})).toEqual([
+      "neko_interaction",
+      "neko_records",
+    ]);
     expect(captured?.mcpBridgeEnv?.OPENNEKO_MCP_RECORD_SCOPE).toBe(
       JSON.stringify({ appId: "crm", objectApiName: "activity" }),
     );
@@ -150,7 +155,10 @@ describe("runAgentBackend", () => {
       emit: async () => {},
     });
 
-    expect(Object.keys(captured?.mcpServers ?? {})).toEqual(["neko_records"]);
+    expect(Object.keys(captured?.mcpServers ?? {})).toEqual([
+      "neko_interaction",
+      "neko_records",
+    ]);
     expect(captured?.mcpBridgeEnv?.OPENNEKO_MCP_RECORD_SCOPE).toBeUndefined();
   });
 });

--- a/packages/llm/test/work-artifacts.test.ts
+++ b/packages/llm/test/work-artifacts.test.ts
@@ -1,0 +1,37 @@
+import { mkdtemp, mkdir, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { AgentWorkspace } from "../src/agent-backend";
+import { discoverRunArtifacts } from "../src/work/artifacts";
+
+describe("discoverRunArtifacts", () => {
+  it("publishes regular files under this run and ignores symlinks", async () => {
+    const orgRoot = await mkdtemp(join(tmpdir(), "neko-artifacts-"));
+    const runRoot = join(orgRoot, "runs", "run-1");
+    const artifactRoot = join(runRoot, "artifacts");
+    await mkdir(join(artifactRoot, "reports"), { recursive: true });
+    await writeFile(join(artifactRoot, "reports", "quote.csv"), "sku,total\n1,10\n");
+    await writeFile(join(orgRoot, "private.txt"), "not downloadable");
+    await symlink(join(orgRoot, "private.txt"), join(artifactRoot, "private-link.txt"));
+    const workspace: AgentWorkspace = {
+      orgRoot,
+      skillsRoot: join(orgRoot, "skills"),
+      memoryRoot: join(orgRoot, "memory"),
+      knowledgeRoot: join(orgRoot, "knowledge"),
+      uploadsRoot: join(orgRoot, "uploads"),
+      runsRoot: join(orgRoot, "runs"),
+      threadUploadsRoot: join(orgRoot, "uploads", "thread-1"),
+      runRoot,
+      artifactRoot,
+      binRoot: join(runRoot, "bin"),
+    };
+
+    await expect(discoverRunArtifacts(workspace)).resolves.toEqual([
+      {
+        path: "runs/run-1/artifacts/reports/quote.csv",
+        label: "quote.csv",
+      },
+    ]);
+  });
+});

--- a/packages/llm/test/work-prompt.test.ts
+++ b/packages/llm/test/work-prompt.test.ts
@@ -34,6 +34,7 @@ function build(
     supportsWorkflowTool?: boolean;
     supportsPolicyTool?: boolean;
     supportsSourceConfigTool?: boolean;
+    supportsClarificationTool?: boolean;
     supportsPluginManagerTool?: boolean;
     pluginCatalog?: PluginCatalog;
     installedSkills?: Array<{ name: string; description: string }>;
@@ -59,6 +60,7 @@ function build(
     supportsWorkflowTool: overrides.supportsWorkflowTool ?? false,
     supportsPolicyTool: overrides.supportsPolicyTool ?? false,
     supportsSourceConfigTool: overrides.supportsSourceConfigTool ?? false,
+    supportsClarificationTool: overrides.supportsClarificationTool ?? false,
     supportsPluginManagerTool: overrides.supportsPluginManagerTool ?? false,
     pluginCatalog: overrides.pluginCatalog,
     installedSkills: overrides.installedSkills,
@@ -126,6 +128,26 @@ describe("buildWorkPrompt attachments guidance", () => {
     // explicitly say to read them.
     expect(prompt).not.toMatch(/Uploaded files are auxiliary/);
     expect(prompt).toMatch(/read the file/i);
+  });
+});
+
+describe("buildWorkPrompt clarification contract", () => {
+  it("tells an interactive agent to clarify material uncertainty and stop", () => {
+    const prompt = build("hermes", { supportsClarificationTool: true });
+    expect(prompt).toContain("<clarification>");
+    expect(prompt).toContain("mcp_neko_interaction_ask_user_question");
+    expect(prompt).toContain("FINAL action of the turn");
+    expect(prompt).toContain("material to correctness, scope, cost");
+    expect(prompt).toMatch(/state\s+the limitation and continue/);
+    expect(prompt).toContain("never permits invented sources");
+    expect(prompt).toContain("clarification-tool call is the end");
+  });
+
+  it("publishes only run artifacts as downloads", () => {
+    const prompt = build("hermes", { supportsClarificationTool: true });
+    expect(prompt).toContain("published as downloadable artifacts");
+    expect(prompt).toContain("download boundary rejects every file");
+    expect(prompt).toContain("uploads, skills, memory, knowledge");
   });
 });
 


### PR DESCRIPTION
## Summary

- add a Work-chat-only `AskUserQuestion` MCP tool with deterministic A2UI forms, a terminal `needs_input` lifecycle, persisted questions for thin channels, and suppression of trailing model answers
- teach the Work prompt to clarify material uncertainty instead of guessing, while allowing safe progress when uncertainty is minor
- discover regular files created in each run artifact directory and publish them as explicit artifact events
- allow downloads only when the actor can access the run and the exact path was emitted as an artifact; reject uploads, memory, skills, library files, traversal, symlink escapes, and unpublished run files
- expose emitted artifacts as download links in the Work UI

## Testing

- `@neko/llm`: 37 focused tests passed
- `@neko/web`: 24 focused tests passed
- `@neko/worker`: 7 MCP bridge tests passed
- web and worker TypeScript checks passed
- targeted web ESLint passed
- diff hygiene and branch ancestry checks passed

A PostgreSQL-backed Work-run lifecycle regression was added. It is environment-skipped when the local test database is unavailable.