### PR TITLE
feat(cli): support named multi-instance installs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -45,6 +45,79 @@ As a final optional step, `openneko setup` offers to install **first-party plugi
 
 The AdventureWorks seed pre-fills business onboarding (`AdventureWorks Cycles`, fiscal year `July`, seats `CEO`/`CFO`/`COO`, priorities `Defend wholesale margins` / `Grow DTC in Europe`). Otherwise fill it in at `/onboarding`.
 
+## Multiple customer instances on one host
+
+Give every customer a stable lowercase instance name. A named installation gets
+its own Compose project, databases and named volumes, encrypted config and
+secrets, OpenShell PKI/state, backup namespace, runtime markers, and Docker
+subnet.
+
+```bash
+# Bind customer apps to loopback when Caddy, nginx, or another TLS proxy is
+# the public entry point. Ports and the subnet are persisted by setup.
+openneko --instance acme setup \
+  --mode prod \
+  --port 3101 \
+  --openshell-port 18101 \
+  --bind-address 127.0.0.1
+
+openneko --instance globex setup \
+  --mode prod \
+  --port 3102 \
+  --openshell-port 18102 \
+  --bind-address 127.0.0.1
+```
+
+Route a separate TLS hostname to each loopback web port. For example, with
+Caddy:
+
+```caddyfile
+acme.example.com {
+  reverse_proxy 127.0.0.1:3101
+}
+
+globex.example.com {
+  reverse_proxy 127.0.0.1:3102
+}
+```
+
+Only the reverse proxy needs public `80`/`443` firewall access. The customer web
+ports above and each OpenShell gateway stay on host loopback; databases,
+GraphJin, brokers, and backup services stay inside their private Docker
+networks.
+
+For named instances, omitting `--port`, `--openshell-port`, or
+`--docker-subnet` makes setup choose an available value and persist it. Inspect
+the resulting inventory with:
+
+```bash
+openneko instances
+```
+
+Target every later operation explicitly:
+
+```bash
+openneko --instance acme status
+openneko --instance acme logs -f
+openneko --instance acme upgrade
+openneko --instance acme backup now
+openneko --instance acme stop
+```
+
+Named settings live under
+`~/.config/openneko/instances/<name>/installation.json`; durable runtime and
+OpenShell state live under
+`${XDG_STATE_HOME:-$HOME/.local/state}/openneko/instances/<name>/`. Do not reuse
+an instance name for two customers on the same Docker daemon. Each customer is
+still a complete OpenNeko stack, so size VM memory, disk, and backup retention
+for the number of concurrent instances.
+
+Named instances are an operational and data-placement boundary, not a
+hypervisor security boundary. A host administrator or anyone with Docker daemon
+access can reach every stack. Use a separate VM or equivalent tenant boundary
+when a customer contract, threat model, or compliance regime requires host-level
+isolation.
+
 ## Use your own data
 
 ```bash
@@ -69,7 +142,9 @@ Browse the marketplace at [open-neko.github.io/plugins](https://open-neko.github
 ## Command reference
 
 ```bash
-openneko setup [--mode prod|dev|demo]  # guided: preflight + bring-up + configure
+openneko [--instance name] setup [--mode prod|dev|demo] [--port N] \
+  [--openshell-port N] [--bind-address IPv4] [--docker-subnet IPv4/24]
+openneko instances                 # configured host installations
 openneko start [--mode prod|dev|demo] [--detach]
 openneko upgrade [--version vX.Y.Z] [--mode auto|prod|dev|demo]
 openneko status                    # docker compose ps proxy
@@ -212,20 +287,27 @@ openneko reset --all      # wipes everything including secrets and marketplaces
 
 ## Ports
 
-Defaults:
+The packaged stack publishes only two host ports:
 
-- App: `3000`
-- Metadata Postgres: `5432`
-- Metadata GraphJin: `8089`
+- Web app: `3000` by default
+- OpenShell gateway: loopback-only `18080` by default
 
-In `--mode demo` the AdventureWorks Postgres is internal-only.
+Postgres, GraphJin, worker broker, backup API, and demo data services remain on
+the private Docker network. Web is the only port intended to be reachable from
+another machine; the OpenShell host mapping exists only for local sandbox
+callbacks.
 
-Override:
+Configure and persist ports during guided installation:
 
 ```bash
-OPENNEKO_PORT=3001 OPENNEKO_DB_PORT=55432 OPENNEKO_GRAPHJIN_PORT=8090 \
-  openneko start --mode demo --detach
+openneko setup --mode prod --port 3001 --openshell-port 18081
 ```
+
+For the backward-compatible unnamed installation, `OPENNEKO_PORT` and
+`OPENSHELL_PORT` remain available as one-process environment overrides. Named
+instances use their persisted assignments; re-run setup with explicit flags to
+change them. `--bind-address 127.0.0.1` restricts the web listener to the host
+for a reverse-proxy deployment.
 
 ## Build from source (advanced)
 
@@ -320,7 +402,8 @@ CI runs this with `--check` and fails on drift.
 
 **Docker not running.** Start Docker Desktop or the daemon; re-run `openneko start`.
 
-**Port in use.** Override via `OPENNEKO_PORT` / `OPENNEKO_DB_PORT` / `OPENNEKO_GRAPHJIN_PORT`.
+**Port in use.** Re-run setup with `--port` / `--openshell-port`, or use the
+equivalent `OPENNEKO_PORT` / `OPENSHELL_PORT` environment overrides.
 
 **Image pull `unauthorized`.** Confirm packages are public at https://github.com/orgs/open-neko/packages.
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ The demo seeds three watchers against sample data — kick off **Slow-Ship Opera
 
 Full propose-and-approve walkthrough, the live trial (order simulator + scenario injector), and connecting your own data → **[INSTALL.md](INSTALL.md)**.
 
