### PR TITLE
fix(compose): self-heal GraphJin datasource upgrades

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -191,15 +191,48 @@ jobs:
             # from the legacy default network to the fixed runtime network.
             OPENNEKO_VERSION="$DEPLOY_IMAGE_TAG" OPENNEKO_PORT=80 \
               openneko upgrade --mode demo --version "$DEPLOY_IMAGE_TAG" --no-prune
-            OPENNEKO_PORT=80 openneko status || true
+            OPENNEKO_PORT=80 openneko status
 
-            # Exercise the path that ordinary HTTP health checks missed in
-            # PR #208: a supervisor inside a fresh sandbox must call back to
-            # the containerised gateway and reach Ready.
             WORKER=$(docker ps -q \
               --filter label=com.docker.compose.project=openneko-demo \
               --filter label=com.docker.compose.service=worker | head -1)
             test -n "$WORKER"
+
+            # Container health is insufficient for a datasource deployment:
+            # require the authenticated worker -> GraphJin -> AdventureWorks
+            # path to return a real row before accepting the rollout.
+            docker exec "$WORKER" node --import tsx/esm --input-type=module --eval '
+              import { mintGraphjinToken, callGraphjinMcpTool } from "@neko/llm";
+              const token = mintGraphjinToken({
+                orgId: "adventureworks",
+                userId: null,
+                role: "service",
+              });
+              const response = await callGraphjinMcpTool({
+                baseUrl: "http://graphjin:8080/api/v1/mcp",
+                headers: { authorization: "Bearer " + token },
+                signal: AbortSignal.timeout(10_000),
+              }, {
+                name: "execute_graphql",
+                arguments: {
+                  query: "query { soh(limit: 1, order_by: { id: desc }) { id } }",
+                },
+              });
+              const text = response.content
+                .map((item) => item.type === "text" ? item.text : "")
+                .join("");
+              const payload = JSON.parse(text);
+              if (response.isError ||
+                  !Array.isArray(payload.data?.soh) ||
+                  payload.data.soh.length !== 1) {
+                throw new Error("authenticated datasource query failed");
+              }
+              console.log("authenticated_datasource_query=ok");
+            '
+
+            # Exercise the path that ordinary HTTP health checks missed in
+            # PR #208: a supervisor inside a fresh sandbox must call back to
+            # the containerised gateway and reach Ready.
             docker exec "$WORKER" openshell sandbox create \
               --gateway openneko \
               --from "ghcr.io/open-neko/agent:$DEPLOY_IMAGE_TAG" \

--- a/.github/workflows/post-release-smoke.yml
+++ b/.github/workflows/post-release-smoke.yml
@@ -100,8 +100,9 @@ jobs:
           set -euxo pipefail
           tag="${{ steps.ctx.outputs.tag }}"
           # With --pull never, any image the stack references but this list
-          # misses fails the boot — so derive the list from the compose files
-          # `--mode prod` actually runs instead of hand-maintaining it
+          # misses fails the boot — so derive the list from the full demo
+          # stack instead of hand-maintaining it. Demo includes every core
+          # service plus the upgrade-sensitive datasource overlay.
           # (busybox:latest for openshell-reg was the second one missed).
           # OPENSHELL_VERSION is intentionally literal in the second sed expression.
           # The final expression unwraps ANY other ${VAR:-default} to its
