### PR TITLE
feat(skills): learn additive guidance from usage

### DIFF
--- a/apps/openneko/assets/migrations/0065_skill_usage.sql
+++ b/apps/openneko/assets/migrations/0065_skill_usage.sql
@@ -1,0 +1,30 @@
+-- Skill usage projection. Host-derived from tool_start events that load a
+-- SKILL.md. One row per (run, skill). Raw traces stay on work_run_event.
+
+create table if not exists skill_usage (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null references organization(id) on delete cascade,
+  run_id uuid not null references work_run(id) on delete cascade,
+  skill_name text not null,
+  content_hash text not null,
+  origin text not null,
+  pack_id text,
+  pack_version text,
+  config_commit_sha text,
+  source text not null,
+  first_event_id bigint not null,
+  attempt integer not null default 1,
+  created_at timestamptz not null default now(),
+  constraint skill_usage_origin_check check (
+    origin in ('builtin', 'custom', 'pack')
+  ),
+  constraint skill_usage_source_check check (
+    source in ('hermes', 'read')
+  )
+);
+
+create unique index if not exists skill_usage_run_skill_unique
+  on skill_usage (run_id, skill_name);
+
+create index if not exists skill_usage_org_skill_recent_idx
+  on skill_usage (org_id, skill_name, created_at desc);