+Hosting several smaller customers on one VM? Named installations isolate each
+customer's Compose project, databases, secrets, sandbox state, backups, ports,
+and Docker network. See [Multiple customer instances](INSTALL.md#multiple-customer-instances-on-one-host).
+
 ## What you get
 
 The full feature catalog, in plain language, lives in **[FEATURES.md](FEATURES.md)** — ask-anything answers, chat-first administration, watchers, channels (Slack / Telegram), personal-vs-team knowledge, and the verifiable security model. The highlights:

--- a/apps/openneko/README.md
+++ b/apps/openneko/README.md
@@ -30,7 +30,9 @@ You also need Docker (Docker Desktop on macOS, Docker Engine on Linux).
 ### Stack supervision
 
 ```bash
-openneko setup [--mode prod|dev|demo]   # guided install: preflight + bring-up + configure
+openneko [--instance name] setup [--mode prod|dev|demo] [--port N] \
+  [--openshell-port N] [--bind-address IPv4] [--docker-subnet IPv4/24]
+openneko instances                       # list configured installations
 openneko start [--mode prod|dev|demo] [--detach]
 openneko upgrade [--version vX.Y.Z] [--mode auto|prod|dev|demo] [--stack-only|--cli-only]
 openneko stop [--volumes]
@@ -49,10 +51,18 @@ Modes:
 - `dev` — developer defaults; from a source checkout use repo-root `pnpm dev:setup` + `pnpm dev` for demo data and hot-reloaded web/worker
 - `demo` — core + AdventureWorks trial bundle
 
-The binary materializes its embedded compose files to `.openneko/runtime/`
-in the current working directory before invoking `docker compose`. A
-project- or user-level override at `~/.config/openneko/compose.override.yml`
-is appended automatically when present.
+The unnamed backward-compatible installation materializes its embedded Compose
+files to `.openneko/runtime/` in the current working directory. A named
+installation uses
+`${XDG_STATE_HOME:-$HOME/.local/state}/openneko/instances/<name>/runtime/`, so
+it can be managed consistently from any working directory. Its host config and
+override live under `~/.config/openneko/instances/<name>/`. The CLI appends the
+matching `compose.override.yml` automatically when present.
+
+Named instances allow multiple production stacks on one Docker host. Setup
+persists the web/OpenShell ports and assigns an isolated Docker subnet; Compose
+resources use `openneko-<instance>-<mode>`. Always pass `--instance <name>` to
+lifecycle and plugin commands for that customer.
 
 `openneko upgrade` resolves the latest stable release (or the exact
 `--version`), updates the local CLI first, and re-executes that new binary
@@ -82,13 +92,11 @@ into the database and backup containers. This also avoids rootful Docker
 changing ownership of metadata the rootless host CLI must read.
 
 Default repositories are isolated by Compose project and a persistent
-installation ID under `~/.local/share/openneko/repositories/`. Two demo
-stacks launched from different working directories therefore cannot attach
-their PostgreSQL clusters to each other's pgBackRest stanzas. Reinstalling in
-the same working directory reuses the installation ID; a fresh directory gets
-a new repository and leaves the old one untouched. `stop --volumes` and
-`reset` also rotate the installation ID after deleting database volumes, so a
-new PostgreSQL cluster is never pointed at the previous cluster's stanzas.
+installation ID under `~/.local/share/openneko/repositories/`. Named instances
+therefore cannot attach their PostgreSQL clusters to another customer's
+pgBackRest stanzas. `stop --volumes` and `reset` also rotate the installation
+ID after deleting database volumes, so a new PostgreSQL cluster is never
+pointed at the previous cluster's stanzas.
 
 - Rootless Linux and macOS default to
   `${XDG_STATE_HOME:-$HOME/.local/state}/openneko/backup-keys/`.

--- a/apps/openneko/assets/env/.env.example
+++ b/apps/openneko/assets/env/.env.example
@@ -1,13 +1,14 @@
-# Defaults for `openneko start`. Drop a copy at .env in the current directory
-# to override. Anything unset falls back to the values below.
+# Legacy process-environment overrides for an unnamed `openneko start`.
+# Prefer `openneko setup --port ... --openshell-port ...`; setup persists those
+# values in the installation settings used by later lifecycle commands. Named
+# instances always use their persisted assignments.
 
 # Host port the OpenNeko web UI listens on.
 OPENNEKO_PORT=3000
 
-# Host port GraphJin's GraphQL endpoint binds to.
-OPENNEKO_GRAPHJIN_PORT=8089
+# Address the public web port binds to. Use loopback behind a host proxy.
+OPENNEKO_WEB_BIND_ADDRESS=0.0.0.0
 
-# Host port the operator-facing Postgres binds to. Migrations run against
-# this port from the binary, so changing it requires updating any external
-# tooling that talks to neko-db directly.
-OPENNEKO_DB_PORT=5432
+# Loopback-only OpenShell gateway port. Every concurrent instance needs a
+# distinct value.
+OPENSHELL_PORT=18080

--- a/apps/openneko/internal/cli/backup_environment.go
+++ b/apps/openneko/internal/cli/backup_environment.go
@@ -19,6 +19,7 @@ import (
 	"github.com/open-neko/neko/apps/openneko/assets"
 	"github.com/open-neko/neko/apps/openneko/internal/compose"
 	"github.com/open-neko/neko/apps/openneko/internal/config"
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
 	"github.com/open-neko/neko/apps/openneko/internal/version"
 )
 
@@ -64,7 +65,7 @@ func configureBackupEnvironment(projectNames ...string) error {
 	// container's environment metadata.
 	_ = os.Unsetenv("OPENNEKO_BACKUP_CIPHER_PASS")
 
-	if os.Getenv("OPENNEKO_HOST_CONFIG_DIR") == "" {
+	if instance.Current() != "" || os.Getenv("OPENNEKO_HOST_CONFIG_DIR") == "" {
 		hostConfig, err := filepath.Abs(config.Dir(""))
 		if err != nil {
 			return err

--- a/apps/openneko/internal/cli/backup_environment_test.go
+++ b/apps/openneko/internal/cli/backup_environment_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/open-neko/neko/apps/openneko/assets"
 	"github.com/open-neko/neko/apps/openneko/internal/compose"
 	"github.com/open-neko/neko/apps/openneko/internal/config"
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
 )
 
 func configureBackupTestEnvironment(t *testing.T) (string, string, string) {
@@ -84,6 +85,19 @@ func TestConfigureBackupEnvironmentCreatesRepositoryBoundExternalKey(t *testing.
 	}
 	if got := os.Getenv("OPENNEKO_HOST_CONFIG_DIR"); got != filepath.Join(configHome, "openneko") {
 		t.Fatalf("host config snapshot path = %q", got)
+	}
+}
+
+func TestNamedBackupEnvironmentOverridesGlobalHostConfigPath(t *testing.T) {
+	configHome, _, _ := configureBackupTestEnvironment(t)
+	t.Setenv(instance.EnvName, "acme")
+	t.Setenv("OPENNEKO_HOST_CONFIG_DIR", filepath.Join(t.TempDir(), "another-customer"))
+	if err := configureBackupEnvironment("openneko-acme-prod"); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(configHome, "openneko", "instances", "acme")
+	if got := os.Getenv("OPENNEKO_HOST_CONFIG_DIR"); got != want {
+		t.Fatalf("host config dir = %q, want %q", got, want)
 	}
 }
 

--- a/apps/openneko/internal/cli/cli_test.go
+++ b/apps/openneko/internal/cli/cli_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
 	"github.com/open-neko/neko/apps/openneko/internal/plugin/manifest"
 )
 
@@ -23,7 +24,7 @@ func TestExitCodeFor(t *testing.T) {
 
 func TestRootHasAllCommands(t *testing.T) {
 	root := NewRoot()
-	want := []string{"setup", "init", "install", "remove", "list", "doctor", "marketplace", "secrets", "pack", "version", "start", "upgrade", "stop", "status", "backup", "restore", "records", "storage", "logs", "migrate", "seed", "reset", "eval"}
+	want := []string{"setup", "instances", "init", "install", "remove", "list", "doctor", "marketplace", "secrets", "pack", "version", "start", "upgrade", "stop", "status", "backup", "restore", "records", "storage", "logs", "migrate", "seed", "reset", "eval"}
 	got := map[string]bool{}
 	for _, c := range root.Commands() {
 		got[c.Name()] = true
@@ -64,6 +65,39 @@ func TestVersionSubcommandShort(t *testing.T) {
 	got := strings.TrimSpace(out.String())
 	if got == "" || strings.Contains(got, "\n") || strings.Contains(got, "OpenNeko") {
 		t.Fatalf("expected short version output, got %q", out.String())
+	}
+}
+
+func TestPersistentInstanceFlagWorksAfterSubcommand(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv(instance.EnvName, "")
+	root := NewRoot()
+	var out bytes.Buffer
+	root.SetOut(&out)
+	root.SetErr(&out)
+	root.SetArgs([]string{"version", "--short", "--instance", "acme"})
+	if err := root.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got := instance.Current(); got != "acme" {
+		t.Fatalf("selected instance = %q", got)
+	}
+}
+
+func TestNamedInstanceFromWorkerContainer(t *testing.T) {
+	name, ok := namedInstanceFromWorkerContainer("openneko-acme-west-prod-worker-1")
+	if !ok || name != "acme-west" {
+		t.Fatalf("named worker = %q, ok=%v", name, ok)
+	}
+	for _, container := range []string{
+		"openneko-prod-worker-1",
+		"openneko-acme-prod-web-1",
+		"unrelated-worker-1",
+	} {
+		if name, ok := namedInstanceFromWorkerContainer(container); ok || name != "" {
+			t.Fatalf("%q parsed as named instance %q", container, name)
+		}
 	}
 }
 

--- a/apps/openneko/internal/cli/instance_settings.go
+++ b/apps/openneko/internal/cli/instance_settings.go
@@ -1,0 +1,393 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"net"
+	"net/netip"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-neko/neko/apps/openneko/internal/compose"
+	"github.com/open-neko/neko/apps/openneko/internal/config"
+	"github.com/open-neko/neko/apps/openneko/internal/installation"
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
+)
+
+type setupHostOptions struct {
+	webPort             int
+	webPortChanged      bool
+	openShellPort       int
+	openShellChanged    bool
+	webBindAddress      string
+	webBindChanged      bool
+	dockerSubnet        string
+	dockerSubnetChanged bool
+}
+
+// activateInstallation runs before every host-side command. It selects the
+// per-instance config directory, then restores persisted ports and network
+// settings. Named assignments are authoritative; the legacy unnamed install
+// continues to honor explicit environment overrides.
+func activateInstallation(selected string) error {
+	if os.Getenv("OPENNEKO_PROXIED") == "1" {
+		// The target worker container is already isolated by its Compose project
+		// and mounts its instance config at /config/openneko directly.
+		return nil
+	}
+	if strings.TrimSpace(selected) == "" {
+		selected = os.Getenv(instance.EnvName)
+	}
+	if err := instance.Select(selected); err != nil {
+		return err
+	}
+	settings, ok, err := installation.Load(config.Dir(""))
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	if settings.Instance != instance.Current() {
+		return fmt.Errorf("installation settings belong to instance %q, not %q", settings.Instance, instance.Current())
+	}
+	// Named installations treat the persisted listener/network assignment as
+	// authoritative. Otherwise a service-account environment left over from a
+	// different customer can silently remap this stack during start or upgrade.
+	// The legacy unnamed install retains its historical environment overrides.
+	named := instance.Current() != ""
+	if err := installation.ApplyEnvironment(settings, named); err != nil {
+		return err
+	}
+	if named {
+		// These values are deterministic children of DockerSubnet. Clear legacy
+		// process-wide values so configureOpenShellNetwork derives this
+		// customer's gateway addresses from its persisted subnet.
+		for _, key := range []string{openShellNetworkGatewayEnv, openShellNetworkIPRangeEnv, openShellGatewayIPEnv} {
+			if err := os.Unsetenv(key); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func loadCurrentInstallation() (installation.Settings, bool, error) {
+	return installation.Load(config.Dir(""))
+}
+
+func requireConfiguredNamedInstallation() (installation.Settings, bool, error) {
+	settings, ok, err := loadCurrentInstallation()
+	if err != nil || !ok || instance.Current() == "" {
+		return settings, ok, err
+	}
+	if settings.Instance != instance.Current() {
+		return installation.Settings{}, false, fmt.Errorf("installation settings belong to instance %q, not %q", settings.Instance, instance.Current())
+	}
+	return settings, true, nil
+}
+
+// prepareSetupInstallation resolves flag > environment > persisted setting >
+// default, persists the result, and applies it before preflight or Compose run.
+func prepareSetupInstallation(ctx context.Context, cmd *cobra.Command, requestedMode string, opts setupHostOptions) (installation.Settings, error) {
+	existing, exists, err := loadCurrentInstallation()
+	if err != nil {
+		return installation.Settings{}, err
+	}
+	name := instance.Current()
+	mode := strings.TrimSpace(requestedMode)
+	if exists {
+		if existing.Instance != name {
+			return installation.Settings{}, fmt.Errorf("installation settings belong to instance %q, not %q", existing.Instance, name)
+		}
+		if !cmd.Flags().Changed("mode") {
+			mode = existing.Mode
+		} else if name != "" && mode != existing.Mode {
+			return installation.Settings{}, fmt.Errorf("instance %q is installed in %s mode; use another instance name instead of changing it to %s", name, existing.Mode, mode)
+		}
+	}
+	if mode == "" {
+		mode = string(compose.ModeProd)
+	}
+
+	reservedPorts, err := installationPortReservations(name)
+	if err != nil {
+		return installation.Settings{}, err
+	}
+	excludedPorts := make(map[int]bool, len(reservedPorts)+1)
+	for port := range reservedPorts {
+		excludedPorts[port] = true
+	}
+	autoPorts := name != "" && !exists
+	webPort, err := resolveInstallPort(opts.webPort, opts.webPortChanged, "OPENNEKO_PORT", existing.WebPort, 3000, autoPorts, excludedPorts)
+	if err != nil {
+		return installation.Settings{}, err
+	}
+	if owner, reserved := reservedPorts[webPort]; reserved {
+		return installation.Settings{}, fmt.Errorf("web port %d is reserved by instance %s", webPort, owner)
+	}
+	excludedPorts[webPort] = true
+	openShellPort, err := resolveInstallPort(opts.openShellPort, opts.openShellChanged, "OPENSHELL_PORT", existing.OpenShellPort, 18080, autoPorts, excludedPorts)
+	if err != nil {
+		return installation.Settings{}, err
+	}
+	if owner, reserved := reservedPorts[openShellPort]; reserved {
+		return installation.Settings{}, fmt.Errorf("OpenShell port %d is reserved by instance %s", openShellPort, owner)
+	}
+
+	bindAddress := strings.TrimSpace(opts.webBindAddress)
+	if !opts.webBindChanged {
+		if env := strings.TrimSpace(os.Getenv("OPENNEKO_WEB_BIND_ADDRESS")); env != "" {
+			bindAddress = env
+		} else if exists {
+			bindAddress = existing.WebBindAddress
+		} else {
+			bindAddress = "0.0.0.0"
+		}
+	}
+
+	dockerSubnet := strings.TrimSpace(opts.dockerSubnet)
+	if !opts.dockerSubnetChanged {
+		if env := strings.TrimSpace(os.Getenv(openShellNetworkSubnetEnv)); env != "" {
+			dockerSubnet = env
+		} else if exists {
+			dockerSubnet = existing.DockerSubnet
+		} else if name != "" {
+			dockerSubnet, err = allocateInstanceSubnet(ctx, name+"-"+mode)
+			if err != nil {
+				return installation.Settings{}, err
+			}
+		}
+	}
+	if dockerSubnet != "" {
+		candidate, parseErr := netip.ParsePrefix(dockerSubnet)
+		if parseErr == nil {
+			reservations, reservationErr := installationSubnetReservations(name)
+			if reservationErr != nil {
+				return installation.Settings{}, reservationErr
+			}
+			for reserved, owner := range reservations {
+				if prefixOverlapsAny(candidate.Masked(), []netip.Prefix{reserved}) {
+					return installation.Settings{}, fmt.Errorf("Docker subnet %s is reserved by instance %s", dockerSubnet, owner)
+				}
+			}
+		}
+	}
+
+	settings := installation.Settings{
+		Version:        installation.CurrentVersion,
+		Instance:       name,
+		Mode:           mode,
+		WebPort:        webPort,
+		WebBindAddress: bindAddress,
+		OpenShellPort:  openShellPort,
+		DockerSubnet:   dockerSubnet,
+	}
+	if err := settings.Validate(); err != nil {
+		return installation.Settings{}, err
+	}
+	if err := installation.Save(config.Dir(""), settings); err != nil {
+		return installation.Settings{}, fmt.Errorf("persist installation settings: %w", err)
+	}
+	if err := installation.ApplyEnvironment(settings, true); err != nil {
+		return installation.Settings{}, err
+	}
+	return settings, nil
+}
+
+func resolveInstallPort(flagValue int, flagChanged bool, envName string, persisted, fallback int, auto bool, excluded map[int]bool) (int, error) {
+	if flagChanged {
+		if flagValue < 1 || flagValue > 65535 {
+			return 0, fmt.Errorf("--%s must be between 1 and 65535", portFlagName(envName))
+		}
+		return flagValue, nil
+	}
+	if raw := strings.TrimSpace(os.Getenv(envName)); raw != "" {
+		port, err := strconv.Atoi(raw)
+		if err != nil || port < 1 || port > 65535 {
+			return 0, fmt.Errorf("%s must be a port between 1 and 65535", envName)
+		}
+		return port, nil
+	}
+	if persisted != 0 {
+		return persisted, nil
+	}
+	if !auto {
+		return fallback, nil
+	}
+	return firstAvailablePort(fallback, excluded)
+}
+
+func portFlagName(envName string) string {
+	if envName == "OPENSHELL_PORT" {
+		return "openshell-port"
+	}
+	return "port"
+}
+
+func firstAvailablePort(start int, excluded map[int]bool) (int, error) {
+	for port := start; port <= 65535; port++ {
+		if excluded[port] {
+			continue
+		}
+		listener, err := net.Listen("tcp", net.JoinHostPort("0.0.0.0", strconv.Itoa(port)))
+		if err != nil {
+			continue
+		}
+		_ = listener.Close()
+		return port, nil
+	}
+	return 0, fmt.Errorf("no free host port found at or above %d", start)
+}
+
+func installationPortReservations(current string) (map[int]string, error) {
+	entries, err := configuredInstallations()
+	if err != nil {
+		return nil, err
+	}
+	reserved := map[int]string{}
+	for _, entry := range entries {
+		if entry.Name == current {
+			continue
+		}
+		label := entry.Name
+		if label == "" {
+			label = "(default)"
+		}
+		reserved[entry.Settings.WebPort] = label
+		reserved[entry.Settings.OpenShellPort] = label
+	}
+	return reserved, nil
+}
+
+func installationSubnetReservations(current string) (map[netip.Prefix]string, error) {
+	entries, err := configuredInstallations()
+	if err != nil {
+		return nil, err
+	}
+	reserved := map[netip.Prefix]string{}
+	for _, entry := range entries {
+		if entry.Name == current || entry.Settings.DockerSubnet == "" {
+			continue
+		}
+		prefix, err := netip.ParsePrefix(entry.Settings.DockerSubnet)
+		if err != nil {
+			continue
+		}
+		label := entry.Name
+		if label == "" {
+			label = "(default)"
+		}
+		reserved[prefix.Masked()] = label
+	}
+	return reserved, nil
+}
+
+// allocateInstanceSubnet selects a stable candidate from a large private pool,
+// skipping subnets already claimed by Docker. The chosen value is persisted,
+// so later commands never depend on Docker network enumeration order.
+func allocateInstanceSubnet(ctx context.Context, seed string) (string, error) {
+	occupied, err := listDockerNetworkSubnets(ctx)
+	if err != nil {
+		return "", fmt.Errorf("inspect Docker networks for instance allocation: %w", err)
+	}
+	entries, err := configuredInstallations()
+	if err != nil {
+		return "", err
+	}
+	for _, entry := range entries {
+		if entry.Settings.DockerSubnet == "" {
+			continue
+		}
+		if prefix, parseErr := netip.ParsePrefix(entry.Settings.DockerSubnet); parseErr == nil {
+			occupied = append(occupied, prefix.Masked())
+		}
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(seed))
+	const candidates = 8192 // 10.224.0.0/11 split into /24 networks.
+	start := int(h.Sum32() % candidates)
+	for offset := 0; offset < candidates; offset++ {
+		index := (start + offset) % candidates
+		candidate, _ := netip.ParsePrefix(fmt.Sprintf("10.%d.%d.0/24", 224+index/256, index%256))
+		if !prefixOverlapsAny(candidate, occupied) {
+			return candidate.String(), nil
+		}
+	}
+	return "", fmt.Errorf("no unused OpenNeko Docker /24 found; pass --docker-subnet with an available private subnet")
+}
+
+var listDockerNetworkSubnets = dockerNetworkSubnets
+
+func prefixOverlapsAny(candidate netip.Prefix, occupied []netip.Prefix) bool {
+	for _, prefix := range occupied {
+		if candidate.Contains(prefix.Masked().Addr()) || prefix.Contains(candidate.Masked().Addr()) {
+			return true
+		}
+	}
+	return false
+}
+
+func dockerNetworkSubnets(ctx context.Context) ([]netip.Prefix, error) {
+	idsRaw, err := exec.CommandContext(ctx, "docker", "network", "ls", "-q").Output()
+	if err != nil {
+		return nil, err
+	}
+	ids := strings.Fields(string(idsRaw))
+	if len(ids) == 0 {
+		return nil, nil
+	}
+	args := append([]string{"network", "inspect"}, ids...)
+	raw, err := exec.CommandContext(ctx, "docker", args...).Output()
+	if err != nil {
+		return nil, err
+	}
+	var networks []struct {
+		IPAM struct {
+			Config []struct {
+				Subnet string `json:"Subnet"`
+			} `json:"Config"`
+		} `json:"IPAM"`
+	}
+	if err := json.Unmarshal(raw, &networks); err != nil {
+		return nil, err
+	}
+	var prefixes []netip.Prefix
+	for _, network := range networks {
+		for _, cfg := range network.IPAM.Config {
+			if prefix, err := netip.ParsePrefix(cfg.Subnet); err == nil && prefix.Addr().Is4() {
+				prefixes = append(prefixes, prefix.Masked())
+			}
+		}
+	}
+	return prefixes, nil
+}
+
+func modeForStart(cmd *cobra.Command, requested string) (compose.Mode, error) {
+	settings, ok, err := loadCurrentInstallation()
+	if err != nil {
+		return "", err
+	}
+	if instance.Current() != "" && !ok {
+		return "", fmt.Errorf("instance %q has not been configured; run `openneko setup --instance %s` first", instance.Current(), instance.Current())
+	}
+	if ok && !cmd.Flags().Changed("mode") {
+		requested = settings.Mode
+	}
+	mode := compose.Mode(requested)
+	switch mode {
+	case compose.ModeProd, compose.ModeDev, compose.ModeDemo:
+	default:
+		return "", fmt.Errorf("--mode must be one of: prod, dev, demo (got %q)", requested)
+	}
+	if ok && instance.Current() != "" && settings.Mode != string(mode) {
+		return "", fmt.Errorf("instance %q is installed in %s mode, not %s", instance.Current(), settings.Mode, mode)
+	}
+	return mode, nil
+}

--- a/apps/openneko/internal/cli/instance_settings_test.go
+++ b/apps/openneko/internal/cli/instance_settings_test.go
@@ -1,0 +1,310 @@
+package cli
+
+import (
+	"context"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-neko/neko/apps/openneko/internal/config"
+	"github.com/open-neko/neko/apps/openneko/internal/installation"
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
+)
+
+func isolateNamedInstallation(t *testing.T, name string) {
+	t.Helper()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("OPENNEKO_WORKSPACE_ROOT", "")
+	t.Setenv("OPENNEKO_PORT", "")
+	t.Setenv("OPENNEKO_WEB_BIND_ADDRESS", "")
+	t.Setenv("OPENSHELL_PORT", "")
+	t.Setenv(openShellNetworkSubnetEnv, "")
+	t.Setenv(openShellNetworkGatewayEnv, "")
+	t.Setenv(openShellNetworkIPRangeEnv, "")
+	t.Setenv(openShellGatewayIPEnv, "")
+	t.Setenv(instance.EnvName, name)
+}
+
+func TestPrepareSetupInstallationPersistsExplicitInstanceSettings(t *testing.T) {
+	isolateNamedInstallation(t, "acme")
+	cmd := newSetupCmd()
+	for name, value := range map[string]string{
+		"mode":           "prod",
+		"port":           "3100",
+		"openshell-port": "18100",
+		"bind-address":   "127.0.0.1",
+		"docker-subnet":  "10.224.10.0/24",
+	} {
+		if err := cmd.Flags().Set(name, value); err != nil {
+			t.Fatal(err)
+		}
+	}
+	settings, err := prepareSetupInstallation(context.Background(), cmd, "prod", setupHostOptions{
+		webPort:             3100,
+		webPortChanged:      true,
+		openShellPort:       18100,
+		openShellChanged:    true,
+		webBindAddress:      "127.0.0.1",
+		webBindChanged:      true,
+		dockerSubnet:        "10.224.10.0/24",
+		dockerSubnetChanged: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settings.Instance != "acme" || settings.WebPort != 3100 || settings.OpenShellPort != 18100 {
+		t.Fatalf("settings = %+v", settings)
+	}
+	readBack, ok, err := installation.Load(config.Dir(""))
+	if err != nil || !ok || readBack != settings {
+		t.Fatalf("readBack = %+v, ok=%v, err=%v", readBack, ok, err)
+	}
+	if got := os.Getenv("OPENNEKO_PORT"); got != "3100" {
+		t.Fatalf("OPENNEKO_PORT = %q", got)
+	}
+}
+
+func TestActivateInstallationRestoresPersistedPorts(t *testing.T) {
+	isolateNamedInstallation(t, "acme")
+	settings := installation.Settings{
+		Version:        installation.CurrentVersion,
+		Instance:       "acme",
+		Mode:           "prod",
+		WebPort:        3200,
+		WebBindAddress: "127.0.0.1",
+		OpenShellPort:  18200,
+		DockerSubnet:   "10.224.20.0/24",
+	}
+	if err := installation.Save(config.Dir(""), settings); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(instance.EnvName, "")
+	t.Setenv("OPENNEKO_PORT", "")
+	t.Setenv("OPENSHELL_PORT", "")
+	if err := activateInstallation("acme"); err != nil {
+		t.Fatal(err)
+	}
+	if os.Getenv("OPENNEKO_PORT") != "3200" || os.Getenv("OPENSHELL_PORT") != "18200" {
+		t.Fatalf("persisted ports not restored: web=%q openshell=%q", os.Getenv("OPENNEKO_PORT"), os.Getenv("OPENSHELL_PORT"))
+	}
+}
+
+func TestActivateNamedInstallationDoesNotInheritAnotherStacksPorts(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv(instance.EnvName, "acme")
+	settings := installation.Settings{
+		Version:        installation.CurrentVersion,
+		Instance:       "acme",
+		Mode:           "prod",
+		WebPort:        3100,
+		WebBindAddress: "127.0.0.1",
+		OpenShellPort:  18100,
+		DockerSubnet:   "10.224.10.0/24",
+	}
+	if err := installation.Save(config.Dir(""), settings); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OPENNEKO_PORT", "3999")
+	t.Setenv("OPENSHELL_PORT", "19999")
+	t.Setenv(openShellNetworkGatewayEnv, "10.225.1.1")
+	t.Setenv(openShellNetworkIPRangeEnv, "10.225.1.128/25")
+	t.Setenv(openShellGatewayIPEnv, "10.225.1.2")
+	if err := activateInstallation("acme"); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv("OPENNEKO_PORT"); got != "3100" {
+		t.Fatalf("web port = %q, want persisted 3100", got)
+	}
+	if got := os.Getenv("OPENSHELL_PORT"); got != "18100" {
+		t.Fatalf("OpenShell port = %q, want persisted 18100", got)
+	}
+	for _, key := range []string{openShellNetworkGatewayEnv, openShellNetworkIPRangeEnv, openShellGatewayIPEnv} {
+		if got := os.Getenv(key); got != "" {
+			t.Fatalf("derived network override %s was retained as %q", key, got)
+		}
+	}
+}
+
+func TestModeForStartRequiresNamedSetup(t *testing.T) {
+	isolateNamedInstallation(t, "not-installed")
+	cmd := newStartCmd()
+	_, err := modeForStart(cmd, "prod")
+	if err == nil || !strings.Contains(err.Error(), "openneko setup --instance not-installed") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestModeForStartUsesPersistedMode(t *testing.T) {
+	isolateNamedInstallation(t, "demo-customer")
+	settings := installation.Settings{
+		Version:        installation.CurrentVersion,
+		Instance:       "demo-customer",
+		Mode:           "demo",
+		WebPort:        3300,
+		WebBindAddress: "127.0.0.1",
+		OpenShellPort:  18300,
+		DockerSubnet:   "10.224.30.0/24",
+	}
+	if err := installation.Save(config.Dir(""), settings); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newStartCmd()
+	mode, err := modeForStart(cmd, "prod")
+	if err != nil || string(mode) != "demo" {
+		t.Fatalf("mode=%q err=%v", mode, err)
+	}
+}
+
+func TestPrefixOverlap(t *testing.T) {
+	occupied := mustPrefixes(t, "10.224.20.0/24", "172.17.0.0/16")
+	if !prefixOverlapsAny(mustPrefixes(t, "10.224.20.0/24")[0], occupied) {
+		t.Fatal("exact overlap not detected")
+	}
+	if prefixOverlapsAny(mustPrefixes(t, "10.225.20.0/24")[0], occupied) {
+		t.Fatal("unrelated subnet reported as overlap")
+	}
+}
+
+func TestAllocateInstanceSubnetIsStableAndSkipsPersistedReservation(t *testing.T) {
+	isolateNamedInstallation(t, "globex")
+	previous := listDockerNetworkSubnets
+	t.Cleanup(func() { listDockerNetworkSubnets = previous })
+	listDockerNetworkSubnets = func(context.Context) ([]netip.Prefix, error) { return nil, nil }
+
+	first, err := allocateInstanceSubnet(context.Background(), "stable-seed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	acme := installation.Settings{
+		Version:        1,
+		Instance:       "acme",
+		Mode:           "prod",
+		WebPort:        3100,
+		WebBindAddress: "127.0.0.1",
+		OpenShellPort:  18100,
+		DockerSubnet:   first,
+	}
+	if err := installation.Save(filepath.Join(config.RootDir(), "instances", "acme"), acme); err != nil {
+		t.Fatal(err)
+	}
+	second, err := allocateInstanceSubnet(context.Background(), "stable-seed")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first == second {
+		t.Fatalf("allocator reused persisted subnet %s", first)
+	}
+}
+
+func TestSetupRejectsPortReservedByStoppedInstance(t *testing.T) {
+	isolateNamedInstallation(t, "globex")
+	acme := installation.Settings{
+		Version:        1,
+		Instance:       "acme",
+		Mode:           "prod",
+		WebPort:        3100,
+		WebBindAddress: "127.0.0.1",
+		OpenShellPort:  18100,
+		DockerSubnet:   "10.224.10.0/24",
+	}
+	if err := installation.Save(filepath.Join(config.RootDir(), "instances", "acme"), acme); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newSetupCmd()
+	if err := cmd.Flags().Set("port", "3100"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("openshell-port", "18101"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("bind-address", "127.0.0.1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := cmd.Flags().Set("docker-subnet", "10.224.11.0/24"); err != nil {
+		t.Fatal(err)
+	}
+	_, err := prepareSetupInstallation(context.Background(), cmd, "prod", setupHostOptions{
+		webPort:             3100,
+		webPortChanged:      true,
+		openShellPort:       18101,
+		openShellChanged:    true,
+		webBindAddress:      "127.0.0.1",
+		webBindChanged:      true,
+		dockerSubnet:        "10.224.11.0/24",
+		dockerSubnetChanged: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "reserved by instance acme") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestSetupRejectsSubnetReservedByStoppedInstance(t *testing.T) {
+	isolateNamedInstallation(t, "globex")
+	acme := installation.Settings{
+		Version:        1,
+		Instance:       "acme",
+		Mode:           "prod",
+		WebPort:        3100,
+		WebBindAddress: "127.0.0.1",
+		OpenShellPort:  18100,
+		DockerSubnet:   "10.224.10.0/24",
+	}
+	if err := installation.Save(filepath.Join(config.RootDir(), "instances", "acme"), acme); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newSetupCmd()
+	for name, value := range map[string]string{
+		"port":           "3101",
+		"openshell-port": "18101",
+		"bind-address":   "127.0.0.1",
+		"docker-subnet":  "10.224.10.0/24",
+	} {
+		if err := cmd.Flags().Set(name, value); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_, err := prepareSetupInstallation(context.Background(), cmd, "prod", setupHostOptions{
+		webPort:             3101,
+		webPortChanged:      true,
+		openShellPort:       18101,
+		openShellChanged:    true,
+		webBindAddress:      "127.0.0.1",
+		webBindChanged:      true,
+		dockerSubnet:        "10.224.10.0/24",
+		dockerSubnetChanged: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "subnet 10.224.10.0/24 is reserved by instance acme") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func mustPrefixes(t *testing.T, values ...string) []netip.Prefix {
+	t.Helper()
+	out := make([]netip.Prefix, 0, len(values))
+	for _, value := range values {
+		prefix, err := netip.ParsePrefix(value)
+		if err != nil {
+			t.Fatal(err)
+		}
+		out = append(out, prefix)
+	}
+	return out
+}
+
+func TestNamedRuntimeAndConfigDoNotSharePaths(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(base, "config"))
+	t.Setenv("XDG_STATE_HOME", filepath.Join(base, "state"))
+	t.Setenv(instance.EnvName, "acme")
+	acmeConfig := config.Dir("")
+	if err := instance.Select("globex"); err != nil {
+		t.Fatal(err)
+	}
+	globexConfig := config.Dir("")
+	if acmeConfig == globexConfig {
+		t.Fatalf("instances share config path %q", acmeConfig)
+	}
+}

--- a/apps/openneko/internal/cli/instances.go
+++ b/apps/openneko/internal/cli/instances.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-neko/neko/apps/openneko/internal/compose"
+	"github.com/open-neko/neko/apps/openneko/internal/config"
+	"github.com/open-neko/neko/apps/openneko/internal/installation"
+)
+
+type installationInventoryEntry struct {
+	Name     string
+	Settings installation.Settings
+}
+
+func newInstancesCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "instances",
+		Short: "List configured OpenNeko installations on this host",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			entries, err := configuredInstallations()
+			if err != nil {
+				return err
+			}
+			if len(entries) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(), "No configured OpenNeko installations found.")
+				return nil
+			}
+			writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 4, 2, ' ', 0)
+			fmt.Fprintln(writer, "INSTANCE\tMODE\tWEB\tCOMPOSE PROJECT")
+			for _, entry := range entries {
+				label := entry.Name
+				if label == "" {
+					label = "(default)"
+				}
+				settings := entry.Settings
+				webHost := settings.WebBindAddress
+				if webHost == "0.0.0.0" {
+					webHost = "localhost"
+				}
+				fmt.Fprintf(
+					writer,
+					"%s\t%s\thttp://%s:%d\t%s\n",
+					label,
+					settings.Mode,
+					webHost,
+					settings.WebPort,
+					compose.ProjectNameForModeAndInstance(compose.Mode(settings.Mode), settings.Instance),
+				)
+			}
+			return writer.Flush()
+		},
+	}
+}
+
+func configuredInstallations() ([]installationInventoryEntry, error) {
+	root := config.RootDir()
+	var entries []installationInventoryEntry
+	if settings, ok, err := installation.Load(root); err != nil {
+		return nil, err
+	} else if ok {
+		if settings.Instance != "" {
+			return nil, fmt.Errorf("default installation settings contain named instance %q", settings.Instance)
+		}
+		entries = append(entries, installationInventoryEntry{Settings: settings})
+	}
+
+	instancesDir := filepath.Join(root, "instances")
+	dirs, err := os.ReadDir(instancesDir)
+	if errors.Is(err, fs.ErrNotExist) {
+		return entries, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	for _, dir := range dirs {
+		if !dir.IsDir() {
+			continue
+		}
+		settings, ok, err := installation.Load(filepath.Join(instancesDir, dir.Name()))
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			continue
+		}
+		if settings.Instance != dir.Name() {
+			return nil, fmt.Errorf("installation directory %q contains settings for instance %q", dir.Name(), settings.Instance)
+		}
+		entries = append(entries, installationInventoryEntry{Name: dir.Name(), Settings: settings})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	return entries, nil
+}

--- a/apps/openneko/internal/cli/instances_test.go
+++ b/apps/openneko/internal/cli/instances_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/open-neko/neko/apps/openneko/internal/config"
+	"github.com/open-neko/neko/apps/openneko/internal/installation"
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
+)
+
+func TestConfiguredInstallationsListsNamedInstances(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv(instance.EnvName, "")
+	for _, settings := range []installation.Settings{
+		{Version: 1, Instance: "acme", Mode: "prod", WebPort: 3100, WebBindAddress: "127.0.0.1", OpenShellPort: 18100, DockerSubnet: "10.224.1.0/24"},
+		{Version: 1, Instance: "globex", Mode: "prod", WebPort: 3101, WebBindAddress: "127.0.0.1", OpenShellPort: 18101, DockerSubnet: "10.224.2.0/24"},
+	} {
+		dir := filepath.Join(config.RootDir(), "instances", settings.Instance)
+		if err := installation.Save(dir, settings); err != nil {
+			t.Fatal(err)
+		}
+	}
+	entries, err := configuredInstallations()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 || entries[0].Name != "acme" || entries[1].Name != "globex" {
+		t.Fatalf("entries = %+v", entries)
+	}
+}
+
+func TestInstancesCommandOutput(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv(instance.EnvName, "")
+	settings := installation.Settings{Version: 1, Instance: "acme", Mode: "prod", WebPort: 3100, WebBindAddress: "127.0.0.1", OpenShellPort: 18100, DockerSubnet: "10.224.1.0/24"}
+	if err := installation.Save(filepath.Join(config.RootDir(), "instances", "acme"), settings); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newInstancesCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"acme", "127.0.0.1:3100", "openneko-acme-prod"} {
+		if !strings.Contains(out.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, out.String())
+		}
+	}
+}

--- a/apps/openneko/internal/cli/openshell_test.go
+++ b/apps/openneko/internal/cli/openshell_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/open-neko/neko/apps/openneko/internal/compose"
 	"github.com/open-neko/neko/apps/openneko/internal/config"
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
 )
 
 func TestAgentImageRef(t *testing.T) {
@@ -32,6 +33,39 @@ func TestOpenShellStateDirOverride(t *testing.T) {
 	// An explicit existing value is always respected (no override).
 	if got := openShellStateDirOverride("darwin", "/Users/x", "/custom/state"); got != "" {
 		t.Fatalf("existing value must win: got %q", got)
+	}
+}
+
+func TestConfigureOpenShellStateDirScopesNamedInstance(t *testing.T) {
+	stateHome := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv(instance.EnvName, "acme")
+	t.Setenv("OPENSHELL_STATE_DIR", filepath.Join(t.TempDir(), "another-customer"))
+	if err := configureOpenShellStateDir(); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(stateHome, "openneko", "instances", "acme", "openshell")
+	if got := os.Getenv("OPENSHELL_STATE_DIR"); got != want {
+		t.Fatalf("OPENSHELL_STATE_DIR = %q, want %q", got, want)
+	}
+}
+
+func TestConfigureOpenShellDBURLScopesNamedInstance(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv(instance.EnvName, "acme")
+	t.Setenv(openShellDBPasswordEnv, "another-customer-password")
+	t.Setenv("OPENSHELL_DB_URL", "postgres://other:secret@other-db:5432/other")
+
+	configureOpenShellDBURL()
+	wantPassword, err := config.OpenShellDBPassword("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv(openShellDBPasswordEnv); got != wantPassword {
+		t.Fatal("named OpenShell password was not derived from selected config")
+	}
+	if got := os.Getenv("OPENSHELL_DB_URL"); !strings.Contains(got, "@neko-db:5432/") || strings.Contains(got, "other-db") {
+		t.Fatalf("named OPENSHELL_DB_URL = %q", got)
 	}
 }
 
@@ -114,6 +148,7 @@ func TestConfigureOpenShellNetworkRejectsBridgeGatewayOutsideSubnet(t *testing.T
 
 func TestConfigureOpenShellDBURL(t *testing.T) {
 	// Operator-set URL always wins.
+	t.Setenv(instance.EnvName, "")
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	t.Setenv(openShellDBPasswordEnv, "")
 	t.Setenv("OPENSHELL_DB_URL", "postgres://op:set@elsewhere:5432/db")

--- a/apps/openneko/internal/cli/reset.go
+++ b/apps/openneko/internal/cli/reset.go
@@ -32,9 +32,10 @@ func newResetCmd() *cobra.Command {
 				return err
 			}
 			// Tear down every possible project name an operator could have used
-			// in this dir, so reset works regardless of the last mode.
+			// for this instance, so reset works regardless of the last mode without
+			// touching another customer's projects.
 			for _, m := range []compose.Mode{compose.ModeProd, compose.ModeDev, compose.ModeDemo} {
-				_, _ = sup.Run(context.Background(), "openneko-"+string(m), files, []string{"down", "-v"}, os.Stdout, os.Stderr)
+				_, _ = sup.Run(context.Background(), compose.ProjectNameForMode(m), files, []string{"down", "-v"}, os.Stdout, os.Stderr)
 			}
 			oldRepository := os.Getenv("OPENNEKO_BACKUP_REPOSITORY")
 			_, newID, err := sup.RotateInstallationID()

--- a/apps/openneko/internal/cli/root.go
+++ b/apps/openneko/internal/cli/root.go
@@ -10,11 +10,16 @@ package cli
 
 import (
 	"errors"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/open-neko/neko/apps/openneko/assets"
+	"github.com/open-neko/neko/apps/openneko/internal/compose"
 	"github.com/open-neko/neko/apps/openneko/internal/dockerproxy"
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
 	"github.com/open-neko/neko/apps/openneko/internal/version"
 )
 
@@ -27,11 +32,58 @@ func MaybeProxyToWorker(cmd *cobra.Command) (int, bool) {
 	if local, _ := cmd.Flags().GetBool("local"); local {
 		return 0, false
 	}
-	container := dockerproxy.FindRunningWorker()
+	project := ""
+	settings, ok, err := loadCurrentInstallation()
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "openneko: cannot read selected installation: %v\n", err)
+		return 1, true
+	}
+	if ok {
+		project = compose.ProjectNameForModeAndInstance(compose.Mode(settings.Mode), settings.Instance)
+		if settings.Instance == "" {
+			sup := compose.New(assets.ComposeFS)
+			if saved, savedErr := sup.ProjectName(""); savedErr == nil && saved != "" {
+				project = saved
+			}
+		}
+	} else if instance.Current() != "" {
+		fmt.Fprintf(cmd.ErrOrStderr(), "openneko: instance %q has not been configured; run `openneko --instance %s setup` first\n", instance.Current(), instance.Current())
+		return 1, true
+	}
+	container, resolveErr := dockerproxy.ResolveRunningWorker(project)
+	if resolveErr != nil {
+		if project == "" && !errors.Is(resolveErr, dockerproxy.ErrAmbiguousWorkers) {
+			// No packaged installation was selected. Preserve the source-dev
+			// workflow, where plugin operations intentionally execute locally.
+			return 0, false
+		}
+		fmt.Fprintf(cmd.ErrOrStderr(), "openneko: cannot locate instance worker: %v\n", resolveErr)
+		return 1, true
+	}
 	if container == "" {
+		if project != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), "openneko: worker for %s is not running; start the selected instance or pass --local\n", project)
+			return 1, true
+		}
 		return 0, false
 	}
+	if project == "" {
+		if name, named := namedInstanceFromWorkerContainer(container); named {
+			fmt.Fprintf(cmd.ErrOrStderr(), "openneko: worker %s belongs to named instance %q; re-run with --instance %s\n", container, name, name)
+			return 1, true
+		}
+	}
 	return dockerproxy.ProxyToWorker(container, os.Args[1:]), true
+}
+
+func namedInstanceFromWorkerContainer(container string) (string, bool) {
+	const suffix = "-worker-1"
+	project := strings.TrimSuffix(strings.TrimSpace(container), suffix)
+	if project == container {
+		return "", false
+	}
+	_, name, ok := compose.IdentityFromProjectName(project)
+	return name, ok && name != ""
 }
 
 type exitErr struct {
@@ -62,6 +114,7 @@ func ExitCodeFor(err error) int {
 }
 
 func NewRoot() *cobra.Command {
+	var selectedInstance string
 	cmd := &cobra.Command{
 		Use:   "openneko",
 		Short: "OpenNeko operator CLI",
@@ -70,11 +123,14 @@ func NewRoot() *cobra.Command {
 Getting started: setup (guided install — preflight, bring-up, configure).
 Plugin ops: init, install, list, remove, marketplace, secrets, doctor.
 Solution packs: pack list, pack inspect, pack plan, pack install, pack status.
-Stack ops:  start, upgrade, stop, logs, status, backup, restore, storage, migrate, seed, reset.
+Stack ops:  instances, start, upgrade, stop, logs, status, backup, restore, storage, migrate, seed, reset.
 Developer ops: eval.`,
 		Version:       version.Version,
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		PersistentPreRunE: func(_ *cobra.Command, _ []string) error {
+			return activateInstallation(selectedInstance)
+		},
 	}
 	cmd.SetVersionTemplate("{{.Version}}\n")
 	// Persistent flag: plugin-op commands (init/install/remove/list/
