### PR TITLE
fix(cli): prevent OpenShell migration credential drift

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -73,8 +73,11 @@ jobs:
           go-version: "1.25"
           cache-dependency-path: apps/openneko/go.sum
 
-      - name: go test (integration tag)
+      - name: go test (database integration)
         run: go test -tags=integration -count=1 -timeout 10m ./internal/db/...
+
+      - name: go test (OpenShell credential integration)
+        run: go test -tags=integration -count=1 -timeout 10m -run '^TestMigrateOpenShellRoleCredentialContract$' ./internal/cli
 
   goreleaser-check:
     name: goreleaser check

--- a/apps/openneko/assets/compose/core.yml
+++ b/apps/openneko/assets/compose/core.yml
@@ -415,9 +415,11 @@ services:
       NEKO_PG_DATABASE: neko
       # The host supervisor derives this from its per-install secret and passes
       # it into the private migration container for gateway-role provisioning.
-      # Direct `docker compose up` may leave it empty; migrate then derives it
-      # from the shared config volume instead.
+      # Directly running the generated Compose files may leave it empty; the
+      # guard below then fails before changing the role. Use the OpenNeko CLI
+      # so migration and gateway always receive the same credential.
       OPENNEKO_OPENSHELL_DB_PASSWORD: ${OPENNEKO_OPENSHELL_DB_PASSWORD:-}
+      OPENNEKO_REQUIRE_EXPLICIT_OPENSHELL_DB_PASSWORD: "1"
       OPENNEKO_SKIP_MIGRATE: ${OPENNEKO_SKIP_MIGRATE:-}
       XDG_CONFIG_HOME: /config
     volumes:

--- a/apps/openneko/assets/compose_parity_test.go
+++ b/apps/openneko/assets/compose_parity_test.go
@@ -115,6 +115,13 @@ func TestStorageReconciliationGatesEveryDatabaseConsumer(t *testing.T) {
 				t.Fatalf("%s storage-reconcile is missing %s", label, key)
 			}
 		}
