### PR TITLE
Fix worker provider configuration handoff

### DIFF
--- a/apps/web/src/lib/onboarding-failure.ts
+++ b/apps/web/src/lib/onboarding-failure.ts
@@ -7,6 +7,9 @@ const TIMEOUT_MESSAGE =
 const PROVIDER_MESSAGE =
   "Setup could not finish because the model provider rejected or interrupted the request. Re-test the model in Admin → Settings → Agent, then try again.";
 
+const MODEL_HANDOFF_MESSAGE =
+  "Setup could not finish because the worker could not load the saved model configuration. Re-save or re-test the model in Admin → Settings → Agent, then try again; if it repeats, inspect `openneko logs` for the configuration handoff error.";
+
 const DATA_MESSAGE =
   "Setup could not finish while reading the configured data source. Re-test the source in Admin → Settings → Data Sources, then try again.";
 
@@ -31,6 +34,13 @@ export function profileBuildFailureMessage(error: string | null): string {
     )
   ) {
     return RUNTIME_MESSAGE;
+  }
+  if (
+    /no llm provider configured|hermes (?:model|setup)|hermes.*config\.yaml|OPENNEKO_AGENT_HERMES_HOME/i.test(
+      error,
+    )
+  ) {
+    return MODEL_HANDOFF_MESSAGE;
   }
   if (
     /provider|gemini http|anthropic http|rate.?limit|quota|api key|authentication/i.test(

--- a/apps/web/test/lib/onboarding-failure.test.ts
+++ b/apps/web/test/lib/onboarding-failure.test.ts
@@ -18,6 +18,14 @@ describe("profileBuildFailureMessage", () => {
     ).toContain("agent became unavailable");
   });
 
+  it("classifies missing local Hermes configuration as a worker handoff failure", () => {
+    const message = profileBuildFailureMessage(
+      "Internal error: No LLM provider configured. Run `hermes model` to select a provider, or run `hermes setup` for first-time configuration.",
+    );
+    expect(message).toContain("worker could not load the saved model configuration");
+    expect(message).not.toContain("model provider rejected");
+  });
+
   it("does not expose an unknown persisted error to the browser", () => {
     const internal = "unexpected /private/path containing sensitive context";
     expect(profileBuildFailureMessage(internal)).not.toContain(internal);

--- a/apps/worker/src/jobs/bootstrap-metrics-build.ts
+++ b/apps/worker/src/jobs/bootstrap-metrics-build.ts
@@ -10,7 +10,10 @@ import {
 } from "@neko/db";
 import { enqueue, QUEUE } from "@neko/db/jobs";
 import { updateProgress } from "../progress.js";
-import { runBootstrapMetricsWriter } from "@neko/llm";
+import {
+  ensureHostConfigProvisioned,
+  runBootstrapMetricsWriter,
+} from "@neko/llm";
 
 /**
  * bootstrap_metrics_build job handler.
@@ -96,6 +99,7 @@ export async function runBootstrapMetricsBuild(jobId: string, orgId: string) {
 
   await updateProgress(jobId, "Generating cards");
 
+  await ensureHostConfigProvisioned(orgId);
   const { metrics } = await runBootstrapMetricsWriter({
     orgId,
     orgName,

--- a/apps/worker/src/jobs/business-profile-build.ts
+++ b/apps/worker/src/jobs/business-profile-build.ts
@@ -11,7 +11,11 @@ import {
 } from "@neko/db";
 import { enqueue, QUEUE } from "@neko/db/jobs";
 import { updateProgress } from "../progress.js";
-import { resolveResearchProviderConfig, runProfiler } from "@neko/llm";
+import {
+  ensureHostConfigProvisioned,
+  resolveResearchProviderConfig,
+  runProfiler,
+} from "@neko/llm";
 
 /**
  * business_profile_build job handler.
@@ -58,6 +62,7 @@ export async function runBusinessProfileBuild(jobId: string, orgId: string) {
   await updateProgress(jobId, "Reading data source");
 
   // 2. Run the profiler through Hermes — the same runtime the metric agent uses.
+  await ensureHostConfigProvisioned(orgId);
   const { businessProfile } = await runProfiler({
     orgId,
     mcpUrl: source.mcp_url,

--- a/apps/worker/src/jobs/industry-insights-build.ts
+++ b/apps/worker/src/jobs/industry-insights-build.ts
@@ -8,7 +8,7 @@ import {
 } from "@neko/db";
 import { enqueue, QUEUE } from "@neko/db/jobs";
 import { updateProgress } from "../progress.js";
-import { runIndustryResearcher } from "@neko/llm";
+import { ensureHostConfigProvisioned, runIndustryResearcher } from "@neko/llm";
 
 /**
  * industry_insights_build job handler.
@@ -61,6 +61,7 @@ export async function runIndustryInsightsBuild(jobId: string, orgId: string) {
   await updateProgress(jobId, "Loading business profile");
 
   // 2. Run the researcher (mission writer + sonar-deep-research).
+  await ensureHostConfigProvisioned(orgId);
   const { industryInsights, missionCharter } = await runIndustryResearcher({
     orgId,
     orgName,

--- a/apps/worker/src/jobs/metric-refresh.ts
+++ b/apps/worker/src/jobs/metric-refresh.ts
@@ -10,6 +10,7 @@ import {
 } from "@neko/db";
 import { updateProgress } from "../progress.js";
 import {
+  ensureHostConfigProvisioned,
   runMetricAgent,
   type AgentTokenUsage,
   type MetricAgentInput,
@@ -241,6 +242,7 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
         },
       });
     }
+    await ensureHostConfigProvisioned(orgId);
     result = await runMetricAgent({
       ...input,
       jobId,

--- a/apps/worker/test/jobs/business-profile-build.test.ts
+++ b/apps/worker/test/jobs/business-profile-build.test.ts
@@ -30,7 +30,8 @@ import {
   processing_job,
 } from "@neko/db";
 
-const { mockResolveResearch, mockRunProfiler, mockEnqueue } = vi.hoisted(() => ({
+const { mockEnsureHostConfig, mockResolveResearch, mockRunProfiler, mockEnqueue } = vi.hoisted(() => ({
+  mockEnsureHostConfig: vi.fn(),
   mockResolveResearch: vi.fn(),
   mockRunProfiler: vi.fn(),
   mockEnqueue: vi.fn(),
@@ -40,6 +41,7 @@ vi.mock("@neko/llm", async () => {
   const actual = await vi.importActual<typeof import("@neko/llm")>("@neko/llm");
   return {
     ...actual,
+    ensureHostConfigProvisioned: mockEnsureHostConfig,
     resolveResearchProviderConfig: mockResolveResearch,
     runProfiler: mockRunProfiler,
   };
@@ -95,6 +97,7 @@ describeIfDb("runBusinessProfileBuild", () => {
     mockRunProfiler.mockResolvedValue({
       businessProfile: "Stub business profile content.",
     });
+    mockEnsureHostConfig.mockResolvedValue(undefined);
     mockEnqueue.mockResolvedValue("queue-id-stub");
   });
 
@@ -157,6 +160,10 @@ describeIfDb("runBusinessProfileBuild", () => {
     await runBusinessProfileBuild(jobId, orgId);
 
     expect(mockRunProfiler).toHaveBeenCalledTimes(1);
+    expect(mockEnsureHostConfig).toHaveBeenCalledWith(orgId);
+    expect(mockEnsureHostConfig.mock.invocationCallOrder[0]).toBeLessThan(
+      mockRunProfiler.mock.invocationCallOrder[0],
+    );
     const args = mockRunProfiler.mock.calls[0][0];
     expect(args).toMatchObject({
       orgId,

--- a/apps/worker/test/jobs/metric-refresh.test.ts
+++ b/apps/worker/test/jobs/metric-refresh.test.ts
@@ -35,7 +35,8 @@ import {
   processing_job,
 } from "@neko/db";
 
-const { mockRunMetricAgent, mockGraphjinQuery } = vi.hoisted(() => ({
+const { mockEnsureHostConfig, mockRunMetricAgent, mockGraphjinQuery } = vi.hoisted(() => ({
+  mockEnsureHostConfig: vi.fn(),
   mockRunMetricAgent: vi.fn(),
   mockGraphjinQuery: vi.fn(),
 }));
@@ -44,6 +45,7 @@ vi.mock("@neko/llm", async () => {
   const actual = await vi.importActual<typeof import("@neko/llm")>("@neko/llm");
   return {
     ...actual,
+    ensureHostConfigProvisioned: mockEnsureHostConfig,
     runMetricAgent: mockRunMetricAgent,
   };
 });
@@ -141,6 +143,7 @@ describeIfDb("runMetricRefresh", () => {
   beforeEach(async () => {
     orgId = uniqueOrgId("job-metric-refresh");
     await createTestOrg(orgId);
+    mockEnsureHostConfig.mockResolvedValue(undefined);
     mockRunMetricAgent.mockResolvedValue(stubResult());
   });
 
@@ -175,6 +178,10 @@ describeIfDb("runMetricRefresh", () => {
           role: "CEO",
           jobId,
         }),
+      );
+      expect(mockEnsureHostConfig).toHaveBeenCalledWith(orgId);
+      expect(mockEnsureHostConfig.mock.invocationCallOrder[0]).toBeLessThan(
+        mockRunMetricAgent.mock.invocationCallOrder[0],
       );
       const [job] = await db()
         .select({ result: processing_job.result })

--- a/packages/llm/src/host-provision.ts
+++ b/packages/llm/src/host-provision.ts
@@ -1,8 +1,19 @@
-import { mkdir, chmod } from "node:fs/promises";
+import { chmod, mkdir, unlink } from "node:fs/promises";
+import { createHash } from "node:crypto";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
 
-import { and, data_source, db, desc, eq, like, llm_provider_config, or } from "@neko/db";
+import {
+  and,
+  data_source,
+  db,
+  desc,
+  eq,
+  inArray,
+  like,
+  llm_provider_config,
+  or,
+} from "@neko/db";
 import { maybeDecryptSecret } from "./secrets";
 import { VENDORED_HERMES_MODEL_BINARY } from "./agent-runtime-contract";
 import { hermesHomeForOrg } from "./hermes-home";
@@ -367,7 +378,14 @@ function hermesDelegationConfigLines(): string[] {
 
 async function provisionHermes(orgId: string): Promise<void> {
   const row = await loadProviderRow(orgId, "primary");
-  if (!row || !row.enabled) return;
+  const hermesHome = hermesHomeForOrg(orgId);
+  if (!row || !row.enabled) {
+    await Promise.all([
+      unlink(join(hermesHome, "config.yaml")).catch(() => undefined),
+      unlink(join(hermesHome, ".env")).catch(() => undefined),
+    ]);
+    return;
+  }
 
   const { provider, keyVar, needsBaseUrl } = mapHermesProvider(row.provider);
   const cfg = (row.config ?? {}) as { url?: string; baseUrl?: string };
@@ -376,7 +394,6 @@ async function provisionHermes(orgId: string): Promise<void> {
   const apiKey = secrets.apiKey;
   const model = row.model ?? "";
 
-  const hermesHome = hermesHomeForOrg(orgId);
   await mkdir(hermesHome, { recursive: true });
 
   const yamlLines = [
@@ -475,10 +492,33 @@ function setAgentEnv(key: string, operator: string, derived: string): void {
 
 async function provisionOpenShellRuntime(orgId: string): Promise<void> {
   const row = await loadProviderRow(orgId, "primary");
-  if (!row || !row.enabled) return;
+  if (!row || !row.enabled) {
+    setAgentEnv(
+      "OPENNEKO_AGENT_MODEL_PROVIDER",
+      OPERATOR_AGENT_ENV.provider,
+      "",
+    );
+    setAgentEnv("OPENNEKO_AGENT_MODEL_HOST", OPERATOR_AGENT_ENV.host, "");
+    setAgentEnv(
+      "OPENNEKO_AGENT_MODEL_KEY_ENV",
+      OPERATOR_AGENT_ENV.keyEnv,
+      "",
+    );
+    setAgentEnv(
+      "OPENNEKO_AGENT_HERMES_HOME",
+      OPERATOR_AGENT_ENV.hermesHome,
+      "",
+    );
+    return;
+  }
 
   const { hosts, keyEnv } = deriveAgentEgress(row);
-  setAgentEnv("OPENNEKO_AGENT_MODEL_PROVIDER", OPERATOR_AGENT_ENV.provider, "openneko-agent");
+  const apiKey = decryptSecrets(row.secrets).apiKey;
+  setAgentEnv(
+    "OPENNEKO_AGENT_MODEL_PROVIDER",
+    OPERATOR_AGENT_ENV.provider,
+    apiKey ? "openneko-agent" : "",
+  );
   setAgentEnv("OPENNEKO_AGENT_MODEL_HOST", OPERATOR_AGENT_ENV.host, hosts.join(","));
   setAgentEnv("OPENNEKO_AGENT_MODEL_KEY_ENV", OPERATOR_AGENT_ENV.keyEnv, keyEnv);
   // hermes reads its model + provider from config.yaml under HERMES_HOME. In the
@@ -492,7 +532,6 @@ async function provisionOpenShellRuntime(orgId: string): Promise<void> {
     hermesHomeForOrg(orgId),
   );
 
-  const apiKey = decryptSecrets(row.secrets).apiKey;
   if (!apiKey) return;
   // The gateway can be restarting exactly while we register the provider
   // (deploys recreate it alongside the worker). A single failed attempt
@@ -543,29 +582,93 @@ export async function verifyAgentRuntimeReady(orgId: string): Promise<void> {
   await provisionOpenShellRuntime(orgId);
 }
 
-const provisionedOrgs = new Map<string, Promise<void>>();
+type HostProvisionState = {
+  appliedRevision?: string;
+  tail: Promise<void>;
+};
+
+const provisionedOrgs = new Map<string, HostProvisionState>();
 
 type ProvisionHostConfigOptions = {
   requireOpenShellSync?: boolean;
+  requireHermesSync?: boolean;
 };
 
+/** Build a content revision without retaining provider secrets in process
+ * state. Every setting that changes the files or sandbox launch contract is
+ * covered, including same-provider key rotation. */
+async function hostConfigRevision(orgId: string): Promise<string> {
+  const [providers, sources] = await Promise.all([
+    db()
+      .select({
+        id: llm_provider_config.id,
+        scope: llm_provider_config.scope,
+        provider: llm_provider_config.provider,
+        model: llm_provider_config.model,
+        enabled: llm_provider_config.enabled,
+        config: llm_provider_config.config,
+        secrets: llm_provider_config.secrets,
+        updatedAt: llm_provider_config.updated_at,
+      })
+      .from(llm_provider_config)
+      .where(
+        and(
+          eq(llm_provider_config.org_id, orgId),
+          inArray(llm_provider_config.scope, ["primary", "agent"]),
+        ),
+      )
+      .orderBy(llm_provider_config.scope),
+    db()
+      .select({
+        id: data_source.id,
+        graphqlUrl: data_source.graphql_url,
+        mcpUrl: data_source.mcp_url,
+        authMode: data_source.auth_mode,
+        enabled: data_source.enabled,
+        isDefault: data_source.is_default,
+        updatedAt: data_source.updated_at,
+      })
+      .from(data_source)
+      .where(eq(data_source.org_id, orgId))
+      .orderBy(desc(data_source.is_default), data_source.created_at),
+  ]);
+
+  return createHash("sha256")
+    .update(JSON.stringify({ providers, sources }))
+    .digest("hex");
+}
+
 /**
- * provisionHostConfig, once per org per process. The worker provisions at
- * boot, but the web process used to derive the agent-sandbox env (model
- * egress, gateway provider, key alias) only on a settings save — so every
- * web restart silently launched sandboxes that couldn't reach the model
- * until someone re-saved settings. Run paths call this instead.
+ * Worker-owned provisioning gate for every agent-backed job.
+ *
+ * A successful pass is reused only while the persisted host configuration is
+ * unchanged. This matters because provider settings are saved by the web
+ * process, whose environment mutations cannot reach an already-running
+ * worker. Calls for one org are serialized so a key rotation or provider
+ * family switch cannot race two writers against the same Hermes files.
  */
-export function ensureHostConfigProvisioned(orgId: string): Promise<void> {
-  let p = provisionedOrgs.get(orgId);
-  if (!p) {
-    p = provisionHostConfig(orgId, { requireOpenShellSync: true }).catch((err) => {
-      provisionedOrgs.delete(orgId);
-      throw err;
-    });
-    provisionedOrgs.set(orgId, p);
+export async function ensureHostConfigProvisioned(orgId: string): Promise<void> {
+  const requestedRevision = await hostConfigRevision(orgId);
+  let state = provisionedOrgs.get(orgId);
+  if (!state) {
+    state = { tail: Promise.resolve() };
+    provisionedOrgs.set(orgId, state);
   }
-  return p;
+  if (state.appliedRevision === requestedRevision) return;
+
+  const run = state.tail.catch(() => undefined).then(async () => {
+    // Re-read after earlier callers finish. A settings save may have landed
+    // while this call was queued, and only the newest revision should win.
+    const currentRevision = await hostConfigRevision(orgId);
+    if (state.appliedRevision === currentRevision) return;
+    await provisionHostConfig(orgId, {
+      requireOpenShellSync: true,
+      requireHermesSync: true,
+    });
+    state.appliedRevision = currentRevision;
+  });
+  state.tail = run;
+  await run;
 }
 
 export async function provisionHostConfig(
@@ -598,9 +701,11 @@ export async function provisionHostConfig(
     );
   }
 
+  let hermesError: unknown;
   try {
     await provisionHermes(orgId);
   } catch (e) {
+    hermesError = e;
     console.warn(
       `[host-provision] hermes write failed: ${e instanceof Error ? e.message : e}`,
     );
@@ -608,5 +713,8 @@ export async function provisionHostConfig(
 
   if (openShellError && options.requireOpenShellSync) {
     throw openShellError;
+  }
+  if (hermesError && options.requireHermesSync) {
+    throw hermesError;
   }
 }

--- a/packages/llm/test/host-provision.test.ts
+++ b/packages/llm/test/host-provision.test.ts
@@ -26,7 +26,14 @@ import {
   seedProvider,
   uniqueOrgId,
 } from "@neko/db/test-helpers";
-import { db, eq, data_source, pool } from "@neko/db";
+import {
+  and,
+  data_source,
+  db,
+  eq,
+  llm_provider_config,
+  pool,
+} from "@neko/db";
 import {
   ensureHostConfigProvisioned,
   hermesHomeForOrg,
@@ -605,6 +612,105 @@ describeIfDb("provisionHostConfig", () => {
       "No active gateway",
     );
     expect(ensureOpenShellProviderMock).not.toHaveBeenCalled();
+  });
+
+  it("refreshes worker-owned provisioning after first setup, key rotation, and provider switch", async () => {
+    const refreshOrgId = uniqueOrgId("provision-refresh");
+    await createTestOrg(refreshOrgId);
+    try {
+      await seedDataSource(refreshOrgId);
+      await seedProvider(refreshOrgId, {
+        scope: "agent",
+        provider: "hermes",
+        config: { backend: "hermes" },
+      });
+
+      // The worker can become healthy before System Setup creates a primary
+      // provider. That empty pass must not be memoized for the process lifetime.
+      await ensureHostConfigProvisioned(refreshOrgId);
+      expect(ensureOpenShellProviderMock).not.toHaveBeenCalled();
+
+      await seedProvider(refreshOrgId, {
+        scope: "primary",
+        provider: "google-gemini",
+        model: "gemini-pro-latest",
+        secrets: { apiKey: "key-a" },
+      });
+      await ensureHostConfigProvisioned(refreshOrgId);
+      expect(ensureOpenShellProviderMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({ apiKey: "key-a" }),
+      );
+
+      await db()
+        .update(llm_provider_config)
+        .set({ secrets: { apiKey: "key-b" }, updated_at: new Date() })
+        .where(
+          and(
+            eq(llm_provider_config.org_id, refreshOrgId),
+            eq(llm_provider_config.scope, "primary"),
+          ),
+        );
+      await ensureHostConfigProvisioned(refreshOrgId);
+      expect(ensureOpenShellProviderMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({ apiKey: "key-b" }),
+      );
+      await expect(
+        readFile(join(hermesHomeForOrg(refreshOrgId), ".env"), "utf8"),
+      ).resolves.toContain("GEMINI_API_KEY=key-b");
+
+      await db()
+        .update(llm_provider_config)
+        .set({
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          secrets: { apiKey: "key-c" },
+          updated_at: new Date(),
+        })
+        .where(
+          and(
+            eq(llm_provider_config.org_id, refreshOrgId),
+            eq(llm_provider_config.scope, "primary"),
+          ),
+        );
+      await ensureHostConfigProvisioned(refreshOrgId);
+      expect(ensureOpenShellProviderMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({ apiKey: "key-c" }),
+      );
+      expect(process.env.OPENNEKO_AGENT_MODEL_KEY_ENV).toBe("ANTHROPIC_API_KEY");
+
+      // Removing the saved key must not leave the previous gateway provider
+      // attached to future sandboxes in this long-lived worker process.
+      await db()
+        .update(llm_provider_config)
+        .set({ secrets: {}, updated_at: new Date() })
+        .where(
+          and(
+            eq(llm_provider_config.org_id, refreshOrgId),
+            eq(llm_provider_config.scope, "primary"),
+          ),
+        );
+      await ensureHostConfigProvisioned(refreshOrgId);
+      expect(process.env.OPENNEKO_AGENT_MODEL_PROVIDER).toBeUndefined();
+      await expect(
+        readFile(join(hermesHomeForOrg(refreshOrgId), ".env"), "utf8"),
+      ).resolves.toBe("");
+
+      await db()
+        .update(llm_provider_config)
+        .set({ enabled: false, updated_at: new Date() })
+        .where(
+          and(
+            eq(llm_provider_config.org_id, refreshOrgId),
+            eq(llm_provider_config.scope, "primary"),
+          ),
+        );
+      await ensureHostConfigProvisioned(refreshOrgId);
+      await expect(
+        readFile(join(hermesHomeForOrg(refreshOrgId), "config.yaml"), "utf8"),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await deleteTestOrg(refreshOrgId);
+    }
   });
 
   it("retries memoized provisioning after an OpenShell provider sync failure", async () => {


### PR DESCRIPTION
Closes #274

## Summary

- refresh worker-owned Hermes and OpenShell configuration whenever saved provider or data-source state changes
- serialize provisioning per organization and retry failed synchronization without memoizing stale state
- provision every agent-backed onboarding and metric job before execution, with a safe operator-facing handoff error

## Verification

- provider handoff suite: 26 passed
- worker profile and metric suites against the demo database: 13 passed
- onboarding failure-message suite: 4 passed
- git diff --check