@@ -84,8 +140,10 @@ Developer ops: eval.`,
 	// host-side execution (use this for source-build dev workflows that
 	// happen to have a compose stack running alongside `pnpm dev`).
 	cmd.PersistentFlags().Bool("local", false, "Force local execution; don't auto-proxy plugin ops into a running worker container")
+	cmd.PersistentFlags().StringVar(&selectedInstance, "instance", "", "Target a named OpenNeko installation")
 	cmd.AddCommand(
 		newSetupCmd(),
+		newInstancesCmd(),
 		newInitCmd(),
 		newInstallCmd(),
 		newRemoveCmd(),

--- a/apps/openneko/internal/cli/seed.go
+++ b/apps/openneko/internal/cli/seed.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/open-neko/neko/apps/openneko/assets"
 	"github.com/open-neko/neko/apps/openneko/internal/compose"
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
 )
 
 func newSeedCmd() *cobra.Command {
@@ -24,6 +25,18 @@ func newSeedCmd() *cobra.Command {
 			}
 			if target != "adventureworks" {
 				return WithExit(2, fmt.Errorf("seed: unknown target %q (want: adventureworks)", target))
+			}
+			if instance.Current() != "" {
+				settings, ok, err := requireConfiguredNamedInstallation()
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("instance %q has not been configured; run `openneko --instance %s setup --mode demo` first", instance.Current(), instance.Current())
+				}
+				if settings.Mode != string(compose.ModeDemo) {
+					return fmt.Errorf("instance %q is installed in %s mode; AdventureWorks seed requires a demo instance", instance.Current(), settings.Mode)
+				}
 			}
 			sup := compose.New(assets.ComposeFS)
 			project, err := sup.ProjectName(compose.ModeDemo)

--- a/apps/openneko/internal/cli/setup.go
+++ b/apps/openneko/internal/cli/setup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"strconv"
@@ -28,6 +29,10 @@ func newSetupCmd() *cobra.Command {
 		mode           string
 		verbose        bool
 		skipOnboarding bool
+		webPort        int
+		openShellPort  int
+		webBindAddress string
+		dockerSubnet   string
 
 		// Headless onboarding overrides. Setting any credential flag opts the
 		// run into headless mode (no prompts), so CI and the demo-install skill
@@ -67,15 +72,28 @@ at the prompt) to finish at the web UI. Credential flags
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
 
-			m := compose.Mode(mode)
-			if m == "" {
-				m = compose.ModeProd
+			settings, err := prepareSetupInstallation(ctx, cmd, mode, setupHostOptions{
+				webPort:             webPort,
+				webPortChanged:      cmd.Flags().Changed("port"),
+				openShellPort:       openShellPort,
+				openShellChanged:    cmd.Flags().Changed("openshell-port"),
+				webBindAddress:      webBindAddress,
+				webBindChanged:      cmd.Flags().Changed("bind-address"),
+				dockerSubnet:        dockerSubnet,
+				dockerSubnetChanged: cmd.Flags().Changed("docker-subnet"),
+			})
+			if err != nil {
+				return err
 			}
+			m := compose.Mode(settings.Mode)
 			baseURL := webBaseURL()
 			client := setup.NewClient(baseURL)
 			alreadyUp := client.Ready(ctx)
 
 			subtitle := string(m) + " mode"
+			if settings.Instance != "" {
+				subtitle = settings.Instance + " · " + subtitle
+			}
 			if alreadyUp {
 				subtitle += " · stack already running"
 			}
@@ -90,11 +108,22 @@ at the prompt) to finish at the web UI. Credential flags
 				// The wizard configures WHATEVER stack answers on this port.
 				// `setup --mode demo` next to a live prod stack silently
 				// configured prod with demo defaults; refuse the mismatch.
-				if project := runningWebProject(); project != "" {
-					if detected, ok := compose.ModeFromProjectName(project); ok && detected != m {
+				project := runningWebProject(strconv.Itoa(settings.WebPort))
+				if settings.Instance != "" && project == "" {
+					return fmt.Errorf("%s is already answering, but it is not the web container for instance %q; choose another --port", baseURL, settings.Instance)
+				}
+				if project != "" {
+					detectedMode, detectedInstance, ok := compose.IdentityFromProjectName(project)
+					if project == "openneko" {
+						detectedMode, detectedInstance, ok = compose.ModeProd, "", true
+					}
+					if !ok && settings.Instance != "" {
+						return fmt.Errorf("the stack answering %s has unrecognized Compose project %q", baseURL, project)
+					}
+					if ok && (detectedMode != m || detectedInstance != settings.Instance) {
 						return fmt.Errorf(
-							"the stack answering %s is %q (mode %s), but --mode %s was requested; stop that stack first or re-run with --mode %s",
-							baseURL, project, detected, m, detected,
+							"the stack answering %s is %q (instance %q, mode %s), not requested instance %q in mode %s",
+							baseURL, project, detectedInstance, detectedMode, settings.Instance, m,
 						)
 					}
 				}
@@ -180,6 +209,10 @@ at the prompt) to finish at the web UI. Credential flags
 	}
 
 	cmd.Flags().StringVar(&mode, "mode", "prod", "Stack mode: prod|dev|demo")
+	cmd.Flags().IntVar(&webPort, "port", 0, "Host port for the web app (named instances auto-select when omitted)")
+	cmd.Flags().IntVar(&openShellPort, "openshell-port", 0, "Loopback host port for the OpenShell gateway (named instances auto-select when omitted)")
+	cmd.Flags().StringVar(&webBindAddress, "bind-address", "", "IPv4 address for the web listener (default 0.0.0.0; use 127.0.0.1 behind a reverse proxy)")
+	cmd.Flags().StringVar(&dockerSubnet, "docker-subnet", "", "Private IPv4 /24 for this instance (named instances auto-select when omitted)")
 	cmd.Flags().BoolVar(&verbose, "verbose", false, "Stream full image-pull output during bring-up")
 	cmd.Flags().BoolVar(&skipOnboarding, "skip-onboarding", false, "Bring up the stack only; finish configuration in the browser")
 	cmd.Flags().StringVar(&adminPassword, "admin-password", "", "Headless: admin database password")
@@ -337,19 +370,20 @@ func matchPlugins(tokens []string, plugins []marketplace.Plugin) []string {
 // runningWebProject returns the compose project of the running web
 // container, or "" when none is found / docker is unreachable. Used to
 // detect which stack actually owns the port setup is about to configure.
-func runningWebProject() string {
+func runningWebProject(port string) string {
 	out, err := exec.Command(
 		"docker", "ps",
 		"--filter", "status=running",
 		"--filter", "label=com.docker.compose.service=web",
-		"--format", `{{.Label "com.docker.compose.project"}}`,
+		"--format", `{{.Label "com.docker.compose.project"}}|{{.Ports}}`,
 	).Output()
 	if err != nil {
 		return ""
 	}
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if line = strings.TrimSpace(line); line != "" {
-			return line
+		project, ports, ok := strings.Cut(strings.TrimSpace(line), "|")
+		if ok && project != "" && strings.Contains(ports, ":"+port+"->8080/tcp") {
+			return project
 		}
 	}
 	return ""
@@ -360,7 +394,11 @@ func webBaseURL() string {
 	if port == "" {
 		port = "3000"
 	}
-	return "http://localhost:" + port
+	host := strings.TrimSpace(os.Getenv("OPENNEKO_WEB_BIND_ADDRESS"))
+	if host == "" || host == "0.0.0.0" {
+		host = "localhost"
+	}
+	return "http://" + net.JoinHostPort(host, port)
 }
 
 // runPreflight runs the host readiness checks and prints them, returning a

--- a/apps/openneko/internal/cli/setup_test.go
+++ b/apps/openneko/internal/cli/setup_test.go
@@ -8,6 +8,18 @@ import (
 	"github.com/open-neko/neko/apps/openneko/internal/plugin/marketplace"
 )
 
+func TestWebBaseURLUsesPersistedBindAddress(t *testing.T) {
+	t.Setenv("OPENNEKO_PORT", "3100")
+	t.Setenv("OPENNEKO_WEB_BIND_ADDRESS", "192.0.2.10")
+	if got := webBaseURL(); got != "http://192.0.2.10:3100" {
+		t.Fatalf("webBaseURL = %q", got)
+	}
+	t.Setenv("OPENNEKO_WEB_BIND_ADDRESS", "0.0.0.0")
+	if got := webBaseURL(); got != "http://localhost:3100" {
+		t.Fatalf("wildcard webBaseURL = %q", got)
+	}
+}
+
 func TestSetupRetainsHermesOnlyBackendFlagCompatibility(t *testing.T) {
 	flag := newSetupCmd().Flags().Lookup("backend")
 	if flag == nil || flag.Deprecated == "" {
@@ -19,6 +31,15 @@ func TestSetupRetainsHermesOnlyBackendFlagCompatibility(t *testing.T) {
 	err := validateLegacyAgentBackend("removed-runtime")
 	if err == nil || !strings.Contains(err.Error(), "Hermes is the only agent runtime") {
 		t.Fatalf("removed backend must fail with a Hermes-only message, got %v", err)
+	}
+}
+
+func TestSetupExposesPersistentHostSettingsFlags(t *testing.T) {
+	cmd := newSetupCmd()
+	for _, name := range []string{"port", "openshell-port", "bind-address", "docker-subnet"} {
+		if cmd.Flags().Lookup(name) == nil {
+			t.Fatalf("setup is missing --%s", name)
+		}
 	}
 }
 

--- a/apps/openneko/internal/cli/start.go
+++ b/apps/openneko/internal/cli/start.go
@@ -17,6 +17,7 @@ import (
 	"github.com/open-neko/neko/apps/openneko/internal/compose"
 	"github.com/open-neko/neko/apps/openneko/internal/config"
 	"github.com/open-neko/neko/apps/openneko/internal/db"
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
 	"github.com/open-neko/neko/apps/openneko/internal/setup"
 	"github.com/open-neko/neko/apps/openneko/internal/version"
 )
@@ -39,6 +40,10 @@ Modes:
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
+			selectedMode, err := modeForStart(cmd, mode)
+			if err != nil {
+				return err
+			}
 			// Same host checks setup runs; `start` used to skip them and race
 			// straight into an opaque compose failure (port conflict with a
 			// neighboring stack, docker gone away). A stack already answering
@@ -48,7 +53,7 @@ Modes:
 					return err
 				}
 			}
-			return bringUpStack(ctx, cmd, compose.Mode(mode), bringUpOptions{
+			return bringUpStack(ctx, cmd, selectedMode, bringUpOptions{
 				detach:      detach,
 				skipMigrate: skipMigrate,
 				pullPolicy:  pullPolicy,
@@ -249,6 +254,17 @@ func openShellStateDirOverride(goos, home, existing string) string {
 }
 
 func configureOpenShellStateDir() error {
+	if stateDir, ok, err := instance.StateDir(); err != nil {
+		return err
+	} else if ok {
+		// A named stack's PKI and gateway state must never inherit a global
+		// OPENSHELL_STATE_DIR from another customer.
+		dir := filepath.Join(stateDir, "openshell")
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return err
+		}
+		return os.Setenv("OPENSHELL_STATE_DIR", dir)
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return err
@@ -372,7 +388,8 @@ func defaultOpenShellSubnet(mode compose.Mode) string {
 // password authentication failed"), which kills all agent runs. The local
 // config is the single source of the rotated password (ReadLocal decrypts
 // it), so build the URL from it on every start. An operator-set
-// OPENSHELL_DB_URL always wins.
+// OPENSHELL_DB_URL remains available for the legacy unnamed installation;
+// named installations always derive their own internal database URL.
 // openShellDBRole is the gateway's dedicated neko-db login role. It exists so
 // the gateway's DB credential is independent of the `neko` admin password the
 // operator rotates during setup — rotating that password never strands the
@@ -383,6 +400,13 @@ const openShellDBPasswordEnv = "OPENNEKO_OPENSHELL_DB_PASSWORD"
 const requireExplicitOpenShellDBPasswordEnv = "OPENNEKO_REQUIRE_EXPLICIT_OPENSHELL_DB_PASSWORD"
 
 func configureOpenShellDBURL() {
+	if instance.Current() != "" {
+		// These values are derived from the selected instance's secret-key and
+		// internal Compose database. Do not let a host-wide override point one
+		// customer's gateway at another customer's credentials or database.
+		_ = os.Unsetenv(openShellDBPasswordEnv)
+		_ = os.Unsetenv("OPENSHELL_DB_URL")
+	}
 	if os.Getenv(openShellDBPasswordEnv) == "" {
 		if pw, err := config.OpenShellDBPassword(""); err == nil {
 			_ = os.Setenv(openShellDBPasswordEnv, pw)

--- a/apps/openneko/internal/cli/status.go
+++ b/apps/openneko/internal/cli/status.go
@@ -196,17 +196,14 @@ func describeState(s composeService) string {
 // published web port. It never fails status on its own — it's an extra
 // human signal alongside the container verdict.
 func probeWeb() string {
-	port := strings.TrimSpace(os.Getenv("OPENNEKO_PORT"))
-	if port == "" {
-		port = "3000"
-	}
+	baseURL := webBaseURL()
 	client := &http.Client{Timeout: 3 * time.Second}
-	resp, err := client.Get("http://localhost:" + port + "/")
+	resp, err := client.Get(baseURL + "/")
 	if err != nil {
-		return fmt.Sprintf("  ·  web front door (localhost:%s): not answering yet", port)
+		return fmt.Sprintf("  ·  web front door (%s): not answering yet", strings.TrimPrefix(baseURL, "http://"))
 	}
 	defer func() { _, _ = io.Copy(io.Discard, resp.Body); _ = resp.Body.Close() }()
-	return fmt.Sprintf("  ·  web front door (localhost:%s): answering (HTTP %d)", port, resp.StatusCode)
+	return fmt.Sprintf("  ·  web front door (%s): answering (HTTP %d)", strings.TrimPrefix(baseURL, "http://"), resp.StatusCode)
 }
 
 func writeStatus(w io.Writer, state health, lines []string, webLine string) {

--- a/apps/openneko/internal/cli/upgrade.go
+++ b/apps/openneko/internal/cli/upgrade.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/open-neko/neko/apps/openneko/assets"
 	"github.com/open-neko/neko/apps/openneko/internal/compose"
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
 	opennekoversion "github.com/open-neko/neko/apps/openneko/internal/version"
 )
 
@@ -69,6 +70,13 @@ func runUpgrade(ctx context.Context, cmd *cobra.Command, opts upgradeOptions) er
 	errOut := cmd.ErrOrStderr()
 	if opts.stackOnly && opts.cliOnly {
 		return errors.New("--stack-only and --cli-only are mutually exclusive")
+	}
+	if instance.Current() != "" && !opts.cliOnly {
+		if _, ok, err := requireConfiguredNamedInstallation(); err != nil {
+			return err
+		} else if !ok {
+			return fmt.Errorf("instance %q has not been configured; run `openneko --instance %s setup` first", instance.Current(), instance.Current())
+		}
 	}
 	target, err := resolveUpgradeTarget(ctx, opts.imageVersion, opts.stackOnly)
 	if err != nil {
@@ -201,10 +209,20 @@ func resolveUpgradeMode(ctx context.Context, flag string, sup *compose.Superviso
 	if mode != "" && mode != "auto" {
 		switch compose.Mode(mode) {
 		case compose.ModeProd, compose.ModeDev, compose.ModeDemo:
+			if settings, ok, err := loadCurrentInstallation(); err != nil {
+				return "", false, err
+			} else if ok && instance.Current() != "" && settings.Mode != mode {
+				return "", false, fmt.Errorf("instance %q is installed in %s mode, not %s", instance.Current(), settings.Mode, mode)
+			}
 			return compose.Mode(mode), false, nil
 		default:
 			return "", false, fmt.Errorf("--mode must be one of: auto, prod, dev, demo (got %q)", flag)
 		}
+	}
+	if settings, ok, err := loadCurrentInstallation(); err != nil {
+		return "", false, err
+	} else if ok {
+		return compose.Mode(settings.Mode), false, nil
 	}
 	project, err := sup.ProjectName("")
 	if err != nil {
@@ -256,46 +274,54 @@ func dockerComposeProjectNames(ctx context.Context, all bool) ([]string, error) 
 }
 
 func modeFromExistingProjects(projects []string) (compose.Mode, bool, error) {
-	modes := map[compose.Mode]string{}
+	matches := map[string]compose.Mode{}
+	var named []string
+	selected := instance.Current()
 	for _, project := range projects {
-		mode, ok := modeFromLegacyProjectName(project)
+		mode, projectInstance, ok := compose.IdentityFromProjectName(project)
+		if !ok && project == "openneko" {
+			mode, ok = compose.ModeProd, true
+		}
 		if !ok {
 			continue
 		}
-		modes[mode] = project
+		if selected != "" {
+			if projectInstance == selected {
+				matches[project] = mode
+			}
+			continue
+		}
+		if projectInstance != "" {
+			named = append(named, project)
+			continue
+		}
+		matches[project] = mode
 	}
-	if len(modes) == 0 {
+	if len(matches) == 0 && len(named) > 0 && selected == "" {
+		sort.Strings(named)
+		return "", false, fmt.Errorf("found named OpenNeko stacks (%s); re-run with --instance <name>", strings.Join(named, ", "))
+	}
+	if len(matches) == 0 {
 		return "", false, nil
 	}
-	if len(modes) == 1 {
-		for mode := range modes {
+	if len(matches) == 1 {
+		for _, mode := range matches {
 			return mode, true, nil
 		}
 	}
-	return "", false, fmt.Errorf("found multiple OpenNeko stacks (%s); re-run with --mode prod, --mode dev, or --mode demo", strings.Join(sortedProjectNames(modes), ", "))
-}
-
-func modeFromLegacyProjectName(project string) (compose.Mode, bool) {
-	if project == "openneko" {
-		return compose.ModeProd, true
+	selectedProjects := make([]string, 0, len(matches))
+	for project := range matches {
+		selectedProjects = append(selectedProjects, project)
 	}
-	if mode, ok := compose.ModeFromProjectName(project); ok {
-		return mode, true
+	sort.Strings(selectedProjects)
+	if selected == "" {
+		return "", false, fmt.Errorf("found multiple OpenNeko stacks (%s); re-run with --mode prod, --mode dev, or --mode demo", strings.Join(selectedProjects, ", "))
 	}
-	return "", false
+	return "", false, fmt.Errorf("instance %q has multiple OpenNeko stack projects (%s); remove the obsolete project before upgrading", selected, strings.Join(selectedProjects, ", "))
 }
 
 func uniqueLines(s string) []string {
 	return uniqueStrings(strings.Split(s, "\n"))
-}
-
-func sortedProjectNames(modes map[compose.Mode]string) []string {
-	names := make([]string, 0, len(modes))
-	for _, project := range modes {
-		names = append(names, project)
-	}
-	sort.Strings(names)
-	return names
 }
 
 var semverishImageVersion = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+.*$`)