+		migrate := document.Services["neko-migrate"]
+		if _, ok := migrate.Environment["OPENNEKO_OPENSHELL_DB_PASSWORD"]; !ok {
+			t.Fatalf("%s neko-migrate is missing the propagated OpenShell credential", label)
+		}
+		if got := migrate.Environment["OPENNEKO_REQUIRE_EXPLICIT_OPENSHELL_DB_PASSWORD"]; got != "1" {
+			t.Fatalf("%s neko-migrate explicit-credential guard = %v, want 1", label, got)
+		}
 		for _, consumer := range []string{
 			"neko-migrate", "neko-backup", "records-graphjin", "records-watch-graphjin",
 		} {

--- a/apps/openneko/assets/compose_security_test.go
+++ b/apps/openneko/assets/compose_security_test.go
@@ -188,6 +188,9 @@ func TestPackagedComposeKeepsRuntimeTrafficOnDockerNetwork(t *testing.T) {
 	if _, ok := migrate.Environment["OPENNEKO_OPENSHELL_DB_PASSWORD"]; !ok {
 		t.Fatal("migration service must receive the gateway-role password")
 	}
+	if migrate.Environment["OPENNEKO_REQUIRE_EXPLICIT_OPENSHELL_DB_PASSWORD"] != "1" {
+		t.Fatal("migration service must fail closed when the gateway-role password is absent")
+	}
 	if core.Services["web"].DependsOn["worker"].Condition != "service_healthy" {
 		t.Fatal("web must start after the worker control plane is healthy")
 	}

--- a/apps/openneko/internal/cli/migrate.go
+++ b/apps/openneko/internal/cli/migrate.go
@@ -21,6 +21,10 @@ func newMigrateCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := cmd.Context()
 			out := cmd.OutOrStdout()
+			gatewayPassword, err := openShellDBPassword()
+			if err != nil {
+				return fmt.Errorf("resolve OpenShell gateway database credential: %w", err)
+			}
 			skip := skipSchema || envTruthy("OPENNEKO_SKIP_MIGRATE")
 			if !skip {
 				conn, err := pgx.Connect(ctx, defaultConn().DSN())
@@ -39,7 +43,7 @@ func newMigrateCmd() *cobra.Command {
 			} else {
 				fmt.Fprintln(out, "schema migrations skipped")
 			}
-			if err := ensureOpenShellGatewayRole(ctx); err != nil {
+			if err := ensureOpenShellGatewayRole(ctx, gatewayPassword); err != nil {
 				return err
 			}
 			fmt.Fprintln(out, "OpenShell database role ready")

--- a/apps/openneko/internal/cli/migrate_integration_test.go
+++ b/apps/openneko/internal/cli/migrate_integration_test.go
@@ -13,9 +13,11 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/postgres"
 	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/open-neko/neko/apps/openneko/internal/config"
 )
 
-func TestMigrateSkipSchemaStillProvisionsOpenShellRole(t *testing.T) {
+func TestMigrateOpenShellRoleCredentialContract(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
@@ -64,18 +66,66 @@ func TestMigrateSkipSchemaStillProvisionsOpenShellRole(t *testing.T) {
 		t.Fatalf("unexpected output: %s", out.String())
 	}
 
-	dsn := "postgres://openshell:private-container-password@" + host + ":" +
-		port.Port() + "/neko?sslmode=disable"
-	conn, err := pgx.Connect(ctx, dsn)
+	dsn := func(password string) string {
+		return "postgres://openshell:" + password + "@" + host + ":" +
+			port.Port() + "/neko?sslmode=disable"
+	}
+	conn, err := pgx.Connect(ctx, dsn("private-container-password"))
 	if err != nil {
 		t.Fatalf("connect as provisioned role: %v", err)
 	}
-	defer conn.Close(ctx)
 	var member bool
 	if err := conn.QueryRow(ctx, "SELECT pg_has_role(current_user, 'neko', 'member')").Scan(&member); err != nil {
 		t.Fatal(err)
 	}
 	if !member {
 		t.Fatal("openshell role is not a member of neko")
+	}
+	if err := conn.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reproduce the dangerous lifecycle: an existing gateway uses the explicit
+	// credential above, while a separately launched migration container sees a
+	// different config volume and no propagated password. It must fail before
+	// ALTER ROLE instead of replacing the gateway's working credential.
+	containerConfigHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", containerConfigHome)
+	t.Setenv(openShellDBPasswordEnv, "")
+	t.Setenv(requireExplicitOpenShellDBPasswordEnv, "1")
+
+	refused := newMigrateCmd()
+	refused.SetArgs([]string{"--skip-schema"})
+	var refusedOut bytes.Buffer
+	refused.SetOut(&refusedOut)
+	refused.SetErr(&refusedOut)
+	err = refused.ExecuteContext(ctx)
+	if err == nil || !strings.Contains(err.Error(), openShellDBPasswordEnv) ||
+		!strings.Contains(err.Error(), "refusing") {
+		t.Fatalf("missing credential error = %v, want fail-closed refusal\n%s", err, refusedOut.String())
+	}
+	if strings.Contains(refusedOut.String(), "OpenShell database role ready") {
+		t.Fatalf("refused migration reported role readiness: %s", refusedOut.String())
+	}
+
+	// The original gateway credential still authenticates after the refusal.
+	conn, err = pgx.Connect(ctx, dsn("private-container-password"))
+	if err != nil {
+		t.Fatalf("original gateway credential was changed: %v", err)
+	}
+	if err := conn.Close(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// And the password that the old fallback would have derived from the
+	// container-local key was not installed on the database role.
+	containerPassword, err := config.OpenShellDBPassword("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrongConn, wrongErr := pgx.Connect(ctx, dsn(containerPassword))
+	if wrongErr == nil {
+		_ = wrongConn.Close(ctx)
+		t.Fatal("container-local fallback credential unexpectedly authenticates")
 	}
 }

--- a/apps/openneko/internal/cli/migrate_test.go
+++ b/apps/openneko/internal/cli/migrate_test.go
@@ -1,6 +1,11 @@
 package cli
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestEnvTruthy(t *testing.T) {
 	for _, value := range []string{"1", "true", "TRUE", "yes", "on", " on "} {
@@ -19,11 +24,28 @@ func TestEnvTruthy(t *testing.T) {
 
 func TestOpenShellDBPasswordEnvironmentOverride(t *testing.T) {
 	t.Setenv(openShellDBPasswordEnv, "container-provided-password")
+	t.Setenv(requireExplicitOpenShellDBPasswordEnv, "1")
 	got, err := openShellDBPassword()
 	if err != nil {
 		t.Fatal(err)
 	}
 	if got != "container-provided-password" {
 		t.Fatalf("password = %q", got)
+	}
+}
+
+func TestOpenShellDBPasswordManagedMigrationFailsClosed(t *testing.T) {
+	configHome := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configHome)
+	t.Setenv(openShellDBPasswordEnv, "")
+	t.Setenv(requireExplicitOpenShellDBPasswordEnv, "1")
+
+	_, err := openShellDBPassword()
+	if err == nil || !strings.Contains(err.Error(), openShellDBPasswordEnv) ||
+		!strings.Contains(err.Error(), "refusing") {
+		t.Fatalf("error = %v, want fail-closed missing-credential error", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(configHome, "openneko", "secret-key")); !os.IsNotExist(statErr) {
+		t.Fatalf("managed migration derived a container-local secret-key: %v", statErr)
 	}
 }

--- a/apps/openneko/internal/cli/openshell_test.go
+++ b/apps/openneko/internal/cli/openshell_test.go
@@ -146,6 +146,9 @@ func TestConfigureOpenShellDBURL(t *testing.T) {
 	if pw != want || len(pw) != 64 { // sha256 hex
 		t.Fatalf("password should be the derived secret-key value (64 hex): got %d chars", len(pw))
 	}
+	if propagated := os.Getenv(openShellDBPasswordEnv); propagated != pw {
+		t.Fatal("gateway URL and managed-migration credential diverged")
+	}
 
 	// A rotated neko password in config.json must NOT leak into the gateway URL
 	// (the role is decoupled), and a custom database name is honored.

--- a/apps/openneko/internal/cli/start.go
+++ b/apps/openneko/internal/cli/start.go
@@ -380,6 +380,7 @@ func defaultOpenShellSubnet(mode compose.Mode) string {
 const openShellDBRole = "openshell"
 
 const openShellDBPasswordEnv = "OPENNEKO_OPENSHELL_DB_PASSWORD"
+const requireExplicitOpenShellDBPasswordEnv = "OPENNEKO_REQUIRE_EXPLICIT_OPENSHELL_DB_PASSWORD"
 
 func configureOpenShellDBURL() {
 	if os.Getenv(openShellDBPasswordEnv) == "" {
@@ -427,11 +428,7 @@ func deriveOpenShellDBURL() (string, bool) {
 // table); its password is the stable per-install value from the host
 // secret-key. Runs as the app superuser over the same connection migrations
 // use — which is reachable by the time this is called (stage 1 waited on it).
-func ensureOpenShellGatewayRole(ctx context.Context) error {
-	pw, err := openShellDBPassword()
-	if err != nil {
-		return fmt.Errorf("derive gateway DB password: %w", err)
-	}
+func ensureOpenShellGatewayRole(ctx context.Context, password string) error {
 	cc := defaultConn()
 	conn, err := pgx.Connect(ctx, cc.DSN())
 	if err != nil {
@@ -447,7 +444,7 @@ func ensureOpenShellGatewayRole(ctx context.Context) error {
 	// are fixed/operator-owned identifiers, not request input.
 	stmts := []string{
 		fmt.Sprintf(`DO $$ BEGIN IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '%s') THEN CREATE ROLE %s LOGIN; END IF; END $$`, openShellDBRole, openShellDBRole),
-		fmt.Sprintf(`ALTER ROLE %s WITH LOGIN PASSWORD '%s'`, openShellDBRole, pw),
+		fmt.Sprintf(`ALTER ROLE %s WITH LOGIN PASSWORD '%s'`, openShellDBRole, password),
 		fmt.Sprintf(`GRANT %s TO %s`, appRole, openShellDBRole),
 	}
 	for _, s := range stmts {
@@ -462,6 +459,19 @@ func openShellDBPassword() (string, error) {
 	if pw := os.Getenv(openShellDBPasswordEnv); pw != "" {
 		return pw, nil
 	}
+	// Managed migration containers must receive the exact password that the
+	// host supervisor put in the gateway's OPENSHELL_DB_URL. Falling back to
+	// the container volume's secret-key can derive a different password from
+	// the host and silently ALTER ROLE underneath an already-running gateway.
+	if envTruthy(requireExplicitOpenShellDBPasswordEnv) {
+		return "", fmt.Errorf(
+			"%s is required for managed migrations; refusing to derive a replacement from container-local config",
+			openShellDBPasswordEnv,
+		)
+	}
+	// Standalone host-side `openneko migrate` keeps its historical behavior:
+	// derive from the host install's secret-key when no managed-container guard
+	// is present.
 	return config.OpenShellDBPassword("")
 }
 

--- a/compose.yml
+++ b/compose.yml
@@ -487,6 +487,9 @@ services:
       # per-install derived gateway password. Keep migration + gateway on one
       # stable development-only value; packaged installs derive a unique one.
       OPENNEKO_OPENSHELL_DB_PASSWORD: ${OPENNEKO_OPENSHELL_DB_PASSWORD:-openneko-openshell-development-password}
+      # A managed migration must never fall back to a container-local key and
+      # rotate the role independently of the gateway credential.
+      OPENNEKO_REQUIRE_EXPLICIT_OPENSHELL_DB_PASSWORD: "1"
       OPENNEKO_SKIP_MIGRATE: ${OPENNEKO_SKIP_MIGRATE:-}
       XDG_CONFIG_HOME: /config
     volumes:


### PR DESCRIPTION
## Summary

- require managed migration containers to receive the exact OpenShell database credential propagated by the host supervisor
- fail before schema or role mutation when that credential is missing, instead of deriving a replacement from container-local config
- preserve standalone host-side migrate behavior
- enforce the guard in source and packaged Compose contracts
- run the existing CLI migrator integration suite in the real-Postgres CI job

## Root cause

A migration container launched directly from generated Compose could receive an empty OPENNEKO_OPENSHELL_DB_PASSWORD. It then derived a password from the Docker-volume secret key and changed the openshell role while an existing gateway retained its host-derived credential.

## Regression coverage

The real-Postgres test provisions an existing OpenShell role, reproduces a second migration with a distinct container config and missing propagated credential, confirms migration refuses, confirms the original gateway credential still authenticates, and confirms the container-derived credential does not.

## Local verification

- go test ./... -count=1
- go vet ./...
- go build ./...
- embedded migration sync check
- database integration suite
- OpenShell credential integration test