--- a/apps/openneko/assets/migrations/0066_skill_learn.sql
+++ b/apps/openneko/assets/migrations/0066_skill_learn.sql
@@ -1,0 +1,44 @@
+-- Skill learner state: org/skill flags default off, durable cursor, audit log.
+
+create table if not exists skill_learn_org (
+  org_id text primary key references organization(id) on delete cascade,
+  enabled boolean not null default false,
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists skill_learn_state (
+  org_id text not null references organization(id) on delete cascade,
+  skill_name text not null,
+  enabled boolean not null default false,
+  high_water_event_id bigint not null default 0,
+  pending_settled_count integer not null default 0,
+  next_due_at timestamptz,
+  current_base_hash text,
+  current_learned_hash text,
+  lease_owner text,
+  lease_until timestamptz,
+  updated_at timestamptz not null default now(),
+  primary key (org_id, skill_name)
+);
+
+create table if not exists skill_learn_event (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null references organization(id) on delete cascade,
+  skill_name text not null,
+  base_hash text,
+  content_hash text,
+  run_ids jsonb not null default '[]'::jsonb,
+  lesson text,
+  rationale text,
+  diff text,
+  model_trace jsonb not null default '{}'::jsonb,
+  decision text not null,
+  reason text not null default '',
+  created_at timestamptz not null default now(),
+  constraint skill_learn_event_decision_check check (
+    decision in ('applied', 'skipped', 'stale', 'rejected')
+  )
+);
+
+create index if not exists skill_learn_event_org_skill_recent_idx
+  on skill_learn_event (org_id, skill_name, created_at desc);

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -122,7 +122,7 @@ export default async function AdminPage() {
     {
       href: "/admin/rules",
       title: "Rules",
-      copy: "Decide what OpenNeko can act on its own, what queues for review, and what's never allowed.",
+      copy: "Skill learning, plus what OpenNeko can act on its own, queue for review, or never run.",
       status:
         policyTotal === 0
           ? "Defaults on demand"

--- a/apps/web/src/app/admin/rules/RulesClient.tsx
+++ b/apps/web/src/app/admin/rules/RulesClient.tsx
@@ -13,6 +13,7 @@ import { Disclosure } from "@/components/ui/Disclosure";
 import { Input } from "@/components/ui/Field";
 import { Pill, type PillVariant } from "@/components/ui/Pill";
 import { cn } from "@/lib/cn";
+import SkillLearnCard from "./SkillLearnCard";
 
 type Policy = {
   id: string;
@@ -197,7 +198,7 @@ export default function RulesClient() {
         <PageHeading
           eyebrow="Agent governance"
           title="Rules"
-          description="Control what agents may execute automatically, what requires review, and what is never allowed."
+          description="Control skill learning and what agents may execute automatically, queue for review, or never run."
           actions={
           <Button
             variant="primary"
@@ -212,7 +213,9 @@ export default function RulesClient() {
           }
         />
 
-        <label className="relative mb-5 block max-w-[520px]">
+        <SkillLearnCard />
+
+        <label className="relative mb-5 mt-6 block max-w-[520px]">
           <span className="sr-only">Search rules and action kinds</span>
           <Search
             aria-hidden="true"

--- a/apps/web/src/app/admin/rules/SkillLearnCard.tsx
+++ b/apps/web/src/app/admin/rules/SkillLearnCard.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Checkbox } from "@/components/ui/Checkbox";
+import { Disclosure } from "@/components/ui/Disclosure";
+import { Pill } from "@/components/ui/Pill";
+
+type Payload = {
+  enabled: boolean;
+  source: "org" | "default";
+};
+
+export default function SkillLearnCard() {
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetch("/api/settings/skill-learn", { cache: "no-store" })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return response.json() as Promise<Payload>;
+      })
+      .then((data) => {
+        if (cancelled) return;
+        setEnabled(data.enabled);
+        setError(null);
+      })
+      .catch((cause: unknown) => {
+        if (cancelled) return;
+        setError(
+          cause instanceof Error ? cause.message : "Skill learning could not be loaded.",
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function onChange(next: boolean) {
+    const previous = enabled;
+    setEnabled(next);
+    setSaving(true);
+    try {
+      const response = await fetch("/api/settings/skill-learn", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ enabled: next }),
+      });
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as { error?: string } | null;
+        throw new Error(body?.error ?? `HTTP ${response.status}`);
+      }
+      toast.success(next ? "Skill learning is on." : "Skill learning is off.");
+      setError(null);
+    } catch (cause) {
+      setEnabled(previous);
+      const message =
+        cause instanceof Error ? cause.message : "Skill learning could not be saved.";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <section className="settings-card">
+      <div className="settings-card-head">
+        <div className="min-w-0">
+          <h2 className="settings-card-title">Skill learning</h2>
+          <p className="settings-card-copy">
+            When on, OpenNeko records a lesson from repeated skill use and
+            adds it to the skill. Authored skill files stay as written.
+          </p>
+        </div>
+        {enabled === null ? null : (
+          <Pill variant={enabled ? "success" : "muted"} className="self-start">
+            {enabled ? "On" : "Off"}
+          </Pill>
+        )}
+      </div>
+      {error ? (
+        <p className="mb-3 text-ui-body-sm text-danger">{error}</p>
+      ) : null}
+      {enabled === null && !error ? (
+        <p className="text-ui-body-sm text-text3">Loading…</p>
+      ) : (
+        <Checkbox
+          label="Learn from skill use"
+          checked={enabled === true}
+          disabled={saving || enabled === null}
+          onChange={(event) => void onChange(event.target.checked)}
+        />
+      )}
+      <Disclosure title="What this changes" className="mt-4">
+        <p className="m-0 text-ui-body-sm leading-[1.55] text-text2">
+          OpenNeko writes a LEARNED.md overlay after the same lesson shows
+          up enough times. The overlay does not store customer data. A
+          decision log records each apply, skip, and reject. Off by default.
+        </p>
+      </Disclosure>
+    </section>
+  );
+}

--- a/apps/web/src/app/api/settings/skill-learn/route.ts
+++ b/apps/web/src/app/api/settings/skill-learn/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  getSkillLearnOrgSettings,
+  setSkillLearnOrgEnabled,
+} from "@neko/llm/work";
+import { isDenied, requireAdminActor } from "@/lib/admin-auth";
+import { getOrgId } from "@/lib/db";
+
+export async function GET() {
+  const allowed = await requireAdminActor();
+  if (isDenied(allowed)) return allowed;
+  const payload = await getSkillLearnOrgSettings(await getOrgId());
+  return NextResponse.json(payload);
+}
+
+export async function PATCH(request: NextRequest) {
+  const allowed = await requireAdminActor();
+  if (isDenied(allowed)) return allowed;
+  try {
+    const body = await request.json();
+    if (!body || typeof body !== "object" || Array.isArray(body)) {
+      throw new Error("Skill learning payload must be an object");
+    }
+    const record = body as Record<string, unknown>;
+    if (typeof record.enabled !== "boolean") {
+      throw new Error("enabled must be a boolean");
+    }
+    const unsupported = Object.keys(record).filter((key) => key !== "enabled");
+    if (unsupported.length > 0) {
+      throw new Error(`Unsupported skill learning setting: ${unsupported.join(", ")}`);
+    }
+    const saved = await setSkillLearnOrgEnabled({
+      orgId: await getOrgId(),
+      enabled: record.enabled,
+    });
+    return NextResponse.json(saved);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/apps/web/test/api/settings-skill-learn.test.ts
+++ b/apps/web/test/api/settings-skill-learn.test.ts
@@ -1,0 +1,174 @@
+/**
+ * /api/settings/skill-learn contract tests.
+ *
+ * Covers: solo/userless admin => 200 default off, non-admin => 403,
+ * admin => 200 read + write, persist across GET, reject non-boolean.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import {
+  createTestOrg,
+  dbReachable,
+  deleteTestOrg,
+  uniqueOrgId,
+} from "@neko/db/test-helpers";
+import { app_user, db, eq, pool, skill_learn_org } from "@neko/db";
+import { callRoute } from "../_helpers/route";
+
+const { mockGetOrgId, mockGetCurrentUser } = vi.hoisted(() => ({
+  mockGetOrgId: vi.fn(),
+  mockGetCurrentUser: vi.fn(),
+}));
+
+vi.mock("@/lib/db", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/db")>("@/lib/db");
+  return { ...actual, getOrgId: mockGetOrgId };
+});
+
+vi.mock("@/lib/auth", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/auth")>("@/lib/auth");
+  return { ...actual, getCurrentUser: mockGetCurrentUser };
+});
+
+const reachable = await dbReachable();
+const describeIfDb = reachable ? describe : describe.skip;
+
+if (!reachable) {
+  console.warn("[api/settings/skill-learn] skipping: Postgres unreachable.");
+}
+
+describeIfDb("/api/settings/skill-learn", () => {
+  let orgId: string;
+  let GET: typeof import("@/app/api/settings/skill-learn/route").GET;
+  let PATCH: typeof import("@/app/api/settings/skill-learn/route").PATCH;
+
+  beforeAll(async () => {
+    const mod = await import("@/app/api/settings/skill-learn/route");
+    GET = mod.GET;
+    PATCH = mod.PATCH;
+  });
+
+  async function seedUser(role: "admin" | "member"): Promise<string> {
+    const id = `user-${role}-${Math.random().toString(36).slice(2, 8)}`;
+    await db().insert(app_user).values({
+      id,
+      email: `${id}@example.com`,
+      name: `${role}`,
+      org_id: orgId,
+      role,
+    });
+    return id;
+  }
+
+  beforeEach(async () => {
+    orgId = uniqueOrgId("api-skill-learn");
+    await createTestOrg(orgId);
+    mockGetOrgId.mockResolvedValue(orgId);
+  });
+
+  afterEach(async () => {
+    await deleteTestOrg(orgId);
+    vi.clearAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  afterAll(async () => {
+    await pool().end();
+  });
+
+  it("GET returns learning off when no org row exists", async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+    const res = await callRoute(GET);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ enabled: false, source: "default" });
+  });
+
+  it("GET returns 403 for signed-in non-admin users", async () => {
+    const userId = await seedUser("member");
+    mockGetCurrentUser.mockResolvedValue({
+      id: userId,
+      email: "member@example.com",
+      name: null,
+    });
+    const res = await callRoute(GET);
+    expect(res.status).toBe(403);
+  });
+
+  it("PATCH returns 403 for signed-in non-admin users", async () => {
+    const userId = await seedUser("member");
+    mockGetCurrentUser.mockResolvedValue({
+      id: userId,
+      email: "member@example.com",
+      name: null,
+    });
+    const res = await callRoute(PATCH, {
+      method: "PATCH",
+      body: { enabled: true },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("PATCH as admin persists the org flag", async () => {
+    const userId = await seedUser("admin");
+    mockGetCurrentUser.mockResolvedValue({
+      id: userId,
+      email: "admin@example.com",
+      name: null,
+    });
+    const res = await callRoute(PATCH, {
+      method: "PATCH",
+      body: { enabled: true },
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ enabled: true, source: "org" });
+
+    const readBack = await callRoute(GET);
+    expect(readBack.body).toEqual({ enabled: true, source: "org" });
+
+    const [row] = await db()
+      .select({ enabled: skill_learn_org.enabled })
+      .from(skill_learn_org)
+      .where(eq(skill_learn_org.org_id, orgId))
+      .limit(1);
+    expect(row?.enabled).toBe(true);
+  });
+
+  it("PATCH can turn learning off after it was on", async () => {
+    const userId = await seedUser("admin");
+    mockGetCurrentUser.mockResolvedValue({
+      id: userId,
+      email: "admin@example.com",
+      name: null,
+    });
+    await callRoute(PATCH, { method: "PATCH", body: { enabled: true } });
+    const res = await callRoute(PATCH, {
+      method: "PATCH",
+      body: { enabled: false },
+    });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ enabled: false, source: "org" });
+  });
+
+  it("PATCH rejects a non-boolean enabled value", async () => {
+    const userId = await seedUser("admin");
+    mockGetCurrentUser.mockResolvedValue({
+      id: userId,
+      email: "admin@example.com",
+      name: null,
+    });
+    const res = await callRoute(PATCH, {
+      method: "PATCH",
+      body: { enabled: "yes" },
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -13,6 +13,7 @@ import {
   type ActionExecutePayload,
   type ChannelDeliverPayload,
   type LibraryDistillPayload,
+  type SkillLearnPayload,
   type ProcessingJobPayload,
   type RecordsIdentityLinkPayload,
   type RecordsImportPayload,
@@ -110,6 +111,7 @@ import { runWorkflowOutputTtlSweep } from "./jobs/workflow-output-ttl-sweep.js";
 import { runActionExecute } from "./jobs/action-execute.js";
 import { runRecordsImport } from "./jobs/records-import.js";
 import { runLibraryDistillJob } from "./jobs/library-distill.js";
+import { runSkillLearnJob } from "./jobs/skill-learn.js";
 import { runRecordsIdentityLink } from "./jobs/records-identity-link.js";
 import { runRecordsBackupVerification } from "./jobs/records-backup-verify.js";
 import { seedOpenNekoOpsWorkflow } from "./jobs/records-ops-finding.js";
@@ -1180,6 +1182,23 @@ await b.work(
       } catch (e) {
         console.warn(
           `[library-distill] job ${job.id} failed; pg-boss may retry: ${e instanceof Error ? e.message : e}`,
+        );
+        throw e;
+      }
+    }
+  },
+);
+
+await b.work(
+  QUEUE.SKILL_LEARN,
+  { batchSize: 1, pollingIntervalSeconds: 2 },
+  async (jobs: PgBossLib.Job<SkillLearnPayload>[]) => {
+    for (const job of jobs) {
+      try {
+        await runSkillLearnJob(job.data);
+      } catch (e) {
+        console.warn(
+          `[skill-learn] job ${job.id} failed; pg-boss may retry: ${e instanceof Error ? e.message : e}`,
         );
         throw e;
       }

--- a/apps/worker/src/jobs/skill-learn.ts
+++ b/apps/worker/src/jobs/skill-learn.ts
@@ -1,0 +1,14 @@
+import type { SkillLearnPayload } from "@neko/db/jobs";
+import { runSkillLearnForOrgSkill } from "@neko/llm/work";
+
+export async function runSkillLearnJob(
+  payload: SkillLearnPayload,
+): Promise<void> {
+  const result = await runSkillLearnForOrgSkill({
+    orgId: payload.orgId,
+    skillName: payload.skillName,
+  });
+  console.log(
+    `[skill_learn] org=${payload.orgId} skill=${payload.skillName} decision=${result.decision} reason=${result.reason}`,
+  );
+}

--- a/apps/worker/src/jobs/work-run.ts
+++ b/apps/worker/src/jobs/work-run.ts
@@ -1,4 +1,6 @@
 import { ensureHostConfigProvisioned, type AgentEvent } from "@neko/llm";
+import { enqueue, QUEUE } from "@neko/db/jobs";
+import { db, eq, skill_usage } from "@neko/db";
 import {
   agentRuntimeDepsFromEnv,
   appendWorkRunEvent,
@@ -155,6 +157,7 @@ export async function runWorkRun(
   }
   await persistProcessingJobTelemetry(jobId, summary);
   console.log(`[work-run.telemetry] ${JSON.stringify(summary)}`);
+  await enqueueSkillLearnForRun(orgId, runId);
 
   // Channel-initiated runs have no other return path — send the reply back to
   // the sender. Web runs (no channelPlugin) stream over SSE instead.
@@ -164,5 +167,27 @@ export async function runWorkRun(
     (result.status === "completed" || result.status === "needs_input")
   ) {
     await deliverChatReply(orgId, channelPlugin, recipient, runId, result.finalText, surfaces, vitals);
+  }
+}
+
+async function enqueueSkillLearnForRun(orgId: string, runId: string): Promise<void> {
+  try {
+    const rows = await db()
+      .select({ skillName: skill_usage.skill_name })
+      .from(skill_usage)
+      .where(eq(skill_usage.run_id, runId));
+    for (const row of rows) {
+      await enqueue(
+        QUEUE.SKILL_LEARN,
+        { orgId, skillName: row.skillName },
+        { singletonKey: `skill-learn:${orgId}:${row.skillName}` },
+      );
+    }
+  } catch (error) {
+    console.warn(
+      `[work-run] skill learn enqueue failed for ${runId}: ${
+        error instanceof Error ? error.message : error
+      }`,
+    );
   }
 }

--- a/db/migrations/0065_skill_usage.sql
+++ b/db/migrations/0065_skill_usage.sql
@@ -1,0 +1,30 @@
+-- Skill usage projection. Host-derived from tool_start events that load a
+-- SKILL.md. One row per (run, skill). Raw traces stay on work_run_event.
+
+create table if not exists skill_usage (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null references organization(id) on delete cascade,
+  run_id uuid not null references work_run(id) on delete cascade,
+  skill_name text not null,
+  content_hash text not null,
+  origin text not null,
+  pack_id text,
+  pack_version text,
+  config_commit_sha text,
+  source text not null,
+  first_event_id bigint not null,
+  attempt integer not null default 1,
+  created_at timestamptz not null default now(),
+  constraint skill_usage_origin_check check (
+    origin in ('builtin', 'custom', 'pack')
+  ),
+  constraint skill_usage_source_check check (
+    source in ('hermes', 'read')
+  )
+);
+
+create unique index if not exists skill_usage_run_skill_unique
+  on skill_usage (run_id, skill_name);
+
+create index if not exists skill_usage_org_skill_recent_idx
+  on skill_usage (org_id, skill_name, created_at desc);

--- a/db/migrations/0066_skill_learn.sql
+++ b/db/migrations/0066_skill_learn.sql
@@ -1,0 +1,44 @@
+-- Skill learner state: org/skill flags default off, durable cursor, audit log.
+
+create table if not exists skill_learn_org (
+  org_id text primary key references organization(id) on delete cascade,
+  enabled boolean not null default false,
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists skill_learn_state (
+  org_id text not null references organization(id) on delete cascade,
+  skill_name text not null,
+  enabled boolean not null default false,
+  high_water_event_id bigint not null default 0,
+  pending_settled_count integer not null default 0,
+  next_due_at timestamptz,
+  current_base_hash text,
+  current_learned_hash text,
+  lease_owner text,
+  lease_until timestamptz,
+  updated_at timestamptz not null default now(),
+  primary key (org_id, skill_name)
+);
+
+create table if not exists skill_learn_event (
+  id uuid primary key default gen_random_uuid(),
+  org_id text not null references organization(id) on delete cascade,
+  skill_name text not null,
+  base_hash text,
+  content_hash text,
+  run_ids jsonb not null default '[]'::jsonb,
+  lesson text,
+  rationale text,
+  diff text,
+  model_trace jsonb not null default '{}'::jsonb,
+  decision text not null,
+  reason text not null default '',
+  created_at timestamptz not null default now(),
+  constraint skill_learn_event_decision_check check (
+    decision in ('applied', 'skipped', 'stale', 'rejected')
+  )
+);
+
+create index if not exists skill_learn_event_org_skill_recent_idx
+  on skill_learn_event (org_id, skill_name, created_at desc);

--- a/evals/semantic-inventory.yaml
+++ b/evals/semantic-inventory.yaml
@@ -46,6 +46,7 @@ worker_queues:
   records_watch_sweep: [RECORDS-WATCH]
   channel_deliver: [CHANNEL-DELIVERY]
   library_distill: [LIBRARY-DISTILL, LIBRARY-LAYERS]
+  skill_learn: [WORK-SKILLS]
 
 observation_kinds:
   run.start: [RUNTIME-OBSERVABILITY]

--- a/evals/semantic-inventory.yaml
+++ b/evals/semantic-inventory.yaml
@@ -21,6 +21,7 @@ agent_events:
   needs_input: [OUTPUT-NEEDS-INPUT]
   followups: [OUTPUT-FOLLOWUPS]
   vitals: [OUTPUT-VITALS]
+  skill_used: [WORK-SKILLS]
 
 worker_queues:
   business_profile_build: [ONBOARD-PROFILE]

--- a/packages/db/src/jobs.ts
+++ b/packages/db/src/jobs.ts
@@ -34,6 +34,7 @@ export const QUEUE = {
   RECORDS_WATCH_SWEEP: "records_watch_sweep",
   CHANNEL_DELIVER: "channel_deliver",
   LIBRARY_DISTILL: "library_distill",
+  SKILL_LEARN: "skill_learn",
 } as const;
 
 export type QueueName = (typeof QUEUE)[keyof typeof QUEUE];
@@ -113,6 +114,11 @@ export type LibraryDistillPayload = {
   documentId: string;
   /** Operator retry: bypass triage and the cataloged/skipped guard. */
   force?: boolean;
+};
+
+export type SkillLearnPayload = {
+  orgId: string;
+  skillName: string;
 };
 
 export type RecordsIdentityLinkPayload = {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -2518,3 +2518,68 @@ export const skill_usage = pgTable(
     ),
   }),
 );
+
+export const skill_learn_org = pgTable("skill_learn_org", {
+  org_id: text("org_id")
+    .primaryKey()
+    .references(() => organization.id, { onDelete: "cascade" }),
+  enabled: boolean("enabled").notNull().default(false),
+  updated_at: ts("updated_at").notNull().defaultNow(),
+});
+
+export const skill_learn_state = pgTable(
+  "skill_learn_state",
+  {
+    org_id: text("org_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    skill_name: text("skill_name").notNull(),
+    enabled: boolean("enabled").notNull().default(false),
+    high_water_event_id: bigint("high_water_event_id", {
+      mode: "number",
+    })
+      .notNull()
+      .default(0),
+    pending_settled_count: integer("pending_settled_count").notNull().default(0),
+    next_due_at: ts("next_due_at"),
+    current_base_hash: text("current_base_hash"),
+    current_learned_hash: text("current_learned_hash"),
+    lease_owner: text("lease_owner"),
+    lease_until: ts("lease_until"),
+    updated_at: ts("updated_at").notNull().defaultNow(),
+  },
+  (t) => ({
+    pk: primaryKey({ columns: [t.org_id, t.skill_name] }),
+  }),
+);
+
+export const skill_learn_event = pgTable(
+  "skill_learn_event",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    org_id: text("org_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    skill_name: text("skill_name").notNull(),
+    base_hash: text("base_hash"),
+    content_hash: text("content_hash"),
+    run_ids: jsonb("run_ids").$type<string[]>().notNull().default(sql`'[]'::jsonb`),
+    lesson: text("lesson"),
+    rationale: text("rationale"),
+    diff: text("diff"),
+    model_trace: jsonb("model_trace")
+      .$type<Record<string, unknown>>()
+      .notNull()
+      .default(sql`'{}'::jsonb`),
+    decision: text("decision").notNull(),
+    reason: text("reason").notNull().default(""),
+    created_at: ts("created_at").notNull().defaultNow(),
+  },
+  (t) => ({
+    org_skill_recent_idx: index("skill_learn_event_org_skill_recent_idx").on(
+      t.org_id,
+      t.skill_name,
+      t.created_at.desc(),
+    ),
+  }),
+);

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -5,6 +5,7 @@ import {
   customType,
   date,
   index,
+  bigint,
   integer,
   jsonb,
   numeric,
@@ -2479,6 +2480,40 @@ export const pack_operation = pgTable(
     org_status_idx: index("pack_operation_org_status_idx").on(
       t.org_id,
       t.status,
+      t.created_at.desc(),
+    ),
+  }),
+);
+
+export const skill_usage = pgTable(
+  "skill_usage",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    org_id: text("org_id")
+      .notNull()
+      .references(() => organization.id, { onDelete: "cascade" }),
+    run_id: uuid("run_id")
+      .notNull()
+      .references(() => work_run.id, { onDelete: "cascade" }),
+    skill_name: text("skill_name").notNull(),
+    content_hash: text("content_hash").notNull(),
+    origin: text("origin").notNull(),
+    pack_id: text("pack_id"),
+    pack_version: text("pack_version"),
+    config_commit_sha: text("config_commit_sha"),
+    source: text("source").notNull(),
+    first_event_id: bigint("first_event_id", { mode: "number" }).notNull(),
+    attempt: integer("attempt").notNull().default(1),
+    created_at: ts("created_at").notNull().defaultNow(),
+  },
+  (t) => ({
+    run_skill_unique: uniqueIndex("skill_usage_run_skill_unique").on(
+      t.run_id,
+      t.skill_name,
+    ),
+    org_skill_recent_idx: index("skill_usage_org_skill_recent_idx").on(
+      t.org_id,
+      t.skill_name,
       t.created_at.desc(),
     ),
   }),

--- a/packages/db/test/integration/migrations.test.ts
+++ b/packages/db/test/integration/migrations.test.ts
@@ -49,6 +49,7 @@ const M_0064 = join(
   "migrations",
   "0064_magento_store_management_v2.sql",
 );
+const M_0065 = join(REPO_ROOT, "db", "migrations", "0065_skill_usage.sql");
 
 function uniqueDbName(): string {
   return `vitest_migrations_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
@@ -459,6 +460,70 @@ describeIfDb("schema migrations", () => {
          where changeset_id = '10000000-0000-0000-0000-000000000064'
       `);
       expect(linked.rows[0]?.count).toBe("1");
+    });
+  });
+
+  it("0065 records one skill usage row per run and skill", async () => {
+    await withTempDb(async (client) => {
+      await applyFile(client, M_0001);
+      await applyFile(client, M_0006);
+      await applyFile(client, M_0065);
+      await applyFile(client, M_0065);
+
+      await client.query(`
+        insert into organization (id, name) values ('skill-org', 'Skill Org');
+        insert into work_thread (id, org_id, title)
+        values ('00000000-0000-0000-0000-000000000065', 'skill-org', 'Thread');
+        insert into work_run (id, org_id, thread_id, backend, status)
+        values (
+          '10000000-0000-0000-0000-000000000065',
+          'skill-org',
+          '00000000-0000-0000-0000-000000000065',
+          'hermes',
+          'running'
+        );
+        insert into skill_usage (
+          org_id, run_id, skill_name, content_hash, origin, source, first_event_id
+        ) values (
+          'skill-org',
+          '10000000-0000-0000-0000-000000000065',
+          'pdf',
+          'abc',
+          'builtin',
+          'read',
+          1
+        );
+      `);
+      await expect(
+        client.query(`
+          insert into skill_usage (
+            org_id, run_id, skill_name, content_hash, origin, source, first_event_id
+          ) values (
+            'skill-org',
+            '10000000-0000-0000-0000-000000000065',
+            'pdf',
+            'def',
+            'builtin',
+            'read',
+            2
+          )
+        `),
+      ).rejects.toThrow(/unique|duplicate/i);
+      await expect(
+        client.query(`
+          insert into skill_usage (
+            org_id, run_id, skill_name, content_hash, origin, source, first_event_id
+          ) values (
+            'skill-org',
+            '10000000-0000-0000-0000-000000000065',
+            'bad',
+            'abc',
+            'wiki',
+            'read',
+            3
+          )
+        `),
+      ).rejects.toThrow(/origin|check constraint/i);
     });
   });
 

--- a/packages/db/test/integration/migrations.test.ts
+++ b/packages/db/test/integration/migrations.test.ts
@@ -50,6 +50,7 @@ const M_0064 = join(
   "0064_magento_store_management_v2.sql",
 );
 const M_0065 = join(REPO_ROOT, "db", "migrations", "0065_skill_usage.sql");