--- a/apps/openneko/internal/cli/upgrade_test.go
+++ b/apps/openneko/internal/cli/upgrade_test.go
@@ -3,11 +3,16 @@ package cli
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/open-neko/neko/apps/openneko/internal/compose"
+	"github.com/open-neko/neko/apps/openneko/internal/config"
+	"github.com/open-neko/neko/apps/openneko/internal/installation"
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
 	opennekoversion "github.com/open-neko/neko/apps/openneko/internal/version"
 )
 
@@ -135,12 +140,70 @@ func TestResolveUpgradeModeDetectsLegacyProdProject(t *testing.T) {
 }
 
 func TestResolveUpgradeModeErrorsOnMultipleStacks(t *testing.T) {
+	t.Setenv(instance.EnvName, "")
 	s := &compose.Supervisor{RuntimeDir: t.TempDir()}
 	stubComposeProjects(t, []string{"openneko-dev", "openneko-demo"}, []string{"openneko-dev", "openneko-demo"})
 
 	_, _, err := resolveUpgradeMode(context.Background(), "auto", s)
 	if err == nil {
 		t.Fatal("expected multiple stack error")
+	}
+}
+
+func TestResolveUpgradeModeRefusesUnnamedGuessForNamedStack(t *testing.T) {
+	t.Setenv(instance.EnvName, "")
+	s := &compose.Supervisor{RuntimeDir: t.TempDir()}
+	stubComposeProjects(t, []string{"openneko-acme-prod"}, []string{"openneko-acme-prod"})
+	_, _, err := resolveUpgradeMode(context.Background(), "auto", s)
+	if err == nil || !strings.Contains(err.Error(), "--instance") {
+		t.Fatalf("error = %v, want named-instance guidance", err)
+	}
+}
+
+func TestUpgradeRefusesUnconfiguredNamedInstanceBeforeResolvingRelease(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv(instance.EnvName, "missing")
+	cmd := newUpgradeCmd()
+	cmd.SetArgs([]string{"--stack-only", "--version", "v9.8.7"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "has not been configured") {
+		t.Fatalf("error = %v, want unconfigured instance error", err)
+	}
+}
+
+func TestSeedRefusesNamedProductionInstance(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv(instance.EnvName, "acme")
+	settings := installation.Settings{
+		Version:        installation.CurrentVersion,
+		Instance:       "acme",
+		Mode:           "prod",
+		WebPort:        3101,
+		WebBindAddress: "127.0.0.1",
+		OpenShellPort:  18101,
+		DockerSubnet:   "10.224.1.0/24",
+	}
+	if err := os.MkdirAll(filepath.Dir(installation.Path(config.Dir(""))), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := installation.Save(config.Dir(""), settings); err != nil {
+		t.Fatal(err)
+	}
+	cmd := newSeedCmd()
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "requires a demo instance") {
+		t.Fatalf("error = %v, want demo-mode requirement", err)
+	}
+}
+
+func TestModeFromExistingProjectsTargetsSelectedInstance(t *testing.T) {
+	t.Setenv(instance.EnvName, "acme")
+	mode, ok, err := modeFromExistingProjects([]string{
+		"openneko-globex-demo",
+		"openneko-acme-prod",
+	})
+	if err != nil || !ok || mode != compose.ModeProd {
+		t.Fatalf("mode = %q, ok=%v, err=%v", mode, ok, err)
 	}
 }
 

--- a/apps/openneko/internal/compose/compose.go
+++ b/apps/openneko/internal/compose/compose.go
@@ -20,6 +20,8 @@ import (
 	"syscall"
 
 	"github.com/open-neko/neko/apps/openneko/internal/config"
+	"github.com/open-neko/neko/apps/openneko/internal/installation"
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
 )
 
 type Mode string
@@ -69,7 +71,15 @@ func (s *Supervisor) runtimeDir() (string, error) {
 		if err != nil {
 			return "", err
 		}
+		if name := instance.Current(); name != "" {
+			return filepath.Join(root, ".openneko", "instances", name, "runtime"), nil
+		}
 		return filepath.Join(root, ".openneko", "runtime"), nil
+	}
+	if stateDir, ok, err := instance.StateDir(); err != nil {
+		return "", err
+	} else if ok {
+		return filepath.Join(stateDir, "runtime"), nil
 	}
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -126,8 +136,9 @@ func (s *Supervisor) Materialize(mode Mode) ([]string, error) {
 // invocation. On `start`, callers should pass the mode so containers/
 // volumes/networks land as openneko-<mode>-*. start persists the chosen
 // project name to .openneko/runtime/.project-name so stop/logs/status
-// pick the same project up without needing --mode every time. Falls
-// back to "openneko" when no .project-name marker exists.
+// pick the same project up without needing --mode every time. A named install
+// safely derives its own project when the marker is absent; the unnamed legacy
+// install falls back to "openneko".
 func (s *Supervisor) ProjectName(modeIfStarting Mode) (string, error) {
 	rt, err := s.runtimeDir()
 	if err != nil {
@@ -145,6 +156,18 @@ func (s *Supervisor) ProjectName(modeIfStarting Mode) (string, error) {
 		if v != "" {
 			return v, nil
 		}
+	}
+	if name := instance.Current(); name != "" {
+		settings, ok, err := installation.Load(config.Dir(""))
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			return ProjectNameForModeAndInstance(Mode(settings.Mode), name), nil
+		}
+		// A named command must never fall through to the legacy "openneko"
+		// project: even an incomplete setup should remain inside its namespace.
+		return ProjectNameForModeAndInstance(ModeProd, name), nil
 	}
 	return "openneko", nil
 }
@@ -247,8 +270,17 @@ func generateInstallationID() (string, error) {
 
 // ProjectNameForMode is the canonical compose project name for a stack mode.
 func ProjectNameForMode(mode Mode) string {
+	return ProjectNameForModeAndInstance(mode, instance.Current())
+}
+
+// ProjectNameForModeAndInstance returns the stable Compose project name. The
+// empty instance retains the pre-multi-instance project names exactly.
+func ProjectNameForModeAndInstance(mode Mode, name string) string {
 	if mode == "" {
 		mode = ModeProd
+	}
+	if name != "" {
+		return "openneko-" + name + "-" + string(mode)
 	}
 	return "openneko-" + string(mode)
 }
@@ -256,16 +288,31 @@ func ProjectNameForMode(mode Mode) string {
 // ModeFromProjectName recovers the stack mode from a project marker written by
 // ProjectName. The bool is false for legacy names or unrelated projects.
 func ModeFromProjectName(project string) (Mode, bool) {
+	mode, _, ok := IdentityFromProjectName(project)
+	return mode, ok
+}
+
+// IdentityFromProjectName parses both legacy openneko-<mode> projects and
+// named openneko-<instance>-<mode> projects.
+func IdentityFromProjectName(project string) (Mode, string, bool) {
 	const prefix = "openneko-"
 	if !strings.HasPrefix(project, prefix) {
-		return "", false
+		return "", "", false
 	}
-	switch m := Mode(strings.TrimPrefix(project, prefix)); m {
-	case ModeProd, ModeDev, ModeDemo:
-		return m, true
-	default:
-		return "", false
+	rest := strings.TrimPrefix(project, prefix)
+	for _, mode := range []Mode{ModeProd, ModeDev, ModeDemo} {
+		if rest == string(mode) {
+			return mode, "", true
+		}
+		suffix := "-" + string(mode)
+		if strings.HasSuffix(rest, suffix) {
+			name := strings.TrimSuffix(rest, suffix)
+			if instance.Validate(name) == nil && name != "" {
+				return mode, name, true
+			}
+		}
 	}
+	return "", "", false
 }
 
 // ImageVersion reads the persisted image tag for this install. An empty string

--- a/apps/openneko/internal/compose/compose_test.go
+++ b/apps/openneko/internal/compose/compose_test.go
@@ -5,11 +5,14 @@ import (
 	"strings"
 	"testing"
 	"testing/fstest"
+
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
 )
 
 func isolateConfig(t *testing.T) {
 	t.Helper()
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	t.Setenv(instance.EnvName, "")
 }
 
 func sampleFS() fstest.MapFS {
@@ -89,6 +92,7 @@ func TestMaterializeUnknownMode(t *testing.T) {
 }
 
 func TestRuntimeDirUsesWorkspaceRoot(t *testing.T) {
+	t.Setenv(instance.EnvName, "")
 	workspaceRoot := t.TempDir()
 	t.Setenv("OPENNEKO_WORKSPACE_ROOT", workspaceRoot)
 
@@ -98,6 +102,38 @@ func TestRuntimeDirUsesWorkspaceRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := filepath.Join(workspaceRoot, ".openneko", "runtime")
+	if got != want {
+		t.Fatalf("runtime dir = %q, want %q", got, want)
+	}
+}
+
+func TestRuntimeDirScopesNamedInstance(t *testing.T) {
+	workspaceRoot := t.TempDir()
+	t.Setenv("OPENNEKO_WORKSPACE_ROOT", workspaceRoot)
+	t.Setenv(instance.EnvName, "acme")
+
+	s := &Supervisor{}
+	got, err := s.runtimeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(workspaceRoot, ".openneko", "instances", "acme", "runtime")
+	if got != want {
+		t.Fatalf("runtime dir = %q, want %q", got, want)
+	}
+}
+
+func TestRuntimeDirUsesNamedInstanceStateOutsideWorkspace(t *testing.T) {
+	t.Setenv("OPENNEKO_WORKSPACE_ROOT", "")
+	t.Setenv("XDG_STATE_HOME", "/var/state")
+	t.Setenv(instance.EnvName, "acme")
+
+	s := &Supervisor{}
+	got, err := s.runtimeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join("/var/state", "openneko", "instances", "acme", "runtime")
 	if got != want {
 		t.Fatalf("runtime dir = %q, want %q", got, want)
 	}
@@ -139,6 +175,33 @@ func TestProjectNameModeRoundTrip(t *testing.T) {
 	mode, ok := ModeFromProjectName(readBack)
 	if !ok || mode != ModeDemo {
 		t.Fatalf("mode = %q ok=%v", mode, ok)
+	}
+}
+
+func TestNamedProjectIdentityRoundTrip(t *testing.T) {
+	project := ProjectNameForModeAndInstance(ModeProd, "acme-west")
+	if project != "openneko-acme-west-prod" {
+		t.Fatalf("project = %q", project)
+	}
+	mode, name, ok := IdentityFromProjectName(project)
+	if !ok || mode != ModeProd || name != "acme-west" {
+		t.Fatalf("identity = %q %q %v", mode, name, ok)
+	}
+	if _, _, ok := IdentityFromProjectName("openneko-Bad-prod"); ok {
+		t.Fatal("invalid instance project parsed successfully")
+	}
+}
+
+func TestNamedProjectFallbackNeverTargetsLegacyProject(t *testing.T) {
+	isolateConfig(t)
+	t.Setenv(instance.EnvName, "acme")
+	s := &Supervisor{RuntimeDir: t.TempDir()}
+	project, err := s.ProjectName("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if project != "openneko-acme-prod" {
+		t.Fatalf("named fallback project = %q", project)
 	}
 }
 

--- a/apps/openneko/internal/config/config.go
+++ b/apps/openneko/internal/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
 )
 
 const AppDirName = "openneko"
@@ -11,6 +13,12 @@ func Dir(override string) string {
 	if override != "" {
 		return override
 	}
+	return instance.ScopeConfigDir(RootDir())
+}
+
+// RootDir returns the unscoped OpenNeko config directory. Most callers should
+// use Dir; inventory commands use RootDir to discover named installations.
+func RootDir() string {
 	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
 		return filepath.Join(xdg, AppDirName)
 	}

--- a/apps/openneko/internal/config/config_test.go
+++ b/apps/openneko/internal/config/config_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
 )
 
 func TestDirOverride(t *testing.T) {
@@ -12,6 +14,7 @@ func TestDirOverride(t *testing.T) {
 }
 
 func TestDirXDG(t *testing.T) {
+	t.Setenv(instance.EnvName, "")
 	t.Setenv("XDG_CONFIG_HOME", "/var/cfg")
 	if got := Dir(""); got != filepath.Join("/var/cfg", "openneko") {
 		t.Fatalf("expected XDG-derived path, got %q", got)
@@ -19,10 +22,31 @@ func TestDirXDG(t *testing.T) {
 }
 
 func TestDirFallback(t *testing.T) {
+	t.Setenv(instance.EnvName, "")
 	t.Setenv("XDG_CONFIG_HOME", "")
 	t.Setenv("HOME", "/home/test")
 	if got := Dir(""); got != "/home/test/.config/openneko" {
 		t.Fatalf("expected HOME-derived path, got %q", got)
+	}
+}
+
+func TestDirScopesNamedInstance(t *testing.T) {
+	t.Setenv(instance.EnvName, "acme")
+	t.Setenv("XDG_CONFIG_HOME", "/var/cfg")
+	want := filepath.Join("/var/cfg", "openneko", "instances", "acme")
+	if got := Dir(""); got != want {
+		t.Fatalf("named config path = %q, want %q", got, want)
+	}
+	if got := Dir("/explicit"); got != "/explicit" {
+		t.Fatalf("explicit override was scoped: %q", got)
+	}
+}
+
+func TestRootDirIsNeverInstanceScoped(t *testing.T) {
+	t.Setenv(instance.EnvName, "acme")
+	t.Setenv("XDG_CONFIG_HOME", "/var/cfg")
+	if got := RootDir(); got != filepath.Join("/var/cfg", "openneko") {
+		t.Fatalf("root config path = %q", got)
 	}
 }
 

--- a/apps/openneko/internal/config/local.go
+++ b/apps/openneko/internal/config/local.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
 )
 
 // LocalPg mirrors the `pg` block of ~/.config/openneko/config.json, written
@@ -31,7 +33,7 @@ type Local struct {
 func ReadLocal(override string) (Local, string) {
 	candidates := []string{filepath.Join(Dir(override), "config.json")}
 	// Pre-rebrand fallback path; matches the TS reader.
-	if override == "" {
+	if override == "" && instance.Current() == "" {
 		base := os.Getenv("XDG_CONFIG_HOME")
 		if base == "" {
 			if home, err := os.UserHomeDir(); err == nil && home != "" {

--- a/apps/openneko/internal/config/local_test.go
+++ b/apps/openneko/internal/config/local_test.go
@@ -5,7 +5,24 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
 )
+
+func TestNamedInstanceDoesNotReadLegacyGlobalConfig(t *testing.T) {
+	base := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", base)
+	t.Setenv(instance.EnvName, "acme")
+	if err := os.MkdirAll(filepath.Join(base, "neko"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(base, "neko", "config.json"), []byte(`{"pg":{"password":"legacy"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got, path := ReadLocal(""); path != "" || got.Pg != nil {
+		t.Fatalf("named instance read global legacy config: path=%q config=%+v", path, got)
+	}
+}
 
 func TestWriteLocalPgPasswordRoundTrip(t *testing.T) {
 	dir := t.TempDir()

--- a/apps/openneko/internal/dockerproxy/proxy.go
+++ b/apps/openneko/internal/dockerproxy/proxy.go
@@ -26,15 +26,29 @@ import (
 // the worker container doesn't try to detect-and-proxy itself recursively.
 const EnvMarker = "OPENNEKO_PROXIED"
 
-// FindRunningWorker returns the name of a running openneko-{prod,dev,demo}-
-// worker-1 container, or "" if none / docker unreachable / we are already
-// inside a proxied invocation. With prod and demo both up, `docker ps`
-// order used to pick an arbitrary stack — plugin installs then landed in
-// the wrong install's config volume — so an ambiguous match now refuses
-// (falls back to the local implementation) and says why.
-func FindRunningWorker() string {
+var ErrAmbiguousWorkers = errors.New("multiple OpenNeko workers are running")
+
+// FindRunningWorker returns a running OpenNeko worker container. When project
+// is non-empty it targets that exact named installation; without a project it
+// retains the legacy single-stack behavior and refuses ambiguous matches.
+func FindRunningWorker(project ...string) string {
+	target := ""
+	if len(project) > 0 {
+		target = strings.TrimSpace(project[0])
+	}
+	name, err := ResolveRunningWorker(target)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[openneko] %v\n", err)
+	}
+	return name
+}
+
+// ResolveRunningWorker is the error-reporting form used by the root CLI. An
+// ambiguous multi-stack host must fail closed instead of silently performing a
+// plugin operation in the caller's current directory.
+func ResolveRunningWorker(project string) (string, error) {
 	if os.Getenv(EnvMarker) == "1" {
-		return ""
+		return "", nil
 	}
 	out, err := exec.Command(
 		"docker", "ps",
@@ -42,25 +56,34 @@ func FindRunningWorker() string {
 		"--format", "{{.Names}}",
 	).Output()
 	if err != nil {
-		return ""
+		return "", err
 	}
-	name, ambiguous := selectWorker(strings.Split(strings.TrimSpace(string(out)), "\n"))
+	name, ambiguous := selectWorkerForProject(strings.Split(strings.TrimSpace(string(out)), "\n"), strings.TrimSpace(project))
 	if len(ambiguous) > 0 {
-		fmt.Fprintf(os.Stderr,
-			"[openneko] multiple running stacks found (%s); refusing to guess — stop the stack you don't mean, or pass --local\n",
-			strings.Join(ambiguous, ", "))
+		return "", fmt.Errorf("%w (%s); select one with --instance <name> or pass --local", ErrAmbiguousWorkers, strings.Join(ambiguous, ", "))
 	}
-	return name
+	return name, nil
 }
 
 // selectWorker picks the single matching worker container from `docker ps`
 // output lines. With more than one match it returns "" plus the sorted
 // candidates so the caller can explain the refusal.
 func selectWorker(lines []string) (string, []string) {
+	return selectWorkerForProject(lines, "")
+}
+
+func selectWorkerForProject(lines []string, project string) (string, []string) {
 	var workers []string
+	target := ""
+	if project != "" {
+		target = project + "-worker-1"
+	}
 	for _, line := range lines {
 		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "openneko-") && strings.HasSuffix(line, "-worker-1") {
+		if target != "" && line == target {
+			return line, nil
+		}
+		if target == "" && strings.HasPrefix(line, "openneko-") && strings.HasSuffix(line, "-worker-1") {
 			workers = append(workers, line)
 		}
 	}

--- a/apps/openneko/internal/dockerproxy/proxy_test.go
+++ b/apps/openneko/internal/dockerproxy/proxy_test.go
@@ -118,3 +118,18 @@ func TestSelectWorker(t *testing.T) {
 		t.Fatalf("ambiguous candidates = %v", amb)
 	}
 }
+
+func TestSelectWorkerTargetsNamedProject(t *testing.T) {
+	lines := []string{
+		"openneko-acme-prod-worker-1",
+		"openneko-globex-prod-worker-1",
+	}
+	name, ambiguous := selectWorkerForProject(lines, "openneko-globex-prod")
+	if name != "openneko-globex-prod-worker-1" || ambiguous != nil {
+		t.Fatalf("targeted selection = %q %v", name, ambiguous)
+	}
+	name, ambiguous = selectWorkerForProject(lines, "openneko-missing-prod")
+	if name != "" || ambiguous != nil {
+		t.Fatalf("missing target = %q %v", name, ambiguous)
+	}
+}

--- a/apps/openneko/internal/installation/settings.go
+++ b/apps/openneko/internal/installation/settings.go
@@ -1,0 +1,162 @@
+// Package installation persists the non-secret host settings needed to target
+// the same OpenNeko stack on every later CLI invocation.
+package installation
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/netip"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/open-neko/neko/apps/openneko/internal/instance"
+)
+
+const (
+	Filename       = "installation.json"
+	CurrentVersion = 1
+)
+
+// Settings is intentionally free of credentials. Secret material remains in
+// the existing encrypted per-instance config and repository-bound key stores.
+type Settings struct {
+	Version        int    `json:"version"`
+	Instance       string `json:"instance,omitempty"`
+	Mode           string `json:"mode"`
+	WebPort        int    `json:"web_port"`
+	WebBindAddress string `json:"web_bind_address"`
+	OpenShellPort  int    `json:"openshell_port"`
+	DockerSubnet   string `json:"docker_subnet,omitempty"`
+}
+
+func Path(configDir string) string {
+	return filepath.Join(configDir, Filename)
+}
+
+func Load(configDir string) (Settings, bool, error) {
+	raw, err := os.ReadFile(Path(configDir))
+	if errors.Is(err, fs.ErrNotExist) {
+		return Settings{}, false, nil
+	}
+	if err != nil {
+		return Settings{}, false, err
+	}
+	var settings Settings
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		return Settings{}, false, fmt.Errorf("read installation settings: %w", err)
+	}
+	if err := settings.Validate(); err != nil {
+		return Settings{}, false, fmt.Errorf("invalid installation settings %s: %w", Path(configDir), err)
+	}
+	return settings, true, nil
+}
+
+func Save(configDir string, settings Settings) error {
+	if settings.Version == 0 {
+		settings.Version = CurrentVersion
+	}
+	if err := settings.Validate(); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		return err
+	}
+	raw, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	raw = append(raw, '\n')
+	tmp, err := os.CreateTemp(configDir, ".installation-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer func() { _ = os.Remove(tmpPath) }()
+	if err := tmp.Chmod(0o600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(raw); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, Path(configDir))
+}
+
+func (s Settings) Validate() error {
+	if s.Version != CurrentVersion {
+		return fmt.Errorf("unsupported settings version %d", s.Version)
+	}
+	if err := instance.Validate(s.Instance); err != nil {
+		return err
+	}
+	switch s.Mode {
+	case "prod", "dev", "demo":
+	default:
+		return fmt.Errorf("mode must be prod, dev, or demo")
+	}
+	if err := validatePort("web port", s.WebPort); err != nil {
+		return err
+	}
+	if err := validatePort("OpenShell port", s.OpenShellPort); err != nil {
+		return err
+	}
+	if s.WebPort == s.OpenShellPort {
+		return fmt.Errorf("web port and OpenShell port must be different")
+	}
+	address, err := netip.ParseAddr(strings.TrimSpace(s.WebBindAddress))
+	if err != nil || !address.Is4() {
+		return fmt.Errorf("web bind address must be an IPv4 address")
+	}
+	if s.Instance != "" && s.DockerSubnet == "" {
+		return fmt.Errorf("named installations require an isolated Docker subnet")
+	}
+	if s.DockerSubnet != "" {
+		prefix, err := netip.ParsePrefix(s.DockerSubnet)
+		if err != nil || !prefix.Addr().Is4() || prefix.Bits() != 24 || prefix != prefix.Masked() {
+			return fmt.Errorf("Docker subnet must be a canonical IPv4 /24")
+		}
+	}
+	return nil
+}
+
+func validatePort(label string, port int) error {
+	if port < 1 || port > 65535 {
+		return fmt.Errorf("%s must be between 1 and 65535", label)
+	}
+	return nil
+}
+
+// ApplyEnvironment makes persisted settings visible to the existing Compose
+// and CLI code. When overwrite is false, an explicit operator environment
+// override retains precedence.
+func ApplyEnvironment(settings Settings, overwrite bool) error {
+	values := map[string]string{
+		"OPENNEKO_PORT":             strconv.Itoa(settings.WebPort),
+		"OPENNEKO_WEB_BIND_ADDRESS": settings.WebBindAddress,
+		"OPENSHELL_PORT":            strconv.Itoa(settings.OpenShellPort),
+	}
+	if settings.DockerSubnet != "" {
+		values["OPENNEKO_DOCKER_SUBNET"] = settings.DockerSubnet
+	}
+	for key, value := range values {
+		if !overwrite && strings.TrimSpace(os.Getenv(key)) != "" {
+			continue
+		}
+		if err := os.Setenv(key, value); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/apps/openneko/internal/installation/settings_test.go
+++ b/apps/openneko/internal/installation/settings_test.go
@@ -1,0 +1,73 @@
+package installation
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func sampleSettings() Settings {
+	return Settings{
+		Version:        CurrentVersion,
+		Instance:       "acme",
+		Mode:           "prod",
+		WebPort:        3100,
+		WebBindAddress: "127.0.0.1",
+		OpenShellPort:  18100,
+		DockerSubnet:   "10.224.1.0/24",
+	}
+}
+
+func TestSettingsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := sampleSettings()
+	if err := Save(dir, want); err != nil {
+		t.Fatal(err)
+	}
+	got, ok, err := Load(dir)
+	if err != nil || !ok {
+		t.Fatalf("Load = %+v, %v, %v", got, ok, err)
+	}
+	if got != want {
+		t.Fatalf("got %+v, want %+v", got, want)
+	}
+	info, err := os.Stat(filepath.Join(dir, Filename))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Fatalf("settings mode = %v", info.Mode().Perm())
+	}
+}
+
+func TestSettingsValidation(t *testing.T) {
+	settings := sampleSettings()
+	settings.WebPort = settings.OpenShellPort
+	if err := settings.Validate(); err == nil {
+		t.Fatal("expected duplicate port error")
+	}
+	settings = sampleSettings()
+	settings.DockerSubnet = "10.224.1.1/24"
+	if err := settings.Validate(); err == nil {
+		t.Fatal("expected non-canonical subnet error")
+	}
+	settings = sampleSettings()
+	settings.DockerSubnet = ""
+	if err := settings.Validate(); err == nil {
+		t.Fatal("expected named-instance subnet error")
+	}
+}
+
+func TestApplyEnvironmentPreservesExplicitOverrides(t *testing.T) {
+	t.Setenv("OPENNEKO_PORT", "3999")
+	t.Setenv("OPENSHELL_PORT", "")
+	if err := ApplyEnvironment(sampleSettings(), false); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv("OPENNEKO_PORT"); got != "3999" {
+		t.Fatalf("explicit web port replaced with %q", got)
+	}
+	if got := os.Getenv("OPENSHELL_PORT"); got != "18100" {
+		t.Fatalf("persisted OpenShell port not applied: %q", got)
+	}
+}

--- a/apps/openneko/internal/instance/instance.go
+++ b/apps/openneko/internal/instance/instance.go
@@ -1,0 +1,91 @@
+// Package instance defines the host-side identity and filesystem boundaries
+// for a named OpenNeko installation. Containers do not receive
+// OPENNEKO_INSTANCE: their Compose project already gives them isolated named
+// volumes, while the host CLI uses this package to isolate its own state.
+package instance
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const (
+	// EnvName selects a named OpenNeko installation for the current CLI process.
+	EnvName = "OPENNEKO_INSTANCE"
+	maxName = 32
+)
+
+var validName = regexp.MustCompile(`^[a-z0-9]+(-[a-z0-9]+)*$`)
+
+// Current returns the selected instance name, or the empty string for the
+// legacy unnamed installation.
+func Current() string {
+	return strings.TrimSpace(os.Getenv(EnvName))
+}
+
+// Validate checks the stable identifier used in Docker project names and host
+// paths. Keeping the alphabet deliberately small avoids ambiguous or unsafe
+// filesystem and Compose interpolation behavior.
+func Validate(name string) error {
+	if name == "" {
+		return nil
+	}
+	if len(name) > maxName {
+		return fmt.Errorf("instance name must be at most %d characters", maxName)
+	}
+	if !validName.MatchString(name) {
+		return fmt.Errorf("instance name %q must use lowercase letters, numbers, and single hyphen separators", name)
+	}
+	return nil
+}
+
+// Select validates and activates a named instance for this process. An empty
+// value deliberately selects the backward-compatible unnamed installation.
+func Select(name string) error {
+	name = strings.TrimSpace(name)
+	if err := Validate(name); err != nil {
+		return err
+	}
+	if name == "" {
+		return os.Unsetenv(EnvName)
+	}
+	return os.Setenv(EnvName, name)
+}
+
+// ScopeConfigDir adds the per-instance namespace beneath the normal OpenNeko
+// config directory. Explicit config overrides bypass this helper in config.Dir.
+func ScopeConfigDir(base string) string {
+	if name := Current(); name != "" {
+		return filepath.Join(base, "instances", name)
+	}
+	return base
+}
+
+// StateHome returns the XDG-compatible host state root.
+func StateHome() (string, error) {
+	if base := strings.TrimSpace(os.Getenv("XDG_STATE_HOME")); base != "" {
+		return filepath.Abs(base)
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".local", "state"), nil
+}
+
+// StateDir returns the durable host state directory for the selected named
+// instance. The bool is false for the legacy unnamed installation.
+func StateDir() (string, bool, error) {
+	name := Current()
+	if name == "" {
+		return "", false, nil
+	}
+	base, err := StateHome()
+	if err != nil {
+		return "", false, err
+	}
+	return filepath.Join(base, "openneko", "instances", name), true, nil
+}

--- a/apps/openneko/internal/instance/instance_test.go
+++ b/apps/openneko/internal/instance/instance_test.go
@@ -1,0 +1,45 @@
+package instance
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	for _, name := range []string{"", "acme", "customer-12", "a"} {
+		if err := Validate(name); err != nil {
+			t.Fatalf("Validate(%q): %v", name, err)
+		}
+	}
+	for _, name := range []string{"Acme", "-acme", "acme-", "acme--west", "acme_customer", "two words", strings.Repeat("a", 33)} {
+		if err := Validate(name); err == nil {
+			t.Fatalf("Validate(%q) unexpectedly succeeded", name)
+		}
+	}
+}
+
+func TestScopedDirectories(t *testing.T) {
+	t.Setenv(EnvName, "acme")
+	t.Setenv("XDG_STATE_HOME", "/var/state")
+	if got := ScopeConfigDir("/var/config/openneko"); got != "/var/config/openneko/instances/acme" {
+		t.Fatalf("config dir = %q", got)
+	}
+	got, ok, err := StateDir()
+	if err != nil || !ok {
+		t.Fatalf("StateDir = %q, %v, %v", got, ok, err)
+	}
+	if want := filepath.Join("/var/state", "openneko", "instances", "acme"); got != want {
+		t.Fatalf("state dir = %q, want %q", got, want)
+	}
+}
+
+func TestUnnamedInstanceKeepsLegacyPaths(t *testing.T) {
+	t.Setenv(EnvName, "")
+	if got := ScopeConfigDir("/var/config/openneko"); got != "/var/config/openneko" {
+		t.Fatalf("config dir = %q", got)
+	}
+	if got, ok, err := StateDir(); err != nil || ok || got != "" {
+		t.Fatalf("StateDir = %q, %v, %v", got, ok, err)
+	}
+}

--- a/apps/openneko/internal/preflight/preflight.go
+++ b/apps/openneko/internal/preflight/preflight.go
@@ -81,17 +81,19 @@ func Docker() Result {
 // PortSpec is a host port the stack publishes, with the env var that overrides
 // it (matching start.go's envInt lookups).
 type PortSpec struct {
-	Label  string
-	EnvVar string
-	Def    int
+	Label       string
+	EnvVar      string
+	Def         int
+	BindEnvVar  string
+	DefaultBind string
 }
 
 // DefaultPorts are the only host ports a packaged bring-up publishes. Web is
 // the intentional server boundary. OpenShell's Docker driver requires a
 // loopback-only callback port; databases, GraphJin, and brokers stay private.
 var DefaultPorts = []PortSpec{
-	{"web", "OPENNEKO_PORT", 3000},
-	{"OpenShell gateway (loopback only)", "OPENSHELL_PORT", 18080},
+	{Label: "web", EnvVar: "OPENNEKO_PORT", Def: 3000, BindEnvVar: "OPENNEKO_WEB_BIND_ADDRESS", DefaultBind: "0.0.0.0"},
+	{Label: "OpenShell gateway (loopback only)", EnvVar: "OPENSHELL_PORT", Def: 18080, DefaultBind: "127.0.0.1"},
 }
 
 // Port resolves a spec's effective port from its env override.
@@ -104,20 +106,34 @@ func (s PortSpec) Port() int {
 	return s.Def
 }
 
-// Ports checks each spec's port is bindable on the loopback. A bound port means
-// something already holds it — including a previous OpenNeko, so callers that
-// might be re-running against a live stack should skip this (see setup).
+func (s PortSpec) BindAddress() string {
+	if s.BindEnvVar != "" {
+		if value := strings.TrimSpace(os.Getenv(s.BindEnvVar)); value != "" {
+			return value
+		}
+	}
+	if s.DefaultBind != "" {
+		return s.DefaultBind
+	}
+	return "127.0.0.1"
+}
+
+// Ports checks each spec's port on its configured bind address (the OpenShell
+// spec is always loopback). A bound port means something already holds it —
+// including a previous OpenNeko, so callers that might be re-running against a
+// live stack should skip this (see setup).
 func Ports(specs []PortSpec) []Result {
 	out := make([]Result, 0, len(specs))
 	for _, s := range specs {
 		port := s.Port()
 		name := fmt.Sprintf("port %d (%s)", port, s.Label)
-		ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+		bindAddress := s.BindAddress()
+		ln, err := net.Listen("tcp", net.JoinHostPort(bindAddress, strconv.Itoa(port)))
 		if err != nil {
 			out = append(out, Result{
 				Name:        name,
 				Level:       Fail,
-				Detail:      "in use",
+				Detail:      fmt.Sprintf("cannot bind %s", net.JoinHostPort(bindAddress, strconv.Itoa(port))),
 				Remediation: fmt.Sprintf("Free it, or pick another port with %s=<port>.", s.EnvVar),
 			})
 			continue

--- a/apps/openneko/internal/preflight/preflight_test.go
+++ b/apps/openneko/internal/preflight/preflight_test.go
@@ -9,8 +9,18 @@ import (
 func TestDefaultPortsIncludeWebAndLoopbackGateway(t *testing.T) {
 	if len(DefaultPorts) != 2 ||
 		DefaultPorts[0].Label != "web" || DefaultPorts[0].Def != 3000 ||
-		DefaultPorts[1].EnvVar != "OPENSHELL_PORT" || DefaultPorts[1].Def != 18080 {
+		DefaultPorts[0].BindEnvVar != "OPENNEKO_WEB_BIND_ADDRESS" ||
+		DefaultPorts[1].EnvVar != "OPENSHELL_PORT" || DefaultPorts[1].Def != 18080 ||
+		DefaultPorts[1].BindAddress() != "127.0.0.1" {
 		t.Fatalf("packaged host ports = %+v, want web and loopback OpenShell gateway", DefaultPorts)
+	}
+}
+
+func TestPortSpecBindAddressHonorsEnvironment(t *testing.T) {
+	t.Setenv("OPENNEKO_TEST_BIND", "127.0.0.2")
+	spec := PortSpec{BindEnvVar: "OPENNEKO_TEST_BIND", DefaultBind: "0.0.0.0"}
+	if got := spec.BindAddress(); got != "127.0.0.2" {
+		t.Fatalf("bind address = %q", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `--instance` and persistent per-instance port, bind-address, and subnet settings so multiple full OpenNeko stacks can coexist on one Docker host.
- Isolate Compose projects and volumes, config and secrets, runtime and OpenShell state, backups, plugin proxying, and port/subnet reservations per customer.
- Add `openneko instances`, Acme/Globex installation examples, reverse-proxy guidance, and the host-level security-boundary warning.

## Verification

- [x] `./scripts/sync-migrations.sh --check`
- [x] `gofmt -l .` (clean)
- [x] `go vet ./...`
- [x] `go test ./... -count=1`
- [x] `go build ./...`
- [x] `go test -race -count=1` for all changed Go packages
- [ ] Container-backed integration tests (Docker daemon unavailable locally; CI will run them)