@@ -112,6 +113,7 @@ jobs:
           mapfile -t refs < <(
             sed -n 's/^[[:space:]]*image:[[:space:]]*//p' \
               apps/openneko/assets/compose/core.yml \
+              apps/openneko/assets/compose/demo.yml \
               apps/openneko/assets/compose/openshell.yml \
             | sed -e "s/\${OPENNEKO_VERSION:-latest}/${tag}/" \
                   -e 's/\${OPENSHELL_VERSION:-\([0-9.][0-9.]*\)}/\1/' \
@@ -185,13 +187,13 @@ jobs:
             test "$runtime" = "glibc 2.36 / PostgreSQL 16.15 (Debian 16.15-1.pgdg12+2) / $image_owner"
           done
 
-      - name: openneko start (detached) against pre-pulled images
+      - name: openneko demo start (detached) against pre-pulled images
         if: ${{ steps.ctx.outputs.build_ok == 'true' }}
         env:
           OPENNEKO_VERSION: ${{ steps.ctx.outputs.tag }}
         run: |
           set -euxo pipefail
-          openneko start --mode prod --detach --pull never
+          openneko start --mode demo --detach --pull never
 
       - name: openneko status (poll until serving)
         if: ${{ steps.ctx.outputs.build_ok == 'true' }}
@@ -199,17 +201,90 @@ jobs:
           OPENNEKO_VERSION: ${{ steps.ctx.outputs.tag }}
         run: |
           set -euo pipefail
-          for i in $(seq 1 60); do
+          for i in $(seq 1 90); do
             if openneko status; then
               echo "stack is serving after ${i} polls"
               exit 0
             fi
             sleep 2
           done
-          echo "stack did not reach 'serving' within 120s — final state:"
+          echo "stack did not reach 'serving' within 180s — final state:"
           openneko status -v || true
           openneko logs || true
           exit 1
+
+      - name: Retained-volume upgrade repairs and serves GraphJin
+        if: ${{ steps.ctx.outputs.build_ok == 'true' }}
+        env:
+          OPENNEKO_VERSION: ${{ steps.ctx.outputs.tag }}
+        run: |
+          set -euo pipefail
+          worker_image="ghcr.io/open-neko/neko-worker:$OPENNEKO_VERSION"
+          config_volume="openneko-demo_graphjin-config"
+
+          # Recreate the production regression exactly: the persisted config
+          # exists, but the runtime supervisor artifact is absent. Also keep a
+          # sentinel proving the upgrade reused rather than replaced the volume.
+          docker run --rm --user 0:0 \
+            --entrypoint /bin/sh \
+            -v "$config_volume:/config" \
+            "$worker_image" -ceu '
+              test -s /config/agentic.yml
+              printf "%s\n" retained-state > /config/.upgrade-smoke-sentinel
+              rm -f /config/.openneko-graphjin-supervisor.sh \
+                    /config/.openneko-graphjin-supervisor.sh.tmp
+            '
+
+          openneko upgrade --stack-only --mode demo \
+            --version "$OPENNEKO_VERSION" --no-prune
+
+          docker run --rm --user 0:0 \
+            --entrypoint /bin/sh \
+            -v "$config_volume:/config" \
+            "$worker_image" -ceu '
+              test "$(cat /config/.upgrade-smoke-sentinel)" = retained-state
+              test -x /config/.openneko-graphjin-supervisor.sh
+            '
+
+          graphjin=$(docker ps -q \
+            --filter label=com.docker.compose.project=openneko-demo \
+            --filter label=com.docker.compose.service=graphjin | head -1)
+          test -n "$graphjin"
+          test "$(docker inspect --format '{{.State.Health.Status}}' "$graphjin")" = healthy
+
+          worker=$(docker ps -q \
+            --filter label=com.docker.compose.project=openneko-demo \
+            --filter label=com.docker.compose.service=worker | head -1)
+          test -n "$worker"
+          docker exec "$worker" node --import tsx/esm --input-type=module --eval '
+            import { mintGraphjinToken, callGraphjinMcpTool } from "@neko/llm";
+            const token = mintGraphjinToken({
+              orgId: "adventureworks",
+              userId: null,
+              role: "service",
+            });
+            const response = await callGraphjinMcpTool({
+              baseUrl: "http://graphjin:8080/api/v1/mcp",
+              headers: { authorization: "Bearer " + token },
+              signal: AbortSignal.timeout(10_000),
+            }, {
+              name: "execute_graphql",
+              arguments: {
+                query: "query { soh(limit: 1, order_by: { id: desc }) { id } }",
+              },
+            });
+            const text = response.content
+              .map((item) => item.type === "text" ? item.text : "")
+              .join("");
+            const payload = JSON.parse(text);
+            if (response.isError ||
+                !Array.isArray(payload.data?.soh) ||
+                payload.data.soh.length !== 1) {
+              throw new Error("authenticated datasource query failed");
+            }
+            console.log("authenticated_datasource_query=ok");
+          '
+          openneko status
 
       - name: Verify reconciled database volumes and pg-boss equality
         if: ${{ steps.ctx.outputs.build_ok == 'true' }}
@@ -217,7 +292,7 @@ jobs:
           set -euo pipefail
           container_for() {
             docker ps -q \
-              --filter label=com.docker.compose.project=openneko-prod \
+              --filter label=com.docker.compose.project=openneko-demo \
               --filter "label=com.docker.compose.service=$1" | head -1
           }
           neko_db=$(container_for neko-db)
@@ -258,7 +333,7 @@ jobs:
         run: |
           set -euo pipefail
           worker=$(docker ps -q \
-            --filter label=com.docker.compose.project=openneko-prod \
+            --filter label=com.docker.compose.project=openneko-demo \
             --filter label=com.docker.compose.service=worker | head -1)
           test -n "$worker"
           docker exec "$worker" openshell sandbox create \

--- a/Dockerfile
+++ b/Dockerfile
@@ -521,6 +521,8 @@ CMD ["--help"]
 FROM alpine:3.22 AS graphjin-runtime
 RUN apk add --no-cache ca-certificates curl tini
 COPY --from=graphjin-bin /usr/local/bin/graphjin /usr/local/bin/graphjin
+COPY scripts/graphjin-supervisor.sh /usr/local/bin/openneko-graphjin-supervisor.sh
+RUN chmod +x /usr/local/bin/openneko-graphjin-supervisor.sh
 
 FROM graphjin-runtime AS neko-graphjin
 COPY scripts/neko-graphjin-entrypoint.sh /usr/local/bin/neko-graphjin-entrypoint.sh

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -213,8 +213,9 @@ Docker — already required to run OpenNeko.
 
 1. Pulls the latest OpenNeko service, agent, and plugin-base images.
 2. Detects the mode recorded by your last `setup` or `start` (`prod`, `dev`, or `demo`) and recreates that stack detached.
-3. Runs pending migrations through the stack's `neko-migrate` container.
-4. Removes old OpenNeko image tags and dangling image layers unless you pass `--no-prune`.
+3. Re-runs every idempotent initializer against the existing volumes, including runtime-artifact repair and pending migrations.
+4. Waits for every declared service health check; a crash loop or unreachable data plane fails the upgrade instead of being reported as success.
+5. Persists the new version and removes old OpenNeko image tags only after the stack is healthy (unless you pass `--no-prune`).
 
 Run it from the same install directory you use for `openneko start`:
 

--- a/apps/openneko/assets/compose/core.yml
+++ b/apps/openneko/assets/compose/core.yml
@@ -315,7 +315,12 @@ services:
           KEY=$$(node -e 'console.log(require("crypto").randomBytes(32).toString("base64"))')
           sed -i "s|REPLACE_WITH_BASE64_32_BYTE_KEY|$$KEY|" /config/agentic.yml
         fi
-        cp /app/scripts/graphjin-supervisor.sh /config/.openneko-graphjin-supervisor.sh
+        # Compatibility fallback for a main supervisor paired with a released
+        # records-graphjin image that predates the image-owned supervisor.
+        # Refresh it unconditionally so existing persistent volumes self-heal.
+        cp /app/scripts/graphjin-supervisor.sh /config/.openneko-graphjin-supervisor.sh.tmp
+        chmod 0755 /config/.openneko-graphjin-supervisor.sh.tmp
+        mv /config/.openneko-graphjin-supervisor.sh.tmp /config/.openneko-graphjin-supervisor.sh
         chmod -R a+rwX /config
     volumes:
       - openneko-graphjin-cli:/config
@@ -366,10 +371,20 @@ services:
 
   graphjin:
     # Reuse the already-required records-graphjin image: it contains the same
-    # pinned GraphJin binary, so a full install does not pull a second 120 MiB
-    # runtime. Overriding the records entrypoint selects vanilla GraphJin.
+    # pinned GraphJin binary and owns its supervisor, so a full install does
+    # not pull a second runtime or execute code from a persistent config
+    # volume. The fallback preserves main-supervisor/release-image skew during
+    # the first release that introduces the image-owned path.
     image: ${OPENNEKO_GRAPHJIN_IMAGE:-ghcr.io/open-neko/records-graphjin:${OPENNEKO_VERSION:-latest}}
-    entrypoint: ["/bin/sh", "/config/.openneko-graphjin-supervisor.sh"]
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        if [ -x /usr/local/bin/openneko-graphjin-supervisor.sh ]; then
+          exec /usr/local/bin/openneko-graphjin-supervisor.sh "$$@"
+        fi
+        exec /bin/sh /config/.openneko-graphjin-supervisor.sh "$$@"
+      - --
     restart: unless-stopped
     depends_on:
       graphjin-config-init:
@@ -389,6 +404,14 @@ services:
     volumes:
       - openneko-graphjin-cli:/config
     command: ["serve", "--path", "/config"]
+    healthcheck:
+      # JWT-protected GraphQL may return a non-2xx response to this anonymous
+      # request. Any HTTP response proves the data plane is accepting traffic.
+      test: ["CMD", "curl", "-sS", "-o", "/dev/null", "http://127.0.0.1:8080/api/v1/graphql"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
 
   # One-shot: applies SQL migrations to neko-db after both database volumes
   # satisfy the enforced storage contract. Every long-running service depends

--- a/apps/openneko/assets/compose/demo.yml
+++ b/apps/openneko/assets/compose/demo.yml
@@ -63,6 +63,11 @@ services:
           KEY=$(node -e 'console.log(require("crypto").randomBytes(32).toString("base64"))')
           sed -i "s|REPLACE_WITH_BASE64_32_BYTE_KEY|$$KEY|" /config/agentic.yml
         fi
+        # This overlay replaces the core initializer, so it must preserve the
+        # compatibility repair for existing volumes and older released images.
+        cp /app/scripts/graphjin-supervisor.sh /config/.openneko-graphjin-supervisor.sh.tmp
+        chmod 0755 /config/.openneko-graphjin-supervisor.sh.tmp
+        mv /config/.openneko-graphjin-supervisor.sh.tmp /config/.openneko-graphjin-supervisor.sh
         chmod -R a+rwX /config
     volumes:
       - graphjin-config:/config

--- a/apps/openneko/assets/compose_parity_test.go
+++ b/apps/openneko/assets/compose_parity_test.go
@@ -3,6 +3,8 @@ package assets
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"strings"
@@ -42,23 +44,228 @@ func TestPackagedGraphJinReusesReleasedRuntime(t *testing.T) {
 	if !strings.Contains(graphjin.Image, "ghcr.io/open-neko/records-graphjin:") {
 		t.Fatalf("packaged graphjin image = %q, want the shared records-graphjin runtime", graphjin.Image)
 	}
-	if want := []string{"/bin/sh", "/config/.openneko-graphjin-supervisor.sh"}; !reflect.DeepEqual(graphjin.Entrypoint, want) {
-		t.Fatalf("packaged graphjin entrypoint = %v, want %v", graphjin.Entrypoint, want)
+	entrypoint := strings.Join(graphjin.Entrypoint, "\n")
+	for _, required := range []string{
+		"/usr/local/bin/openneko-graphjin-supervisor.sh",
+		"/config/.openneko-graphjin-supervisor.sh",
+	} {
+		if !strings.Contains(entrypoint, required) {
+			t.Fatalf("packaged graphjin entrypoint does not include %s: %v", required, graphjin.Entrypoint)
+		}
+	}
+	wantHealthcheck := []string{
+		"CMD", "curl", "-sS", "-o", "/dev/null",
+		"http://127.0.0.1:8080/api/v1/graphql",
+	}
+	if got := composeHealthcheckTest(t, "packaged", "graphjin", graphjin); !reflect.DeepEqual(got, wantHealthcheck) {
+		t.Fatalf("packaged graphjin readiness check = %v, want %v", got, wantHealthcheck)
 	}
 	configInit, ok := core.Services["graphjin-config-init"]
 	if !ok {
 		t.Fatal("packaged core is missing graphjin-config-init")
 	}
-	if !strings.Contains(strings.Join(configInit.Entrypoint, "\n"), "graphjin-supervisor.sh") {
-		t.Fatal("packaged graphjin config init does not install the supervisor entrypoint")
-	}
+	assertGraphJinSupervisorRepair(t, "packaged core", configInit, "/app/scripts/graphjin-supervisor.sh")
+	assertGraphJinConfigVolumeMatches(t, "packaged core", configInit, graphjin)
 
 	demoRaw, err := ComposeFS.ReadFile("compose/demo.yml")
 	if err != nil {
 		t.Fatal(err)
 	}
+	demo := loadComposeParityDocument(t, demoRaw)
+	demoConfigInit := demo.Services["graphjin-config-init"]
+	assertGraphJinSupervisorRepair(t, "packaged demo overlay", demoConfigInit, "/app/scripts/graphjin-supervisor.sh")
+	assertGraphJinConfigVolumeMatches(t, "packaged demo overlay", demoConfigInit, demo.Services["graphjin"])
 	if strings.Contains(string(demoRaw), "dosco/graphjin") {
 		t.Fatal("packaged demo restores the duplicate upstream GraphJin image")
+	}
+}
+
+func TestGraphJinSupervisorIsImageOwnedAndEverySourceOverlayRepairsOldVolumes(t *testing.T) {
+	root := repoRootForTest(t)
+	dockerfile, err := os.ReadFile(root + "/Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{
+		"COPY scripts/graphjin-supervisor.sh /usr/local/bin/openneko-graphjin-supervisor.sh",
+		"chmod +x /usr/local/bin/openneko-graphjin-supervisor.sh",
+	} {
+		if !strings.Contains(string(dockerfile), required) {
+			t.Fatalf("GraphJin runtime does not own its supervisor: missing %q", required)
+		}
+	}
+
+	baseRaw, err := os.ReadFile(root + "/compose.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := loadComposeParityDocument(t, baseRaw)
+	if strings.Contains(base.Services["graphjin"].Image, "dosco/graphjin") {
+		t.Fatal("source graphjin uses the shell-less upstream image with a shell supervisor")
+	}
+	assertGraphJinSupervisorRepair(t, "source core", base.Services["graphjin-config-init"], "/seed/graphjin-supervisor.sh")
+	assertGraphJinConfigVolumeMatches(t, "source core", base.Services["graphjin-config-init"], base.Services["graphjin"])
+
+	for _, overlayName := range []string{"compose.adventureworks.yml", "compose.graphjin-agent.yml"} {
+		raw, err := os.ReadFile(root + "/" + overlayName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		overlay := loadComposeParityDocument(t, raw)
+		initializer := overlay.Services["graphjin-config-init"]
+		if len(initializer.Command) != 0 {
+			t.Fatalf("%s appends a command that the inherited initializer entrypoint would ignore", overlayName)
+		}
+		assertGraphJinSupervisorRepair(t, overlayName, initializer, "/seed/graphjin-supervisor.sh")
+	}
+}
+
+func assertGraphJinSupervisorRepair(t *testing.T, label string, service composeParityService, source string) {
+	t.Helper()
+	script := strings.Join(service.Entrypoint, "\n")
+	copyLine := "cp " + source + " /config/.openneko-graphjin-supervisor.sh.tmp"
+	for _, required := range []string{
+		copyLine,
+		"chmod 0755 /config/.openneko-graphjin-supervisor.sh.tmp",
+		"mv /config/.openneko-graphjin-supervisor.sh.tmp /config/.openneko-graphjin-supervisor.sh",
+	} {
+		if !strings.Contains(script, required) {
+			t.Fatalf("%s does not atomically repair an existing GraphJin supervisor volume: missing %q", label, required)
+		}
+	}
+	if lastConditionalEnd := strings.LastIndex(script, "\nfi\n"); lastConditionalEnd >= 0 && strings.Index(script, copyLine) < lastConditionalEnd {
+		t.Fatalf("%s repairs the supervisor only on first install; upgrades must refresh it unconditionally", label)
+	}
+}
+
+func assertGraphJinConfigVolumeMatches(t *testing.T, label string, initializer, graphjin composeParityService) {
+	t.Helper()
+	initSource := composeMountSourceAt(initializer.Volumes, "/config")
+	graphjinSource := composeMountSourceAt(graphjin.Volumes, "/config")
+	if initSource == "" || graphjinSource == "" || initSource != graphjinSource {
+		t.Fatalf("%s repairs GraphJin volume %q but serves volume %q", label, initSource, graphjinSource)
+	}
+}
+
+func composeMountSourceAt(mounts []string, target string) string {
+	for _, mount := range mounts {
+		parts := strings.Split(mount, ":")
+		if len(parts) >= 2 && parts[1] == target {
+			return parts[0]
+		}
+	}
+	return ""
+}
+
+func TestPackagedDemoInitializerHealsAnExistingVolumeMissingTheSupervisor(t *testing.T) {
+	root := repoRootForTest(t)
+	supervisorSource := filepath.Join(root, "scripts", "graphjin-supervisor.sh")
+	wantSupervisor, err := os.ReadFile(supervisorSource)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, composeFile := range []string{"core.yml", "demo.yml"} {
+		t.Run(composeFile, func(t *testing.T) {
+			raw, err := ComposeFS.ReadFile("compose/" + composeFile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			service := loadComposeParityDocument(t, raw).Services["graphjin-config-init"]
+			script := strings.Join(service.Entrypoint[2:], "\n")
+
+			configDir := t.TempDir()
+			persistedConfig := filepath.Join(configDir, "agentic.yml")
+			if err := os.WriteFile(persistedConfig, []byte("persisted: true\n"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			// This is the v2.33-v2.35 production state: config survived the
+			// upgrade, while the supervisor file was never installed.
+			missingSupervisor := filepath.Join(configDir, ".openneko-graphjin-supervisor.sh")
+			if err := os.Remove(missingSupervisor); err != nil && !os.IsNotExist(err) {
+				t.Fatal(err)
+			}
+
+			script = strings.ReplaceAll(script, "/app/scripts/graphjin-supervisor.sh", supervisorSource)
+			script = strings.ReplaceAll(script, "/config", configDir)
+			// Docker Compose turns $$ into a literal $ before invoking the shell.
+			script = strings.ReplaceAll(script, "$$", "$")
+			cmd := exec.Command("/bin/sh", "-c", script)
+			if output, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("run %s initializer against existing volume: %v\n%s", composeFile, err, output)
+			}
+
+			gotSupervisor, err := os.ReadFile(missingSupervisor)
+			if err != nil {
+				t.Fatalf("repaired supervisor is missing: %v", err)
+			}
+			if !reflect.DeepEqual(gotSupervisor, wantSupervisor) {
+				t.Fatal("repaired supervisor does not match the released runtime artifact")
+			}
+			info, err := os.Stat(missingSupervisor)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.Mode().Perm()&0o111 == 0 {
+				t.Fatalf("repaired supervisor mode = %o, want executable", info.Mode().Perm())
+			}
+			persisted, err := os.ReadFile(persistedConfig)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(persisted) != "persisted: true\n" {
+				t.Fatalf("initializer replaced existing datasource config: %q", persisted)
+			}
+		})
+	}
+}
+
+func TestPostReleaseSmokeGatesRetainedDemoUpgrades(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(repoRootForTest(t), ".github", "workflows", "post-release-smoke.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsedWorkflow any
+	if err := yaml.Unmarshal(raw, &parsedWorkflow); err != nil {
+		t.Fatalf("post-release smoke is not valid YAML: %v", err)
+	}
+	workflow := string(raw)
+	for _, required := range []string{
+		"openneko start --mode demo --detach --pull never",
+		"rm -f /config/.openneko-graphjin-supervisor.sh",
+		"openneko upgrade --stack-only --mode demo",
+		"test -x /config/.openneko-graphjin-supervisor.sh",
+		"{{.State.Health.Status}}",
+		"authenticated_datasource_query=ok",
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Fatalf("post-release smoke no longer gates retained demo upgrades: missing %q", required)
+		}
+	}
+}
+
+func TestProductionDeployRequiresAuthenticatedDatasourceQuery(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(repoRootForTest(t), ".github", "workflows", "deploy.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsedWorkflow any
+	if err := yaml.Unmarshal(raw, &parsedWorkflow); err != nil {
+		t.Fatalf("production deploy is not valid YAML: %v", err)
+	}
+	workflow := string(raw)
+	for _, required := range []string{
+		"openneko upgrade --mode demo",
+		"OPENNEKO_PORT=80 openneko status",
+		"callGraphjinMcpTool",
+		"authenticated_datasource_query=ok",
+	} {
+		if !strings.Contains(workflow, required) {
+			t.Fatalf("production deploy no longer verifies the datasource upgrade: missing %q", required)
+		}
+	}
+	if strings.Contains(workflow, "OPENNEKO_PORT=80 openneko status || true") {
+		t.Fatal("production deploy ignores an unhealthy upgraded stack")
 	}
 }
 

--- a/apps/openneko/internal/cli/upgrade.go
+++ b/apps/openneko/internal/cli/upgrade.go
@@ -194,14 +194,24 @@ func restartUpgradedStack(ctx context.Context, sup *compose.Supervisor, project 
 	// otherwise reuses already-exited containers during the one-time migration
 	// from the legacy dynamic <project>_default network, leaving them unable to
 	// resolve services that have moved to <project>_runtime.
-	code, err := sup.Run(ctx, project, files, []string{"up", "-d", "--pull", "never", "--remove-orphans", "--force-recreate"}, os.Stdout, os.Stderr)
+	code, err := sup.Run(ctx, project, files, upgradeStackUpArgs(), os.Stdout, os.Stderr)
 	if err != nil {
 		return err
 	}
 	if code != 0 {
-		return WithExit(code, nil)
+		return WithExit(code, errors.New("upgraded stack failed its readiness checks"))
 	}
 	return nil
+}
+
+func upgradeStackUpArgs() []string {
+	// An upgrade is not successful merely because Compose created containers.
+	// Wait for every declared healthcheck so crash loops and unreachable data
+	// planes fail before the new image marker is persisted or old images prune.
+	return []string{
+		"up", "-d", "--wait", "--wait-timeout", "180",
+		"--pull", "never", "--remove-orphans", "--force-recreate",
+	}
 }
 
 func resolveUpgradeMode(ctx context.Context, flag string, sup *compose.Supervisor) (compose.Mode, bool, error) {

--- a/apps/openneko/internal/cli/upgrade_test.go
+++ b/apps/openneko/internal/cli/upgrade_test.go
@@ -60,6 +60,16 @@ func TestNormalizeUpgradeImageVersion(t *testing.T) {
 	}
 }
 
+func TestUpgradeWaitsForEveryServiceReadinessCheck(t *testing.T) {
+	want := []string{
+		"up", "-d", "--wait", "--wait-timeout", "180",
+		"--pull", "never", "--remove-orphans", "--force-recreate",
+	}
+	if got := upgradeStackUpArgs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("upgrade stack args = %v, want %v", got, want)
+	}
+}
+
 func TestResolveUpgradeMode(t *testing.T) {
 	s := &compose.Supervisor{RuntimeDir: t.TempDir()}
 	stubComposeProjects(t, []string{"openneko-prod"}, []string{"openneko-prod"})

--- a/compose.adventureworks.yml
+++ b/compose.adventureworks.yml
@@ -53,6 +53,9 @@ services:
         if [ ! -f /config/dev.yml ]; then
           cp /seed/dev.yml /config/dev.yml
         fi
+        cp /seed/graphjin-supervisor.sh /config/.openneko-graphjin-supervisor.sh.tmp
+        chmod 0755 /config/.openneko-graphjin-supervisor.sh.tmp
+        mv /config/.openneko-graphjin-supervisor.sh.tmp /config/.openneko-graphjin-supervisor.sh
         chmod -R a+rwX /config
     restart: "no"
 
@@ -64,7 +67,6 @@ services:
       GRAPHJIN_SOURCES_CONFIG: ""
 
   graphjin:
-    image: dosco/graphjin:3.20.47
     restart: unless-stopped
     depends_on:
       adventureworks-init:

--- a/compose.graphjin-agent.yml
+++ b/compose.graphjin-agent.yml
@@ -19,7 +19,9 @@ services:
     volumes:
       - graphjin-config:/config
       - ./db/graphjin/dev.sources.example.yml:/seed/agentic.yml:ro
-    command:
+    # This overlay replaces the base initializer rather than appending a
+    # command that the base shell entrypoint would ignore.
+    entrypoint:
       - /bin/sh
       - -c
       - |
@@ -29,6 +31,9 @@ services:
           KEY=$$(head -c 32 /dev/urandom | base64 | tr -d '\n')
           sed -i "s|REPLACE_WITH_BASE64_32_BYTE_KEY|$$KEY|" /config/agentic.yml
         fi
+        cp /seed/graphjin-supervisor.sh /config/.openneko-graphjin-supervisor.sh.tmp
+        chmod 0755 /config/.openneko-graphjin-supervisor.sh.tmp
+        mv /config/.openneko-graphjin-supervisor.sh.tmp /config/.openneko-graphjin-supervisor.sh
         chmod -R a+rwX /config
 
   graphjin:

--- a/compose.yml
+++ b/compose.yml
@@ -385,7 +385,9 @@ services:
           KEY=$$(head -c 32 /dev/urandom | base64 | tr -d '\n')
           sed -i "s|REPLACE_WITH_BASE64_32_BYTE_KEY|$$KEY|" /config/agentic.yml
         fi
-        cp /seed/graphjin-supervisor.sh /config/.openneko-graphjin-supervisor.sh
+        cp /seed/graphjin-supervisor.sh /config/.openneko-graphjin-supervisor.sh.tmp
+        chmod 0755 /config/.openneko-graphjin-supervisor.sh.tmp
+        mv /config/.openneko-graphjin-supervisor.sh.tmp /config/.openneko-graphjin-supervisor.sh
         chmod -R a+rwX /config
     volumes:
       - openneko-graphjin-cli:/config
@@ -437,8 +439,18 @@ services:
     restart: "no"
 
   graphjin:
-    image: ${OPENNEKO_GRAPHJIN_IMAGE:-dosco/graphjin:3.20.47}
-    entrypoint: ["/bin/sh", "/config/.openneko-graphjin-supervisor.sh"]
+    # The upstream GraphJin image is distroless, while the reload supervisor
+    # requires a shell. Reuse OpenNeko's released Alpine GraphJin runtime.
+    image: ${OPENNEKO_GRAPHJIN_IMAGE:-ghcr.io/open-neko/records-graphjin:${OPENNEKO_VERSION:-latest}}
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        if [ -x /usr/local/bin/openneko-graphjin-supervisor.sh ]; then
+          exec /usr/local/bin/openneko-graphjin-supervisor.sh "$$@"
+        fi
+        exec /bin/sh /config/.openneko-graphjin-supervisor.sh "$$@"
+      - --
     restart: unless-stopped
     depends_on:
       graphjin-config-init:
@@ -458,6 +470,12 @@ services:
     volumes:
       - openneko-graphjin-cli:/config
     command: ["serve", "--path", "/config"]
+    healthcheck:
+      test: ["CMD", "curl", "-sS", "-o", "/dev/null", "http://127.0.0.1:8080/api/v1/graphql"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+      start_period: 10s
 
   # One-shot: applies SQL migrations to neko-db after both database volumes
   # satisfy the enforced storage contract. Every long-running service depends


### PR DESCRIPTION
## Summary

- repair the GraphJin supervisor atomically and unconditionally on every prod or demo initializer run, preserving existing datasource configuration
- ship the supervisor inside the released GraphJin image while retaining a compatibility fallback for older released images used by main-supervisor deployments
- add GraphJin readiness checks and make `openneko upgrade` wait for the whole stack before persisting the new version or pruning old images
- gate releases with a retained-volume demo upgrade that recreates the missing-supervisor regression and executes an authenticated AdventureWorks query
- make the production deploy fail unless stack status and the authenticated worker to GraphJin to AdventureWorks path succeed

## Incident

Run `14a6d6f3-1043-4f39-ad92-3e42fd066fde` failed because the demo overlay replaced `graphjin-config-init` but omitted the supervisor copy. The upgraded GraphJin container then crash-looped on a missing `/config/.openneko-graphjin-supervisor.sh`. AdventureWorks PostgreSQL remained healthy; the GraphJin service layer was unreachable.

The live demo was repaired separately and an authenticated query now succeeds. This PR makes the repair automatic for existing persistent volumes on the next deployment.

## Verification

- [x] `cd apps/openneko && go test ./... -count=1`
- [x] `cd apps/openneko && go vet ./...`
- [x] `cd apps/openneko && go build ./...`
- [x] `pnpm --filter @neko/worker exec vitest run test/graphjin-supervisor.test.ts`
- [x] Packaged prod/demo and source Compose combinations render successfully
- [x] Existing-volume regression test preserves `agentic.yml` and restores the executable supervisor
- [x] Live worker received HTTP 200 from GraphJin and completed a fresh authenticated AdventureWorks query
- [x] Relevant lint, typecheck, and tests pass
- [x] Changed behavior was exercised locally