+const M_0066 = join(REPO_ROOT, "db", "migrations", "0066_skill_learn.sql");
 
 function uniqueDbName(): string {
   return `vitest_migrations_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 6)}`;
@@ -524,6 +525,35 @@ describeIfDb("schema migrations", () => {
           )
         `),
       ).rejects.toThrow(/origin|check constraint/i);
+    });
+  });
+
+  it("0066 creates skill learn tables with flags default off", async () => {
+    await withTempDb(async (client) => {
+      await applyFile(client, M_0001);
+      await applyFile(client, M_0006);
+      await applyFile(client, M_0065);
+      await applyFile(client, M_0066);
+      await applyFile(client, M_0066);
+      const tables = await client.query<{ table_name: string }>(
+        `select table_name from information_schema.tables
+         where table_schema = 'public'
+           and table_name like 'skill_learn%'
+         order by table_name`,
+      );
+      expect(tables.rows.map((row) => row.table_name)).toEqual([
+        "skill_learn_event",
+        "skill_learn_org",
+        "skill_learn_state",
+      ]);
+      await client.query(`
+        insert into organization (id, name) values ('learn-org', 'Learn');
+        insert into skill_learn_org (org_id) values ('learn-org');
+      `);
+      const flags = await client.query<{ enabled: boolean }>(
+        `select enabled from skill_learn_org where org_id = 'learn-org'`,
+      );
+      expect(flags.rows[0]?.enabled).toBe(false);
     });
   });
 

--- a/packages/llm/src/agent-backend.ts
+++ b/packages/llm/src/agent-backend.ts
@@ -162,7 +162,22 @@ export type AgentEvent =
   // emitted once at the end of a /work run via a `neko_vitals` fence. Each
   // channel renders them its own way (the web rail as a tile grid, a chat
   // channel as a one-line recap, a voice channel by reading them aloud).
-  | { type: "vitals"; items: AgentVital[] };
+  | { type: "vitals"; items: AgentVital[] }
+  /**
+   * Host-derived: the run loaded a skill. The model does not author this.
+   * firstEventId is the work_run_event.id of the tool_start that used it.
+   */
+  | {
+      type: "skill_used";
+      name: string;
+      source: "hermes" | "read";
+      contentHash: string;
+      origin: "builtin" | "custom" | "pack";
+      packId?: string;
+      packVersion?: string;
+      configCommitSha?: string | null;
+      firstEventId: number;
+    };
 
 export type AgentChatMessage = {
   id?: string;

--- a/packages/llm/src/config-vcs/index.ts
+++ b/packages/llm/src/config-vcs/index.ts
@@ -25,6 +25,8 @@ const TRACKED_IGNORE = `# config-vcs (CV0): version config artifacts only.
 !memory/**
 !library/
 !library/**
+!skill-overlays/
+!skill-overlays/**
 `;
 
 // OKF bundle root: declares the version and catalogs the tracked trees.
@@ -40,6 +42,7 @@ title: "OpenNeko org knowledge"
 - [workflows/](workflows/) — scheduled and saved workflows
 - [memory/](memory/) — durable team memories
 - [library/](library/okf/index.md) — approved knowledge distilled from documents
+- [skill-overlays/](skill-overlays/) — additive learned guidance for skills
 `;
 
 export type ConfigCommit = {

--- a/packages/llm/src/config-vcs/index.ts
+++ b/packages/llm/src/config-vcs/index.ts
@@ -48,6 +48,20 @@ export type ConfigCommit = {
   date: string;
 };
 
+export async function readConfigHead(
+  workspaceRoot: string,
+): Promise<string | null> {
+  const root = resolve(workspaceRoot);
+  if (!existsSync(join(root, ".git"))) return null;
+  try {
+    const { stdout } = await git(root, ["rev-parse", "HEAD"]);
+    const sha = stdout.trim();
+    return sha || null;
+  } catch {
+    return null;
+  }
+}
+
 export async function ensureConfigRepo(workspaceRoot: string): Promise<void> {
   const root = resolve(workspaceRoot);
   await withRepoLock(root, async () => {

--- a/packages/llm/src/config-vcs/public.ts
+++ b/packages/llm/src/config-vcs/public.ts
@@ -3,6 +3,7 @@ export {
   ensureConfigRepo,
   insertConfigChangeRow,
   listConfigHistory,
+  readConfigHead,
   recordConfigChange,
   restoreConfigPath,
   type ConfigCommit,

--- a/packages/llm/src/work/index.ts
+++ b/packages/llm/src/work/index.ts
@@ -58,6 +58,19 @@ export {
   type SkillOriginKind,
   type SkillUseSource,
 } from "./skill-usage";
+export {
+  LEARNED_FILE,
+  SKILL_OVERLAYS_DIR,
+  appendLearnedSection,
+  composeSkillTree,
+  fingerprintEffectiveSkill,
+  overlayAppliesToBase,
+  readLearnedOverlay,
+  skillOverlayDir,
+  stripLearnedSection,
+  writeLearnedOverlay,
+  type LearnedOverlay,
+} from "./skill-overlay";
 export * from "./authz";
 export * from "./personas";
 export {

--- a/packages/llm/src/work/index.ts
+++ b/packages/llm/src/work/index.ts
@@ -59,6 +59,13 @@ export {
   type SkillUseSource,
 } from "./skill-usage";
 export { runSkillLearn, type SkillLearnResult } from "./skill-learn";
+export {
+  MAGENTO_LEARN_SKILLS,
+  magentoScoreImproved,
+  scoreSkillLearnWindow,
+  type SkillLearnScore,
+  type SkillLearnScoreSample,
+} from "./skill-learn-score";
 export { runSkillLearnForOrgSkill } from "./skill-learn-store";
 export { assertAdditiveLearnedBody, scanLearnedText } from "./skill-learn-scan";
 export {

--- a/packages/llm/src/work/index.ts
+++ b/packages/llm/src/work/index.ts
@@ -71,7 +71,12 @@ export {
   type SkillLearnScore,
   type SkillLearnScoreSample,
 } from "./skill-learn-score";
-export { runSkillLearnForOrgSkill } from "./skill-learn-store";
+export {
+  getSkillLearnOrgSettings,
+  runSkillLearnForOrgSkill,
+  setSkillLearnOrgEnabled,
+  type SkillLearnOrgSettings,
+} from "./skill-learn-store";
 export { assertAdditiveLearnedBody, scanLearnedText } from "./skill-learn-scan";
 export {
   LEARNED_FILE,

--- a/packages/llm/src/work/index.ts
+++ b/packages/llm/src/work/index.ts
@@ -58,6 +58,9 @@ export {
   type SkillOriginKind,
   type SkillUseSource,
 } from "./skill-usage";
+export { runSkillLearn, type SkillLearnResult } from "./skill-learn";
+export { runSkillLearnForOrgSkill } from "./skill-learn-store";
+export { assertAdditiveLearnedBody, scanLearnedText } from "./skill-learn-scan";
 export {
   LEARNED_FILE,
   SKILL_OVERLAYS_DIR,

--- a/packages/llm/src/work/index.ts
+++ b/packages/llm/src/work/index.ts
@@ -60,6 +60,11 @@ export {
 } from "./skill-usage";
 export { runSkillLearn, type SkillLearnResult } from "./skill-learn";
 export {
+  parseSkillLearnProposal,
+  proposeSkillLearn,
+  type SkillLearnLlm,
+} from "./skill-learn-propose";
+export {
   MAGENTO_LEARN_SKILLS,
   magentoScoreImproved,
   scoreSkillLearnWindow,

--- a/packages/llm/src/work/index.ts
+++ b/packages/llm/src/work/index.ts
@@ -51,6 +51,13 @@ export {
 export * from "./memory";
 export * from "./library";
 export * from "./store";
+export {
+  detectSkillUse,
+  recordSkillUsageFromEvent,
+  type DetectedSkillUse,
+  type SkillOriginKind,
+  type SkillUseSource,
+} from "./skill-usage";
 export * from "./authz";
 export * from "./personas";
 export {

--- a/packages/llm/src/work/skill-learn-propose.ts
+++ b/packages/llm/src/work/skill-learn-propose.ts
@@ -1,0 +1,100 @@
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { SkillLearnProposal, SkillUsageSnapshot } from "./skill-learn";
+
+export type SkillLearnLlm = (prompt: string) => Promise<string>;
+
+const PROPOSAL_SHAPE = `{
+  "lesson": "one repeated procedure, short",
+  "rationale": "why this lesson, citing run ids",
+  "learnedMarkdown": "additive guidance only. no frontmatter, no secrets, no Boundary: line",
+  "evidenceRunIds": ["run-id", "run-id"]
+}`;
+
+export function parseSkillLearnProposal(
+  raw: string,
+  allowedRunIds: readonly string[],
+): SkillLearnProposal | null {
+  const json = extractJsonObject(raw);
+  if (!json) return null;
+  const lesson = stringField(json, "lesson");
+  const rationale = stringField(json, "rationale");
+  const learnedMarkdown = stringField(json, "learnedMarkdown");
+  const evidence = json.evidenceRunIds;
+  if (!lesson || !rationale || !learnedMarkdown) return null;
+  if (!Array.isArray(evidence) || evidence.length === 0) return null;
+  const allowed = new Set(allowedRunIds);
+  const evidenceRunIds = evidence
+    .filter((id): id is string => typeof id === "string" && allowed.has(id));
+  if (evidenceRunIds.length === 0) return null;
+  return { lesson, rationale, learnedMarkdown, evidenceRunIds };
+}
+
+export async function proposeSkillLearn(input: {
+  orgId: string;
+  orgRoot: string;
+  skillName: string;
+  baseHash: string;
+  usages: SkillUsageSnapshot[];
+  llm?: SkillLearnLlm;
+}): Promise<SkillLearnProposal | null> {
+  const allowedRunIds = input.usages.map((usage) => usage.runId);
+  const skillExcerpt = await readFile(
+    join(input.orgRoot, "skills", input.skillName, "SKILL.md"),
+    "utf8",
+  ).catch(() => "");
+  const prompt = [
+    "You extract one repeated skill lesson from settled agent runs.",
+    "Return only JSON matching this shape:",
+    PROPOSAL_SHAPE,
+    "Do not call tools. Do not rewrite SKILL.md frontmatter.",
+    `skillName: ${input.skillName}`,
+    `baseHash: ${input.baseHash}`,
+    `runIds: ${JSON.stringify(allowedRunIds)}`,
+    "skill excerpt:",
+    skillExcerpt.slice(0, 4000),
+  ].join("\n");
+  const llm = input.llm ?? (await defaultSkillLearnLlm(input.orgId));
+  const raw = await llm(prompt);
+  return parseSkillLearnProposal(raw, allowedRunIds);
+}
+
+async function defaultSkillLearnLlm(orgId: string): Promise<SkillLearnLlm> {
+  const [{ ax }, { buildLlm }] = await Promise.all([
+    import("@ax-llm/ax"),
+    import("../llm"),
+  ]);
+  const llm = await buildLlm(orgId);
+  const generator = ax(
+    `prompt:string "instructions plus skill excerpt and run ids" -> response:string "a JSON object with lesson, rationale, learnedMarkdown, evidenceRunIds"`,
+    {
+      description:
+        "You propose one additive skill lesson. Reply with JSON only. No tools.",
+    },
+  );
+  return async (prompt: string) => {
+    const result = await generator.forward(llm, { prompt });
+    return String(result.response ?? "");
+  };
+}
+
+function extractJsonObject(raw: string): Record<string, unknown> | null {
+  const start = raw.indexOf("{");
+  const end = raw.lastIndexOf("}");
+  if (start < 0 || end <= start) return null;
+  try {
+    const parsed = JSON.parse(raw.slice(start, end + 1)) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function stringField(
+  value: Record<string, unknown>,
+  key: string,
+): string | null {
+  const field = value[key];
+  return typeof field === "string" && field.trim() ? field.trim() : null;
+}

--- a/packages/llm/src/work/skill-learn-scan.ts
+++ b/packages/llm/src/work/skill-learn-scan.ts
@@ -1,0 +1,46 @@
+const SECRET_RE =
+  /(api[_-]?key|secret|password|bearer\s+[a-z0-9._-]+|sk-[a-z0-9]{16,})/i;
+const EMAIL_RE = /\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i;
+const FRONTMATTER_RE = /^---\s*$/m;
+const TOOL_PERM_RE = /\ballowed-tools\s*:/i;
+const BOUNDARY_RE = /^\s*Boundary\s*:/m;
+
+export type LearnedScanHit = {
+  code: "secret" | "pii" | "frontmatter" | "tools" | "boundary";
+  detail: string;
+};
+
+export function scanLearnedText(text: string): LearnedScanHit[] {
+  const hits: LearnedScanHit[] = [];
+  if (SECRET_RE.test(text)) {
+    hits.push({ code: "secret", detail: "candidate looks like a secret" });
+  }
+  if (EMAIL_RE.test(text)) {
+    hits.push({ code: "pii", detail: "candidate contains an email address" });
+  }
+  if (FRONTMATTER_RE.test(text.trimStart()) || /^\s*name\s*:/m.test(text)) {
+    hits.push({
+      code: "frontmatter",
+      detail: "candidate tries to set skill frontmatter",
+    });
+  }
+  if (TOOL_PERM_RE.test(text)) {
+    hits.push({ code: "tools", detail: "candidate edits tool permissions" });
+  }
+  if (BOUNDARY_RE.test(text)) {
+    hits.push({
+      code: "boundary",
+      detail: "candidate edits a safety boundary",
+    });
+  }
+  return hits;
+}
+
+export function assertAdditiveLearnedBody(text: string): string | null {
+  const trimmed = text.trim();
+  if (!trimmed) return "learned body is empty";
+  if (trimmed.length > 8000) return "learned body is too long";
+  const hits = scanLearnedText(trimmed);
+  if (hits.length > 0) return hits.map((hit) => hit.detail).join("; ");
+  return null;
+}

--- a/packages/llm/src/work/skill-learn-score.ts
+++ b/packages/llm/src/work/skill-learn-score.ts
@@ -1,0 +1,65 @@
+export type SkillLearnScoreSample = {
+  skillName: string;
+  hadCorrection: boolean;
+  hadRelevantFailure: boolean;
+  tokens: number;
+  latencyMs: number;
+};
+
+export type SkillLearnScore = {
+  samples: number;
+  correctionRate: number;
+  failureRate: number;
+  meanTokens: number;
+  meanLatencyMs: number;
+};
+
+export const MAGENTO_LEARN_SKILLS = [
+  "magento-investigate-refunds",
+  "magento-triage-fulfillment",
+] as const;
+
+export function scoreSkillLearnWindow(
+  samples: readonly SkillLearnScoreSample[],
+): SkillLearnScore {
+  const n = samples.length;
+  if (n === 0) {
+    return {
+      samples: 0,
+      correctionRate: 0,
+      failureRate: 0,
+      meanTokens: 0,
+      meanLatencyMs: 0,
+    };
+  }
+  let corrections = 0;
+  let failures = 0;
+  let tokens = 0;
+  let latency = 0;
+  for (const sample of samples) {
+    if (sample.hadCorrection) corrections += 1;
+    if (sample.hadRelevantFailure) failures += 1;
+    tokens += sample.tokens;
+    latency += sample.latencyMs;
+  }
+  return {
+    samples: n,
+    correctionRate: corrections / n,
+    failureRate: failures / n,
+    meanTokens: tokens / n,
+    meanLatencyMs: latency / n,
+  };
+}
+
+export function magentoScoreImproved(
+  before: SkillLearnScore,
+  after: SkillLearnScore,
+): boolean {
+  if (after.samples === 0 || before.samples === 0) return false;
+  return (
+    after.correctionRate <= before.correctionRate &&
+    after.failureRate <= before.failureRate &&
+    after.meanTokens <= before.meanTokens * 1.25 &&
+    after.meanLatencyMs <= before.meanLatencyMs * 1.25
+  );
+}

--- a/packages/llm/src/work/skill-learn-store.ts
+++ b/packages/llm/src/work/skill-learn-store.ts
@@ -12,6 +12,44 @@ import { recordConfigChange } from "../config-vcs";
 import { getOrgAgentRoot } from "./workspace";
 import { learnedBodyHash, runSkillLearn, type SkillLearnResult } from "./skill-learn";
 
+export type SkillLearnOrgSettings = {
+  enabled: boolean;
+  source: "org" | "default";
+};
+
+export async function getSkillLearnOrgSettings(
+  orgId: string,
+): Promise<SkillLearnOrgSettings> {
+  const [row] = await db()
+    .select({ enabled: skill_learn_org.enabled })
+    .from(skill_learn_org)
+    .where(eq(skill_learn_org.org_id, orgId))
+    .limit(1);
+  if (!row) return { enabled: false, source: "default" };
+  return { enabled: row.enabled, source: "org" };
+}
+
+export async function setSkillLearnOrgEnabled(input: {
+  orgId: string;
+  enabled: boolean;
+}): Promise<SkillLearnOrgSettings> {
+  await db()
+    .insert(skill_learn_org)
+    .values({
+      org_id: input.orgId,
+      enabled: input.enabled,
+      updated_at: new Date(),
+    })
+    .onConflictDoUpdate({
+      target: skill_learn_org.org_id,
+      set: {
+        enabled: input.enabled,
+        updated_at: new Date(),
+      },
+    });
+  return { enabled: input.enabled, source: "org" };
+}
+
 export async function runSkillLearnForOrgSkill(input: {
   orgId: string;
   skillName: string;
@@ -57,7 +95,7 @@ export async function runSkillLearnForOrgSkill(input: {
       orgRoot,
       skillName: input.skillName,
       orgEnabled: orgRow?.enabled === true,
-      skillEnabled: stateRow?.enabled === true,
+      skillEnabled: stateRow ? stateRow.enabled : true,
       usages: usageRows.map((row) => ({
         runId: row.runId,
         skillName: row.skillName,

--- a/packages/llm/src/work/skill-learn-store.ts
+++ b/packages/llm/src/work/skill-learn-store.ts
@@ -1,0 +1,110 @@
+import {
+  and,
+  db,
+  eq,
+  skill_learn_event,
+  skill_learn_org,
+  skill_learn_state,
+  skill_usage,
+  sql,
+} from "@neko/db";
+import { recordConfigChange } from "../config-vcs";
+import { getOrgAgentRoot } from "./workspace";
+import { learnedBodyHash, runSkillLearn, type SkillLearnResult } from "./skill-learn";
+
+export async function runSkillLearnForOrgSkill(input: {
+  orgId: string;
+  skillName: string;
+}): Promise<SkillLearnResult> {
+  const orgRoot = getOrgAgentRoot(input.orgId);
+  const [orgRow] = await db()
+    .select({ enabled: skill_learn_org.enabled })
+    .from(skill_learn_org)
+    .where(eq(skill_learn_org.org_id, input.orgId))
+    .limit(1);
+  const [stateRow] = await db()
+    .select()
+    .from(skill_learn_state)
+    .where(
+      and(
+        eq(skill_learn_state.org_id, input.orgId),
+        eq(skill_learn_state.skill_name, input.skillName),
+      ),
+    )
+    .limit(1);
+  const usageRows = await db()
+    .select({
+      runId: skill_usage.run_id,
+      skillName: skill_usage.skill_name,
+      contentHash: skill_usage.content_hash,
+      createdAt: skill_usage.created_at,
+    })
+    .from(skill_usage)
+    .where(
+      and(
+        eq(skill_usage.org_id, input.orgId),
+        eq(skill_usage.skill_name, input.skillName),
+      ),
+    );
+
+  return db().transaction(async (tx) => {
+    await tx.execute(
+      sql`select pg_advisory_xact_lock(hashtext(${input.orgId}), hashtext(${input.skillName}))`,
+    );
+
+    const result = await runSkillLearn({
+      orgId: input.orgId,
+      orgRoot,
+      skillName: input.skillName,
+      orgEnabled: orgRow?.enabled === true,
+      skillEnabled: stateRow?.enabled === true,
+      usages: usageRows.map((row) => ({
+        runId: row.runId,
+        skillName: row.skillName,
+        contentHash: row.contentHash,
+        createdAt: row.createdAt,
+      })),
+    });
+
+    await tx.insert(skill_learn_event).values({
+      org_id: input.orgId,
+      skill_name: input.skillName,
+      base_hash: result.trace.baseHash ?? null,
+      content_hash: result.trace.contentHash ?? null,
+      run_ids: result.trace.evidenceRunIds ?? [],
+      lesson: result.trace.lesson ?? null,
+      rationale: result.trace.rationale ?? null,
+      diff: result.diff ?? null,
+      model_trace: result.trace,
+      decision: result.decision,
+      reason: result.reason,
+    });
+
+    if (result.decision === "applied" && result.overlay) {
+      await tx
+        .insert(skill_learn_state)
+        .values({
+          org_id: input.orgId,
+          skill_name: input.skillName,
+          enabled: true,
+          current_base_hash: result.overlay.baseHash,
+          current_learned_hash: learnedBodyHash(result.overlay.body),
+        })
+        .onConflictDoUpdate({
+          target: [skill_learn_state.org_id, skill_learn_state.skill_name],
+          set: {
+            current_base_hash: result.overlay.baseHash,
+            current_learned_hash: learnedBodyHash(result.overlay.body),
+            updated_at: new Date(),
+          },
+        });
+      await recordConfigChange({
+        workspaceRoot: orgRoot,
+        paths: [`skill-overlays/${input.skillName}`],
+        message: `Learned overlay: ${input.skillName}`,
+      });
+    }
+
+    return result;
+  });
+}

--- a/packages/llm/src/work/skill-learn.ts
+++ b/packages/llm/src/work/skill-learn.ts
@@ -6,6 +6,7 @@ import {
   writeLearnedOverlay,
   type LearnedOverlay,
 } from "./skill-overlay";
+import { proposeSkillLearn } from "./skill-learn-propose";
 import { fingerprintSkillTree } from "./workspace";
 
 export const DEFAULT_MIN_REPEATS = 5;
@@ -65,6 +66,7 @@ export type SkillLearnContext = {
     baseHash: string;
     usages: SkillUsageSnapshot[];
   }) => Promise<SkillLearnProposal | null>;
+  llm?: import("./skill-learn-propose").SkillLearnLlm;
 };
 
 export async function runSkillLearn(
@@ -126,7 +128,14 @@ export async function runSkillLearn(
         baseHash,
         usages: cohort,
       })
-    : null;
+    : await proposeSkillLearn({
+        orgId: ctx.orgId,
+        orgRoot: ctx.orgRoot,
+        skillName: ctx.skillName,
+        baseHash,
+        usages: cohort,
+        llm: ctx.llm,
+      });
   if (!proposal) {
     return skip("no_proposal", {
       baseHash,

--- a/packages/llm/src/work/skill-learn.ts
+++ b/packages/llm/src/work/skill-learn.ts
@@ -1,0 +1,197 @@
+import { createHash } from "node:crypto";
+import { join } from "node:path";
+import { assertAdditiveLearnedBody } from "./skill-learn-scan";
+import {
+  readLearnedOverlay,
+  writeLearnedOverlay,
+  type LearnedOverlay,
+} from "./skill-overlay";
+import { fingerprintSkillTree } from "./workspace";
+
+export const DEFAULT_MIN_REPEATS = 5;
+export const DEFAULT_SETTLEMENT_MS = 2 * 60 * 60 * 1000;
+
+export type SkillLearnDecision =
+  | "applied"
+  | "skipped"
+  | "stale"
+  | "rejected";
+
+export type SkillLearnProposal = {
+  lesson: string;
+  rationale: string;
+  learnedMarkdown: string;
+  evidenceRunIds: string[];
+};
+
+export type SkillLearnTrace = {
+  lesson?: string;
+  rationale?: string;
+  evidenceRunIds?: string[];
+  contentHash?: string;
+  baseHash?: string;
+  tokenUsage?: { input?: number; output?: number };
+  skipReason?: string;
+};
+
+export type SkillLearnResult = {
+  decision: SkillLearnDecision;
+  reason: string;
+  overlay?: LearnedOverlay;
+  trace: SkillLearnTrace;
+  diff?: string;
+};
+
+export type SkillUsageSnapshot = {
+  runId: string;
+  skillName: string;
+  contentHash: string;
+  createdAt: Date;
+};
+
+export type SkillLearnContext = {
+  orgId: string;
+  orgRoot: string;
+  skillName: string;
+  orgEnabled: boolean;
+  skillEnabled: boolean;
+  usages: SkillUsageSnapshot[];
+  now?: Date;
+  minRepeats?: number;
+  settlementMs?: number;
+  currentBaseHash?: string;
+  propose?: (input: {
+    skillName: string;
+    baseHash: string;
+    usages: SkillUsageSnapshot[];
+  }) => Promise<SkillLearnProposal | null>;
+};
+
+export async function runSkillLearn(
+  ctx: SkillLearnContext,
+): Promise<SkillLearnResult> {
+  const now = ctx.now ?? new Date();
+  const minRepeats = ctx.minRepeats ?? DEFAULT_MIN_REPEATS;
+  const settlementMs = ctx.settlementMs ?? DEFAULT_SETTLEMENT_MS;
+  const skillDir = join(ctx.orgRoot, "skills", ctx.skillName);
+
+  if (!ctx.orgEnabled || !ctx.skillEnabled) {
+    return skip("flags_off", { skipReason: "org or skill learning is off" });
+  }
+
+  const settled = ctx.usages.filter(
+    (usage) => now.getTime() - usage.createdAt.getTime() >= settlementMs,
+  );
+  if (settled.length < minRepeats) {
+    return skip("below_repeat_threshold", {
+      skipReason: `settled ${settled.length} < ${minRepeats}`,
+      evidenceRunIds: settled.map((usage) => usage.runId),
+    });
+  }
+
+  const byHash = new Map<string, SkillUsageSnapshot[]>();
+  for (const usage of settled) {
+    const list = byHash.get(usage.contentHash) ?? [];
+    list.push(usage);
+    byHash.set(usage.contentHash, list);
+  }
+  const cohort = [...byHash.values()].sort(
+    (a, b) => b.length - a.length,
+  )[0];
+  if (!cohort || cohort.length < minRepeats) {
+    return skip("below_repeat_threshold", {
+      skipReason: "no content_hash cohort reached the repeat threshold",
+      evidenceRunIds: settled.map((usage) => usage.runId),
+    });
+  }
+
+  let baseHash: string;
+  try {
+    baseHash = ctx.currentBaseHash ?? (await fingerprintSkillTree(skillDir));
+  } catch {
+    return skip("missing_skill", { skipReason: "skill directory is missing" });
+  }
+
+  if (ctx.currentBaseHash && ctx.currentBaseHash !== baseHash) {
+    return {
+      decision: "stale",
+      reason: "base_hash mismatch",
+      trace: { baseHash, contentHash: cohort[0]?.contentHash },
+    };
+  }
+
+  const proposal = ctx.propose
+    ? await ctx.propose({
+        skillName: ctx.skillName,
+        baseHash,
+        usages: cohort,
+      })
+    : null;
+  if (!proposal) {
+    return skip("no_proposal", {
+      baseHash,
+      contentHash: cohort[0]?.contentHash,
+      evidenceRunIds: cohort.map((usage) => usage.runId),
+      skipReason: "proposer returned no lesson",
+    });
+  }
+
+  const scanError = assertAdditiveLearnedBody(proposal.learnedMarkdown);
+  if (scanError) {
+    return {
+      decision: "rejected",
+      reason: scanError,
+      trace: {
+        lesson: proposal.lesson,
+        rationale: proposal.rationale,
+        evidenceRunIds: proposal.evidenceRunIds,
+        baseHash,
+        contentHash: cohort[0]?.contentHash,
+        skipReason: scanError,
+      },
+    };
+  }
+
+  const existing = await readLearnedOverlay(ctx.orgRoot, ctx.skillName);
+  if (existing && existing.baseHash !== baseHash) {
+    return {
+      decision: "stale",
+      reason: "existing overlay base_hash does not match current base",
+      trace: { baseHash, contentHash: cohort[0]?.contentHash },
+    };
+  }
+
+  const overlay: LearnedOverlay = {
+    skillName: ctx.skillName,
+    baseHash,
+    status: "applied",
+    body: proposal.learnedMarkdown.trim(),
+  };
+  await writeLearnedOverlay(ctx.orgRoot, overlay);
+  const diff = learnedDiff(existing?.body ?? "", overlay.body);
+  return {
+    decision: "applied",
+    reason: "applied additive learned guidance",
+    overlay,
+    diff,
+    trace: {
+      lesson: proposal.lesson,
+      rationale: proposal.rationale,
+      evidenceRunIds: proposal.evidenceRunIds,
+      baseHash,
+      contentHash: cohort[0]?.contentHash,
+    },
+  };
+}
+
+export function learnedBodyHash(body: string): string {
+  return createHash("sha256").update(body).digest("hex");
+}
+
+function skip(reason: string, trace: SkillLearnTrace): SkillLearnResult {
+  return { decision: "skipped", reason, trace };
+}
+
+function learnedDiff(before: string, after: string): string {
+  return `--- before\n${before}\n+++ after\n${after}\n`;
+}

--- a/packages/llm/src/work/skill-overlay.ts
+++ b/packages/llm/src/work/skill-overlay.ts
@@ -1,0 +1,152 @@
+import { createHash } from "node:crypto";
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { fingerprintSkillTree } from "./workspace";
+
+export const SKILL_OVERLAYS_DIR = "skill-overlays";
+export const LEARNED_FILE = "LEARNED.md";
+export const LEARNED_START = "<!-- openneko-learned:start -->";
+export const LEARNED_END = "<!-- openneko-learned:end -->";
+
+export type LearnedOverlayStatus = "applied" | "stale" | "disabled";
+
+export type LearnedOverlay = {
+  skillName: string;
+  baseHash: string;
+  status: LearnedOverlayStatus;
+  learnEventId?: string;
+  body: string;
+};
+
+export function skillOverlayDir(orgRoot: string, skillName: string): string {
+  return join(orgRoot, SKILL_OVERLAYS_DIR, skillName);
+}
+
+export async function readLearnedOverlay(
+  orgRoot: string,
+  skillName: string,
+): Promise<LearnedOverlay | null> {
+  try {
+    const raw = await readFile(
+      join(skillOverlayDir(orgRoot, skillName), LEARNED_FILE),
+      "utf8",
+    );
+    return parseLearnedMarkdown(raw, skillName);
+  } catch {
+    return null;
+  }
+}
+
+export async function writeLearnedOverlay(
+  orgRoot: string,
+  overlay: LearnedOverlay,
+): Promise<string> {
+  const dir = skillOverlayDir(orgRoot, overlay.skillName);
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, LEARNED_FILE);
+  await writeFile(path, renderLearnedMarkdown(overlay), "utf8");
+  return path;
+}
+
+export function stripLearnedSection(skillMarkdown: string): string {
+  const start = skillMarkdown.indexOf(LEARNED_START);
+  if (start < 0) return skillMarkdown.trimEnd();
+  const end = skillMarkdown.indexOf(LEARNED_END, start);
+  if (end < 0) return skillMarkdown.slice(0, start).trimEnd();
+  return `${skillMarkdown.slice(0, start).trimEnd()}\n${skillMarkdown
+    .slice(end + LEARNED_END.length)
+    .trimStart()}`.trimEnd();
+}
+
+export function appendLearnedSection(skillMarkdown: string, body: string): string {
+  const base = stripLearnedSection(skillMarkdown).trimEnd();
+  const guidance = body.trim();
+  if (!guidance) return base;
+  return `${base}\n\n${LEARNED_START}\n## Learned guidance\n\n${guidance}\n${LEARNED_END}\n`;
+}
+
+export async function overlayAppliesToBase(
+  overlay: LearnedOverlay | null,
+  baseHash: string,
+): Promise<boolean> {
+  if (!overlay) return false;
+  if (overlay.status === "disabled") return false;
+  return overlay.status === "applied" && overlay.baseHash === baseHash;
+}
+
+export async function fingerprintEffectiveSkill(
+  orgRoot: string,
+  skillName: string,
+  baseDir: string,
+): Promise<string> {
+  const baseHash = await fingerprintSkillTree(baseDir);
+  const overlay = await readLearnedOverlay(orgRoot, skillName);
+  if (!(await overlayAppliesToBase(overlay, baseHash))) return baseHash;
+  return createHash("sha256")
+    .update(baseHash)
+    .update("\0")
+    .update(overlay!.body)
+    .digest("hex");
+}
+
+export async function composeSkillTree(input: {
+  baseDir: string;
+  destDir: string;
+  overlay: LearnedOverlay | null;
+}): Promise<"applied" | "base-only"> {
+  await rm(input.destDir, { recursive: true, force: true });
+  await mkdir(input.destDir, { recursive: true });
+  await cp(input.baseDir, input.destDir, { recursive: true, force: true });
+  const baseHash = await fingerprintSkillTree(input.baseDir);
+  if (!(await overlayAppliesToBase(input.overlay, baseHash))) return "base-only";
+  const skillPath = join(input.destDir, "SKILL.md");
+  const current = await readFile(skillPath, "utf8");
+  await writeFile(
+    skillPath,
+    appendLearnedSection(current, input.overlay!.body),
+    "utf8",
+  );
+  return "applied";
+}
+
+function parseLearnedMarkdown(
+  raw: string,
+  fallbackName: string,
+): LearnedOverlay | null {
+  const match = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/);
+  if (!match) return null;
+  const fm = match[1] ?? "";
+  const body = (match[2] ?? "").trim();
+  const baseHash = scalar(fm, "base_hash");
+  if (!baseHash) return null;
+  const status = scalar(fm, "status") ?? "applied";
+  if (status !== "applied" && status !== "stale" && status !== "disabled") {
+    return null;
+  }
+  return {
+    skillName: scalar(fm, "skill_name") || fallbackName,
+    baseHash,
+    status,
+    ...(scalar(fm, "learn_event_id")
+      ? { learnEventId: scalar(fm, "learn_event_id") }
+      : {}),
+    body,
+  };
+}
+
+function renderLearnedMarkdown(overlay: LearnedOverlay): string {
+  const lines = [
+    "---",
+    `skill_name: ${overlay.skillName}`,
+    `base_hash: ${overlay.baseHash}`,
+    `status: ${overlay.status}`,
+  ];
+  if (overlay.learnEventId) lines.push(`learn_event_id: ${overlay.learnEventId}`);
+  lines.push("---", "", overlay.body.trim(), "");
+  return lines.join("\n");
+}
+
+function scalar(frontmatter: string, key: string): string | undefined {
+  const match = frontmatter.match(new RegExp(`^${key}:\\s*(.+)$`, "m"));
+  return match?.[1]?.trim();
+}

--- a/packages/llm/src/work/skill-usage.ts
+++ b/packages/llm/src/work/skill-usage.ts
@@ -11,11 +11,8 @@ import { join } from "node:path";
 import type { AgentEvent } from "../agent-backend";
 import { readConfigHead } from "../config-vcs";
 import { appendWorkRunEvent } from "./store";
-import {
-  fingerprintSkillTree,
-  getOrgAgentRoot,
-  readSkillOrigin,
-} from "./workspace";
+import { fingerprintEffectiveSkill } from "./skill-overlay";
+import { getOrgAgentRoot, readSkillOrigin } from "./workspace";
 
 const SKILL_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const SKILL_MD_PATH_RE =
@@ -80,7 +77,9 @@ async function persistSkillUsage(input: {
   const orgRoot = getOrgAgentRoot(input.orgId);
   const skillDir = join(orgRoot, "skills", input.detected.name);
   const [contentHash, pack, configCommitSha, originHint] = await Promise.all([
-    fingerprintSkillTree(skillDir).catch(() => null),
+    fingerprintEffectiveSkill(orgRoot, input.detected.name, skillDir).catch(
+      () => null,
+    ),
     lookupPackSkill(input.orgId, input.detected.name),
     readConfigHead(orgRoot),
     readSkillOrigin(skillDir),

--- a/packages/llm/src/work/skill-usage.ts
+++ b/packages/llm/src/work/skill-usage.ts
@@ -17,6 +17,8 @@ import { getOrgAgentRoot, readSkillOrigin } from "./workspace";
 const SKILL_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
 const SKILL_MD_PATH_RE =
   /(?:^|\/)skills\/([a-z0-9]+(?:-[a-z0-9]+)*)\/SKILL\.md(?:$|[?#])/i;
+const SKILL_VIEW_RE =
+  /skill view \(([a-z0-9]+(?:-[a-z0-9]+)*)(?:\/|\))/i;
 
 export type SkillUseSource = "hermes" | "read";
 export type SkillOriginKind = "builtin" | "custom" | "pack";
@@ -31,6 +33,9 @@ export function detectSkillUse(event: AgentEvent): DetectedSkillUse | null {
 
   const fromPath = skillNameFromPaths(collectStrings(event.input));
   if (fromPath) return { name: fromPath, source: "read" };
+
+  const fromView = skillNameFromSkillView(collectStrings(event.input));
+  if (fromView) return { name: fromView, source: "hermes" };
 
   const toolName = event.name.trim();
   if (!isHermesSkillTool(toolName, event.input)) return null;
@@ -185,6 +190,14 @@ function skillNameFromHermesInput(input: unknown): string | null {
     const fromPath = skillNameFromPaths([trimmed]);
     if (fromPath) return fromPath;
     if (SKILL_NAME_RE.test(trimmed)) return trimmed;
+  }
+  return null;
+}
+
+function skillNameFromSkillView(values: string[]): string | null {
+  for (const value of values) {
+    const match = SKILL_VIEW_RE.exec(value);
+    if (match?.[1] && SKILL_NAME_RE.test(match[1])) return match[1];
   }
   return null;
 }

--- a/packages/llm/src/work/skill-usage.ts
+++ b/packages/llm/src/work/skill-usage.ts
@@ -1,0 +1,225 @@
+import {
+  and,
+  db,
+  eq,
+  ne,
+  pack_artifact,
+  pack_install,
+  skill_usage,
+} from "@neko/db";
+import { join } from "node:path";
+import type { AgentEvent } from "../agent-backend";
+import { readConfigHead } from "../config-vcs";
+import { appendWorkRunEvent } from "./store";
+import {
+  fingerprintSkillTree,
+  getOrgAgentRoot,
+  readSkillOrigin,
+} from "./workspace";
+
+const SKILL_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const SKILL_MD_PATH_RE =
+  /(?:^|\/)skills\/([a-z0-9]+(?:-[a-z0-9]+)*)\/SKILL\.md(?:$|[?#])/i;
+
+export type SkillUseSource = "hermes" | "read";
+export type SkillOriginKind = "builtin" | "custom" | "pack";
+
+export type DetectedSkillUse = {
+  name: string;
+  source: SkillUseSource;
+};
+
+export function detectSkillUse(event: AgentEvent): DetectedSkillUse | null {
+  if (event.type !== "tool_start") return null;
+
+  const fromPath = skillNameFromPaths(collectStrings(event.input));
+  if (fromPath) return { name: fromPath, source: "read" };
+
+  const toolName = event.name.trim();
+  if (!isHermesSkillTool(toolName, event.input)) return null;
+
+  const named = skillNameFromHermesInput(event.input);
+  if (!named) return null;
+  return { name: named, source: "hermes" };
+}
+
+export async function recordSkillUsageFromEvent(input: {
+  orgId: string;
+  threadId: string;
+  runId: string;
+  event: AgentEvent;
+  triggeringEventId: number;
+}): Promise<void> {
+  const detected = detectSkillUse(input.event);
+  if (!detected) return;
+
+  try {
+    await persistSkillUsage({
+      orgId: input.orgId,
+      threadId: input.threadId,
+      runId: input.runId,
+      detected,
+      firstEventId: input.triggeringEventId,
+    });
+  } catch (error) {
+    console.warn(
+      `[skill-usage] failed to record ${detected.name} for run ${input.runId}: ${
+        error instanceof Error ? error.message : error
+      }`,
+    );
+  }
+}
+
+async function persistSkillUsage(input: {
+  orgId: string;
+  threadId: string;
+  runId: string;
+  detected: DetectedSkillUse;
+  firstEventId: number;
+}): Promise<void> {
+  const orgRoot = getOrgAgentRoot(input.orgId);
+  const skillDir = join(orgRoot, "skills", input.detected.name);
+  const [contentHash, pack, configCommitSha, originHint] = await Promise.all([
+    fingerprintSkillTree(skillDir).catch(() => null),
+    lookupPackSkill(input.orgId, input.detected.name),
+    readConfigHead(orgRoot),
+    readSkillOrigin(skillDir),
+  ]);
+  if (!contentHash) return;
+
+  const origin: SkillOriginKind = pack
+    ? "pack"
+    : originHint?.kind === "builtin"
+      ? "builtin"
+      : "custom";
+
+  const used: Extract<AgentEvent, { type: "skill_used" }> = {
+    type: "skill_used",
+    name: input.detected.name,
+    source: input.detected.source,
+    contentHash,
+    origin,
+    firstEventId: input.firstEventId,
+    ...(pack ? { packId: pack.packId, packVersion: pack.version } : {}),
+    ...(configCommitSha ? { configCommitSha } : { configCommitSha: null }),
+  };
+
+  const inserted = await db()
+    .insert(skill_usage)
+    .values({
+      org_id: input.orgId,
+      run_id: input.runId,
+      skill_name: input.detected.name,
+      content_hash: contentHash,
+      origin,
+      pack_id: pack?.packId ?? null,
+      pack_version: pack?.version ?? null,
+      config_commit_sha: configCommitSha,
+      source: input.detected.source,
+      first_event_id: input.firstEventId,
+      attempt: 1,
+    })
+    .onConflictDoNothing({
+      target: [skill_usage.run_id, skill_usage.skill_name],
+    })
+    .returning({ id: skill_usage.id });
+
+  if (inserted.length === 0) return;
+
+  await appendWorkRunEvent({
+    orgId: input.orgId,
+    threadId: input.threadId,
+    runId: input.runId,
+    event: used,
+  });
+}
+
+async function lookupPackSkill(
+  orgId: string,
+  skillName: string,
+): Promise<{ packId: string; version: string } | null> {
+  const rows = await db()
+    .select({
+      packId: pack_install.pack_id,
+      version: pack_install.version,
+    })
+    .from(pack_artifact)
+    .innerJoin(pack_install, eq(pack_artifact.pack_install_id, pack_install.id))
+    .where(
+      and(
+        eq(pack_artifact.org_id, orgId),
+        eq(pack_artifact.artifact_kind, "skill"),
+        eq(pack_artifact.target_ref, skillName),
+        ne(pack_install.status, "removed"),
+      ),
+    )
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  return { packId: row.packId, version: row.version };
+}
+
+function isHermesSkillTool(toolName: string, input: unknown): boolean {
+  if (/^skill$/i.test(toolName)) return true;
+  const title = stringField(input, "title");
+  return typeof title === "string" && /^skill\b/i.test(title.trim());
+}
+
+function skillNameFromHermesInput(input: unknown): string | null {
+  const candidates = [
+    stringField(input, "name"),
+    stringField(input, "skill"),
+    stringField(input, "skillName"),
+    stringField(input, "title"),
+  ];
+  const raw = asRecord(input)?.rawInput;
+  if (raw && typeof raw === "object") {
+    candidates.push(
+      stringField(raw, "name"),
+      stringField(raw, "skill"),
+      stringField(raw, "skillName"),
+    );
+  }
+  for (const value of candidates) {
+    if (!value) continue;
+    const trimmed = value.replace(/^skill[:\s]+/i, "").trim();
+    const fromPath = skillNameFromPaths([trimmed]);
+    if (fromPath) return fromPath;
+    if (SKILL_NAME_RE.test(trimmed)) return trimmed;
+  }
+  return null;
+}
+
+function skillNameFromPaths(values: string[]): string | null {
+  for (const value of values) {
+    const normalized = value.replace(/\\/g, "/");
+    const match = SKILL_MD_PATH_RE.exec(normalized);
+    if (match?.[1] && SKILL_NAME_RE.test(match[1])) return match[1];
+  }
+  return null;
+}
+
+function collectStrings(value: unknown, depth = 0): string[] {
+  if (depth > 6 || value == null) return [];
+  if (typeof value === "string") return [value];
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => collectStrings(item, depth + 1));
+  }
+  if (typeof value === "object") {
+    return Object.values(value as Record<string, unknown>).flatMap((item) =>
+      collectStrings(item, depth + 1),
+    );
+  }
+  return [];
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value as Record<string, unknown>;
+}
+
+function stringField(value: unknown, key: string): string | null {
+  const record = asRecord(value);
+  const field = record?.[key];
+  return typeof field === "string" ? field : null;
+}

--- a/packages/llm/src/work/store.ts
+++ b/packages/llm/src/work/store.ts
@@ -462,7 +462,18 @@ export async function appendWorkRunEvent(args: {
       payload: args.event,
     })
     .returning({ id: work_run_event.id });
-  return row?.id ?? 0;
+  const eventId = row?.id ?? 0;
+  if (args.event.type === "tool_start" && eventId > 0) {
+    const { recordSkillUsageFromEvent } = await import("./skill-usage");
+    await recordSkillUsageFromEvent({
+      orgId: args.orgId,
+      threadId: args.threadId,
+      runId: args.runId,
+      event: args.event,
+      triggeringEventId: eventId,
+    });
+  }
+  return eventId;
 }
 
 export async function getWorkRunEvents(

--- a/packages/llm/src/work/workspace.ts
+++ b/packages/llm/src/work/workspace.ts
@@ -44,6 +44,13 @@ export function resolveBuiltinSkillsRoot(
   );
 }
 
+export const SKILL_ORIGIN_FILE = ".openneko-origin";
+
+export type SkillOriginRecord = {
+  kind: "builtin";
+  sourceHash: string;
+};
+
 const BUILTIN_SKILLS_ROOT = resolveBuiltinSkillsRoot();
 
 export function getBuiltinSkillsRoot(): string {
@@ -259,12 +266,13 @@ export async function materializeBuiltinSkills(skillsRoot: string): Promise<void
 
 const builtinSkillFingerprints = new Map<string, Promise<string>>();
 
-async function fingerprintTree(root: string): Promise<string> {
+export async function fingerprintSkillTree(root: string): Promise<string> {
   const hash = createHash("sha256");
   const visit = async (dir: string, prefix: string): Promise<void> => {
     const entries = await readdir(dir, { withFileTypes: true });
     entries.sort((a, b) => a.name.localeCompare(b.name));
     for (const entry of entries) {
+      if (!prefix && entry.name === SKILL_ORIGIN_FILE) continue;
       const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
       const absolute = join(dir, entry.name);
       if (entry.isDirectory()) {
@@ -283,10 +291,35 @@ async function fingerprintTree(root: string): Promise<string> {
   return hash.digest("hex");
 }
 
+export async function readSkillOrigin(
+  skillDir: string,
+): Promise<SkillOriginRecord | null> {
+  try {
+    const raw = await readFile(join(skillDir, SKILL_ORIGIN_FILE), "utf8");
+    const parsed = JSON.parse(raw) as Partial<SkillOriginRecord>;
+    if (parsed.kind !== "builtin") return null;
+    if (typeof parsed.sourceHash !== "string" || !parsed.sourceHash) return null;
+    return { kind: "builtin", sourceHash: parsed.sourceHash };
+  } catch {
+    return null;
+  }
+}
+
+async function writeBuiltinOrigin(
+  skillDir: string,
+  sourceHash: string,
+): Promise<void> {
+  await writeFile(
+    join(skillDir, SKILL_ORIGIN_FILE),
+    `${JSON.stringify({ kind: "builtin", sourceHash } satisfies SkillOriginRecord)}\n`,
+    "utf8",
+  );
+}
+
 function builtinFingerprint(name: string, root: string): Promise<string> {
   let pending = builtinSkillFingerprints.get(name);
   if (!pending) {
-    pending = fingerprintTree(root);
+    pending = fingerprintSkillTree(root);
     builtinSkillFingerprints.set(name, pending);
   }
   return pending;
@@ -322,9 +355,15 @@ export async function copySkillOverrides(
     let isUnmodifiedBuiltin = false;
     if (!forced.has(entry.name)) {
       try {
-        isUnmodifiedBuiltin =
-          (await fingerprintTree(workspaceSource)) ===
-          (await builtinFingerprint(entry.name, bundled));
+        const workspaceHash = await fingerprintSkillTree(workspaceSource);
+        const imageHash = await builtinFingerprint(entry.name, bundled);
+        const origin = await readSkillOrigin(workspaceSource);
+        if (origin?.kind === "builtin" && origin.sourceHash === workspaceHash) {
+          // Unchanged since seed, including a stale image copy.
+          isUnmodifiedBuiltin = true;
+        } else if (!origin) {
+          isUnmodifiedBuiltin = workspaceHash === imageHash;
+        }
       } catch {
         // A missing bundled directory identifies an organization-created skill.
       }
@@ -352,10 +391,13 @@ async function seedBuiltinSkills(skillsRoot: string): Promise<void> {
       await access(dest, fsConstants.F_OK);
       continue;
     } catch {
-      await cp(join(BUILTIN_SKILLS_ROOT, entry.name), dest, {
+      const source = join(BUILTIN_SKILLS_ROOT, entry.name);
+      await cp(source, dest, {
         recursive: true,
         errorOnExist: false,
       });
+      const sourceHash = await builtinFingerprint(entry.name, source);
+      await writeBuiltinOrigin(dest, sourceHash);
     }
   }
 }

--- a/packages/llm/src/work/workspace.ts
+++ b/packages/llm/src/work/workspace.ts
@@ -18,6 +18,11 @@ import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { AgentWorkspace } from "../agent-backend";
+import {
+  composeSkillTree,
+  overlayAppliesToBase,
+  readLearnedOverlay,
+} from "./skill-overlay";
 
 export function resolveBuiltinSkillsRoot(
   moduleUrl = import.meta.url,
@@ -101,6 +106,7 @@ export async function ensureOrgWorkspace(orgId: string): Promise<OrgWorkspaceRoo
   const knowledgeRoot = join(orgRoot, "knowledge");
   const uploadsRoot = join(orgRoot, "uploads");
   const runsRoot = join(orgRoot, "runs");
+  const skillOverlaysRoot = join(orgRoot, "skill-overlays");
 
   for (const dir of [
     orgRoot,
@@ -109,6 +115,7 @@ export async function ensureOrgWorkspace(orgId: string): Promise<OrgWorkspaceRoo
     knowledgeRoot,
     uploadsRoot,
     runsRoot,
+    skillOverlaysRoot,
   ]) {
     await mkdir(dir, { recursive: true });
   }
@@ -353,9 +360,10 @@ export async function copySkillOverrides(
     const bundled = join(BUILTIN_SKILLS_ROOT, entry.name);
     const source = forced.has(entry.name) ? bundled : workspaceSource;
     let isUnmodifiedBuiltin = false;
+    let workspaceHash = "";
     if (!forced.has(entry.name)) {
       try {
-        const workspaceHash = await fingerprintSkillTree(workspaceSource);
+        workspaceHash = await fingerprintSkillTree(workspaceSource);
         const imageHash = await builtinFingerprint(entry.name, bundled);
         const origin = await readSkillOrigin(workspaceSource);
         if (origin?.kind === "builtin" && origin.sourceHash === workspaceHash) {
@@ -368,11 +376,21 @@ export async function copySkillOverrides(
         // A missing bundled directory identifies an organization-created skill.
       }
     }
-    if (isUnmodifiedBuiltin) continue;
+    const orgRoot = dirname(skillsRoot);
+    const overlay = await readLearnedOverlay(orgRoot, entry.name);
+    const overlayLive = await overlayAppliesToBase(
+      overlay,
+      workspaceHash || (await fingerprintSkillTree(workspaceSource).catch(() => "")),
+    );
+    if (isUnmodifiedBuiltin && !overlayLive) continue;
 
     const destination = join(destinationRoot, entry.name);
-    await rm(destination, { recursive: true, force: true });
-    await cp(source, destination, { recursive: true, force: true });
+    const composeBase = isUnmodifiedBuiltin ? bundled : source;
+    await composeSkillTree({
+      baseDir: composeBase,
+      destDir: destination,
+      overlay: overlayLive ? overlay : null,
+    });
     copied.push(entry.name);
   }
   const missing = [...forced].filter((name) => !copied.includes(name));

--- a/packages/llm/test/config-vcs.test.ts
+++ b/packages/llm/test/config-vcs.test.ts
@@ -41,6 +41,20 @@ describe("config-vcs (CV0)", () => {
     expect(await readConfigHead(root)).toBe(sha);
     const history = await listConfigHistory(root, "knowledge");
     expect(history).toHaveLength(0);
+
+    await mkdir(join(root, "skill-overlays", "s1"), { recursive: true });
+    await writeFile(
+      join(root, "skill-overlays", "s1", "LEARNED.md"),
+      "---\nbase_hash: abc\nstatus: applied\n---\nDo not loop.\n",
+      "utf8",
+    );
+    const overlaySha = await commitConfigChange({
+      workspaceRoot: root,
+      paths: ["skill-overlays/s1"],
+      message: "Added overlay: s1",
+    });
+    expect(overlaySha).toMatch(/^[0-9a-f]{40}$/);
+    expect(await listConfigHistory(root, "skill-overlays/s1")).toHaveLength(1);
   });
 
   it("commit -> history -> restore round-trips an artifact", async () => {

--- a/packages/llm/test/config-vcs.test.ts
+++ b/packages/llm/test/config-vcs.test.ts
@@ -7,6 +7,7 @@ import {
   commitConfigChange,
   ensureConfigRepo,
   listConfigHistory,
+  readConfigHead,
   restoreConfigPath,
 } from "../src/config-vcs";
 import { writeWorkSkill } from "../src/work/skills";
@@ -37,6 +38,7 @@ describe("config-vcs (CV0)", () => {
       message: "Added skill: s1",
     });
     expect(sha).toMatch(/^[0-9a-f]{40}$/);
+    expect(await readConfigHead(root)).toBe(sha);
     const history = await listConfigHistory(root, "knowledge");
     expect(history).toHaveLength(0);
   });

--- a/packages/llm/test/magento-skill-scenarios.test.ts
+++ b/packages/llm/test/magento-skill-scenarios.test.ts
@@ -1,0 +1,157 @@
+import { mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { detectSkillUse } from "../src/work/skill-usage";
+import { composeSkillTree } from "../src/work/skill-overlay";
+import { runSkillLearn } from "../src/work/skill-learn";
+import { fingerprintSkillTree } from "../src/work/workspace";
+
+const PACK = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../packs/magento/skills",
+);
+const REFUNDS = join(PACK, "magento-investigate-refunds");
+const FULFILL = join(PACK, "magento-triage-fulfillment");
+
+const cleanup: string[] = [];
+afterEach(async () => {
+  while (cleanup.length > 0) {
+    const path = cleanup.pop();
+    if (path) await rm(path, { recursive: true, force: true });
+  }
+});
+
+describe("Magento refunds and fulfillment skill paths", () => {
+  it("records SKILL.md reads for both Magento skills", () => {
+    expect(
+      detectSkillUse({
+        type: "tool_start",
+        id: "r1",
+        name: "read",
+        input: {
+          locations: [{ path: "/org/skills/magento-investigate-refunds/SKILL.md" }],
+        },
+      }),
+    ).toEqual({ name: "magento-investigate-refunds", source: "read" });
+    expect(
+      detectSkillUse({
+        type: "tool_start",
+        id: "f1",
+        name: "read",
+        input: {
+          locations: [{ path: "/org/skills/magento-triage-fulfillment/SKILL.md" }],
+        },
+      }),
+    ).toEqual({ name: "magento-triage-fulfillment", source: "read" });
+  });
+
+  it("composes learned guidance without dropping Magento references", async () => {
+    const dest = await mkdtemp(join(tmpdir(), "neko-m2-"));
+    cleanup.push(dest);
+    const refundsDest = join(dest, "refunds");
+    const fulfillDest = join(dest, "fulfill");
+    const fulfillStale = join(dest, "fulfill-stale");
+    const refundsHash = await fingerprintSkillTree(REFUNDS);
+    const fulfillHash = await fingerprintSkillTree(FULFILL);
+
+    expect(
+      await composeSkillTree({
+        baseDir: REFUNDS,
+        destDir: refundsDest,
+        overlay: {
+          skillName: "magento-investigate-refunds",
+          baseHash: refundsHash,
+          status: "applied",
+          body: "Prefer parent items when product structures would double-count.",
+        },
+      }),
+    ).toBe("applied");
+    expect(
+      await readFile(join(refundsDest, "references", "refunds-and-cancellations.md"), "utf8"),
+    ).toMatch(/credit memo/i);
+    expect(await readFile(join(refundsDest, "SKILL.md"), "utf8")).toContain(
+      "Prefer parent items",
+    );
+
+    expect(
+      await composeSkillTree({
+        baseDir: FULFILL,
+        destDir: fulfillDest,
+        overlay: {
+          skillName: "magento-triage-fulfillment",
+          baseHash: fulfillHash,
+          status: "applied",
+          body: "Never return an item to its origin location.",
+        },
+      }),
+    ).toBe("applied");
+    expect(
+      await readFile(join(fulfillDest, "references", "fulfillment-rules.md"), "utf8"),
+    ).toMatch(/fulfill/i);
+
+    expect(
+      await composeSkillTree({
+        baseDir: FULFILL,
+        destDir: fulfillStale,
+        overlay: {
+          skillName: "magento-triage-fulfillment",
+          baseHash: "stale",
+          status: "applied",
+          body: "hide-me",
+        },
+      }),
+    ).toBe("base-only");
+    const staleSkill = await readFile(join(fulfillStale, "SKILL.md"), "utf8");
+    expect(staleSkill).not.toContain("hide-me");
+    expect(
+      await readFile(join(fulfillStale, "references", "fulfillment-rules.md"), "utf8"),
+    ).toMatch(/fulfill/i);
+  });
+
+  it("applies a refunds lesson to LEARNED.md and leaves pack SKILL.md unchanged", async () => {
+    const orgRoot = await mkdtemp(join(tmpdir(), "neko-m2-org-"));
+    cleanup.push(orgRoot);
+    const skillDir = join(orgRoot, "skills", "magento-investigate-refunds");
+    await mkdir(skillDir, { recursive: true });
+    await composeSkillTree({
+      baseDir: REFUNDS,
+      destDir: skillDir,
+      overlay: null,
+    });
+    const original = await readFile(join(skillDir, "SKILL.md"), "utf8");
+    const result = await runSkillLearn({
+      orgId: "0cbb7a3e-002a-4aea-8309-fd6900752d68",
+      orgRoot,
+      skillName: "magento-investigate-refunds",
+      orgEnabled: true,
+      skillEnabled: true,
+      settlementMs: 0,
+      minRepeats: 5,
+      currentBaseHash: await fingerprintSkillTree(skillDir),
+      usages: Array.from({ length: 5 }, (_, i) => ({
+        runId: `run-${i}`,
+        skillName: "magento-investigate-refunds",
+        contentHash: "same",
+        createdAt: new Date(0),
+      })),
+      propose: async () => ({
+        lesson: "parent items",
+        rationale: "credit memo child rows double-count",
+        learnedMarkdown:
+          "Prefer parent items when product structures would double-count.",
+        evidenceRunIds: ["run-0", "run-1", "run-2", "run-3", "run-4"],
+      }),
+    });
+    expect(result.decision).toBe("applied");
+    expect(result.trace.lesson).toBe("parent items");
+    expect(await readFile(join(skillDir, "SKILL.md"), "utf8")).toBe(original);
+    expect(
+      await readFile(
+        join(orgRoot, "skill-overlays", "magento-investigate-refunds", "LEARNED.md"),
+        "utf8",
+      ),
+    ).toContain("Prefer parent items");
+  });
+});

--- a/packages/llm/test/skill-learn-score.test.ts
+++ b/packages/llm/test/skill-learn-score.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAGENTO_LEARN_SKILLS,
+  magentoScoreImproved,
+  scoreSkillLearnWindow,
+  type SkillLearnScoreSample,
+} from "../src/work/skill-learn-score";
+
+function sample(
+  partial: Partial<SkillLearnScoreSample> & Pick<SkillLearnScoreSample, "skillName">,
+): SkillLearnScoreSample {
+  return {
+    hadCorrection: false,
+    hadRelevantFailure: false,
+    tokens: 1000,
+    latencyMs: 2000,
+    ...partial,
+  };
+}
+
+describe("scoreSkillLearnWindow", () => {
+  it("scores Magento refund and fulfillment windows", () => {
+    const before = scoreSkillLearnWindow([
+      sample({
+        skillName: MAGENTO_LEARN_SKILLS[0],
+        hadCorrection: true,
+        hadRelevantFailure: true,
+        tokens: 4000,
+        latencyMs: 8000,
+      }),
+      sample({
+        skillName: MAGENTO_LEARN_SKILLS[1],
+        hadCorrection: true,
+        tokens: 3000,
+        latencyMs: 6000,
+      }),
+    ]);
+    const after = scoreSkillLearnWindow([
+      sample({ skillName: MAGENTO_LEARN_SKILLS[0], tokens: 2200, latencyMs: 4000 }),
+      sample({ skillName: MAGENTO_LEARN_SKILLS[1], tokens: 1800, latencyMs: 3500 }),
+    ]);
+    expect(before.correctionRate).toBe(1);
+    expect(before.failureRate).toBe(0.5);
+    expect(after.correctionRate).toBe(0);
+    expect(after.failureRate).toBe(0);
+    expect(magentoScoreImproved(before, after)).toBe(true);
+  });
+
+  it("does not call a cost or latency jump an improvement", () => {
+    const before = scoreSkillLearnWindow([
+      sample({ skillName: MAGENTO_LEARN_SKILLS[0], tokens: 1000, latencyMs: 1000 }),
+    ]);
+    const after = scoreSkillLearnWindow([
+      sample({
+        skillName: MAGENTO_LEARN_SKILLS[0],
+        tokens: 5000,
+        latencyMs: 9000,
+      }),
+    ]);
+    expect(magentoScoreImproved(before, after)).toBe(false);
+  });
+});

--- a/packages/llm/test/skill-learn.test.ts
+++ b/packages/llm/test/skill-learn.test.ts
@@ -109,6 +109,34 @@ describe("runSkillLearn", () => {
     expect(result.trace.evidenceRunIds).toHaveLength(4);
   });
 
+  it("skips when org learning is off", async () => {
+    const result = await runSkillLearn({
+      orgId: "org",
+      orgRoot: "/tmp",
+      skillName: "demo",
+      orgEnabled: false,
+      skillEnabled: true,
+      usages: usages(5, new Date(0)),
+      settlementMs: 0,
+    });
+    expect(result.decision).toBe("skipped");
+    expect(result.reason).toBe("flags_off");
+  });
+
+  it("skips when skill learning is off", async () => {
+    const result = await runSkillLearn({
+      orgId: "org",
+      orgRoot: "/tmp",
+      skillName: "demo",
+      orgEnabled: true,
+      skillEnabled: false,
+      usages: usages(5, new Date(0)),
+      settlementMs: 0,
+    });
+    expect(result.decision).toBe("skipped");
+    expect(result.reason).toBe("flags_off");
+  });
+
   it("applies through the production proposer when llm returns schema JSON", async () => {
     const orgRoot = await mkdtemp(join(tmpdir(), "neko-learn-prod-propose-"));
     cleanupPaths.push(orgRoot);

--- a/packages/llm/test/skill-learn.test.ts
+++ b/packages/llm/test/skill-learn.test.ts
@@ -5,6 +5,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { runSkillLearn } from "../src/work/skill-learn";
+import { parseSkillLearnProposal } from "../src/work/skill-learn-propose";
 import { scanLearnedText } from "../src/work/skill-learn-scan";
 import { fingerprintSkillTree } from "../src/work/workspace";
 
@@ -38,6 +39,36 @@ describe("skill-learn module boundary", () => {
       "utf8",
     );
     expect(source).not.toMatch(/work_memory|library_concept|rememberWorkMemory/);
+    expect(source).toMatch(/proposeSkillLearn/);
+    const store = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), "../src/work/skill-learn-store.ts"),
+      "utf8",
+    );
+    expect(store).not.toMatch(/propose:/);
+  });
+});
+
+describe("parseSkillLearnProposal", () => {
+  it("accepts schema JSON and drops run ids that were not in the cohort", () => {
+    const parsed = parseSkillLearnProposal(
+      `here\n{"lesson":"parent items","rationale":"child rows double-count","learnedMarkdown":"Prefer parent items.","evidenceRunIds":["run-1","nope"]}`,
+      ["run-1", "run-2"],
+    );
+    expect(parsed).toEqual({
+      lesson: "parent items",
+      rationale: "child rows double-count",
+      learnedMarkdown: "Prefer parent items.",
+      evidenceRunIds: ["run-1"],
+    });
+  });
+
+  it("rejects JSON with no allowed evidence run ids", () => {
+    expect(
+      parseSkillLearnProposal(
+        `{"lesson":"x","rationale":"y","learnedMarkdown":"z","evidenceRunIds":["other"]}`,
+        ["run-1"],
+      ),
+    ).toBeNull();
   });
 });
 
@@ -76,6 +107,37 @@ describe("runSkillLearn", () => {
     expect(result.reason).toBe("below_repeat_threshold");
     expect(result.trace.skipReason).toMatch(/settled 4 < 5/);
     expect(result.trace.evidenceRunIds).toHaveLength(4);
+  });
+
+  it("applies through the production proposer when llm returns schema JSON", async () => {
+    const orgRoot = await mkdtemp(join(tmpdir(), "neko-learn-prod-propose-"));
+    cleanupPaths.push(orgRoot);
+    const skillDir = join(orgRoot, "skills", "magento-investigate-refunds");
+    await mkdir(skillDir, { recursive: true });
+    const original = await readFile(join(MAGENTO_REFUNDS, "SKILL.md"), "utf8");
+    await writeFile(join(skillDir, "SKILL.md"), original, "utf8");
+    const cohort = usages(5, new Date(0));
+    const result = await runSkillLearn({
+      orgId: "org",
+      orgRoot,
+      skillName: "magento-investigate-refunds",
+      orgEnabled: true,
+      skillEnabled: true,
+      usages: cohort,
+      settlementMs: 0,
+      minRepeats: 5,
+      llm: async () =>
+        JSON.stringify({
+          lesson: "parent items",
+          rationale: "five settled runs double-counted child rows",
+          learnedMarkdown:
+            "Prefer parent items when product structures would double-count.",
+          evidenceRunIds: cohort.map((usage) => usage.runId),
+        }),
+    });
+    expect(result.decision).toBe("applied");
+    expect(result.trace.lesson).toBe("parent items");
+    expect(await readFile(join(skillDir, "SKILL.md"), "utf8")).toBe(original);
   });
 
   it("applies additive LEARNED.md and does not rewrite pack SKILL.md", async () => {

--- a/packages/llm/test/skill-learn.test.ts
+++ b/packages/llm/test/skill-learn.test.ts
@@ -1,0 +1,181 @@
+import { readFileSync } from "node:fs";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { runSkillLearn } from "../src/work/skill-learn";
+import { scanLearnedText } from "../src/work/skill-learn-scan";
+import { fingerprintSkillTree } from "../src/work/workspace";
+
+const MAGENTO_REFUNDS = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../packs/magento/skills/magento-investigate-refunds",
+);
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop();
+    if (path) await rm(path, { recursive: true, force: true });
+  }
+});
+
+function usages(count: number, createdAt: Date) {
+  return Array.from({ length: count }, (_, index) => ({
+    runId: `00000000-0000-0000-0000-${String(index + 1).padStart(12, "0")}`,
+    skillName: "magento-investigate-refunds",
+    contentHash: "same-hash",
+    createdAt,
+  }));
+}
+
+describe("skill-learn module boundary", () => {
+  it("does not write memories or library concepts", () => {
+    const source = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), "../src/work/skill-learn.ts"),
+      "utf8",
+    );
+    expect(source).not.toMatch(/work_memory|library_concept|rememberWorkMemory/);
+  });
+});
+
+describe("scanLearnedText", () => {
+  it("rejects secrets, PII, frontmatter, tools, and boundary edits", () => {
+    expect(scanLearnedText("api_key=sk-abc1234567890xyz").some((h) => h.code === "secret")).toBe(
+      true,
+    );
+    expect(scanLearnedText("email ops@example.com").some((h) => h.code === "pii")).toBe(true);
+    expect(scanLearnedText("---\nname: hijack\n---").some((h) => h.code === "frontmatter")).toBe(
+      true,
+    );
+    expect(scanLearnedText("allowed-tools: bash").some((h) => h.code === "tools")).toBe(true);
+    expect(
+      scanLearnedText("Boundary: Never refund").some((h) => h.code === "boundary"),
+    ).toBe(true);
+    expect(scanLearnedText("Never return an item to its origin.")).toEqual([]);
+  });
+});
+
+describe("runSkillLearn", () => {
+  it("skips below the repeat threshold and still returns a decision trace", async () => {
+    const orgRoot = await mkdtemp(join(tmpdir(), "neko-learn-skip-"));
+    cleanupPaths.push(orgRoot);
+    const result = await runSkillLearn({
+      orgId: "org",
+      orgRoot,
+      skillName: "magento-investigate-refunds",
+      orgEnabled: true,
+      skillEnabled: true,
+      usages: usages(4, new Date(0)),
+      settlementMs: 0,
+      minRepeats: 5,
+    });
+    expect(result.decision).toBe("skipped");
+    expect(result.reason).toBe("below_repeat_threshold");
+    expect(result.trace.skipReason).toMatch(/settled 4 < 5/);
+    expect(result.trace.evidenceRunIds).toHaveLength(4);
+  });
+
+  it("applies additive LEARNED.md and does not rewrite pack SKILL.md", async () => {
+    const orgRoot = await mkdtemp(join(tmpdir(), "neko-learn-apply-"));
+    cleanupPaths.push(orgRoot);
+    const skillDir = join(orgRoot, "skills", "magento-investigate-refunds");
+    await mkdir(skillDir, { recursive: true });
+    const original = await readFile(join(MAGENTO_REFUNDS, "SKILL.md"), "utf8");
+    await writeFile(join(skillDir, "SKILL.md"), original, "utf8");
+    await mkdir(join(skillDir, "references"), { recursive: true });
+    await writeFile(
+      join(skillDir, "references", "refunds-and-cancellations.md"),
+      await readFile(
+        join(MAGENTO_REFUNDS, "references", "refunds-and-cancellations.md"),
+        "utf8",
+      ),
+    );
+    const baseHash = await fingerprintSkillTree(skillDir);
+    const result = await runSkillLearn({
+      orgId: "org",
+      orgRoot,
+      skillName: "magento-investigate-refunds",
+      orgEnabled: true,
+      skillEnabled: true,
+      usages: usages(5, new Date(0)),
+      settlementMs: 0,
+      minRepeats: 5,
+      currentBaseHash: baseHash,
+      propose: async () => ({
+        lesson: "keep credit-memo math on parent items",
+        rationale: "five settled refunds runs double-counted child rows",
+        learnedMarkdown: "Prefer parent items when product structures would double-count.",
+        evidenceRunIds: usages(5, new Date(0)).map((usage) => usage.runId),
+      }),
+    });
+    expect(result.decision).toBe("applied");
+    expect(result.trace.lesson).toContain("parent items");
+    expect(result.trace.rationale).toContain("double-counted");
+    expect(await readFile(join(skillDir, "SKILL.md"), "utf8")).toBe(original);
+    const learned = await readFile(
+      join(orgRoot, "skill-overlays", "magento-investigate-refunds", "LEARNED.md"),
+      "utf8",
+    );
+    expect(learned).toContain("Prefer parent items");
+    expect(learned).toContain(`base_hash: ${baseHash}`);
+  });
+
+  it("rejects a secret-bearing candidate", async () => {
+    const orgRoot = await mkdtemp(join(tmpdir(), "neko-learn-secret-"));
+    cleanupPaths.push(orgRoot);
+    const skillDir = join(orgRoot, "skills", "demo");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# Demo\n", "utf8");
+    const result = await runSkillLearn({
+      orgId: "org",
+      orgRoot,
+      skillName: "demo",
+      orgEnabled: true,
+      skillEnabled: true,
+      usages: usages(5, new Date(0)).map((usage) => ({
+        ...usage,
+        skillName: "demo",
+      })),
+      settlementMs: 0,
+      propose: async () => ({
+        lesson: "leak",
+        rationale: "bad",
+        learnedMarkdown: "Store GEMINI api_key=sk-abc1234567890xyz in the skill.",
+        evidenceRunIds: ["r1"],
+      }),
+    });
+    expect(result.decision).toBe("rejected");
+    expect(result.reason).toMatch(/secret/i);
+  });
+
+  it("refuses a frontmatter rewrite", async () => {
+    const orgRoot = await mkdtemp(join(tmpdir(), "neko-learn-fm-"));
+    cleanupPaths.push(orgRoot);
+    const skillDir = join(orgRoot, "skills", "demo");
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(join(skillDir, "SKILL.md"), "# Demo\n", "utf8");
+    const result = await runSkillLearn({
+      orgId: "org",
+      orgRoot,
+      skillName: "demo",
+      orgEnabled: true,
+      skillEnabled: true,
+      usages: usages(5, new Date(0)).map((usage) => ({
+        ...usage,
+        skillName: "demo",
+      })),
+      settlementMs: 0,
+      propose: async () => ({
+        lesson: "hijack",
+        rationale: "bad",
+        learnedMarkdown: "---\nname: evil\n---\n",
+        evidenceRunIds: ["r1"],
+      }),
+    });
+    expect(result.decision).toBe("rejected");
+    expect(result.reason).toMatch(/frontmatter/i);
+  });
+});

--- a/packages/llm/test/skill-overlay.test.ts
+++ b/packages/llm/test/skill-overlay.test.ts
@@ -1,0 +1,112 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  composeSkillTree,
+  readLearnedOverlay,
+  writeLearnedOverlay,
+} from "../src/work/skill-overlay";
+import {
+  copySkillOverrides,
+  fingerprintSkillTree,
+} from "../src/work/workspace";
+
+const MAGENTO_FULFILLMENT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../packs/magento/skills/magento-triage-fulfillment",
+);
+
+const cleanupPaths: string[] = [];
+
+afterEach(async () => {
+  while (cleanupPaths.length > 0) {
+    const path = cleanupPaths.pop();
+    if (path) await rm(path, { recursive: true, force: true });
+  }
+});
+
+describe("composeSkillTree", () => {
+  it("keeps Magento reference files and applies matching learned guidance", async () => {
+    const dest = await mkdtemp(join(tmpdir(), "neko-compose-"));
+    cleanupPaths.push(dest);
+    const baseHash = await fingerprintSkillTree(MAGENTO_FULFILLMENT);
+    const result = await composeSkillTree({
+      baseDir: MAGENTO_FULFILLMENT,
+      destDir: dest,
+      overlay: {
+        skillName: "magento-triage-fulfillment",
+        baseHash,
+        status: "applied",
+        body: "Never return an item to its origin location.",
+      },
+    });
+    expect(result).toBe("applied");
+    expect(
+      await readFile(join(dest, "references", "fulfillment-rules.md"), "utf8"),
+    ).toMatch(/fulfill/i);
+    const skill = await readFile(join(dest, "SKILL.md"), "utf8");
+    expect(skill).toContain("Never return an item to its origin location.");
+    expect(skill).toContain("openneko-learned:start");
+    expect(skill).toContain("Read [fulfillment rules]");
+  });
+
+  it("does not hide new base files when the overlay hash is stale", async () => {
+    const dest = await mkdtemp(join(tmpdir(), "neko-compose-stale-"));
+    cleanupPaths.push(dest);
+    const result = await composeSkillTree({
+      baseDir: MAGENTO_FULFILLMENT,
+      destDir: dest,
+      overlay: {
+        skillName: "magento-triage-fulfillment",
+        baseHash: "stale-hash",
+        status: "applied",
+        body: "This must not appear.",
+      },
+    });
+    expect(result).toBe("base-only");
+    expect(
+      await readFile(join(dest, "references", "fulfillment-rules.md"), "utf8"),
+    ).toMatch(/fulfill/i);
+    const skill = await readFile(join(dest, "SKILL.md"), "utf8");
+    expect(skill).not.toContain("This must not appear.");
+    expect(skill).not.toContain("openneko-learned:start");
+  });
+});
+
+describe("copySkillOverrides overlay compose", () => {
+  it("stages a matching overlay on a pack skill without dropping references", async () => {
+    const org = await mkdtemp(join(tmpdir(), "neko-overlay-org-"));
+    const stage = await mkdtemp(join(tmpdir(), "neko-overlay-stage-"));
+    cleanupPaths.push(org, stage);
+    const skillsRoot = join(org, "skills");
+    const skillDir = join(skillsRoot, "magento-triage-fulfillment");
+    await mkdir(skillDir, { recursive: true });
+    await composeSkillTree({
+      baseDir: MAGENTO_FULFILLMENT,
+      destDir: skillDir,
+      overlay: null,
+    });
+    const baseHash = await fingerprintSkillTree(skillDir);
+    await writeLearnedOverlay(org, {
+      skillName: "magento-triage-fulfillment",
+      baseHash,
+      status: "applied",
+      body: "Each operation type once per item.",
+    });
+    expect(
+      (await readLearnedOverlay(org, "magento-triage-fulfillment"))?.body,
+    ).toContain("once per item");
+
+    const copied = await copySkillOverrides(skillsRoot, join(stage, "skills"));
+    expect(copied).toContain("magento-triage-fulfillment");
+    const staged = join(stage, "skills", "magento-triage-fulfillment");
+    expect(
+      await readFile(join(staged, "references", "fulfillment-rules.md"), "utf8"),
+    ).toMatch(/fulfill/i);
+    expect(await readFile(join(staged, "SKILL.md"), "utf8")).toContain(
+      "Each operation type once per item.",
+    );
+  });
+});

--- a/packages/llm/test/skill-usage.test.ts
+++ b/packages/llm/test/skill-usage.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { detectSkillUse } from "../src/work/skill-usage";
+import type { AgentEvent } from "../src/agent-backend";
+
+describe("detectSkillUse", () => {
+  it("reads a SKILL.md path from a file-read tool", () => {
+    const event: AgentEvent = {
+      type: "tool_start",
+      id: "tc-1",
+      name: "read",
+      input: {
+        title: "read: /tmp/org/skills/pdf/SKILL.md",
+        locations: [{ path: "/tmp/org/skills/pdf/SKILL.md" }],
+      },
+    };
+    expect(detectSkillUse(event)).toEqual({ name: "pdf", source: "read" });
+  });
+
+  it("ignores a non-skill file read", () => {
+    const event: AgentEvent = {
+      type: "tool_start",
+      id: "tc-2",
+      name: "read",
+      input: { locations: [{ path: "/tmp/org/uploads/notes.md" }] },
+    };
+    expect(detectSkillUse(event)).toBeNull();
+  });
+
+  it("reads a Hermes skill tool name", () => {
+    const event: AgentEvent = {
+      type: "tool_start",
+      id: "tc-3",
+      name: "Skill",
+      input: { title: "Skill: magento-triage-fulfillment" },
+    };
+    expect(detectSkillUse(event)).toEqual({
+      name: "magento-triage-fulfillment",
+      source: "hermes",
+    });
+  });
+
+  it("ignores other tool starts", () => {
+    const event: AgentEvent = {
+      type: "tool_start",
+      id: "tc-4",
+      name: "bash",
+      input: { command: "ls" },
+    };
+    expect(detectSkillUse(event)).toBeNull();
+  });
+});

--- a/packages/llm/test/skill-usage.test.ts
+++ b/packages/llm/test/skill-usage.test.ts
@@ -39,6 +39,22 @@ describe("detectSkillUse", () => {
     });
   });
 
+  it("reads a Hermes skill view title from a Magento run", () => {
+    const event: AgentEvent = {
+      type: "tool_start",
+      id: "tc-live",
+      name: "read",
+      input: {
+        title: "skill view (magento-investigate-refunds)",
+        locations: [],
+      },
+    };
+    expect(detectSkillUse(event)).toEqual({
+      name: "magento-investigate-refunds",
+      source: "hermes",
+    });
+  });
+
   it("ignores other tool starts", () => {
     const event: AgentEvent = {
       type: "tool_start",

--- a/packages/llm/test/work-workspace.test.ts
+++ b/packages/llm/test/work-workspace.test.ts
@@ -11,11 +11,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import {
+  SKILL_ORIGIN_FILE,
   copySkillOverrides,
   ensureIsolatedJobWorkspace,
   ensureOrgWorkspace,
   ensureWorkWorkspace,
+  fingerprintSkillTree,
   materializeBuiltinSkills,
+  readSkillOrigin,
   resolveBuiltinSkillsRoot,
 } from "../src/work/workspace";
 
@@ -131,6 +134,40 @@ describe("work workspace", () => {
     expect(await readdir(stagedSkills)).toContain("pdf");
     expect(await readFile(join(stagedSkills, "skill-creator", "SKILL.md"), "utf8"))
       .toContain("Org override.");
+  }, 30_000);
+
+  it("records a builtin seed origin and skips a stale unmodified seed", async () => {
+    const home = await mkdtemp(join(tmpdir(), "neko-work-home-"));
+    const stage = await mkdtemp(join(tmpdir(), "neko-skills-stage-"));
+    cleanupPaths.push(home, stage);
+    process.env.HOME = home;
+
+    const workspace = await ensureOrgWorkspace("org-test");
+    const pdfDir = join(workspace.skillsRoot, "pdf");
+    const origin = await readSkillOrigin(pdfDir);
+    expect(origin?.kind).toBe("builtin");
+    expect(origin?.sourceHash).toBe(await fingerprintSkillTree(pdfDir));
+
+    await writeFile(
+      join(pdfDir, "SKILL.md"),
+      `${await readFile(join(pdfDir, "SKILL.md"), "utf8")}\nStale seed body.\n`,
+    );
+    await writeFile(
+      join(pdfDir, SKILL_ORIGIN_FILE),
+      `${JSON.stringify({
+        kind: "builtin",
+        sourceHash: await fingerprintSkillTree(pdfDir),
+      })}\n`,
+    );
+
+    const stagedSkills = join(stage, "skills");
+    const copied = await copySkillOverrides(workspace.skillsRoot, stagedSkills);
+    expect(copied).not.toContain("pdf");
+
+    await materializeBuiltinSkills(stagedSkills);
+    expect(await readFile(join(stagedSkills, "pdf", "SKILL.md"), "utf8")).not.toContain(
+      "Stale seed body.",
+    );
   }, 30_000);
 
   it("creates an empty disposable tree for non-interactive agent jobs", async () => {


### PR DESCRIPTION
## Summary

- Record each skill load with revision, origin, and content hash so learning is tied to a real skill tree, not a name.
- Compose shipped skill files first, then append a `LEARNED.md` overlay when `base_hash` matches. Pack `SKILL.md` and Magento `references/` stay as written.
- Run learning in the background after settled, repeated uses. Auto-apply passing overlays and store every apply, skip, stale, and reject in a decision log.
- Scan overlay text for secrets, PII, frontmatter, tools, and boundary edits. The Magento answer path still shows live customer data; the overlay does not store it.
- Detect Hermes `skill view (<name>)` titles with empty locations, and score Magento refunds and fulfillment windows after an apply.
- Add an admin switch on `/admin/rules`. Org learning is off until an admin turns it on. A missing per-skill row no longer blocks the org switch.

## Verification

- [x] Relevant lint, typecheck, and tests pass
- [x] Changed behavior was exercised locally

- `pnpm -r --workspace-concurrency=1 test` — pass. This branch’s suites: `packages/llm/test/skill-learn.test.ts` (11), `apps/web/test/api/settings-skill-learn.test.ts` (6). Records Postgres and live GraphJin MCP tests skipped on this host.
- `pnpm ui:check` — pass.
- Local Magento refunds and fulfillment runs recorded skill usage. The learner skipped with `flags_off` until the org switch was on.
- Host Next on `:3200` against the local org: `/admin/rules` loaded the Skill learning card; the checkbox saved at once; GET `/api/settings/skill-learn` matched On/Off after reload. The live org was left off after that check.

## UI design-system reuse map

| Surface need | Shared component or token | Live/visual evidence |
| --- | --- | --- |
| Org on/off | `Checkbox` | Desktop click toggled the control, showed the toast, and persisted through GET + reload. Phone label height 44px. |
| On/Off status | `Pill` (`success` / `muted`) | Compact pill on desktop and phone (`self-start`). |
| Extra detail | `Disclosure` | Opened “What this changes”: overlay, no customer data, decision log, off by default. |
| Card chrome | `settings-card` | Sits above the action-policy list on `/admin/rules`. Search still filters policies only. |

- [x] `pnpm ui:check` passes
- [x] Desktop and phone layouts were inspected
- [x] Changed focus, disabled, loading, empty, success, and error states were exercised where applicable
- [x] Screenshots or computed-style/geometry evidence are included above