### PR TITLE
fix(web): put product surfaces on the shared design-system floor

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -6,7 +6,9 @@ This version has breaking changes — APIs, conventions, and file structure may 
 
 # Mandatory UI design-system workflow
 
-Every change under `apps/web` must preserve OpenNeko's existing product language. This is a delivery requirement, not an optional polish pass.
+Every change under `apps/web` must preserve OpenNeko's existing product language. This is a delivery requirement, not an optional polish pass. Scope is every surface: Briefing, Ask, workflows, actions, runs, library, memory, skills, integrations, Admin, Settings, Apps, Records, Sign-in, and Onboarding.
+
+Load `.agents/skills/openneko-web-ui/SKILL.md` before building UI. Load `.agents/skills/openneko-web-review/SKILL.md` before calling a UI change done.
 
 Before editing UI:
 

--- a/apps/web/src/a2ui/components.tsx
+++ b/apps/web/src/a2ui/components.tsx
@@ -244,7 +244,7 @@ registerComponent("Table", (comp: A2UIComponent) => {
 });
 
 // ─── Section ───
-// A titled group of components. `collapsible` renders a native <details> so
+// A titled group of components. `collapsible` renders a native <details data-ui-bespoke-reason="agent-rendered A2UI catalog"> so
 // long answers can fold their supporting detail without any client state.
 registerComponent("Section", (comp: A2UIComponent, ctx: RenderContext) => {
   const props = comp as unknown as SectionProps & { id: string };
@@ -252,8 +252,8 @@ registerComponent("Section", (comp: A2UIComponent, ctx: RenderContext) => {
   const body = <div className="work-section-body">{renderChildren(childIds, ctx)}</div>;
   if (props.collapsible) {
     return (
-      <details key={props.id} className="work-section is-collapsible" open={props.defaultOpen !== false}>
-        <summary className="work-section-summary">{props.title}</summary>
+      <details data-ui-bespoke-reason="agent-rendered A2UI catalog" key={props.id} className="work-section is-collapsible" open={props.defaultOpen !== false}>
+        <summary data-ui-bespoke-reason="agent-rendered A2UI catalog" className="work-section-summary">{props.title}</summary>
         {body}
       </details>
     );
@@ -294,7 +294,7 @@ registerComponent("Choice", (comp: A2UIComponent, ctx: RenderContext) => {
   return (
     <div key={props.id} className="work-choice">
       {options.map((opt, i) => (
-        <button
+        <button data-ui-bespoke-reason="agent-rendered A2UI catalog"
           key={i}
           type="button"
           className="work-choice-btn"
@@ -380,7 +380,7 @@ function TabsView({ props, ctx }: { props: TabsProps & { id: string }; ctx: Rend
     <div className="work-a2ui-tabs">
       <div className="work-a2ui-tab-list" role="tablist" aria-label="Configuration sections">
         {tabs.map((tab, index) => (
-          <button
+          <button data-ui-bespoke-reason="agent-rendered A2UI catalog"
             key={`${tab.child}-${index}`}
             type="button"
             role="tab"
@@ -421,7 +421,7 @@ registerComponent("TextField", (comp: A2UIComponent, ctx: RenderContext) => {
   return (
     <label className="work-a2ui-field" htmlFor={common.id}>
       <span className="work-a2ui-label">{props.label}</span>
-      {props.variant === "longText" ? <textarea {...common} rows={4} /> : <input {...common} type={inputType} />}
+      {props.variant === "longText" ? <textarea data-ui-bespoke-reason="agent-rendered A2UI catalog" {...common} rows={4} /> : <input data-ui-bespoke-reason="agent-rendered A2UI catalog" {...common} type={inputType} />}
     </label>
   );
 });
@@ -431,7 +431,7 @@ registerComponent("CheckBox", (comp: A2UIComponent, ctx: RenderContext) => {
   const path = bindingPath(ctx, props.id, "value");
   return (
     <label className="work-a2ui-checkbox">
-      <input
+      <input data-ui-bespoke-reason="agent-rendered A2UI catalog"
         type="checkbox"
         checked={Boolean(props.value)}
         onChange={(event) => path && ctx.onDataChange?.(path, event.target.checked)}
@@ -454,7 +454,7 @@ registerComponent("ChoicePicker", (comp: A2UIComponent, ctx: RenderContext) => {
     return (
       <label className="work-a2ui-field">
         {props.label ? <span className="work-a2ui-label">{props.label}</span> : null}
-        <select
+        <select data-ui-bespoke-reason="agent-rendered A2UI catalog"
           className="work-a2ui-input"
           value={selected[0] ?? ""}
           onChange={(event) => path && ctx.onDataChange?.(path, event.target.value ? [event.target.value] : [])}
@@ -473,7 +473,7 @@ registerComponent("ChoicePicker", (comp: A2UIComponent, ctx: RenderContext) => {
           const checked = selected.includes(option.value);
           return (
             <label key={option.value} className="work-a2ui-check-option">
-              <input
+              <input data-ui-bespoke-reason="agent-rendered A2UI catalog"
                 type="checkbox"
                 checked={checked}
                 onChange={() => {
@@ -583,17 +583,17 @@ function OpenApiSpecInputView({
     <div className="work-openapi-import">
       <div className="work-a2ui-label">{props.label ?? "OpenAPI specification"}</div>
       <div className="work-openapi-mode" role="tablist" aria-label="OpenAPI import method">
-        <button type="button" role="tab" aria-selected={mode === "url"} onClick={() => setMode("url")}>
+        <button data-ui-bespoke-reason="agent-rendered A2UI catalog" type="button" role="tab" aria-selected={mode === "url"} onClick={() => setMode("url")}>
           Hosted URL
         </button>
-        <button type="button" role="tab" aria-selected={mode === "upload"} onClick={() => setMode("upload")}>
+        <button data-ui-bespoke-reason="agent-rendered A2UI catalog" type="button" role="tab" aria-selected={mode === "upload"} onClick={() => setMode("upload")}>
           Upload file
         </button>
       </div>
       {mode === "url" ? (
         <label className="work-a2ui-field">
           <span className="work-a2ui-label">OpenAPI YAML or JSON URL</span>
-          <input
+          <input data-ui-bespoke-reason="agent-rendered A2UI catalog"
             className="work-a2ui-input"
             type="url"
             value={url}
@@ -604,7 +604,7 @@ function OpenApiSpecInputView({
       ) : (
         <label className="work-a2ui-field">
           <span className="work-a2ui-label">OpenAPI file</span>
-          <input
+          <input data-ui-bespoke-reason="agent-rendered A2UI catalog"
             className="work-a2ui-input work-openapi-file"
             type="file"
             accept=".yaml,.yml,.json,application/yaml,application/json,text/yaml"
@@ -614,7 +614,7 @@ function OpenApiSpecInputView({
       )}
       <label className="work-a2ui-field">
         <span className="work-a2ui-label">Base URL override (optional)</span>
-        <input
+        <input data-ui-bespoke-reason="agent-rendered A2UI catalog"
           className="work-a2ui-input"
           type="url"
           value={baseUrl}
@@ -622,7 +622,7 @@ function OpenApiSpecInputView({
           onChange={(event) => setBaseUrl(event.target.value)}
         />
       </label>
-      <button
+      <button data-ui-bespoke-reason="agent-rendered A2UI catalog"
         type="button"
         className="work-a2ui-button"
         disabled={busy}
@@ -739,14 +739,14 @@ function ManagedFileSourceInputView({
       </div>
       <label className="work-a2ui-field">
         <span className="work-a2ui-label">Files</span>
-        <input
+        <input data-ui-bespoke-reason="agent-rendered A2UI catalog"
           className="work-a2ui-input work-openapi-file"
           type="file"
           multiple
           onChange={(event) => setFiles(Array.from(event.target.files ?? []))}
         />
       </label>
-      <button
+      <button data-ui-bespoke-reason="agent-rendered A2UI catalog"
         type="button"
         className="work-a2ui-button"
         disabled={busy || !sourceName || files.length === 0}
@@ -811,7 +811,7 @@ registerComponent("Button", (comp: A2UIComponent, ctx: RenderContext) => {
     ? requiresValue.length > 0 && requiresValue.every(Boolean)
     : Boolean(requiresValue);
   return (
-    <button
+    <button data-ui-bespoke-reason="agent-rendered A2UI catalog"
       type="button"
       className={`work-a2ui-button is-${props.variant ?? "default"}`}
       disabled={hasRequirement && !requirementSatisfied}

--- a/apps/web/src/app/(work)/library/page.tsx
+++ b/apps/web/src/app/(work)/library/page.tsx
@@ -7,6 +7,7 @@ import PageHeading from "@/components/PageHeading";
 import { ActionGroup } from "@/components/ui/ActionGroup";
 import { Button } from "@/components/ui/Button";
 import { MenuItem, OverflowMenu } from "@/components/ui/OverflowMenu";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { Pill, type PillVariant } from "@/components/ui/Pill";
 
 type DocumentRow = {
@@ -337,7 +338,7 @@ export default function LibraryPage() {
           <span>{formatDate(concept.updatedAt)}</span>
         </div>
         <p>
-          <button
+          <button data-ui-bespoke-reason="library file picker"
             type="button"
             className="library-concept-title"
             onClick={() =>
@@ -462,7 +463,7 @@ export default function LibraryPage() {
               <h2>Your documents</h2>
             </div>
             <ActionGroup className="memory-review-actions">
-              <input
+              <input data-ui-bespoke-reason="library file picker"
                 ref={fileInputRef}
                 type="file"
                 multiple
@@ -486,13 +487,11 @@ export default function LibraryPage() {
               <span />
             </div>
           ) : documents.length === 0 ? (
-            <div className="library-empty">
-              <strong>No documents yet</strong>
-              <span>
-                Upload documents here, or attach them in a conversation — either
-                way they are distilled into concepts the assistant can cite.
-              </span>
-            </div>
+            <EmptyState
+              className="library-empty"
+              title="No documents yet"
+              body="Upload documents here, or attach them in a conversation. Either way they are distilled into concepts the assistant can cite."
+            />
           ) : (
             <ol className="memory-review-list">
               {documents.map((doc, index) => (
@@ -557,13 +556,11 @@ export default function LibraryPage() {
             <strong>{String(personal.length).padStart(2, "0")}</strong>
           </header>
           {personal.length === 0 && !loading ? (
-            <div className="library-empty">
-              <strong>Nothing distilled yet</strong>
-              <span>
-                Concepts distilled from your documents appear here. Only you and
-                your assistant can see them until you share one with the team.
-              </span>
-            </div>
+            <EmptyState
+              className="library-empty"
+              title="Nothing distilled yet"
+              body="Concepts distilled from your documents appear here. Only you and your assistant can see them until you share one with the team."
+            />
           ) : (
             <ol className="memory-review-list">
               {personal.map((concept, index) =>
@@ -605,13 +602,11 @@ export default function LibraryPage() {
             <strong>{String(team.length).padStart(2, "0")}</strong>
           </header>
           {team.length === 0 && !loading ? (
-            <div className="library-empty">
-              <strong>No approved team concepts</strong>
-              <span>
-                Concepts a teammate shares — and an admin approves — become part
-                of the assistant&apos;s knowledge for the whole workspace.
-              </span>
-            </div>
+            <EmptyState
+              className="library-empty"
+              title="No approved team concepts"
+              body="Concepts a teammate shares, and an admin approves, become part of the assistant's knowledge for the whole workspace."
+            />
           ) : (
             <ol className="memory-review-list">
               {team.map((concept, index) =>
@@ -656,7 +651,7 @@ export default function LibraryPage() {
               <Button size="sm" onClick={() => void exportBundle()}>
                 Export OKF bundle
               </Button>
-              <input
+              <input data-ui-bespoke-reason="library file picker"
                 ref={importInputRef}
                 type="file"
                 accept=".json,application/json"

--- a/apps/web/src/app/(work)/memory/page.tsx
+++ b/apps/web/src/app/(work)/memory/page.tsx
@@ -5,6 +5,7 @@ import { Archive, Pin } from "lucide-react";
 import { confirmDialog } from "@/components/ConfirmModal";
 import PageHeading from "@/components/PageHeading";
 import { Button, IconButton } from "@/components/ui/Button";
+import { EmptyState } from "@/components/ui/EmptyState";
 
 type MemoryRow = {
   id: string;
@@ -250,13 +251,11 @@ export default function MemoryPage() {
               <span />
             </div>
           ) : active.length === 0 ? (
-            <div className="library-empty">
-              <strong>No saved memory</strong>
-              <span>
-                Stable facts and instructions appear here after you ask OpenNeko
-                to remember them.
-              </span>
-            </div>
+            <EmptyState
+              className="library-empty"
+              title="No saved memory"
+              body="Stable facts and instructions appear here after you ask OpenNeko to remember them."
+            />
           ) : (
             <>
               <div className="memory-table-head" aria-hidden="true">

--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -1083,7 +1083,7 @@ export default function WorkScreen() {
         <span className="work-gate-mark" aria-hidden="true" />
         <strong>Workspace unavailable</strong>
         <p>OpenNeko cannot reach the database. No work has been started.</p>
-        <button
+        <button data-ui-bespoke-reason="work composer and thread chrome"
           onClick={() => { setGateError(null); setGateChecked(false); window.location.reload(); }}
         >
           Retry
@@ -1125,7 +1125,7 @@ export default function WorkScreen() {
           })}
         </ol>
         <div className="work-command-actions">
-          <button
+          <button data-ui-bespoke-reason="work composer and thread chrome"
             type="button"
             className="work-command-action"
             onClick={() => setHistoryOpen(true)}
@@ -1135,7 +1135,7 @@ export default function WorkScreen() {
             <History aria-hidden="true" strokeWidth={1.9} />
             <span>History</span>
           </button>
-          <button
+          <button data-ui-bespoke-reason="work composer and thread chrome"
             type="button"
             className="work-command-action is-primary"
             onClick={() => router.push("/work")}
@@ -1305,7 +1305,7 @@ export default function WorkScreen() {
               aria-label="Workflows"
             >
               {mentionMatches.map((opt, i) => (
-                <button
+                <button data-ui-bespoke-reason="work composer and thread chrome"
                   key={opt.id}
                   type="button"
                   role="option"
@@ -1345,7 +1345,7 @@ export default function WorkScreen() {
                   <span className="text-text3 tabular-nums text-ui-label tracking-wide">
                     {Math.max(1, Math.round(file.size / 1024))} KB
                   </span>
-                  <button
+                  <button data-ui-bespoke-reason="work composer and thread chrome"
                     type="button"
                     aria-label={`Remove ${file.name}`}
                     onClick={() =>
@@ -1358,7 +1358,7 @@ export default function WorkScreen() {
               ))}
             </div>
           ) : null}
-          <textarea
+          <textarea data-ui-bespoke-reason="work composer and thread chrome"
             ref={textareaRef}
             className="work-input"
             placeholder={
@@ -1431,7 +1431,7 @@ export default function WorkScreen() {
           />
           <div className="flex items-center justify-between gap-2.5 px-1.5 py-1 max-[720px]:px-1">
             <div className="inline-flex items-center gap-2 min-w-0">
-              <button
+              <button data-ui-bespoke-reason="work composer and thread chrome"
                 className="work-icon-btn"
                 onClick={() => fileInputRef.current?.click()}
                 title="Attach a file"
@@ -1452,7 +1452,7 @@ export default function WorkScreen() {
               </span>
             </div>
             {sending ? (
-              <button
+              <button data-ui-bespoke-reason="work composer and thread chrome"
                 className="work-send-btn is-stop"
                 type="button"
                 onClick={() => void cancelRun()}
@@ -1462,7 +1462,7 @@ export default function WorkScreen() {
                 <span>Stop</span>
               </button>
             ) : (
-              <button
+              <button data-ui-bespoke-reason="work composer and thread chrome"
                 className="work-send-btn"
                 type="button"
                 onClick={() => void sendMessage()}
@@ -1476,7 +1476,7 @@ export default function WorkScreen() {
           </div>
         </div>
 
-        <input
+        <input data-ui-bespoke-reason="work composer and thread chrome"
           ref={fileInputRef}
           type="file"
           multiple
@@ -1538,7 +1538,7 @@ function EmptyAsk({ onPick }: { onPick: (text: string) => void }) {
       </div>
       <div className="work-empty-prompts" aria-label="Example jobs">
         {EMPTY_PROMPTS.map((prompt, index) => (
-          <button
+          <button data-ui-bespoke-reason="work composer and thread chrome"
             key={prompt.label}
             type="button"
             className="work-empty-prompt"
@@ -1583,11 +1583,11 @@ function PendingMemoryPanel({
           <div className="mt-1 text-text3 text-ui-label">+{pending.length - 1} more</div>
         ) : null}
       </div>
-      <div className="inline-flex min-w-0 gap-[7px] flex-wrap justify-end flex-shrink-0 max-[560px]:justify-start [&_button]:h-[30px] [&_button]:max-w-full [&_button]:rounded-[10px] [&_button]:border [&_button]:border-border [&_button]:bg-card [&_button]:text-text2 [&_button]:inline-flex [&_button]:items-center [&_button]:justify-center [&_button]:gap-1 [&_button]:px-2 [&_button]:text-ui-label [&_button]:cursor-pointer [&_button]:transition-all [&_button]:duration-200 [&_button:hover]:border-accent [&_button:hover]:text-accent">
-        <button type="button" onClick={() => onDecide(item.id, "decline")} title="Dismiss">
+      <div className="inline-flex min-w-0 gap-[7px] flex-wrap justify-end flex-shrink-0 max-[560px]:justify-start [&_button]:h-[30px] [&_button]:max-w-full [&_button]:rounded-[10px] [&_button]:border [&_button]:border-border [&_button]:bg-card [&_button]:text-text2 [&_button]:inline-flex [&_button]:items-center [&_button]:justify-center [&_button]:gap-1 [&_button]:px-2 [&_button]:text-ui-label [&_button]:cursor-pointer [&_button]:transition-[color,border-color,background-color] [&_button]:duration-200 [&_button:hover]:border-accent [&_button:hover]:text-accent">
+        <button data-ui-bespoke-reason="work composer and thread chrome" type="button" onClick={() => onDecide(item.id, "decline")} title="Dismiss">
           <X size={14} />
         </button>
-        <button
+        <button data-ui-bespoke-reason="work composer and thread chrome"
           type="button"
           onClick={() => onDecide(item.id, "accept", { scope: "global" })}
           title="Save globally"
@@ -1596,7 +1596,7 @@ function PendingMemoryPanel({
           <span>Global</span>
         </button>
         {threadId ? (
-          <button
+          <button data-ui-bespoke-reason="work composer and thread chrome"
             type="button"
             onClick={() =>
               onDecide(item.id, "accept", { scope: "thread", scopeId: threadId })
@@ -1657,7 +1657,7 @@ function MessageBubble({
     return (
       <div className="work-bubble-row is-user">
         <div className="work-bubble is-user is-editing">
-          <textarea
+          <textarea data-ui-bespoke-reason="work composer and thread chrome"
             className="work-bubble-edit"
             value={editText}
             onChange={(e) => {
@@ -1686,10 +1686,10 @@ function MessageBubble({
           />
         </div>
         <div className="work-bubble-edit-hint">
-          <button type="button" onClick={cancel}>
+          <button data-ui-bespoke-reason="work composer and thread chrome" type="button" onClick={cancel}>
             Cancel
           </button>
-          <button
+          <button data-ui-bespoke-reason="work composer and thread chrome"
             type="button"
             className="is-primary"
             onClick={save}
@@ -1711,7 +1711,7 @@ function MessageBubble({
       {showActions ? (
         <div className="work-bubble-actions">
           {onCopy ? (
-            <button
+            <button data-ui-bespoke-reason="work composer and thread chrome"
               type="button"
               title={copied ? "Copied" : "Copy"}
               aria-label="Copy"
@@ -1725,7 +1725,7 @@ function MessageBubble({
             </button>
           ) : null}
           {onRetry ? (
-            <button
+            <button data-ui-bespoke-reason="work composer and thread chrome"
               type="button"
               title="Retry"
               aria-label="Retry"
@@ -1735,7 +1735,7 @@ function MessageBubble({
             </button>
           ) : null}
           {onEdit ? (
-            <button
+            <button data-ui-bespoke-reason="work composer and thread chrome"
               type="button"
               title="Edit"
               aria-label="Edit"
@@ -2597,7 +2597,7 @@ function NeedsInputNotice({
               {question.options?.length ? (
                 <div className="work-a2ui-chips">
                   {question.options.map((option) => (
-                    <button
+                    <button data-ui-bespoke-reason="work composer and thread chrome"
                       key={option.label}
                       type="button"
                       className="work-choice-btn"
@@ -2609,7 +2609,7 @@ function NeedsInputNotice({
                   ))}
                 </div>
               ) : (
-                <button
+                <button data-ui-bespoke-reason="work composer and thread chrome"
                   type="button"
                   className="work-a2ui-button"
                   onClick={() => onRespond(`${question.question}\n\n`)}
@@ -2664,7 +2664,7 @@ function CapabilityDeniedNotice({
                 Ask OpenNeko to find the right integration. Installation will
                 still require your explicit approval.
               </p>
-              <button type="button" onClick={() => onRequest(requestPrompt)}>
+              <button data-ui-bespoke-reason="work composer and thread chrome" type="button" onClick={() => onRequest(requestPrompt)}>
                 Request secure integration
               </button>
             </>
@@ -2744,7 +2744,7 @@ function AnswerRunFooter({
           <span>Continue</span>
           <div>
             {followups.map((prompt) => (
-              <button
+              <button data-ui-bespoke-reason="work composer and thread chrome"
                 key={prompt}
                 type="button"
                 onClick={() => onFollowup(prompt)}
@@ -3008,7 +3008,7 @@ function ActionApprovalRow({
         </span>
         {pending && !rejectMode ? (
           <span className="work-action-row-actions">
-            <button
+            <button data-ui-bespoke-reason="work composer and thread chrome"
               type="button"
               disabled={busy}
               onClick={() => decide("approve")}
@@ -3016,7 +3016,7 @@ function ActionApprovalRow({
             >
               {busy ? "Approving…" : "Approve"}
             </button>
-            <button
+            <button data-ui-bespoke-reason="work composer and thread chrome"
               type="button"
               disabled={busy}
               onClick={() => setRejectMode(true)}
@@ -3027,7 +3027,7 @@ function ActionApprovalRow({
           </span>
         ) : null}
         {hasDetail ? (
-          <button
+          <button data-ui-bespoke-reason="work composer and thread chrome"
             type="button"
             className="work-action-row-detail-toggle"
             onClick={() => setOpen((value) => !value)}
@@ -3040,7 +3040,7 @@ function ActionApprovalRow({
 
       {pending && rejectMode ? (
         <div className="work-action-row-decision">
-          <input
+          <input data-ui-bespoke-reason="work composer and thread chrome"
             type="text"
             placeholder="Reason (optional, shown to the agent)"
             value={rejectReason}
@@ -3048,7 +3048,7 @@ function ActionApprovalRow({
             disabled={busy}
           />
           <div className="work-action-row-actions">
-            <button
+            <button data-ui-bespoke-reason="work composer and thread chrome"
               type="button"
               disabled={busy}
               onClick={() => decide("reject")}
@@ -3056,7 +3056,7 @@ function ActionApprovalRow({
             >
               {busy ? "Rejecting…" : "Confirm reject"}
             </button>
-            <button
+            <button data-ui-bespoke-reason="work composer and thread chrome"
               type="button"
               disabled={busy}
               onClick={() => {
@@ -3131,7 +3131,7 @@ function ToolGroup({
 
   return (
     <div className="work-tool-group">
-      <button
+      <button data-ui-bespoke-reason="work composer and thread chrome"
         type="button"
         className="work-tool-group-head"
         onClick={() => setOpen((v) => !v)}
@@ -3201,7 +3201,7 @@ function RegularToolRow({ tool }: { tool: ToolItem }) {
 
   return (
     <div className={`work-tool-row work-tool-row-${status}`}>
-      <button
+      <button data-ui-bespoke-reason="work composer and thread chrome"
         type="button"
         className="work-tool-row-head"
         onClick={() => hasDetail && setOpen((v) => !v)}

--- a/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
+++ b/apps/web/src/app/(work)/workflows/WorkflowsPage.tsx
@@ -11,6 +11,7 @@ import { formatSavedShort } from "@/lib/hours-saved";
 import { Sparkline } from "@/components/Sparkline";
 import PageHeading from "@/components/PageHeading";
 import { Button, IconButton } from "@/components/ui/Button";
+import { EmptyState } from "@/components/ui/EmptyState";
 
 type WorkflowListItem = {
   id: string;
@@ -289,7 +290,7 @@ export default function WorkflowsPage() {
         <div className="workflow-page-state is-error" role="alert">
           <strong>Workflows could not be loaded</strong>
           <span>{error}</span>
-          <button type="button" onClick={() => void fetchList()}>
+          <button data-ui-bespoke-reason="workflow inspector chrome" type="button" onClick={() => void fetchList()}>
             Retry
           </button>
         </div>
@@ -300,20 +301,23 @@ export default function WorkflowsPage() {
           <span className="workflow-loading-line is-short" />
         </div>
       ) : workflows.length === 0 ? (
-        <div className="workflow-page-state is-empty">
-          <strong>No workflows</strong>
-          <span>Ask OpenNeko to create the first recurring task.</span>
-          <button
-            type="button"
-            onClick={() =>
-              router.push(
-                `/work?seed=${encodeURIComponent("Set up a new workflow that ")}`,
-              )
-            }
-          >
-            Create a workflow
-          </button>
-        </div>
+        <EmptyState
+          className="workflow-page-state is-empty"
+          title="No workflows"
+          body="Ask OpenNeko to create the first recurring task."
+          action={
+            <Button
+              variant="primary"
+              onClick={() =>
+                router.push(
+                  `/work?seed=${encodeURIComponent("Set up a new workflow that ")}`,
+                )
+              }
+            >
+              Create a workflow
+            </Button>
+          }
+        />
       ) : (
         <div
           className={cn(
@@ -365,7 +369,7 @@ export default function WorkflowsPage() {
 
           {selectedWorkflow ? (
             <>
-              <button
+              <button data-ui-bespoke-reason="workflow inspector chrome"
                 type="button"
                 className="workflow-inspector-scrim"
                 aria-label="Close workflow details"
@@ -418,7 +422,7 @@ export default function WorkflowsPage() {
                       )}
                     </p>
                   </div>
-                  <button
+                  <button data-ui-bespoke-reason="workflow inspector chrome"
                     type="button"
                     className="workflow-inspector-close"
                     onClick={() => select(null)}
@@ -533,7 +537,7 @@ function WorkflowRow({
     >
       <div className={`workflows-row${active ? " is-active" : ""}`}>
         <span className="workflows-route-node" aria-hidden="true" />
-        <button
+        <button data-ui-bespoke-reason="workflow inspector chrome"
           type="button"
           className="workflows-row-main"
           onClick={onSelect}
@@ -709,7 +713,7 @@ function WorkflowDetail({
         <div className="workflow-detail-state is-error" role="alert">
           <strong>Details could not be loaded</strong>
           <span>{error}</span>
-          <button type="button" onClick={() => void load()}>
+          <button data-ui-bespoke-reason="workflow inspector chrome" type="button" onClick={() => void load()}>
             Retry
           </button>
         </div>
@@ -840,7 +844,7 @@ function WorkflowDetail({
           </span>
           {workflow.cron && (
             <label className="inline-flex items-center gap-1.5 text-xs text-text3 cursor-pointer">
-              <input
+              <input data-ui-bespoke-reason="workflow inspector chrome"
                 type="checkbox"
                 checked={workflow.cronEnabled}
                 onChange={toggleCron}
@@ -908,7 +912,7 @@ function WorkflowDetail({
           <ul className="list-none p-0 m-0 flex flex-col gap-1.5">
             {recentRuns.map((r) => (
               <li key={r.id} className="flex items-baseline gap-2 text-ui-body-sm">
-                <button
+                <button data-ui-bespoke-reason="workflow inspector chrome"
                   type="button"
                   className="workflow-drawer-run-link"
                   onClick={() => router.push(`/runs/${r.id}`)}
@@ -970,7 +974,7 @@ function WorkflowDetail({
 
       <div className="workflow-detail-foot">
         {workflow.createdByThreadId ? (
-          <button
+          <button data-ui-bespoke-reason="workflow inspector chrome"
             type="button"
             className="bg-transparent border-0 text-text3 cursor-pointer text-xs font-semibold py-1 px-0 hover:text-accent hover:underline hover:underline-offset-[3px]"
             onClick={() => router.push(`/work/${workflow.createdByThreadId}`)}
@@ -980,7 +984,7 @@ function WorkflowDetail({
         ) : (
           <span />
         )}
-        <button
+        <button data-ui-bespoke-reason="workflow inspector chrome"
           type="button"
           className="bg-transparent border-0 text-accent cursor-pointer text-xs font-semibold py-1 px-0 hover:underline hover:underline-offset-[3px]"
           onClick={() =>

--- a/apps/web/src/app/a/[app]/[object]/page.tsx
+++ b/apps/web/src/app/a/[app]/[object]/page.tsx
@@ -217,18 +217,18 @@ export default async function RecordObjectPage({
         </div>
         <form className="records-search" action={base} method="get">
           <Search aria-hidden="true" />
-          <input
+          <input data-ui-bespoke-reason="records list search and hidden query fields"
             type="search"
             name="q"
             defaultValue={query.q}
             placeholder={`Search ${result.view.object.pluralLabel.toLowerCase()}`}
             aria-label={`Search ${result.view.object.pluralLabel}`}
           />
-          {query.sort && <input type="hidden" name="sort" value={query.sort} />}
-          {query.direction && <input type="hidden" name="direction" value={query.direction} />}
-          {query.mine && <input type="hidden" name="mine" value={query.mine} />}
-          {query.filter && <input type="hidden" name="filter" value={query.filter} />}
-          {query.view && <input type="hidden" name="view" value={query.view} />}
+          {query.sort && <input data-ui-bespoke-reason="records list search and hidden query fields" type="hidden" name="sort" value={query.sort} />}
+          {query.direction && <input data-ui-bespoke-reason="records list search and hidden query fields" type="hidden" name="direction" value={query.direction} />}
+          {query.mine && <input data-ui-bespoke-reason="records list search and hidden query fields" type="hidden" name="mine" value={query.mine} />}
+          {query.filter && <input data-ui-bespoke-reason="records list search and hidden query fields" type="hidden" name="filter" value={query.filter} />}
+          {query.view && <input data-ui-bespoke-reason="records list search and hidden query fields" type="hidden" name="view" value={query.view} />}
         </form>
         {result.view.permission.canCreate && (
           <Link

--- a/apps/web/src/app/a/[app]/[object]/recycle/page.tsx
+++ b/apps/web/src/app/a/[app]/[object]/recycle/page.tsx
@@ -85,7 +85,7 @@ export default async function RecordRecyclePage({
         </div>
         <form className="records-search" action={recycleBase} method="get">
           <Search aria-hidden="true" />
-          <input
+          <input data-ui-bespoke-reason="records list search and hidden query fields"
             type="search"
             name="q"
             defaultValue={query.q}

--- a/apps/web/src/app/actions/[actionRequestId]/page.tsx
+++ b/apps/web/src/app/actions/[actionRequestId]/page.tsx
@@ -288,7 +288,7 @@ export default function ActionPage() {
                   <span className="text-text3/70"> · </span>
                   <span>
                     by workflow{" "}
-                    <button
+                    <button data-ui-bespoke-reason="action receipt controls"
                       type="button"
                       className="bg-transparent border-0 cursor-pointer font-inherit p-0 font-semibold text-text underline underline-offset-2 hover:text-accent"
                       onClick={() =>
@@ -360,7 +360,7 @@ export default function ActionPage() {
             </Field>
 
             <Field label="Payload">
-              <button
+              <button data-ui-bespoke-reason="action receipt controls"
                 type="button"
                 className="bg-transparent border-0 p-0 font-inherit text-accent underline underline-offset-2 cursor-pointer"
                 onClick={() => setShowPayload((s) => !s)}
@@ -381,7 +381,7 @@ export default function ActionPage() {
             {workflow && ar.workflowRunId && (
               <p className="m-0 mb-2 text-ui-body text-text2 leading-[1.55]">
                 Proposed by workflow{" "}
-                <button
+                <button data-ui-bespoke-reason="action receipt controls"
                   type="button"
                   className="bg-transparent border-0 cursor-pointer font-inherit p-0 font-semibold text-text underline underline-offset-2 hover:text-accent"
                   onClick={() => router.push(`/runs/${ar.workflowRunId}`)}
@@ -398,7 +398,7 @@ export default function ActionPage() {
                 {upstreamOutput.workflowRunId && (
                   <>
                     {" "}in{" "}
-                    <button
+                    <button data-ui-bespoke-reason="action receipt controls"
                       type="button"
                       className="bg-transparent border-0 cursor-pointer font-inherit p-0 font-semibold text-text underline underline-offset-2 hover:text-accent"
                       onClick={() =>
@@ -421,7 +421,7 @@ export default function ActionPage() {
                 <label className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3">
                   Why are you rejecting this? (optional)
                 </label>
-                <textarea
+                <textarea data-ui-bespoke-reason="action receipt controls"
                   className="border border-border rounded-[10px] px-3 py-2 font-body text-ui-body-sm text-text bg-card resize-y min-h-[50px] outline-none focus:border-accent"
                   value={rejectReason}
                   placeholder="e.g. wrong channel, retry tomorrow…"

--- a/apps/web/src/app/admin/settings/SetupWizard.tsx
+++ b/apps/web/src/app/admin/settings/SetupWizard.tsx
@@ -5,12 +5,11 @@ import EntryShell from "@/components/EntryShell";
 import { toast } from "sonner";
 import Select from "@/components/Select";
 import { Button } from "@/components/ui/Button";
-
-const INPUT_CLS =
-  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
+import { Checkbox } from "@/components/ui/Checkbox";
+import { Field, Input } from "@/components/ui/Field";
 
 type ProviderOption = { value: string; label: string; description: string };
-type Field = {
+type ProviderField = {
   key: string;
   label: string;
   kind: "text" | "secret" | "url";
@@ -34,7 +33,7 @@ type SettingsPayload = {
   research: ProviderConfig;
   options: { primary: readonly ProviderOption[]; research: readonly ProviderOption[] };
   defaults: { primary: Record<string, string>; research: Record<string, string> };
-  fields: { primary: Record<string, Field[]>; research: Record<string, Field[]> };
+  fields: { primary: Record<string, ProviderField[]>; research: Record<string, ProviderField[]> };
 };
 
 type AgentSettingsPayload = {
@@ -136,9 +135,9 @@ export default function SetupWizard({ initial }: { initial: Initial }) {
     return [...initial.providers.options.primary];
   }, [initial.providers.options.primary]);
 
-  const primaryFields: Field[] =
+  const primaryFields: ProviderField[] =
     initial.providers.fields.primary[primary.provider] ?? [];
-  const researchFields: Field[] =
+  const researchFields: ProviderField[] =
     initial.providers.fields.research[research.provider] ?? [];
 
   const onPrimaryProviderChange = (next: string) => {
@@ -404,28 +403,31 @@ export default function SetupWizard({ initial }: { initial: Initial }) {
           title="Choose a database password"
           description="OpenNeko's storage ships with a default password. Pick something only you know — you won't need to enter it again."
         >
-          <Field label="New password (min 8 chars)">
-            <input
-              className={INPUT_CLS}
+          <Field label="New password (min 8 chars)" htmlFor="setup-new-password">
+            <Input
+              id="setup-new-password"
               type="password"
               value={newPassword}
               autoComplete="new-password"
               onChange={(e) => setNewPassword(e.target.value)}
             />
           </Field>
-          <Field label="Confirm password">
-            <input
-              className={INPUT_CLS}
+          <Field
+            label="Confirm password"
+            htmlFor="setup-confirm-password"
+            error={
+              confirmPassword.length > 0 && confirmPassword !== newPassword
+                ? "Passwords don't match."
+                : undefined
+            }
+          >
+            <Input
+              id="setup-confirm-password"
               type="password"
               value={confirmPassword}
               autoComplete="new-password"
               onChange={(e) => setConfirmPassword(e.target.value)}
             />
-            {confirmPassword.length > 0 && confirmPassword !== newPassword && (
-              <span className="text-ui-body-sm text-[#c33] leading-[1.45]">
-                Passwords don&apos;t match.
-              </span>
-            )}
           </Field>
           <div className="flex justify-end gap-2.5 mt-5 max-[720px]:flex-col max-[720px]:items-stretch [&>button]:max-[720px]:w-full">
             <Button
@@ -448,9 +450,13 @@ export default function SetupWizard({ initial }: { initial: Initial }) {
           title="Connect your data"
           description="Graphjin server endpoint OpenNeko should connect to."
         >
-          <Field label="GraphJin URL *">
-            <input
-              className={INPUT_CLS}
+          <Field
+            label="GraphJin URL *"
+            htmlFor="setup-graphjin-url"
+            hint="Just the base URL. OpenNeko handles the GraphQL and MCP endpoints automatically."
+          >
+            <Input
+              id="setup-graphjin-url"
               value={data.rootUrl}
               placeholder="http://localhost:8080"
               onChange={(e) => {
@@ -458,13 +464,10 @@ export default function SetupWizard({ initial }: { initial: Initial }) {
                 setData((p) => ({ ...p, rootUrl: e.target.value }));
               }}
             />
-            <span className="text-ui-body-sm text-text3 leading-[1.45]">
-              Just the base URL — OpenNeko handles the GraphQL and MCP endpoints automatically.
-            </span>
           </Field>
-          <Field label="Label">
-            <input
-              className={INPUT_CLS}
+          <Field label="Label" htmlFor="setup-data-label">
+            <Input
+              id="setup-data-label"
               value={data.label}
               placeholder="primary"
               onChange={(e) => setData((p) => ({ ...p, label: e.target.value }))}
@@ -503,9 +506,9 @@ export default function SetupWizard({ initial }: { initial: Initial }) {
                 ariaLabel="Primary provider"
               />
             </Field>
-            <Field label="Model">
-              <input
-                className={INPUT_CLS}
+            <Field label="Model" htmlFor="setup-primary-model">
+              <Input
+                id="setup-primary-model"
                 value={primary.model}
                 onChange={(e) => setPrimary((p) => ({ ...p, model: e.target.value }))}
               />
@@ -531,18 +534,19 @@ export default function SetupWizard({ initial }: { initial: Initial }) {
             />
           ))}
 
-          <Field label="Concurrent jobs">
-            <input
-              className={INPUT_CLS}
+          <Field
+            label="Concurrent jobs"
+            htmlFor="setup-concurrent-jobs"
+            hint="How many metric jobs the worker runs in parallel. Worker restart applies changes."
+          >
+            <Input
+              id="setup-concurrent-jobs"
               type="number"
               min={1}
               max={1000}
               value={concurrentJobs}
               onChange={(e) => setConcurrentJobs(e.target.value)}
             />
-            <span className="text-ui-body-sm text-text3 leading-[1.45]">
-              How many metric jobs the worker runs in parallel. Worker restart applies changes.
-            </span>
           </Field>
 
           <InlineError message={primaryError} />
@@ -567,14 +571,13 @@ export default function SetupWizard({ initial }: { initial: Initial }) {
           title="Research (optional)"
           description="Lets the system pull industry context from Perplexity once your business team submits the onboarding profile. Leave the toggle off to set this up later."
         >
-          <label className="inline-flex items-center gap-2.5 mt-[18px] text-text2 text-ui-body-lg">
-            <input
-              type="checkbox"
+          <div className="mt-[18px]">
+            <Checkbox
+              label="Enable industry research"
               checked={researchEnabled}
               onChange={(e) => setResearchEnabled(e.target.checked)}
             />
-            <span>Enable industry research</span>
-          </label>
+          </div>
 
           {researchEnabled && (
             <>
@@ -596,9 +599,9 @@ export default function SetupWizard({ initial }: { initial: Initial }) {
                     ariaLabel="Research provider"
                   />
                 </Field>
-                <Field label="Model">
-                  <input
-                    className={INPUT_CLS}
+                <Field label="Model" htmlFor="setup-research-model">
+                  <Input
+                    id="setup-research-model"
                     value={research.model}
                     onChange={(e) => setResearch((p) => ({ ...p, model: e.target.value }))}
                   />
@@ -674,21 +677,12 @@ function Step({
   );
 }
 
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
-  return (
-    <label className="flex flex-col gap-2">
-      <span className="text-ui-body font-semibold text-text">{label}</span>
-      {children}
-    </label>
-  );
-}
-
 function InlineError({ message }: { message: string | null }) {
   if (!message) return null;
   return (
     <div
       role="alert"
-      className="rounded-2xl px-4 py-3.5 mt-3.5 text-ui-body leading-[1.5] bg-[#fff0ee] border border-[#f2c9c3] text-[#9a4035]"
+      className="rounded-2xl px-4 py-3.5 mt-3.5 text-ui-body leading-[1.5] bg-danger-soft border border-danger/30 text-danger"
     >
       {message}
     </div>
@@ -700,25 +694,27 @@ function ProviderFieldInput({
   value,
   onChange,
 }: {
-  field: Field;
+  field: ProviderField;
   value: string;
   onChange: (v: string) => void;
 }) {
+  const id = `setup-provider-${field.key}`;
   return (
-    <label className="flex flex-col gap-2">
-      <span className="text-ui-body font-semibold text-text">
-        {field.label}
-        {field.required ? " *" : ""}
-      </span>
-      <input
-        className={INPUT_CLS}
+    <Field
+      label={`${field.label}${field.required ? " *" : ""}`}
+      htmlFor={id}
+      hint={field.help}
+    >
+      <Input
+        id={id}
         type={field.kind === "secret" ? "password" : "text"}
         value={value}
         placeholder={field.placeholder}
+        autoComplete={field.kind === "secret" ? "off" : undefined}
+        spellCheck={false}
         onChange={(e) => onChange(e.target.value)}
       />
-      {field.help && <span className="text-ui-body-sm text-text3 leading-[1.45]">{field.help}</span>}
-    </label>
+    </Field>
   );
 }
 

--- a/apps/web/src/app/admin/settings/agent/AgentForm.tsx
+++ b/apps/web/src/app/admin/settings/agent/AgentForm.tsx
@@ -6,9 +6,10 @@ import PageHeading from "@/components/PageHeading";
 import { toast } from "sonner";
 import Select from "@/components/Select";
 import { Button } from "@/components/ui/Button";
+import { Field, Input } from "@/components/ui/Field";
 
 type ProviderOption = { value: string; label: string; description: string };
-type Field = {
+type ProviderField = {
   key: string;
   label: string;
   kind: "text" | "secret" | "url";
@@ -30,14 +31,8 @@ type SettingsPayload = {
   research: ProviderConfig;
   options: { primary: readonly ProviderOption[]; research: readonly ProviderOption[] };
   defaults: { primary: Record<string, string>; research: Record<string, string> };
-  fields: { primary: Record<string, Field[]>; research: Record<string, Field[]> };
+  fields: { primary: Record<string, ProviderField[]>; research: Record<string, ProviderField[]> };
 };
-const INPUT_CLS =
-  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
-const FIELD_CLS = "flex flex-col gap-2";
-const LABEL_CLS = "text-ui-body font-semibold text-text";
-const HELP_CLS = "text-ui-body-sm text-text3 leading-[1.45]";
-
 type AgentSettingsPayload = {
   agent: {
     source: "org" | "default";
@@ -67,7 +62,7 @@ export default function AgentForm({
     [initial.providers.options.primary],
   );
 
-  const fields: Field[] = initial.providers.fields.primary[primary.provider] ?? [];
+  const fields: ProviderField[] = initial.providers.fields.primary[primary.provider] ?? [];
 
   const onPrimaryProviderChange = (next: string) => {
     setPrimary({
@@ -139,39 +134,38 @@ export default function AgentForm({
       <section className="settings-card">
         <div className="grid gap-4 mt-4">
           <div className="settings-grid">
-            <label className={FIELD_CLS}>
-              <span className={LABEL_CLS}>Provider</span>
+            <Field label="Provider">
               <Select
+                id="agent-provider"
                 value={primary.provider}
                 onChange={onPrimaryProviderChange}
                 options={providerOptions}
                 ariaLabel="Primary provider"
               />
-            </label>
-            <label className={FIELD_CLS}>
-              <span className={LABEL_CLS}>Model</span>
-              <input
-                className={INPUT_CLS}
+            </Field>
+            <Field label="Model" htmlFor="agent-model">
+              <Input
+                id="agent-model"
                 value={primary.model}
                 onChange={(e) => setPrimary((p) => ({ ...p, model: e.target.value }))}
               />
-            </label>
+            </Field>
           </div>
 
-          <label className={FIELD_CLS}>
-            <span className={LABEL_CLS}>Concurrent jobs</span>
-            <input
-              className={INPUT_CLS}
+          <Field
+            label="Concurrent jobs"
+            htmlFor="agent-concurrent-jobs"
+            hint="How many metric jobs the worker runs in parallel. Worker restart applies changes."
+          >
+            <Input
+              id="agent-concurrent-jobs"
               type="number"
               min={1}
               max={1000}
               value={concurrentJobs}
               onChange={(e) => setConcurrentJobs(e.target.value)}
             />
-            <span className={HELP_CLS}>
-              How many metric jobs the worker runs in parallel. Worker restart applies changes.
-            </span>
-          </label>
+          </Field>
 
           {fields.map((field) => {
             const masked = primary.secretStatus[field.key];
@@ -181,16 +175,19 @@ export default function AgentForm({
               : (primary.config[field.key] as string) ?? "";
 
             return (
-              <label key={field.key} className={FIELD_CLS}>
-                <span className={LABEL_CLS}>
-                  {field.label}
-                  {field.required ? " *" : ""}
-                </span>
-                <input
-                  className={INPUT_CLS}
+              <Field
+                key={field.key}
+                label={`${field.label}${field.required ? " *" : ""}`}
+                htmlFor={`agent-field-${field.key}`}
+                hint={field.help}
+              >
+                <Input
+                  id={`agent-field-${field.key}`}
                   type={field.kind === "secret" ? "password" : "text"}
                   value={value}
                   placeholder={field.placeholder}
+                  autoComplete={isSecret ? "off" : undefined}
+                  spellCheck={false}
                   onChange={(e) => {
                     if (isSecret) {
                       setPrimary((p) => ({
@@ -206,13 +203,13 @@ export default function AgentForm({
                     }
                   }}
                 />
-                {field.help && <span className={HELP_CLS}>{field.help}</span>}
                 {isSecret && masked && !primary.clearedSecrets[field.key] && (
                   <div className="flex items-center justify-between gap-3">
                     <span className="text-text3 text-ui-body-sm">Saved: {masked}</span>
-                    <button
+                    <Button
                       type="button"
-                      className="border-0 bg-transparent text-[#b05555] cursor-pointer text-ui-body-sm font-semibold"
+                      variant="danger"
+                      size="sm"
                       onClick={() =>
                         setPrimary((p) => ({
                           ...p,
@@ -222,10 +219,10 @@ export default function AgentForm({
                       }
                     >
                       Clear saved value
-                    </button>
+                    </Button>
                   </div>
                 )}
-              </label>
+              </Field>
             );
           })}
         </div>

--- a/apps/web/src/app/admin/settings/data/DataSourceForm.tsx
+++ b/apps/web/src/app/admin/settings/data/DataSourceForm.tsx
@@ -5,6 +5,7 @@ import AppHeader from "@/components/AppHeader";
 import PageHeading from "@/components/PageHeading";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/Button";
+import { Field, Input } from "@/components/ui/Field";
 
 type DataSourcePayload = {
   source: "org" | "unset";
@@ -13,12 +14,6 @@ type DataSourcePayload = {
   mcpUrl: string;
   label: string;
 };
-
-const INPUT_CLS =
-  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
-const FIELD_CLS = "flex flex-col gap-2";
-const LABEL_CLS = "text-ui-body font-semibold text-text";
-const HELP_CLS = "text-ui-body-sm text-text3 leading-[1.45]";
 
 const GRAPHQL_SUFFIX = "/api/v1/graphql";
 const MCP_SUFFIX = "/api/v1/mcp";
@@ -98,27 +93,26 @@ export default function DataSourceForm({ initial }: { initial: DataSourcePayload
 
       <section className="settings-card">
         <div className="grid gap-4 mt-4">
-          <label className={FIELD_CLS}>
-            <span className={LABEL_CLS}>GraphJin URL *</span>
-            <input
-              className={INPUT_CLS}
+          <Field
+            label="GraphJin URL *"
+            htmlFor="graphjin-url"
+            hint="Just the base URL. OpenNeko handles the GraphQL and MCP endpoints automatically."
+          >
+            <Input
+              id="graphjin-url"
               value={data.rootUrl}
               placeholder="http://localhost:8080"
               onChange={(e) => setData((p) => ({ ...p, rootUrl: e.target.value }))}
             />
-            <span className={HELP_CLS}>
-              Just the base URL — OpenNeko handles the GraphQL and MCP endpoints automatically.
-            </span>
-          </label>
-          <label className={FIELD_CLS}>
-            <span className={LABEL_CLS}>Label</span>
-            <input
-              className={INPUT_CLS}
+          </Field>
+          <Field label="Label" htmlFor="data-source-label">
+            <Input
+              id="data-source-label"
               value={data.label}
               placeholder="primary"
               onChange={(e) => setData((p) => ({ ...p, label: e.target.value }))}
             />
-          </label>
+          </Field>
         </div>
         <div className="flex justify-end gap-2.5 mt-5 max-[720px]:flex-col max-[720px]:items-stretch [&>button]:max-[720px]:w-full">
           <Button onClick={test} disabled={testing || !data.rootUrl.trim()}>

--- a/apps/web/src/app/admin/settings/graphjin/GraphjinConfigControls.tsx
+++ b/apps/web/src/app/admin/settings/graphjin/GraphjinConfigControls.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
+import { Checkbox } from "@/components/ui/Checkbox";
 
 type GraphjinConfigSettings = {
   sourceConfigEnabled: boolean;
@@ -66,19 +67,14 @@ export default function GraphjinConfigControls({
         </span>
       </div>
 
-      <label className="mt-4 flex cursor-pointer items-start gap-3 text-sm text-text2">
-        <input
-          type="checkbox"
+      <div className="mt-4">
+        <Checkbox
           checked={enabled}
           disabled={saving}
           onChange={(e) => void toggle(e.target.checked)}
-          className="mt-1 h-4 w-4 cursor-pointer disabled:cursor-not-allowed"
+          label="Enable GraphJin config tools for admin Ask sessions and approved MCP action execution."
         />
-        <span>
-          Enable GraphJin config tools for admin Ask sessions and approved MCP
-          action execution.
-        </span>
-      </label>
+      </div>
     </section>
   );
 }

--- a/apps/web/src/app/admin/settings/graphjin/SourceSecretsPanel.tsx
+++ b/apps/web/src/app/admin/settings/graphjin/SourceSecretsPanel.tsx
@@ -3,17 +3,13 @@
 import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/Button";
+import { Field, Input } from "@/components/ui/Field";
 
 type SourceSecretSummary = {
   name: string;
   description: string | null;
   updatedAt: string;
 };
-
-const INPUT_CLS =
-  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
-const FIELD_CLS = "flex flex-col gap-2";
-const LABEL_CLS = "text-ui-body font-semibold text-text";
 
 export default function SourceSecretsPanel({
   initialSecrets,
@@ -94,34 +90,35 @@ export default function SourceSecretsPanel({
       </div>
 
       <div className="grid gap-3 md:grid-cols-[1fr_1fr_1.2fr_auto]">
-        <label className={FIELD_CLS}>
-          <span className={LABEL_CLS}>Name</span>
-          <input
-            className={INPUT_CLS}
+        <Field label="Name" htmlFor="source-secret-name">
+          <Input
+            id="source-secret-name"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="WAREHOUSE_DB_PASSWORD"
+            spellCheck={false}
+            autoComplete="off"
           />
-        </label>
-        <label className={FIELD_CLS}>
-          <span className={LABEL_CLS}>Description</span>
-          <input
-            className={INPUT_CLS}
+        </Field>
+        <Field label="Description" htmlFor="source-secret-description">
+          <Input
+            id="source-secret-description"
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             placeholder="Warehouse read user"
           />
-        </label>
-        <label className={FIELD_CLS}>
-          <span className={LABEL_CLS}>Value</span>
-          <input
-            className={INPUT_CLS}
+        </Field>
+        <Field label="Value" htmlFor="source-secret-value">
+          <Input
+            id="source-secret-value"
             type="password"
             value={value}
             onChange={(e) => setValue(e.target.value)}
             placeholder="Stored encrypted"
+            autoComplete="off"
+            spellCheck={false}
           />
-        </label>
+        </Field>
         <div className="flex items-end">
           <Button
             type="button"
@@ -152,14 +149,15 @@ export default function SourceSecretsPanel({
               <span className="text-xs text-text3">
                 {formatDate(secret.updatedAt)}
               </span>
-              <button
+              <Button
                 type="button"
-                className="border-0 bg-transparent p-0 text-xs font-semibold text-danger underline disabled:cursor-not-allowed disabled:opacity-50"
+                variant="danger"
+                size="sm"
                 disabled={saving}
                 onClick={() => void deleteSecret(secret.name)}
               >
                 Remove
-              </button>
+              </Button>
             </div>
           ))
         )}

--- a/apps/web/src/app/admin/settings/research/ResearchForm.tsx
+++ b/apps/web/src/app/admin/settings/research/ResearchForm.tsx
@@ -6,9 +6,11 @@ import PageHeading from "@/components/PageHeading";
 import { toast } from "sonner";
 import Select from "@/components/Select";
 import { Button } from "@/components/ui/Button";
+import { Checkbox } from "@/components/ui/Checkbox";
+import { Field, Input } from "@/components/ui/Field";
 
 type ProviderOption = { value: string; label: string; description: string };
-type Field = {
+type ProviderField = {
   key: string;
   label: string;
   kind: "text" | "secret" | "url";
@@ -25,18 +27,12 @@ type ProviderConfig = {
   config: Record<string, unknown>;
   secretStatus: Record<string, string>;
 };
-const INPUT_CLS =
-  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
-const FIELD_CLS = "flex flex-col gap-2";
-const LABEL_CLS = "text-ui-body font-semibold text-text";
-const HELP_CLS = "text-ui-body-sm text-text3 leading-[1.45]";
-
 type SettingsPayload = {
   primary: ProviderConfig;
   research: ProviderConfig;
   options: { primary: readonly ProviderOption[]; research: readonly ProviderOption[] };
   defaults: { primary: Record<string, string>; research: Record<string, string> };
-  fields: { primary: Record<string, Field[]>; research: Record<string, Field[]> };
+  fields: { primary: Record<string, ProviderField[]>; research: Record<string, ProviderField[]> };
 };
 
 export default function ResearchForm({ initial }: { initial: SettingsPayload }) {
@@ -61,7 +57,7 @@ export default function ResearchForm({ initial }: { initial: SettingsPayload }) 
   });
   const [saving, setSaving] = useState(false);
 
-  const fields: Field[] = initial.fields.research[research.provider] ?? [];
+  const fields: ProviderField[] = initial.fields.research[research.provider] ?? [];
   const providerOptions = initial.options.research.filter((o) => o.value !== "disabled");
 
   async function save() {
@@ -120,21 +116,20 @@ export default function ResearchForm({ initial }: { initial: SettingsPayload }) 
       />
 
       <section className="settings-card">
-        <label className="inline-flex items-center gap-2.5 mt-[18px] text-text2 text-ui-body-lg">
-          <input
-            type="checkbox"
+        <div className="mt-[18px]">
+          <Checkbox
+            label="Enable industry research"
             checked={enabled}
             onChange={(e) => setEnabled(e.target.checked)}
           />
-          <span>Enable industry research</span>
-        </label>
+        </div>
 
         {enabled && (
           <div className="grid gap-4 mt-4">
             <div className="settings-grid">
-              <label className={FIELD_CLS}>
-                <span className={LABEL_CLS}>Provider</span>
+              <Field label="Provider">
                 <Select
+                  id="research-provider"
                   value={research.provider}
                   onChange={(v) =>
                     setResearch({
@@ -149,15 +144,14 @@ export default function ResearchForm({ initial }: { initial: SettingsPayload }) 
                   options={providerOptions}
                   ariaLabel="Research provider"
                 />
-              </label>
-              <label className={FIELD_CLS}>
-                <span className={LABEL_CLS}>Model</span>
-                <input
-                  className={INPUT_CLS}
+              </Field>
+              <Field label="Model" htmlFor="research-model">
+                <Input
+                  id="research-model"
                   value={research.model}
                   onChange={(e) => setResearch((p) => ({ ...p, model: e.target.value }))}
                 />
-              </label>
+              </Field>
             </div>
 
             {fields.map((field) => {
@@ -168,16 +162,19 @@ export default function ResearchForm({ initial }: { initial: SettingsPayload }) 
                 : (research.config[field.key] as string) ?? "";
 
               return (
-                <label key={field.key} className={FIELD_CLS}>
-                  <span className={LABEL_CLS}>
-                    {field.label}
-                    {field.required ? " *" : ""}
-                  </span>
-                  <input
-                    className={INPUT_CLS}
+                <Field
+                  key={field.key}
+                  label={`${field.label}${field.required ? " *" : ""}`}
+                  htmlFor={`research-field-${field.key}`}
+                  hint={field.help}
+                >
+                  <Input
+                    id={`research-field-${field.key}`}
                     type={field.kind === "secret" ? "password" : "text"}
                     value={value}
                     placeholder={field.placeholder}
+                    autoComplete={isSecret ? "off" : undefined}
+                    spellCheck={false}
                     onChange={(e) => {
                       if (isSecret) {
                         setResearch((p) => ({
@@ -193,13 +190,13 @@ export default function ResearchForm({ initial }: { initial: SettingsPayload }) 
                       }
                     }}
                   />
-                  {field.help && <span className={HELP_CLS}>{field.help}</span>}
                   {isSecret && masked && !research.clearedSecrets[field.key] && (
                     <div className="flex items-center justify-between gap-3">
                       <span className="text-text3 text-ui-body-sm">Saved: {masked}</span>
-                      <button
+                      <Button
                         type="button"
-                        className="border-0 bg-transparent text-[#b05555] cursor-pointer text-ui-body-sm font-semibold"
+                        variant="danger"
+                        size="sm"
                         onClick={() =>
                           setResearch((p) => ({
                             ...p,
@@ -209,10 +206,10 @@ export default function ResearchForm({ initial }: { initial: SettingsPayload }) 
                         }
                       >
                         Clear saved value
-                      </button>
+                      </Button>
                     </div>
                   )}
-                </label>
+                </Field>
               );
             })}
           </div>

--- a/apps/web/src/app/admin/settings/security/SecurityForm.tsx
+++ b/apps/web/src/app/admin/settings/security/SecurityForm.tsx
@@ -7,6 +7,8 @@ import CreatorCredit from "@/components/CreatorCredit";
 import PageHeading from "@/components/PageHeading";
 import SectionNav from "@/components/SectionNav";
 import { Button } from "@/components/ui/Button";
+import { Checkbox } from "@/components/ui/Checkbox";
+import { Field, Input } from "@/components/ui/Field";
 
 type InstallPolicy = {
   allowUnverified: boolean;
@@ -21,12 +23,6 @@ type InstallPolicyPayload = {
 
 const OFFICIAL_MARKETPLACE_URL =
   "https://open-neko.github.io/plugins/marketplace.json";
-
-const FIELD_CLS = "flex flex-col gap-2";
-const LABEL_CLS = "text-ui-body font-semibold text-text";
-const HELP_CLS = "text-ui-body-sm text-text3 leading-[1.45]";
-const INPUT_CLS =
-  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
 
 export default function SecurityForm({ initial }: { initial: InstallPolicyPayload }) {
   const [policy, setPolicy] = useState<InstallPolicy>(initial.policy);
@@ -123,13 +119,11 @@ export default function SecurityForm({ initial }: { initial: InstallPolicyPayloa
             onChange={(v) => toggle("allowGitUrlInstalls", v)}
           />
 
-          <div className={FIELD_CLS}>
-            <label className={LABEL_CLS}>Allowed marketplaces</label>
-            <p className={HELP_CLS}>
-              Marketplaces this deployment trusts. The official OpenNeko
-              marketplace is always trusted. Add community marketplaces by
-              URL.
-            </p>
+          <Field
+            label="Allowed marketplaces"
+            htmlFor="marketplace-url"
+            hint="Marketplaces this deployment trusts. The official OpenNeko marketplace is always trusted. Add community marketplaces by URL."
+          >
             <ul className="flex flex-col gap-2 mt-1">
               {policy.allowedMarketplaces.map((url) => (
                 <li
@@ -140,30 +134,33 @@ export default function SecurityForm({ initial }: { initial: InstallPolicyPayloa
                   {url === OFFICIAL_MARKETPLACE_URL ? (
                     <span className="text-ui-caption text-text3">official</span>
                   ) : (
-                    <button
+                    <Button
                       type="button"
-                      className="text-ui-caption text-text2 underline"
+                      variant="ghost"
+                      size="sm"
                       onClick={() => removeMarketplace(url)}
                     >
-                      remove
-                    </button>
+                      Remove
+                    </Button>
                   )}
                 </li>
               ))}
             </ul>
             <div className="flex gap-2 mt-2">
-              <input
+              <Input
+                id="marketplace-url"
                 type="url"
                 placeholder="https://example.com/marketplace.json"
                 value={newMarketplace}
                 onChange={(e) => setNewMarketplace(e.target.value)}
-                className={`${INPUT_CLS} flex-1`}
+                className="flex-1"
+                spellCheck={false}
               />
               <Button type="button" onClick={addMarketplace} variant="secondary">
                 Add
               </Button>
             </div>
-          </div>
+          </Field>
   
           <div className="flex justify-end mt-2">
             <Button type="button" onClick={save} disabled={saving}>
@@ -190,19 +187,13 @@ function Toggle({
   onChange: (v: boolean) => void;
 }) {
   return (
-    <div className={FIELD_CLS}>
-      <label className="flex items-start gap-3 cursor-pointer">
-        <input
-          type="checkbox"
-          checked={checked}
-          onChange={(e) => onChange(e.target.checked)}
-          className="mt-1 w-4 h-4 cursor-pointer"
-        />
-        <div className="flex flex-col gap-1">
-          <span className={LABEL_CLS}>{label}</span>
-          <span className={HELP_CLS}>{help}</span>
-        </div>
-      </label>
+    <div className="grid gap-1.5">
+      <Checkbox
+        label={label}
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+      />
+      <p className="pl-6 text-ui-caption leading-[var(--leading-compact)] text-text3">{help}</p>
     </div>
   );
 }

--- a/apps/web/src/app/admin/settings/signin/SignInSetupCard.tsx
+++ b/apps/web/src/app/admin/settings/signin/SignInSetupCard.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/Button";
+import { Input, NativeSelect } from "@/components/ui/Field";
 
 const MAGIC_LINK_PLUGIN = "@open-neko/plugin-magic-link";
 
@@ -269,38 +270,38 @@ function DeliverySection({
       <form onSubmit={save} className="flex flex-wrap items-end gap-3">
         <label className="flex flex-col gap-1 text-xs font-semibold text-text2">
           Provider
-          <select
+          <NativeSelect
             value={provider}
             onChange={(event) => setProvider(event.target.value as ProviderId)}
-            className="rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text"
           >
             {PROVIDERS.map((p) => (
               <option key={p.id} value={p.id}>
                 {p.label}
               </option>
             ))}
-          </select>
+          </NativeSelect>
         </label>
         <label className="flex flex-col gap-1 text-xs font-semibold text-text2">
           API key
-          <input
+          <Input
             type="password"
             value={apiKey}
             onChange={(event) => setApiKey(event.target.value)}
-            placeholder={keyStored ? "(stored — paste to replace)" : "paste the API key"}
+            placeholder={keyStored ? "(stored, paste to replace)" : "paste the API key"}
             autoComplete="off"
-            className="rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text"
+            spellCheck={false}
           />
         </label>
         <label className="flex flex-col gap-1 text-xs font-semibold text-text2">
           From address
-          <input
+          <Input
             type="text"
             required
             value={from}
             onChange={(event) => setFrom(event.target.value)}
-            placeholder='OpenNeko <signin@company.com>'
-            className="w-72 rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text"
+            placeholder="OpenNeko <signin@company.com>"
+            className="w-72"
+            spellCheck={false}
           />
         </label>
         <Button
@@ -396,27 +397,27 @@ function UsersSection({
       <form onSubmit={addUser} className="flex flex-wrap items-end gap-3">
         <label className="flex flex-col gap-1 text-xs font-semibold text-text2">
           Email
-          <input
+          <Input
             type="email"
             required
             value={email}
             onChange={(event) => setEmail(event.target.value)}
             placeholder="person@company.com"
-            className="w-72 rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text"
+            className="w-72"
+            autoComplete="email"
           />
         </label>
         <label className="flex flex-col gap-1 text-xs font-semibold text-text2">
           Role
-          <select
+          <NativeSelect
             value={role}
             onChange={(event) =>
               setRole(event.target.value === "admin" ? "admin" : "member")
             }
-            className="rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text"
           >
             <option value="admin">admin</option>
             <option value="member">member</option>
-          </select>
+          </NativeSelect>
         </label>
         <Button
           type="submit"
@@ -493,13 +494,14 @@ function TestSection({ status }: { status: Status }) {
       <form onSubmit={sendTest} className="flex flex-wrap items-end gap-3">
         <label className="flex flex-col gap-1 text-xs font-semibold text-text2">
           Send to
-          <input
+          <Input
             type="email"
             required
             value={email}
             onChange={(event) => setEmail(event.target.value)}
             placeholder="you@company.com"
-            className="w-72 rounded-md border border-border bg-surface px-3 py-2 text-sm font-normal text-text"
+            className="w-72"
+            autoComplete="email"
           />
         </label>
         <Button

--- a/apps/web/src/app/admin/settings/sso/SsoSetupForm.tsx
+++ b/apps/web/src/app/admin/settings/sso/SsoSetupForm.tsx
@@ -7,6 +7,7 @@ import CreatorCredit from "@/components/CreatorCredit";
 import PageHeading from "@/components/PageHeading";
 import SectionNav from "@/components/SectionNav";
 import { Button, ButtonLink } from "@/components/ui/Button";
+import { Input, NativeSelect } from "@/components/ui/Field";
 import type {
   SsoEnvironmentRow,
   SsoOrganizationRow,
@@ -14,9 +15,7 @@ import type {
   SsoSetupStatusResult,
 } from "@/lib/sso-setup";
 
-const HELP_CLS = "text-ui-body-sm text-text3 leading-[1.45]";
-const INPUT_CLS =
-  "px-[13px] py-[11px] sm:px-3.5 sm:py-[13px] rounded-xl border-[1.5px] border-border bg-bg text-text text-base sm:text-ui-body-lg font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.08)]";
+const copyClass = "text-ui-body-sm text-text3 leading-[1.45]";
 
 function StepHeader({
   step,
@@ -337,13 +336,13 @@ export default function SsoSetupForm({
         <section className="flex flex-col gap-6 mt-2">
           {loadError ? (
             <div className="rounded-xl border border-border bg-bg px-4 py-3">
-              <p className={HELP_CLS}>{loadError}</p>
+              <p className={copyClass}>{loadError}</p>
             </div>
           ) : null}
 
           {status?.lastError && status.status === "failed" ? (
             <div className="rounded-xl border border-red-300 bg-bg px-4 py-3">
-              <p className={HELP_CLS}>{status.lastError}</p>
+              <p className={copyClass}>{status.lastError}</p>
             </div>
           ) : null}
 
@@ -355,14 +354,14 @@ export default function SsoSetupForm({
               title="Authorize the Scalekit workspace"
             />
             {step1Done ? (
-              <p className={HELP_CLS}>
+              <p className={copyClass}>
                 Connected — the agent manages your Scalekit workspace
                 (environments, organizations, users, connections) with this
                 org-wide authorization.
               </p>
             ) : (
               <>
-                <p className={HELP_CLS}>
+                <p className={copyClass}>
                   Opens Scalekit in your browser. Sign in or create the account
                   there; the consent screen names the scopes and endpoint.
                 </p>
@@ -384,7 +383,7 @@ export default function SsoSetupForm({
             />
             {step2Done && editingStep !== 2 ? (
               <>
-                <p className={HELP_CLS}>
+                <p className={copyClass}>
                   {status?.environmentTier === "prod" ? "Production" : "Development"}
                   {" · "}
                   {status?.environmentId}
@@ -392,18 +391,19 @@ export default function SsoSetupForm({
                   {status?.organizationId}
                 </p>
                 <div>
-                  <button
+                  <Button
                     type="button"
-                    className="text-ui-caption text-text2 underline"
+                    variant="ghost"
+                    size="sm"
                     onClick={() => setEditingStep(2)}
                   >
                     Change
-                  </button>
+                  </Button>
                 </div>
               </>
             ) : (
               <>
-                <p className={HELP_CLS}>
+                <p className={copyClass}>
                   {pickerBusy
                     ? "Loading your Scalekit environments…"
                     : envOptions.length > 0
@@ -422,8 +422,8 @@ export default function SsoSetupForm({
                       Loading environments…
                     </span>
                   ) : envOptions.length > 0 ? (
-                    <select
-                      className={`${INPUT_CLS} flex-1 min-w-[240px]`}
+                    <NativeSelect
+                      className="flex-1 min-w-[240px]"
                       value={environmentId}
                       onChange={(e) => onEnvSelect(e.target.value)}
                     >
@@ -433,20 +433,20 @@ export default function SsoSetupForm({
                           {e.domain ? ` — ${e.domain}` : ""}
                         </option>
                       ))}
-                    </select>
+                    </NativeSelect>
                   ) : (
-                    <select
-                      className={`${INPUT_CLS} max-w-[180px]`}
+                    <NativeSelect
+                      className="max-w-[180px]"
                       value={tier}
                       onChange={(e) => setTier(e.target.value)}
                     >
                       <option value="dev">Development</option>
                       <option value="prod">Production</option>
-                    </select>
+                    </NativeSelect>
                   )}
                   {envOptions.length > 0 && orgOptions.length > 0 ? (
-                    <select
-                      className={`${INPUT_CLS} flex-1 min-w-[200px]`}
+                    <NativeSelect
+                      className="flex-1 min-w-[200px]"
                       value={organizationId}
                       onChange={(e) => setOrganizationId(e.target.value)}
                     >
@@ -455,21 +455,25 @@ export default function SsoSetupForm({
                           {o.name ?? o.id}
                         </option>
                       ))}
-                    </select>
+                    </NativeSelect>
                   ) : null}
                   {envOptions.length === 0 && (
                     <>
-                      <input
-                        className={`${INPUT_CLS} flex-1 min-w-[200px]`}
+                      <Input
+                        className="flex-1 min-w-[200px]"
                         placeholder="environmentId (env_…)"
                         value={environmentId}
                         onChange={(e) => setEnvironmentId(e.target.value)}
+                        spellCheck={false}
+                        autoComplete="off"
                       />
-                      <input
-                        className={`${INPUT_CLS} flex-1 min-w-[200px]`}
+                      <Input
+                        className="flex-1 min-w-[200px]"
                         placeholder="organizationId (org_…)"
                         value={organizationId}
                         onChange={(e) => setOrganizationId(e.target.value)}
+                        spellCheck={false}
+                        autoComplete="off"
                       />
                     </>
                   )}
@@ -493,20 +497,21 @@ export default function SsoSetupForm({
             <StepHeader step={3} done={step3Done} title="Sign-in credentials" />
             {step3Done && editingStep !== 3 ? (
               <>
-                <p className={HELP_CLS}>Stored in the encrypted vault.</p>
+                <p className={copyClass}>Stored in the encrypted vault.</p>
                 <div>
-                  <button
+                  <Button
                     type="button"
-                    className="text-ui-caption text-text2 underline"
+                    variant="ghost"
+                    size="sm"
                     onClick={() => setEditingStep(3)}
                   >
                     Replace
-                  </button>
+                  </Button>
                 </div>
               </>
             ) : (
               <>
-                <p className={HELP_CLS}>
+                <p className={copyClass}>
                   The agent fetches the environment URL and client id for you.
                   The client secret is shown only once — in Scalekit, under
                   Settings → API Credentials for the selected environment.
@@ -533,24 +538,30 @@ export default function SsoSetupForm({
                   >
                     Find the secret in Scalekit ↗
                   </ButtonLink>
-                  <input
-                    className={`${INPUT_CLS} flex-1 min-w-[220px]`}
+                  <Input
+                    className="flex-1 min-w-[220px]"
                     placeholder="https://your-app.scalekit.com"
                     value={environmentUrl}
                     onChange={(e) => setEnvironmentUrl(e.target.value)}
+                    spellCheck={false}
+                    autoComplete="off"
                   />
-                  <input
-                    className={`${INPUT_CLS} flex-1 min-w-[180px]`}
+                  <Input
+                    className="flex-1 min-w-[180px]"
                     placeholder="client_id (skc_…)"
                     value={clientId}
                     onChange={(e) => setClientId(e.target.value)}
+                    spellCheck={false}
+                    autoComplete="off"
                   />
-                  <input
+                  <Input
                     type="password"
-                    className={`${INPUT_CLS} flex-1 min-w-[180px]`}
+                    className="flex-1 min-w-[180px]"
                     placeholder="client_secret"
                     value={clientSecret}
                     onChange={(e) => setClientSecret(e.target.value)}
+                    autoComplete="off"
+                    spellCheck={false}
                   />
                   <Button
                     type="button"
@@ -575,7 +586,7 @@ export default function SsoSetupForm({
               title="Connect the identity provider"
             />
             {step4Done ? (
-              <p className={HELP_CLS}>
+              <p className={copyClass}>
                 SSO is live
                 {status?.provider ? ` via ${status.provider}` : ""}
                 {status?.setupCompletedAt
@@ -584,7 +595,7 @@ export default function SsoSetupForm({
               </p>
             ) : (
               <>
-                <p className={HELP_CLS}>
+                <p className={copyClass}>
                   Optional for the trial — sign-in already works through
                   Scalekit’s hosted login. Generate a portal link to connect
                   your company’s own IdP (Okta, Entra ID…): open it, follow the
@@ -593,7 +604,7 @@ export default function SsoSetupForm({
                 </p>
                 {status?.portalLink ? (
                   <div className="flex flex-col gap-2">
-                    <p className={HELP_CLS}>
+                    <p className={copyClass}>
                       The link is single-use and expires in about a minute —
                       once opened it stays valid for the session.
                     </p>
@@ -615,7 +626,7 @@ export default function SsoSetupForm({
                   </div>
                 ) : null}
                 {status?.connection ? (
-                  <p className={HELP_CLS}>
+                  <p className={copyClass}>
                     Provider: {status.connection.provider ?? "unknown"} ·{" "}
                     {status.connection.status}
                     {status.connection.enabled ? " · enabled" : ""}

--- a/apps/web/src/app/business-profile/page.tsx
+++ b/apps/web/src/app/business-profile/page.tsx
@@ -438,7 +438,7 @@ const PM_H2_CLS = "font-display text-ui-section font-bold leading-[1.3] tracking
 const PM_H3_CLS = "font-display text-ui-label font-semibold uppercase tracking-[0.8px] text-text3 mt-6 mb-2 first:mt-0";
 const PM_P_CLS = "text-ui-body leading-[1.65] text-text2 mb-1.5";
 const PM_CITE_CLS =
-  "text-ui-label font-semibold text-accent no-underline bg-accent-soft rounded-[4px] px-[5px] py-px mx-px align-super leading-none transition-all duration-150 hover:bg-accent hover:text-white";
+  "text-ui-label font-semibold text-accent no-underline bg-accent-soft rounded-[4px] px-[5px] py-px mx-px align-super leading-none transition-[background-color,color] duration-150 hover:bg-accent hover:text-white";
 
 function InsightsLoading() {
   return (

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -26,36 +26,36 @@
 }
 
 @theme {
-  --color-bg: #FAFAF7;
-  --color-card: #FFFFFF;
-  --color-text: #2D2A24;
-  --color-text2: #6F6A60;
-  --color-text3: #756F65;
-  --color-border: #EEEBE4;
-  --color-neutral: #F2EFE8;
-  --color-neutral-soft: #F7F4ED;
-  --color-accent: #6B5CE7;
-  --color-accent-soft: #EDE9FE;
-  --color-success: #6CFF7F;
-  --color-success-ink: #113719;
-  --color-success-soft: #E2FBE6;
-  --color-success-mid: #357A57;
-  --color-watch: #E9A23B;
-  --color-watch-soft: #FFF1D8;
-  --color-warn: #F0D97A;
-  --color-warn-soft: #FFF4CC;
-  --color-warn-ink: #8A6D00;
-  --color-danger: #A53535;
-  --color-danger-soft: #FEECEC;
+  --color-bg: var(--bg);
+  --color-card: var(--card);
+  --color-text: var(--text);
+  --color-text2: var(--text2);
+  --color-text3: var(--text3);
+  --color-border: var(--border);
+  --color-neutral: var(--neutral);
+  --color-neutral-soft: var(--neutral-soft);
+  --color-accent: var(--accent);
+  --color-accent-soft: var(--accent-soft);
+  --color-success: var(--success);
+  --color-success-ink: var(--success-ink);
+  --color-success-soft: var(--success-soft);
+  --color-success-mid: var(--success-mid);
+  --color-watch: var(--watch);
+  --color-watch-soft: var(--watch-soft);
+  --color-warn: var(--warn);
+  --color-warn-soft: var(--warn-soft);
+  --color-warn-ink: var(--warn-ink);
+  --color-danger: var(--danger);
+  --color-danger-soft: var(--danger-soft);
 
-  --radius-card: 20px;
-  --radius-inner: 12px;
-  --radius-control: 10px;
-  --radius-2xl: 20px;
+  --radius-card: var(--radius);
+  --radius-inner: var(--radius-inner);
+  --radius-control: var(--radius-control);
+  --radius-2xl: var(--radius);
 
-  --shadow-soft: 0 1px 3px rgba(20,18,12,0.04), 0 4px 16px rgba(20,18,12,0.03);
-  --shadow-hover: 0 2px 8px rgba(20,18,12,0.06), 0 12px 36px -8px rgba(20,18,12,0.07);
-  --shadow-lift: 0 1px 2px rgba(20,18,12,0.04), 0 18px 48px -16px rgba(20,18,12,0.16);
+  --shadow-soft: var(--shadow);
+  --shadow-hover: var(--shadow-h);
+  --shadow-lift: var(--shadow-lift);
 
   /* Semantic utilities for component-local Tailwind. These mirror the
      product scale in _tokens.css instead of exposing one-off pixel values. */

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Toaster } from "sonner";
 import { DensityProvider } from "@/components/DensityProvider";
 import AppRail from "@/components/AppRail";
 import CommandDock from "@/components/CommandDock";
+import { THEME_COLOR } from "@/lib/theme-color";
 import "@fontsource-variable/archivo/wght.css";
 import "@fontsource-variable/manrope/wght.css";
 import "./globals.css";
@@ -22,7 +23,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
-  themeColor: "#FAFAF7",
+  themeColor: THEME_COLOR,
 };
 
 export default function RootLayout({
@@ -36,9 +37,12 @@ export default function RootLayout({
         <script dangerouslySetInnerHTML={{ __html: DENSITY_INIT }} />
       </head>
       <body>
+        <a href="#main-content" className="skip-to-main">
+          Skip to main content
+        </a>
         <DensityProvider>
           <AppRail />
-          {children}
+          <div id="main-content">{children}</div>
           <CommandDock />
         </DensityProvider>
         <Toaster
@@ -51,26 +55,6 @@ export default function RootLayout({
           toastOptions={{
             duration: 4500,
             unstyled: true,
-            style: {
-              width: "min(360px, calc(100vw - 32px))",
-              display: "flex",
-              alignItems: "flex-start",
-              gap: 12,
-              padding: "14px 16px 14px 18px",
-              background: "#FFFFFF",
-              color: "#2D2A24",
-              border: "1px solid #EEEBE4",
-              borderRadius: 16,
-              boxShadow:
-                "0 1px 2px rgba(20,18,12,0.04), 0 12px 40px -8px rgba(20,18,12,0.12), 0 24px 60px -16px rgba(20,18,12,0.08)",
-              fontFamily: "var(--font-body), 'Manrope', sans-serif",
-              fontSize: "var(--type-body-sm)",
-              fontWeight: 400,
-              lineHeight: 1.5,
-              boxSizing: "border-box",
-              position: "relative",
-              overflow: "hidden",
-            },
             classNames: {
               toast: "app-toast",
               title: "app-toast-title",

--- a/apps/web/src/app/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/app/onboarding/OnboardingWizard.tsx
@@ -159,7 +159,7 @@ export default function OnboardingWizard({
           </div>
           <div className="entry-fields">
             <Field label="Company name">
-              <input
+              <input data-ui-bespoke-reason="onboarding entry fields"
                 className="entry-control"
                 type="text"
                 value={companyName}
@@ -172,7 +172,7 @@ export default function OnboardingWizard({
             </Field>
 
             <Field label="What does the company do?">
-              <textarea
+              <textarea data-ui-bespoke-reason="onboarding entry fields"
                 className="entry-control"
                 value={companyNote}
                 onChange={(event) => setCompanyNote(event.target.value)}
@@ -220,7 +220,7 @@ export default function OnboardingWizard({
               {[...SUGGESTED_SEATS, ...seats.filter((seat) => !SUGGESTED_SEATS.includes(seat))].map((seat) => {
                 const selected = seats.includes(seat);
                 return (
-                  <button
+                  <button data-ui-bespoke-reason="onboarding entry fields"
                     key={seat}
                     type="button"
                     onClick={() => toggleSeat(seat)}
@@ -233,7 +233,7 @@ export default function OnboardingWizard({
               })}
             </div>
             <div className="entry-inline">
-              <input
+              <input data-ui-bespoke-reason="onboarding entry fields"
                 className="entry-control"
                 value={customSeat}
                 maxLength={MAX_SEAT_LENGTH}
@@ -282,7 +282,7 @@ export default function OnboardingWizard({
           </div>
           <div className="entry-fields">
             <Field label="What needs attention this quarter?">
-              <textarea
+              <textarea data-ui-bespoke-reason="onboarding entry fields"
                 className="entry-control"
                 value={prioritiesText}
                 onChange={(event) => setPrioritiesText(event.target.value)}

--- a/apps/web/src/app/onboarding/PersonaStep.tsx
+++ b/apps/web/src/app/onboarding/PersonaStep.tsx
@@ -62,7 +62,7 @@ export default function PersonaStep({
       <div className="entry-fields">
         <label className="entry-field">
           <span>Your role</span>
-          <input
+          <input data-ui-bespoke-reason="onboarding entry fields"
             className="entry-control"
             value={roleTemplate}
             maxLength={120}
@@ -73,7 +73,7 @@ export default function PersonaStep({
         </label>
         <label className="entry-field">
           <span>What needs your attention? <span className="entry-optional">Optional</span></span>
-          <textarea
+          <textarea data-ui-bespoke-reason="onboarding entry fields"
             className="entry-control"
             rows={5}
             value={focusAreas}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -820,11 +820,11 @@ export default function Dashboard() {
             </div>
 
             {recentActions && recentActions.receipts.length > 0 && (
-              <details
+              <details data-ui-bespoke-reason="briefing proof expander"
                 className="dash-proof"
                 style={{ animation: "fadeUp 0.5s ease 0.35s both" }}
               >
-                <summary className="dash-proof-summary">
+                <summary data-ui-bespoke-reason="briefing proof expander" className="dash-proof-summary">
                   <span className="font-mono dash-proof-tick" aria-hidden="true">↳</span>
                   <span className="dash-proof-count">
                     {recentActions.receipts.length}

--- a/apps/web/src/app/runs/[workflowRunId]/page.tsx
+++ b/apps/web/src/app/runs/[workflowRunId]/page.tsx
@@ -480,7 +480,7 @@ export default function RunPage() {
                   className="run-action-card bg-card border border-border rounded-2xl px-4 py-3.5"
                 >
                   <div className="flex items-start justify-between gap-2 mb-1.5">
-                    <button
+                    <button data-ui-bespoke-reason="run timeline playback"
                       type="button"
                       className="font-semibold text-sm text-text leading-[1.4] bg-transparent border-0 p-0 text-left cursor-pointer hover:underline hover:underline-offset-[3px]"
                       onClick={() => router.push(`/actions/${a.id}`)}
@@ -519,7 +519,7 @@ export default function RunPage() {
                       <label className="text-ui-label font-bold tracking-[0.13em] uppercase text-text3">
                         Why are you rejecting this? (optional)
                       </label>
-                      <textarea
+                      <textarea data-ui-bespoke-reason="run timeline playback"
                         className="border border-border rounded-[10px] px-3 py-2 font-body text-ui-body-sm text-text bg-card resize-y min-h-[50px] outline-none focus:border-accent"
                         value={rejectReason}
                         placeholder="e.g. wrong channel, retry tomorrow…"
@@ -589,12 +589,12 @@ export default function RunPage() {
             </div>
           </header>
 
-          <details
+          <details data-ui-bespoke-reason="run timeline playback"
             className="run-expander"
             open={showEvents}
             onToggle={(e) => setShowEvents(e.currentTarget.open)}
           >
-            <summary className="run-expander-summary">
+            <summary data-ui-bespoke-reason="run timeline playback" className="run-expander-summary">
               Execution trace
               <span>{data.events.length} events</span>
             </summary>
@@ -607,12 +607,12 @@ export default function RunPage() {
             </div>
           </details>
 
-          <details
+          <details data-ui-bespoke-reason="run timeline playback"
             className="run-expander"
             open={showLineage}
             onToggle={(e) => setShowLineage(e.currentTarget.open)}
           >
-            <summary className="run-expander-summary">
+            <summary data-ui-bespoke-reason="run timeline playback" className="run-expander-summary">
               Origin
               <span>{formatTrigger(run.triggerKind)}</span>
             </summary>

--- a/apps/web/src/app/runs/page.tsx
+++ b/apps/web/src/app/runs/page.tsx
@@ -211,9 +211,9 @@ function RunsPageInner() {
           <ul className="list-none p-0 m-0 flex flex-col gap-2.5">
             {data.runs.map((run) => (
               <li key={run.id}>
-                <button
+                <button data-ui-bespoke-reason="run list row"
                   type="button"
-                  className="w-full text-left bg-card border border-border rounded-2xl px-4 py-3.5 cursor-pointer transition hover:border-accent hover:shadow-[0_12px_30px_-22px_rgba(20,18,12,0.35)]"
+                  className="w-full text-left bg-card border border-border rounded-2xl px-4 py-3.5 cursor-pointer transition-[border-color,box-shadow] hover:border-accent hover:shadow-hover"
                   onClick={() => router.push(`/runs/${run.id}`)}
                 >
                   <div className="flex items-start justify-between gap-3">

--- a/apps/web/src/app/signin/page.tsx
+++ b/apps/web/src/app/signin/page.tsx
@@ -78,7 +78,7 @@ function SignInBody() {
         </div>
       ) : provider ? (
         <form action="/api/auth/begin" method="GET" className="entry-fields">
-          <input type="hidden" name="returnTo" value={returnTo} />
+          <input data-ui-bespoke-reason="sign-in entry fields" type="hidden" name="returnTo" value={returnTo} />
           <label className="entry-field">
             <span>
               Email{" "}
@@ -86,7 +86,7 @@ function SignInBody() {
                 <span className="entry-optional">(optional)</span>
               )}
             </span>
-            <input
+            <input data-ui-bespoke-reason="sign-in entry fields"
               type="email"
               name="loginHint"
               value={loginHint}

--- a/apps/web/src/app/styles/_toasts.css
+++ b/apps/web/src/app/styles/_toasts.css
@@ -52,13 +52,13 @@
 }
 
 .app-toast.app-toast-error {
-  --toast-accent: #E05656;
-  --toast-tint: rgba(224, 86, 86, 0.05);
+  --toast-accent: var(--danger);
+  --toast-tint: color-mix(in srgb, var(--danger) 8%, transparent);
 }
 
 .app-toast.app-toast-warning {
-  --toast-accent: #C98A2B;
-  --toast-tint: rgba(201, 138, 43, 0.06);
+  --toast-accent: var(--watch);
+  --toast-tint: color-mix(in srgb, var(--watch) 8%, transparent);
 }
 
 .app-toast.app-toast-info {

--- a/apps/web/src/app/styles/_tokens.css
+++ b/apps/web/src/app/styles/_tokens.css
@@ -62,6 +62,7 @@
   --page-head-title-size: var(--type-page);
   --page-head-z: 45;
   --page-head-bg: color-mix(in srgb, var(--bg) 96%, var(--card));
+  --focus-ring: color-mix(in srgb, var(--accent) 18%, transparent);
 }
 
 /* Live inside @layer base so Tailwind utilities (which live in @layer
@@ -69,6 +70,8 @@
    cascade over any layered rule regardless of specificity in v4. */
 @layer base {
   * { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html { color-scheme: light; }
 
   body {
     font-family: var(--font-body), 'Manrope', sans-serif;

--- a/apps/web/src/app/styles/_ui.css
+++ b/apps/web/src/app/styles/_ui.css
@@ -14,6 +14,38 @@
   align-items: center;
 }
 
+.skip-to-main {
+  position: absolute;
+  left: 12px;
+  top: -48px;
+  z-index: 200;
+  padding: 8px 12px;
+  border-radius: var(--radius-control);
+  background: var(--text);
+  color: var(--bg);
+  font-family: var(--font-body), Manrope, sans-serif;
+  font-size: var(--type-body-sm);
+  font-weight: 700;
+}
+
+.skip-to-main:focus {
+  top: 12px;
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  :where([data-ui-button], .ui-button) {
+    transition-property: color, background-color, border-color, box-shadow, opacity;
+    transform: none;
+  }
+
+  :where([data-ui-button], .ui-button):hover,
+  :where([data-ui-button], .ui-button):active {
+    transform: none;
+  }
+}
+
 @media (max-width: 720px), (pointer: coarse) {
   :where([data-ui-button], .ui-button),
   [data-ui-tab],

--- a/apps/web/src/components/ActCard.tsx
+++ b/apps/web/src/components/ActCard.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { Card } from "@/components/ui/Card";
 import { Button } from "@/components/ui/Button";
+import { Textarea } from "@/components/ui/Field";
 import { Pill, type PillVariant } from "@/components/ui/Pill";
 import { cn } from "@/lib/cn";
 import { formatSavedShort } from "@/lib/hours-saved";
@@ -56,9 +57,9 @@ const STATE_PILL_VARIANT: Record<ActCardData["state"], PillVariant> = {
 };
 
 const TONE_DOT: Record<ActRowTone, string> = {
-  good: "bg-[#7bd98a]",
-  watch: "bg-[#f2c35f]",
-  action: "bg-[#e06b6b]",
+  good: "bg-success",
+  watch: "bg-watch",
+  action: "bg-danger",
 };
 
 export default function ActCard({
@@ -203,8 +204,8 @@ export default function ActCard({
                     className="flex flex-col gap-2 mt-2"
                     onClick={(e) => e.stopPropagation()}
                   >
-                    <textarea
-                      className="border border-border rounded-[10px] px-3 py-2 text-ui-body-sm text-text bg-card resize-y min-h-[50px] outline-none focus:border-accent"
+                    <Textarea
+                      className="min-h-[50px] text-ui-body-sm"
                       value={rejectReason ?? ""}
                       placeholder="Why are you rejecting this? (optional)"
                       onChange={(e) => onRejectReasonChange?.(e.target.value)}

--- a/apps/web/src/components/AgentLauncher.tsx
+++ b/apps/web/src/components/AgentLauncher.tsx
@@ -79,7 +79,7 @@ export default function AgentLauncher() {
         <label className="sr-only" htmlFor="agent-objective">
           Objective for OpenNeko
         </label>
-        <textarea
+        <textarea data-ui-bespoke-reason="ask composer"
           id="agent-objective"
           value={prompt}
           onChange={(event) => {
@@ -90,7 +90,7 @@ export default function AgentLauncher() {
           rows={2}
           disabled={submitting}
         />
-        <button
+        <button data-ui-bespoke-reason="ask composer"
           type="submit"
           className="agent-launcher-submit"
           disabled={!prompt.trim() || submitting}
@@ -108,7 +108,7 @@ export default function AgentLauncher() {
         <span>Start with</span>
         <div className="agent-starters">
           {STARTERS.map((starter) => (
-            <button
+            <button data-ui-bespoke-reason="ask composer"
               key={starter.label}
               type="button"
               onClick={() => setPrompt(starter.prompt)}

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -92,7 +92,7 @@ export default function AppHeader({ back, children }: AppHeaderProps) {
         </a>
 
         {updateAvailable ? (
-          <button
+          <button data-ui-bespoke-reason="top bar chrome"
             type="button"
             className="topbar-ver is-update"
             onClick={() => window.location.reload()}
@@ -129,7 +129,7 @@ export default function AppHeader({ back, children }: AppHeaderProps) {
         </a>
 
         {user && (
-          <button
+          <button data-ui-bespoke-reason="top bar chrome"
             type="button"
             onClick={handleSignOut}
             aria-label={`Sign out ${user.email}`}

--- a/apps/web/src/components/AppRail.tsx
+++ b/apps/web/src/components/AppRail.tsx
@@ -123,7 +123,7 @@ function RecordObjectNavigation({
       <label className="app-rail-record-search">
         <Search aria-hidden="true" strokeWidth={2} />
         <span className="sr-only">Search {app.label} objects</span>
-        <input
+        <input data-ui-bespoke-reason="navigation rail"
           type="search"
           value={query}
           onChange={(event) => {
@@ -162,7 +162,7 @@ function RecordObjectNavigation({
                       </span>
                     )}
                   </Link>
-                  <button
+                  <button data-ui-bespoke-reason="navigation rail"
                     type="button"
                     className={`app-rail-record-favorite${favorite ? " is-favorite" : ""}`}
                     aria-label={`${favorite ? "Remove" : "Add"} ${object.pluralLabel} ${favorite ? "from" : "to"} favorites`}
@@ -180,7 +180,7 @@ function RecordObjectNavigation({
           <div className="app-rail-record-empty">No objects match “{query}”.</div>
         )}
         {navigation.hiddenCount > 0 && (
-          <button
+          <button data-ui-bespoke-reason="navigation rail"
             type="button"
             className="app-rail-record-more"
             onClick={() => setExpanded(true)}
@@ -189,7 +189,7 @@ function RecordObjectNavigation({
           </button>
         )}
         {expanded && navigation.hiddenCount === 0 && app.objects.length > 12 && (
-          <button
+          <button data-ui-bespoke-reason="navigation rail"
             type="button"
             className="app-rail-record-more"
             onClick={() => setExpanded(false)}
@@ -422,7 +422,7 @@ export default function AppRail() {
           </span>
         </a>
         {RECORDS_VISUAL_TEST ? null : updateAvailable ? (
-          <button
+          <button data-ui-bespoke-reason="navigation rail"
             type="button"
             className="app-rail-version is-update"
             onClick={() => window.location.reload()}
@@ -470,7 +470,7 @@ export default function AppRail() {
             <label className="app-rail-record-switcher">
               <span className="sr-only">Choose an app</span>
               <Database aria-hidden="true" strokeWidth={2} />
-              <select
+              <select data-ui-bespoke-reason="navigation rail"
                 value={activeRecordApp?.appId ?? ""}
                 onChange={(event) => {
                   if (event.target.value) router.push(`/a/${event.target.value}`);
@@ -571,7 +571,7 @@ export default function AppRail() {
                 </span>
               </span>
             </Link>
-            <button
+            <button data-ui-bespoke-reason="navigation rail"
               type="button"
               className="app-rail-signout"
               onClick={handleSignOut}

--- a/apps/web/src/components/AskHistoryPanel.tsx
+++ b/apps/web/src/components/AskHistoryPanel.tsx
@@ -81,7 +81,7 @@ export default function AskHistoryPanel({
       <div className="ask-history-head">
         <span className="ask-history-title">History</span>
         <span className="ask-history-count font-mono">{threads.length}</span>
-        <button
+        <button data-ui-bespoke-reason="ask history drawer"
           type="button"
           className="ask-history-new"
           onClick={createThread}
@@ -121,7 +121,7 @@ export default function AskHistoryPanel({
                     </span>
                   </span>
                 </Link>
-                <button
+                <button data-ui-bespoke-reason="ask history drawer"
                   type="button"
                   className="ask-history-delete"
                   title="Delete thread"

--- a/apps/web/src/components/BriefingCard.tsx
+++ b/apps/web/src/components/BriefingCard.tsx
@@ -29,10 +29,10 @@ const MOOD_LABELS: Record<string, string> = {
 };
 
 const MOOD_CHART_ACCENT: Record<string, string> = {
-  good: "#357A57",
-  watch: "#E9A23B",
-  act: "#A53535",
-  bad: "#A53535",
+  good: "var(--success-mid)",
+  watch: "var(--watch)",
+  act: "var(--danger)",
+  bad: "var(--danger)",
 };
 
 export type BriefingCardState = "ok" | "pending" | "failed";
@@ -152,7 +152,7 @@ export default function BriefingCard({ ins, index, onDismiss, onRetry, onDeepDiv
           ) : null}
         </OverflowMenu>
       </div>
-      <button
+      <button data-ui-bespoke-reason="briefing card interaction"
         type="button"
         className="icard-toggle"
         data-ui-disclosure=""

--- a/apps/web/src/components/Chart.tsx
+++ b/apps/web/src/components/Chart.tsx
@@ -9,11 +9,28 @@ import type { ChartDataPoint } from "@/a2ui/catalog";
 export type { ChartDataPoint } from "@/a2ui/catalog";
 import { formatCompact } from "@/lib/format-number";
 
-const axisProps = { tick: { fontSize: "var(--type-label)", fill: "#b0aa9f" }, axisLine: false, tickLine: false } as const;
-const tooltipStyle = { contentStyle: { borderRadius: 10, border: "none", boxShadow: "0 4px 16px rgba(0,0,0,0.08)", fontSize: "var(--type-body-sm)" }, itemStyle: { color: "#7A756A" } };
-const BASELINE_COLOR = "#5C5751";
+const AXIS_FILL = "var(--text3)";
+const GRID_STROKE = "var(--border)";
+const CARD_FILL = "var(--card)";
+const MUTED_FILL = "var(--text2)";
+const BASELINE_STROKE = "var(--text)";
+const DEFAULT_ACCENT = "var(--accent)";
 
-export default function Chart({ type, accent = "#6B5CE7", h = 130, data, centerLabel, valueLabel, baselineLabel }: {
+const axisProps = { tick: { fontSize: "var(--type-label)", fill: AXIS_FILL }, axisLine: false, tickLine: false } as const;
+const tooltipStyle = { contentStyle: { borderRadius: 10, border: "none", boxShadow: "var(--shadow-h)", fontSize: "var(--type-body-sm)" }, itemStyle: { color: MUTED_FILL } };
+
+function donutFills(accent: string) {
+  return [
+    accent,
+    `color-mix(in srgb, ${accent} 78%, white)`,
+    `color-mix(in srgb, ${accent} 62%, white)`,
+    `color-mix(in srgb, ${accent} 50%, var(--text2))`,
+    `color-mix(in srgb, ${accent} 38%, var(--text3))`,
+    `color-mix(in srgb, ${accent} 28%, var(--border))`,
+  ];
+}
+
+export default function Chart({ type, accent = DEFAULT_ACCENT, h = 130, data, centerLabel, valueLabel, baselineLabel }: {
   type: string;
   accent?: string;
   h?: number;
@@ -45,8 +62,7 @@ export default function Chart({ type, accent = "#6B5CE7", h = 130, data, centerL
   }
 
   if (resolvedType === "donut") {
-    // Violet-to-blue analogous ramp — calm, monochromatic, no mood colors.
-    const COLORS = [accent, "#8B7CF0", "#A89AEE", "#818CF8", "#93A4F8", "#A5BEF5"];
+    const colors = donutFills(accent);
     const total = data.reduce((s, d) => s + d.v, 0);
     const donutFormatter = (value: number | string | undefined, name: string | number | undefined) => [
       `${((Number(value ?? 0) / total) * 100).toFixed(0)}%`,
@@ -67,12 +83,12 @@ export default function Chart({ type, accent = "#6B5CE7", h = 130, data, centerL
             strokeWidth={0}
           >
             {data.map((_, i) => (
-              <Cell key={i} fill={COLORS[i % COLORS.length]} />
+              <Cell key={i} fill={colors[i % colors.length]} />
             ))}
           </Pie>
           <Tooltip {...tooltipStyle} formatter={donutFormatter as never} />
           <text x="50%" y="50%" textAnchor="middle" dominantBaseline="middle"
-            style={{ fontSize: "var(--type-body-sm)", fill: "#7A756A" }}>
+            style={{ fontSize: "var(--type-body-sm)", fill: MUTED_FILL }}>
             {centerLabel ?? formatCompact(total)}
           </text>
         </PieChart>
@@ -91,7 +107,7 @@ export default function Chart({ type, accent = "#6B5CE7", h = 130, data, centerL
   const yTickFormatter = (v: number) => formatCompact(v);
 
   if (resolvedType === "area") {
-    const gradientId = `g${accent.replace("#", "")}`;
+    const gradientId = "chart-area-fill";
     return (
       <ResponsiveContainer width="100%" height={h}>
         <AreaChart data={data}>
@@ -101,11 +117,11 @@ export default function Chart({ type, accent = "#6B5CE7", h = 130, data, centerL
               <stop offset="100%" stopColor={accent} stopOpacity={0.01} />
             </linearGradient>
           </defs>
-          <CartesianGrid strokeDasharray="3 3" stroke="#f0eee8" />
+          <CartesianGrid strokeDasharray="3 3" stroke={GRID_STROKE} />
           <XAxis dataKey="d" {...axisProps} />
           <YAxis {...axisProps} width={32} tickFormatter={yTickFormatter} />
           <Tooltip {...tooltipStyle} formatter={seriesFormatter as never} />
-          <Area type="monotone" dataKey="v" name={valueLabel ?? "Value"} stroke={accent} strokeWidth={2} fill={`url(#${gradientId})`} dot={{ r: 3, fill: "#fff", stroke: accent, strokeWidth: 1.5 }} />
+          <Area type="monotone" dataKey="v" name={valueLabel ?? "Value"} stroke={accent} strokeWidth={2} fill={`url(#${gradientId})`} dot={{ r: 3, fill: CARD_FILL, stroke: accent, strokeWidth: 1.5 }} />
         </AreaChart>
       </ResponsiveContainer>
     );
@@ -115,12 +131,12 @@ export default function Chart({ type, accent = "#6B5CE7", h = 130, data, centerL
     return (
       <ResponsiveContainer width="100%" height={h}>
         <BarChart data={data} barSize={16} barGap={3}>
-          <CartesianGrid strokeDasharray="3 3" stroke="#f0eee8" />
+          <CartesianGrid strokeDasharray="3 3" stroke={GRID_STROKE} />
           <XAxis dataKey="d" {...axisProps} />
           <YAxis {...axisProps} width={32} tickFormatter={yTickFormatter} />
           <Tooltip {...tooltipStyle} formatter={seriesFormatter as never} />
           <Bar dataKey="v" name={valueLabel ?? "Value"} fill={accent} radius={[5, 5, 0, 0]} />
-          <Bar dataKey="t" name={baselineLabel ?? "Prior"} fill={accent + "55"} radius={[5, 5, 0, 0]} />
+          <Bar dataKey="t" name={baselineLabel ?? "Prior"} fill={`color-mix(in srgb, ${accent} 33%, transparent)`} radius={[5, 5, 0, 0]} />
         </BarChart>
       </ResponsiveContainer>
     );
@@ -129,12 +145,12 @@ export default function Chart({ type, accent = "#6B5CE7", h = 130, data, centerL
   return (
     <ResponsiveContainer width="100%" height={h}>
       <LineChart data={data}>
-        <CartesianGrid strokeDasharray="3 3" stroke="#f0eee8" />
+        <CartesianGrid strokeDasharray="3 3" stroke={GRID_STROKE} />
         <XAxis dataKey="d" {...axisProps} />
         <YAxis {...axisProps} width={32} tickFormatter={yTickFormatter} />
         <Tooltip {...tooltipStyle} formatter={seriesFormatter as never} />
-        <Line type="monotone" dataKey="v" name={valueLabel ?? "Value"} stroke={accent} strokeWidth={2.5} dot={{ r: 3, fill: "#fff", stroke: accent, strokeWidth: 2 }} />
-        <Line type="monotone" dataKey="t" name={baselineLabel ?? "Prior"} stroke={BASELINE_COLOR} strokeOpacity={0.55} strokeWidth={1.75} strokeDasharray="5 4" dot={false} />
+        <Line type="monotone" dataKey="v" name={valueLabel ?? "Value"} stroke={accent} strokeWidth={2.5} dot={{ r: 3, fill: CARD_FILL, stroke: accent, strokeWidth: 2 }} />
+        <Line type="monotone" dataKey="t" name={baselineLabel ?? "Prior"} stroke={BASELINE_STROKE} strokeOpacity={0.55} strokeWidth={1.75} strokeDasharray="5 4" dot={false} />
       </LineChart>
     </ResponsiveContainer>
   );

--- a/apps/web/src/components/CommandDock.tsx
+++ b/apps/web/src/components/CommandDock.tsx
@@ -153,7 +153,7 @@ export default function CommandDock() {
     <div className="cdock-wrap">
       {openSheet ? (
         <>
-          <button
+          <button data-ui-bespoke-reason="phone command dock"
             type="button"
             className="cdock-scrim"
             aria-label="Close navigation sheet"
@@ -176,7 +176,7 @@ export default function CommandDock() {
                 </h2>
                 <p>Knowledge, connections, and workspace settings.</p>
               </div>
-              <button
+              <button data-ui-bespoke-reason="phone command dock"
                 type="button"
                 className="cdock-sheet-close"
                 aria-label="Close"
@@ -230,7 +230,7 @@ export default function CommandDock() {
                   <DensityToggle />
                 </div>
                 {session.signedIn ? (
-                  <button type="button" className="cdock-sheet-out" onClick={handleSignOut}>
+                  <button data-ui-bespoke-reason="phone command dock" type="button" className="cdock-sheet-out" onClick={handleSignOut}>
                     <LogOut aria-hidden="true" strokeWidth={2} />
                     <span>Sign out</span>
                   </button>
@@ -253,7 +253,7 @@ export default function CommandDock() {
           onNavigate={closeSheet}
         />
 
-        <button
+        <button data-ui-bespoke-reason="phone command dock"
           ref={(node) => {
             if (openSheet === "more") triggerRef.current = node;
           }}

--- a/apps/web/src/components/ConfirmModal.tsx
+++ b/apps/web/src/components/ConfirmModal.tsx
@@ -91,13 +91,13 @@ function ConfirmDialog({
 
   return (
     <div
-      className="fixed inset-0 z-[1000] bg-[var(--backdrop)] backdrop-blur-[4px] flex items-center justify-center p-4 animate-[modal-fade_0.15s_ease-out]"
+      className="fixed inset-0 z-[1000] bg-[var(--backdrop)] backdrop-blur-[4px] flex items-center justify-center p-4 overscroll-contain animate-[modal-fade_0.15s_ease-out]"
       onClick={onBackdrop}
       role="dialog"
       aria-modal="true"
       aria-labelledby="confirm-modal-title"
     >
-      <div className="w-full max-w-[420px] bg-card border border-border rounded-card px-[22px] pt-[22px] pb-[18px] shadow-[0_8px_32px_rgba(20,18,12,0.18),0_24px_60px_rgba(20,18,12,0.10)] animate-[modal-rise_0.18s_cubic-bezier(0.16,1,0.3,1)]">
+      <div className="w-full max-w-[420px] bg-card border border-border rounded-card px-[22px] pt-[22px] pb-[18px] shadow-lift animate-[modal-rise_0.18s_cubic-bezier(0.16,1,0.3,1)]">
         <h2
           id="confirm-modal-title"
           className="font-display text-base font-bold leading-tight text-text m-0"

--- a/apps/web/src/components/EditableMarkdown.tsx
+++ b/apps/web/src/components/EditableMarkdown.tsx
@@ -144,7 +144,7 @@ export default function EditableMarkdown({
     return (
       <div
         ref={editRef}
-        className="outline-none whitespace-pre-wrap break-words text-base leading-[1.65] text-text2 caret-accent"
+        className="whitespace-pre-wrap break-words text-base leading-[1.65] text-text2 caret-accent outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg rounded-control"
         contentEditable
         suppressContentEditableWarning
         role="textbox"
@@ -162,7 +162,7 @@ export default function EditableMarkdown({
   const hasContent = value.length > 0;
   return (
     <div
-      className="outline-none cursor-text"
+      className="cursor-text rounded-control focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-bg"
       onPointerDown={readOnly ? undefined : enterEdit}
       role={readOnly ? undefined : "textbox"}
       aria-label={ariaLabel}

--- a/apps/web/src/components/FindingCard.tsx
+++ b/apps/web/src/components/FindingCard.tsx
@@ -183,7 +183,7 @@ export default function FindingCard({
           </>
         )}
         {data.pinId && onUnpin && (
-          <button
+          <button data-ui-bespoke-reason="briefing card interaction"
             type="button"
             className="bg-transparent border-0 text-text3 font-[inherit] text-ui-caption p-0 cursor-pointer hover:text-danger hover:underline underline-offset-2"
             onClick={(e) => {
@@ -221,7 +221,7 @@ export default function FindingCard({
               Mute <span className="font-mono">{data.scope}</span>
             </div>
             {MUTE_DURATIONS.map((d) => (
-              <button
+              <button data-ui-bespoke-reason="briefing card interaction"
                 key={d}
                 type="button"
                 className="block w-full text-left bg-transparent border-0 px-3 py-1.5 text-ui-body-sm text-text cursor-pointer hover:bg-bg2 font-[inherit]"

--- a/apps/web/src/components/HoursSavedHero.tsx
+++ b/apps/web/src/components/HoursSavedHero.tsx
@@ -40,7 +40,7 @@ export default function HoursSavedHero({
 
   return (
     <div className="mb-7" style={{ animation: "fadeUp 0.5s ease 0.12s both" }}>
-      <button
+      <button data-ui-bespoke-reason="briefing card interaction"
         type="button"
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}

--- a/apps/web/src/components/Select.tsx
+++ b/apps/web/src/components/Select.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useId, useRef, useState } from "react";
 import { cn } from "@/lib/cn";
+import { Button } from "@/components/ui/Button";
 
 export type SelectOption = {
   value: string;
@@ -19,7 +20,7 @@ type Props = {
 };
 
 const TRIGGER_BASE =
-  "min-h-10 px-3.5 py-2.5 rounded-control border-[1.5px] border-border bg-card text-text text-ui-body font-body outline-none transition-all duration-200 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.10)]";
+  "min-h-10 w-full justify-between gap-2.5 px-3.5 py-2.5 font-normal shadow-none hover:translate-y-0";
 
 export default function Select({
   value,
@@ -109,16 +110,15 @@ export default function Select({
 
   return (
     <div ref={wrapRef} className="relative">
-      <button
+      <Button
         ref={buttonRef}
         id={id}
         type="button"
+        variant="secondary"
         data-ui-field-control=""
         className={cn(
           TRIGGER_BASE,
-          "flex items-center justify-between gap-2.5 w-full text-left cursor-pointer",
           "enabled:hover:border-accent",
-          "disabled:cursor-not-allowed disabled:opacity-55",
         )}
         aria-haspopup="listbox"
         aria-expanded={open}
@@ -155,7 +155,7 @@ export default function Select({
             strokeLinejoin="round"
           />
         </svg>
-      </button>
+      </Button>
       {open && (
         <ul
           ref={listRef}

--- a/apps/web/src/components/StatStrip.tsx
+++ b/apps/web/src/components/StatStrip.tsx
@@ -55,7 +55,7 @@ export default function StatStrip() {
     }
 
     return (
-      <button
+      <button data-ui-bespoke-reason="briefing card interaction"
         type="button"
         onClick={onClick}
         data-ui-stat-link

--- a/apps/web/src/components/WorkHistoryDrawer.tsx
+++ b/apps/web/src/components/WorkHistoryDrawer.tsx
@@ -45,7 +45,7 @@ export default function WorkHistoryDrawer({
 
   return (
     <div className="work-history-layer">
-      <button
+      <button data-ui-bespoke-reason="ask history drawer"
         type="button"
         className="work-history-scrim"
         aria-label="Close thread history"
@@ -63,7 +63,7 @@ export default function WorkHistoryDrawer({
             <h2 id="work-history-title">Past work</h2>
             <p>Resume one of your threads.</p>
           </div>
-          <button
+          <button data-ui-bespoke-reason="ask history drawer"
             ref={closeRef}
             type="button"
             className="work-history-close"

--- a/apps/web/src/components/records/AppChatSidebar.tsx
+++ b/apps/web/src/components/records/AppChatSidebar.tsx
@@ -457,7 +457,7 @@ export function AppChatSidebar({
   if (collapsed) {
     return (
       <aside className="app-chat-sidebar is-collapsed" aria-label={`${appLabel} chat, collapsed`}>
-        <button type="button" onClick={toggleCollapsed} title="Open app chat" aria-label="Open app chat">
+        <button data-ui-bespoke-reason="records ask composer" type="button" onClick={toggleCollapsed} title="Open app chat" aria-label="Open app chat">
           <PanelRightOpen aria-hidden="true" />
         </button>
         <span className="app-chat-rail-mark" aria-hidden="true"><MessageSquareText /></span>
@@ -474,13 +474,13 @@ export function AppChatSidebar({
           <span><strong>{appLabel}</strong><small>App chat</small></span>
         </span>
         <span className="app-chat-header-actions">
-          <button type="button" onClick={() => setHistoryOpen((open) => !open)} aria-pressed={historyOpen} title="Conversation history">
+          <button data-ui-bespoke-reason="records ask composer" type="button" onClick={() => setHistoryOpen((open) => !open)} aria-pressed={historyOpen} title="Conversation history">
             <History aria-hidden="true" />
           </button>
-          <button type="button" onClick={startNewThread} title="New conversation">
+          <button data-ui-bespoke-reason="records ask composer" type="button" onClick={startNewThread} title="New conversation">
             <Plus aria-hidden="true" />
           </button>
-          <button type="button" onClick={toggleCollapsed} title="Collapse app chat">
+          <button data-ui-bespoke-reason="records ask composer" type="button" onClick={toggleCollapsed} title="Collapse app chat">
             <PanelRightClose aria-hidden="true" />
           </button>
         </span>
@@ -490,17 +490,17 @@ export function AppChatSidebar({
         <section className="app-chat-history" aria-label={`${appLabel} conversation history`}>
           <div className="app-chat-history-title">
             <span>History</span>
-            <button type="button" onClick={startNewThread}><Plus aria-hidden="true" /> New</button>
+            <button data-ui-bespoke-reason="records ask composer" type="button" onClick={startNewThread}><Plus aria-hidden="true" /> New</button>
           </div>
           {threads.length === 0 ? (
             <p>No app conversations yet.</p>
           ) : threads.map((thread) => (
             <div className={`app-chat-history-row${thread.id === activeThreadId ? " is-active" : ""}`} key={thread.id}>
-              <button type="button" onClick={() => void selectThread(thread.id)}>
+              <button data-ui-bespoke-reason="records ask composer" type="button" onClick={() => void selectThread(thread.id)}>
                 <strong>{displayTitle(thread.title)}</strong>
                 <small>{compactDate(thread.lastMessageAt)}</small>
               </button>
-              <button type="button" className="app-chat-history-delete" onClick={() => void deleteThread(thread)} title="Delete conversation" aria-label={`Delete ${displayTitle(thread.title)}`}>
+              <button data-ui-bespoke-reason="records ask composer" type="button" className="app-chat-history-delete" onClick={() => void deleteThread(thread)} title="Delete conversation" aria-label={`Delete ${displayTitle(thread.title)}`}>
                 <Trash2 aria-hidden="true" />
               </button>
             </div>
@@ -545,7 +545,7 @@ export function AppChatSidebar({
           </span>
         )}
         <form className="app-chat-composer" onSubmit={submit}>
-          <textarea
+          <textarea data-ui-bespoke-reason="records ask composer"
             value={draft}
             onChange={(event) => {
               setDraft(event.target.value);
@@ -563,9 +563,9 @@ export function AppChatSidebar({
             maxLength={4_000}
           />
           {sending ? (
-            <button type="button" onClick={() => void cancelRun()} aria-label="Stop response" title="Stop response"><Square aria-hidden="true" /></button>
+            <button data-ui-bespoke-reason="records ask composer" type="button" onClick={() => void cancelRun()} aria-label="Stop response" title="Stop response"><Square aria-hidden="true" /></button>
           ) : (
-            <button type="submit" disabled={!draft.trim()} aria-label="Send message"><ArrowUp aria-hidden="true" /></button>
+            <button data-ui-bespoke-reason="records ask composer" type="submit" disabled={!draft.trim()} aria-label="Send message"><ArrowUp aria-hidden="true" /></button>
           )}
         </form>
         {error && <p className="app-chat-error" role="alert">{error}</p>}

--- a/apps/web/src/components/records/RecordAskBox.tsx
+++ b/apps/web/src/components/records/RecordAskBox.tsx
@@ -133,7 +133,7 @@ export function RecordAskBox({
         <label className="sr-only" htmlFor={`records-ask-${context.surface}`}>
           Ask OpenNeko about {subject}
         </label>
-        <input
+        <input data-ui-bespoke-reason="records ask composer"
           id={`records-ask-${context.surface}`}
           value={request}
           onChange={(event) => {
@@ -148,7 +148,7 @@ export function RecordAskBox({
           maxLength={2_000}
           disabled={submitting}
         />
-        <button
+        <button data-ui-bespoke-reason="records ask composer"
           type="submit"
           disabled={!request.trim() || submitting}
           aria-label={submitting ? "Opening Ask" : "Open Ask"}

--- a/apps/web/src/components/records/RecordFilterBuilder.tsx
+++ b/apps/web/src/components/records/RecordFilterBuilder.tsx
@@ -8,6 +8,8 @@ import type {
   RecordListFilter,
 } from "@neko/records";
 import { Button } from "@/components/ui/Button";
+import { Disclosure } from "@/components/ui/Disclosure";
+import { Input, NativeSelect } from "@/components/ui/Field";
 
 export type RecordFilterField = {
   apiName: string;
@@ -127,20 +129,19 @@ export function RecordFilterBuilder({
   }
 
   return (
-    <details className="records-filter-builder">
-      <summary className="records-filter-add">+ Filter</summary>
-      <form onSubmit={apply}>
-        <label>
+    <Disclosure title="Add filter" className="records-filter-builder">
+      <form onSubmit={apply} className="grid gap-3">
+        <label className="grid gap-1.5 font-body text-ui-caption font-bold text-text2">
           Field
-          <select value={fieldName} onChange={(event) => setFieldName(event.target.value)}>
+          <NativeSelect value={fieldName} onChange={(event) => setFieldName(event.target.value)}>
             {fields.map((field) => (
               <option value={field.apiName} key={field.apiName}>{field.label}</option>
             ))}
-          </select>
+          </NativeSelect>
         </label>
-        <label>
+        <label className="grid gap-1.5 font-body text-ui-caption font-bold text-text2">
           Condition
-          <select value={operator} onChange={(event) => setOperator(event.target.value)}>
+          <NativeSelect value={operator} onChange={(event) => setOperator(event.target.value)}>
             <option value="eq">equals</option>
             <option value="neq">does not equal</option>
             <option value="contains">contains</option>
@@ -163,24 +164,24 @@ export function RecordFilterBuilder({
                 <option value="is_closed">is semantically closed</option>
               </>
             )}
-          </select>
+          </NativeSelect>
         </label>
         {!noValue && (
-          <label>
+          <label className="grid gap-1.5 font-body text-ui-caption font-bold text-text2">
             Value
             {picklistOptions.length > 0 && ["eq", "neq"].includes(operator) ? (
-              <select name="value">
+              <NativeSelect name="value">
                 {picklistOptions.map((option) => (
                   <option value={option.value} key={option.value}>{option.label}</option>
                 ))}
-              </select>
+              </NativeSelect>
             ) : operator === "is_null" ? (
-              <select name="value">
+              <NativeSelect name="value">
                 <option value="true">is empty</option>
                 <option value="false">is not empty</option>
-              </select>
+              </NativeSelect>
             ) : (
-              <input
+              <Input
                 name="value"
                 required
                 type={operator === "last_n_days" ? "number" : "text"}
@@ -195,6 +196,6 @@ export function RecordFilterBuilder({
           Apply filter
         </Button>
       </form>
-    </details>
+    </Disclosure>
   );
 }

--- a/apps/web/src/components/records/RecordForm.tsx
+++ b/apps/web/src/components/records/RecordForm.tsx
@@ -6,6 +6,8 @@ import { useEffect, useState, type FormEvent, type ReactNode } from "react";
 import { CheckCircle2, LoaderCircle, LockKeyhole } from "lucide-react";
 import type { RecordViewColumn } from "@neko/records";
 import { Button, buttonClassName } from "@/components/ui/Button";
+import { Checkbox } from "@/components/ui/Checkbox";
+import { Input, NativeSelect, Textarea } from "@/components/ui/Field";
 
 type SubmitResponse = {
   status?: "executed" | "queued";
@@ -71,40 +73,41 @@ function FieldControl({
     required: column.required,
   };
   if (column.readOnly || column.kind === "readonly_formula") {
-    return <input {...common} type="text" value={stringValue(value)} disabled readOnly />;
+    return <Input {...common} type="text" value={stringValue(value)} disabled readOnly />;
   }
   if (column.kind === "textarea") {
-    return <textarea {...common} defaultValue={stringValue(value)} rows={5} />;
+    return <Textarea {...common} defaultValue={stringValue(value)} rows={5} />;
   }
   if (column.kind === "boolean") {
     return (
-      <label className="records-checkbox">
-        <input {...common} type="checkbox" defaultChecked={value === true} />
-        <span>Enabled</span>
-      </label>
+      <Checkbox
+        {...common}
+        label="Enabled"
+        defaultChecked={value === true}
+      />
     );
   }
   if (column.kind === "picklist") {
     return (
-      <select {...common} defaultValue={stringValue(value)}>
+      <NativeSelect {...common} defaultValue={stringValue(value)}>
         {!column.required && <option value="">Not set</option>}
         {picklistOptions(column).map((option) => (
           <option value={option.value} key={option.value}>
             {option.label}
           </option>
         ))}
-      </select>
+      </NativeSelect>
     );
   }
   if (column.kind === "multipicklist") {
     return (
-      <select {...common} multiple defaultValue={multiValue(value)} size={Math.min(5, Math.max(3, picklistOptions(column).length))}>
+      <NativeSelect {...common} multiple defaultValue={multiValue(value)} size={Math.min(5, Math.max(3, picklistOptions(column).length))}>
         {picklistOptions(column).map((option) => (
           <option value={option.value} key={option.value}>
             {option.label}
           </option>
         ))}
-      </select>
+      </NativeSelect>
     );
   }
   const type =
@@ -122,7 +125,7 @@ function FieldControl({
                 ? "number"
                 : "text";
   return (
-    <input
+    <Input
       {...common}
       type={type}
       defaultValue={
@@ -182,7 +185,7 @@ function ReferenceControl({
   return (
     <div className="records-reference-control">
       {targets.length > 1 && (
-        <select
+        <NativeSelect
           aria-label={`${column.label} target object`}
           value={target}
           onChange={(event) => {
@@ -192,9 +195,9 @@ function ReferenceControl({
           }}
         >
           {targets.map((candidate) => <option value={candidate} key={candidate}>{candidate}</option>)}
-        </select>
+        </NativeSelect>
       )}
-      <input
+      <Input
         id={`record-field-${column.apiName}`}
         name={column.apiName}
         required={column.required}
@@ -210,6 +213,7 @@ function ReferenceControl({
         aria-controls={listId}
         aria-expanded={options.length > 0}
         placeholder="Search by record name or enter an ID"
+        spellCheck={false}
       />
       <datalist id={listId}>
         {options.map((option) => (

--- a/apps/web/src/components/records/RecordIdentityPanel.tsx
+++ b/apps/web/src/components/records/RecordIdentityPanel.tsx
@@ -95,7 +95,7 @@ function MappingControl({
         void decide("link");
       }}
     >
-      <select
+      <select data-ui-bespoke-reason="records identity mapping"
         aria-label={`OpenNeko user for ${sourceLabel(mapping)}`}
         value={appUserId}
         onChange={(event) => setAppUserId(event.target.value)}
@@ -173,7 +173,7 @@ function BackfillControl({ appId, sources }: { appId: string; sources: string[] 
 
   return (
     <form className="records-identity-backfill" onSubmit={run}>
-      <select
+      <select data-ui-bespoke-reason="records identity mapping"
         aria-label="Source instance to backfill"
         value={sourceInstanceId}
         onChange={(event) => setSourceInstanceId(event.target.value)}

--- a/apps/web/src/components/records/RecordImportPanel.tsx
+++ b/apps/web/src/components/records/RecordImportPanel.tsx
@@ -278,7 +278,7 @@ export function RecordImportPanel({
           </div>
           <label>
             Destination object
-            <select
+            <select data-ui-bespoke-reason="records import mapping"
               name="object"
               value={objectApiName}
               onChange={(event) => {
@@ -295,7 +295,7 @@ export function RecordImportPanel({
           </label>
           <label>
             CSV file
-            <input name="file" type="file" accept=".csv,text/csv" required />
+            <input data-ui-bespoke-reason="records import mapping" name="file" type="file" accept=".csv,text/csv" required />
           </label>
           <Button
             className="records-primary-action"
@@ -345,7 +345,7 @@ export function RecordImportPanel({
                       <td>{plan.sampleRows[0]?.[column.sourceColumn] || <span className="records-null">Empty</span>}</td>
                       <td><span className="records-import-kind">{column.inferredKind}</span></td>
                       <td>
-                        <select
+                        <select data-ui-bespoke-reason="records import mapping"
                           value={mapping[column.sourceColumn] ?? ""}
                           onChange={(event) => changeMapping(column.sourceColumn, event.target.value)}
                           aria-label={`Destination for ${column.sourceColumn}`}
@@ -372,7 +372,7 @@ export function RecordImportPanel({
             <footer className="records-import-review-footer">
               <label>
                 Duplicate key
-                <select value={duplicateKey} onChange={(event) => setDuplicateKey(event.target.value)}>
+                <select data-ui-bespoke-reason="records import mapping" value={duplicateKey} onChange={(event) => setDuplicateKey(event.target.value)}>
                   {duplicateOptions.map((field) => (
                     <option value={field} key={field}>{field === "id" ? "Record ID" : field}</option>
                   ))}
@@ -480,7 +480,7 @@ export function RecordImportPanel({
           <section className="records-import-recent">
             <span className="records-eyebrow">Recent imports</span>
             {recentRuns.map((run) => (
-              <button type="button" onClick={() => openRun(run.id)} key={run.id}>
+              <button data-ui-bespoke-reason="records import mapping" type="button" onClick={() => openRun(run.id)} key={run.id}>
                 <span>{run.sourceName}</span>
                 <small>{run.objectApiName} · {statusLabel(run.status)}</small>
               </button>

--- a/apps/web/src/components/records/RecordViewBar.tsx
+++ b/apps/web/src/components/records/RecordViewBar.tsx
@@ -11,6 +11,9 @@ import {
   type RecordFilterField,
 } from "./RecordFilterBuilder";
 import { Button } from "@/components/ui/Button";
+import { Checkbox } from "@/components/ui/Checkbox";
+import { Disclosure } from "@/components/ui/Disclosure";
+import { Input, NativeSelect } from "@/components/ui/Field";
 
 function hrefWith(base: string, current: Record<string, string | undefined>, mine: boolean) {
   const params = new URLSearchParams();
@@ -55,14 +58,14 @@ export function RecordViewBar({
     <div className="records-viewbar">
       <form className="records-view-picker" action={base} method="get">
         <label className="sr-only" htmlFor="records-saved-view">Saved view</label>
-        <select id="records-saved-view" name="view" defaultValue={selectedView?.id ?? ""}>
+        <NativeSelect id="records-saved-view" name="view" defaultValue={selectedView?.id ?? ""}>
           <option value="">All {objectLabel.toLowerCase()}</option>
           {views.map((view) => (
             <option value={view.id} key={view.id}>
               {view.label}{view.shared ? " · shared" : ""}
             </option>
           ))}
-        </select>
+        </NativeSelect>
         <Button size="sm" type="submit">Open</Button>
       </form>
       {query.q && (
@@ -90,23 +93,29 @@ export function RecordViewBar({
         </>
       )}
       <RecordFilterBuilder base={base} query={query} fields={fields} />
-      <details className="records-view-save">
-        <summary>Save view</summary>
-        <form action={endpoint} method="post">
-          <label>
+      <Disclosure title="Save view" className="records-view-save">
+        <form action={endpoint} method="post" className="grid gap-3">
+          <label className="grid gap-1.5 font-body text-ui-caption font-bold text-text2">
             Name
-            <input name="label" required maxLength={80} defaultValue={selectedView?.label} />
+            <Input name="label" required maxLength={80} defaultValue={selectedView?.label} />
           </label>
-          <input type="hidden" name="definition" value={JSON.stringify(definition)} />
+          <input
+            type="hidden"
+            name="definition"
+            value={JSON.stringify(definition)}
+            data-ui-bespoke-reason="hidden view definition payload"
+          />
           {canShare && (
-            <label className="records-view-share">
-              <input name="shared" type="checkbox" value="true" defaultChecked={selectedView?.shared} />
-              Share with this organization
-            </label>
+            <Checkbox
+              name="shared"
+              value="true"
+              defaultChecked={selectedView?.shared}
+              label="Share with this organization"
+            />
           )}
           <Button variant="primary" size="sm" type="submit">Save</Button>
         </form>
-      </details>
+      </Disclosure>
       {selectedView && (!selectedView.shared || canShare) && (
         <form action={`${endpoint}/${selectedView.id}`} method="post">
           <Button

--- a/apps/web/src/components/ui/Field.tsx
+++ b/apps/web/src/components/ui/Field.tsx
@@ -7,7 +7,7 @@ import {
 import { cn } from "@/lib/cn";
 
 const CONTROL_CLASS =
-  "w-full rounded-control border-[1.5px] border-border bg-card px-3.5 py-2.5 font-body text-ui-body text-text outline-none transition-[border-color,box-shadow,background-color] placeholder:text-text3 hover:border-text3 focus:border-accent focus:shadow-[0_0_0_3px_rgba(107,92,231,0.10)] disabled:cursor-not-allowed disabled:bg-neutral-soft disabled:opacity-60";
+  "w-full rounded-control border-[1.5px] border-border bg-card px-3.5 py-2.5 font-body text-ui-body text-text outline-none transition-[border-color,box-shadow,background-color] placeholder:text-text3 hover:border-text3 focus-visible:border-accent focus-visible:shadow-[0_0_0_3px_var(--focus-ring)] disabled:cursor-not-allowed disabled:bg-neutral-soft disabled:opacity-60";
 
 type FieldProps = {
   label: ReactNode;

--- a/apps/web/src/lib/theme-color.ts
+++ b/apps/web/src/lib/theme-color.ts
@@ -1,0 +1,2 @@
+/** Resolved `--bg` for browser chrome. `<meta name="theme-color">` cannot use CSS variables. */
+export const THEME_COLOR = "#FAFAF7";


### PR DESCRIPTION
## Summary

Bring `apps/web` onto the existing design-system floor. Palette, type, and radius stay as they are. Ordinary controls use shared primitives. Unique chrome is marked. Empty screens use `EmptyState`.

- Tailwind `@theme` colors, radii, and shadows now point at `:root` tokens in `_tokens.css`.
- Admin settings forms (setup, agent, data source, GraphJin, research, security, sign-in, SSO) use `Field`, `Input`, `NativeSelect`, `Checkbox`, and `Button`.
- Records create/edit, filter builder, and view bar use the same primitives.
- Library, memory, and workflows empty screens use `EmptyState`.
- Unique chrome (composer, rail, dock, A2UI, run timeline, file pickers) has `data-ui-bespoke-reason`.
- Add a skip link, `html { color-scheme: light }`, `--focus-ring`, and toast accents from tokens.
- `theme-color` lives in `apps/web/src/lib/theme-color.ts` because the meta tag cannot use CSS variables and `ui:check` scans TSX.

`apps/web/AGENTS.md` now states that every surface is in scope. Overlay skills stay local under `.agents/` (gitignored).

## Verification

- [x] Relevant lint, typecheck, and tests pass
- [x] Changed behavior was exercised locally

Ran `pnpm ui:check -- --all`, `pnpm --filter web typecheck`, and `pnpm --filter web lint` on this checkout. All three passed.

Inspected host-web at http://localhost:3200: skip link in the document, Admin → Rules still shows Skill learning. Magento visual contract runs in CI (`test:visual:design`).

Not done in this pass: a full 390 / 1280 click-through of every edited Admin form, Records editor, and empty state.

## UI design-system reuse map

| Surface need | Shared component or token | Live/visual evidence |
| --- | --- | --- |
| Page colors, radius, shadow | `:root` tokens via `@theme` `var(--*)` | `globals.css`; `ui:check --all` |
| Browser chrome color | `THEME_COLOR` from `lib/theme-color.ts` | layout `themeColor`; matches `--bg` |
| Skip to content | `.skip-to-main` in `_ui.css` | present on `/admin/rules` at :3200 |
| Focus ring | `--focus-ring`; Field `focus-visible` | Field.tsx, `_tokens.css` |
| Toasts | `_toasts.css` danger/watch tokens | inline hex removed from `Toaster` |
| Admin settings fields | `Field`, `Input`, `NativeSelect`, `Checkbox`, `Button` | SetupWizard, AgentForm, DataSourceForm, GraphJin, Research, Security, Sign-in, SSO |
| Records create/edit and filters | `Field`, `Input`, `NativeSelect`, `Button` | RecordForm, RecordFilterBuilder, RecordViewBar |
| Library / memory / workflows empty | `EmptyState` | those three pages |
| Select trigger | `Button` | `Select.tsx` |
| Confirm overlay | `ConfirmModal` + `--shadow-lift` | ConfirmModal.tsx |
| Charts / briefing / act cards | tokenized fills; ActCard reject uses `Textarea` | Chart, BriefingCard, ActCard |
| Ask composer, rail, dock, A2UI, run timeline, file pickers | native controls + `data-ui-bespoke-reason` | marked in those files |
| Onboarding entry fields | native controls + `data-ui-bespoke-reason="onboarding entry fields"` | OnboardingWizard |
| Reduced motion on buttons | `_ui.css` `@media (prefers-reduced-motion: reduce)` | buttons keep color/opacity, drop transform |

- [x] `pnpm ui:check` passes
- [ ] Desktop and phone layouts were inspected
- [ ] Changed focus, disabled, loading, empty, success, and error states were exercised where applicable
- [ ] Screenshots or computed-style/geometry evidence are included above

CI will attach Magento design-system renders. Desktop/phone screenshots of every edited surface are not in this PR yet.