### PR TITLE
fix(library): align distillation and support 100 MB imports

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import type { NextConfig } from "next";
 import pkg from "./package.json";
+import { MAX_LIBRARY_UPLOAD_REQUEST_BYTES } from "./src/lib/library-upload-contract";
 
 const hostWebDev = process.env.OPENNEKO_HOST_WEB_DEV === "1";
 const demoMode =
@@ -34,6 +35,10 @@ const nextConfig: NextConfig = {
     // Turbopack's FS cache (default-on since Next 16.1) was serving stale
     // globals.css after edits in dev. Disabling for dev only.
     turbopackFileSystemCacheForDev: false,
+    // Proxy clones request bodies before API routes read them. Next defaults
+    // that clone to 10 MB, which would truncate valid Library imports before
+    // the route can enforce its own 100 MB aggregate file allowance.
+    proxyClientMaxBodySize: MAX_LIBRARY_UPLOAD_REQUEST_BYTES,
   },
 };
 

--- a/apps/web/src/app/(work)/library/page.tsx
+++ b/apps/web/src/app/(work)/library/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/Button";
 import { MenuItem, OverflowMenu } from "@/components/ui/OverflowMenu";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Pill, type PillVariant } from "@/components/ui/Pill";
+import { validateLibraryUploadBatch } from "@/lib/library-upload-contract";
 
 type DocumentRow = {
   id: string;
@@ -126,21 +127,28 @@ export default function LibraryPage() {
   const upload = useCallback(
     async (files: FileList | null) => {
       if (!files || files.length === 0) return;
+      const selected = Array.from(files);
+      const validation = validateLibraryUploadBatch(selected);
+      if (!validation.ok) {
+        setError(validation.error);
+        if (fileInputRef.current) fileInputRef.current.value = "";
+        return;
+      }
       setUploading(true);
       try {
-        for (const file of Array.from(files)) {
-          const body = new FormData();
-          body.append("file", file);
-          const response = await fetch("/api/library/upload", {
-            method: "POST",
-            body,
-          });
-          if (!response.ok) {
-            const payload = (await response.json().catch(() => null)) as
-              | { error?: string }
-              | null;
-            throw new Error(payload?.error ?? `"${file.name}" could not be uploaded.`);
-          }
+        const body = new FormData();
+        for (const file of selected) {
+          body.append("files", file);
+        }
+        const response = await fetch("/api/library/upload", {
+          method: "POST",
+          body,
+        });
+        if (!response.ok) {
+          const payload = (await response.json().catch(() => null)) as
+            | { error?: string }
+            | null;
+          throw new Error(payload?.error ?? "The documents could not be imported.");
         }
         setError(null);
         await refresh();
@@ -461,13 +469,18 @@ export default function LibraryPage() {
             <div>
               <span>Uploads</span>
               <h2>Your documents</h2>
+              <small id="library-upload-limit" className="library-upload-limit">
+                Import up to 100 MB at once, across one or more files.
+              </small>
             </div>
-            <ActionGroup className="memory-review-actions">
-              <input data-ui-bespoke-reason="library file picker"
+            <ActionGroup className="memory-review-actions library-upload-actions">
+              <input
+                data-ui-bespoke-reason="library file picker"
                 ref={fileInputRef}
                 type="file"
                 multiple
                 hidden
+                aria-describedby="library-upload-limit"
                 onChange={(event) => void upload(event.target.files)}
               />
               <Button
@@ -490,7 +503,7 @@ export default function LibraryPage() {
             <EmptyState
               className="library-empty"
               title="No documents yet"
-              body="Upload documents here, or attach them in a conversation. Either way they are distilled into concepts the assistant can cite."
+              body="Upload a document above, or attach one in a conversation. OpenNeko distills durable knowledge into concepts it can cite."
             />
           ) : (
             <ol className="memory-review-list">
@@ -558,8 +571,8 @@ export default function LibraryPage() {
           {personal.length === 0 && !loading ? (
             <EmptyState
               className="library-empty"
-              title="Nothing distilled yet"
-              body="Concepts distilled from your documents appear here. Only you and your assistant can see them until you share one with the team."
+              title="No personal concepts"
+              body="Distilled concepts stay private here until you share them with the team."
             />
           ) : (
             <ol className="memory-review-list">
@@ -604,8 +617,8 @@ export default function LibraryPage() {
           {team.length === 0 && !loading ? (
             <EmptyState
               className="library-empty"
-              title="No approved team concepts"
-              body="Concepts a teammate shares, and an admin approves, become part of the assistant's knowledge for the whole workspace."
+              title="No team concepts"
+              body="Shared concepts appear here after an admin approves them for the workspace."
             />
           ) : (
             <ol className="memory-review-list">

--- a/apps/web/src/app/(work)/skills/page.tsx
+++ b/apps/web/src/app/(work)/skills/page.tsx
@@ -6,6 +6,7 @@ import { ArrowUpRight, FileText, Trash2 } from "lucide-react";
 import { confirmDialog } from "@/components/ConfirmModal";
 import PageHeading from "@/components/PageHeading";
 import { Button, IconButton } from "@/components/ui/Button";
+import { EmptyState } from "@/components/ui/EmptyState";
 
 type SkillSummary = {
   name: string;
@@ -145,13 +146,11 @@ export default function SkillsPage() {
               <span />
             </div>
           ) : skills.length === 0 ? (
-            <div className="library-empty">
-              <strong>No installed skills</strong>
-              <span>
-                Skills appear here when OpenNeko saves a reusable capability or
-                one is installed into the organization workspace.
-              </span>
-            </div>
+            <EmptyState
+              className="library-empty"
+              title="No installed skills"
+              body="Skills appear here when OpenNeko saves a reusable capability or one is installed into the organization workspace."
+            />
           ) : (
             <>
               <div className="skills-table-head" aria-hidden="true">

--- a/apps/web/src/app/api/library/upload/route.ts
+++ b/apps/web/src/app/api/library/upload/route.ts
@@ -1,12 +1,15 @@
-import { createHash } from "node:crypto";
 import { NextResponse } from "next/server";
 import { enqueue, QUEUE, type LibraryDistillPayload } from "@neko/db/jobs";
 import { createLibraryDocument } from "@neko/llm/work";
 import { getCurrentActor } from "@/lib/actor";
 import { getOrgId } from "@/lib/db";
 import {
+  MAX_LIBRARY_UPLOAD_REQUEST_BYTES,
+  validateLibraryUploadBatch,
+} from "@/lib/library-upload-contract";
+import {
   ALLOWED_UPLOAD_EXTENSIONS,
-  MAX_UPLOAD_SIZE,
+  safeFileName,
   saveLibraryUpload,
 } from "@/lib/work-files";
 
@@ -15,14 +18,24 @@ export const dynamic = "force-dynamic";
 
 /**
  * Direct-to-library upload (no thread). Always catalogs — uploading
- * here IS the request to distill. Files land under
+ * here IS the request to distill. A batch may contain up to 100 MB of files
+ * in total. Files land under content-addressed paths beneath
  * library/uploads/<owner>/ and stay owner-readable only.
  */
 export async function POST(request: Request) {
-  const contentLength = Number(request.headers.get("content-length") ?? 0);
-  if (contentLength && contentLength > MAX_UPLOAD_SIZE + 4096) {
+  const contentLength = Number.parseInt(
+    request.headers.get("content-length") ?? "0",
+    10,
+  );
+  if (
+    Number.isFinite(contentLength) &&
+    contentLength > MAX_LIBRARY_UPLOAD_REQUEST_BYTES
+  ) {
     return NextResponse.json(
-      { error: `File is over ${Math.round(MAX_UPLOAD_SIZE / (1024 * 1024))} MB.` },
+      {
+        error:
+          "The selected files exceed the 100 MB import limit. Choose fewer or smaller files.",
+      },
       { status: 413 },
     );
   }
@@ -30,44 +43,71 @@ export async function POST(request: Request) {
   if (!form) {
     return NextResponse.json({ error: "Invalid multipart body" }, { status: 400 });
   }
-  const file = form.get("file");
-  if (!(file instanceof File)) {
-    return NextResponse.json({ error: "file is required" }, { status: 400 });
-  }
-  if (file.size > MAX_UPLOAD_SIZE) {
+  // `files` is the batch contract. Keep accepting the original singular
+  // field so existing API clients continue to work after the UI switches.
+  const files = [...form.getAll("files"), ...form.getAll("file")].filter(
+    (value): value is File => value instanceof File,
+  );
+  const validation = validateLibraryUploadBatch(files);
+  if (!validation.ok) {
     return NextResponse.json(
-      { error: `"${file.name}" is over ${Math.round(MAX_UPLOAD_SIZE / (1024 * 1024))} MB.` },
-      { status: 413 },
+      { error: validation.error },
+      { status: validation.status },
     );
   }
-  const idx = file.name.lastIndexOf(".");
-  const ext = idx > 0 ? file.name.slice(idx).toLowerCase() : "";
-  if (!ALLOWED_UPLOAD_EXTENSIONS.has(ext)) {
-    return NextResponse.json(
-      { error: `Unsupported file type "${ext || "(none)"}".` },
-      { status: 415 },
-    );
+
+  const names = new Set<string>();
+  for (const file of files) {
+    const safeName = safeFileName(file.name);
+    if (names.has(safeName)) {
+      return NextResponse.json(
+        {
+          error: `More than one selected file becomes "${safeName}" after filename cleanup. Rename one and try again.`,
+        },
+        { status: 400 },
+      );
+    }
+    names.add(safeName);
+    const idx = file.name.lastIndexOf(".");
+    const ext = idx > 0 ? file.name.slice(idx).toLowerCase() : "";
+    if (!ALLOWED_UPLOAD_EXTENSIONS.has(ext)) {
+      return NextResponse.json(
+        { error: `Unsupported file type "${ext || "(none)"}".` },
+        { status: 415 },
+      );
+    }
   }
 
   const orgId = await getOrgId();
   const actor = await getCurrentActor();
-  const saved = await saveLibraryUpload(orgId, actor.userId, file);
-  const contentHash = createHash("sha256")
-    .update(Buffer.from(await file.arrayBuffer()))
-    .digest("hex");
-  const { document, created } = await createLibraryDocument({
-    orgId,
-    userId: actor.userId,
-    filename: saved.name,
-    relativePath: saved.relativePath.replace(/\\/g, "/"),
-    contentHash,
-    sizeBytes: saved.size,
-  });
-  if (created || document.status === "failed") {
-    const payload: LibraryDistillPayload = { orgId, documentId: document.id };
-    await enqueue(QUEUE.LIBRARY_DISTILL, payload, {
-      singletonKey: `library-distill:${document.id}`,
+  const documents: Array<{
+    document: Awaited<ReturnType<typeof createLibraryDocument>>["document"];
+    created: boolean;
+  }> = [];
+  for (const file of files) {
+    const saved = await saveLibraryUpload(orgId, actor.userId, file);
+    const { document, created } = await createLibraryDocument({
+      orgId,
+      userId: actor.userId,
+      filename: saved.name,
+      relativePath: saved.relativePath.replace(/\\/g, "/"),
+      contentHash: saved.contentHash,
+      sizeBytes: saved.size,
     });
+    if (created || document.status === "failed") {
+      const payload: LibraryDistillPayload = { orgId, documentId: document.id };
+      await enqueue(QUEUE.LIBRARY_DISTILL, payload, {
+        singletonKey: `library-distill:${document.id}`,
+      });
+    }
+    documents.push({ document, created });
   }
-  return NextResponse.json({ ok: true, document, created });
+
+  // Keep the singular response members for clients that still post `file`.
+  return NextResponse.json({
+    ok: true,
+    documents,
+    document: documents[0]?.document,
+    created: documents[0]?.created,
+  });
 }

--- a/apps/web/src/app/styles/_library.css
+++ b/apps/web/src/app/styles/_library.css
@@ -248,14 +248,26 @@
 .library-empty {
   min-height: 138px;
   display: grid;
-  grid-template-columns: minmax(150px, 0.32fr) minmax(240px, 0.68fr);
   align-items: center;
-  gap: 28px;
   padding: 22px 4px;
   border-bottom: 1px solid var(--border);
 }
 
-.library-empty strong {
+section.library-empty {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  justify-items: stretch;
+  text-align: left;
+}
+
+section.library-empty [data-ui-empty-state-copy] {
+  grid-template-columns: minmax(150px, 0.32fr) minmax(240px, 0.68fr);
+  align-items: start;
+  gap: 28px;
+}
+
+section.library-empty [data-ui-empty-state-title] {
   color: var(--text);
   font-family: var(--font-display), "Archivo", sans-serif;
   font-size: var(--type-section);
@@ -263,7 +275,7 @@
   letter-spacing: -0.03em;
 }
 
-.library-empty span {
+section.library-empty [data-ui-empty-state-body] {
   max-width: 62ch;
   color: var(--text2);
   font-size: var(--type-body);
@@ -989,7 +1001,9 @@
 
   .library-empty {
     min-height: 120px;
-    display: grid;
+  }
+
+  section.library-empty [data-ui-empty-state-copy] {
     grid-template-columns: 1fr;
     gap: 8px;
   }
@@ -1278,6 +1292,19 @@
 .document-library .memory-review-meta svg {
   vertical-align: -2px;
   margin-right: 4px;
+}
+
+.document-library .library-upload-limit {
+  display: block;
+  margin-top: 5px;
+  color: var(--text2);
+  font-size: var(--type-caption);
+  font-weight: 500;
+  line-height: var(--leading-compact);
+}
+
+.document-library .library-upload-actions {
+  flex: 0 0 auto;
 }
 
 .document-library .library-concept-title {

--- a/apps/web/src/components/ui/EmptyState.tsx
+++ b/apps/web/src/components/ui/EmptyState.tsx
@@ -18,23 +18,38 @@ export function EmptyState({
 }: EmptyStateProps) {
   return (
     <section
+      data-ui-empty-state=""
       className={cn(
         "mx-auto grid max-w-[520px] justify-items-center gap-3 py-14 text-center",
         className,
       )}
     >
       {icon ? (
-        <span className="grid size-11 place-items-center rounded-inner bg-neutral text-text2 [&_svg]:size-5">
+        <span
+          data-ui-empty-state-icon=""
+          className="grid size-11 place-items-center rounded-inner bg-neutral text-text2 [&_svg]:size-5"
+        >
           {icon}
         </span>
       ) : null}
-      <div className="grid gap-1.5">
-        <h2 className="text-ui-section">{title}</h2>
+      <div data-ui-empty-state-copy="" className="grid gap-1.5">
+        <h2 data-ui-empty-state-title="" className="text-ui-section">
+          {title}
+        </h2>
         {body ? (
-          <div className="text-ui-body-sm leading-[var(--leading-body)] text-text2">{body}</div>
+          <div
+            data-ui-empty-state-body=""
+            className="text-ui-body-sm leading-[var(--leading-body)] text-text2"
+          >
+            {body}
+          </div>
         ) : null}
       </div>
-      {action ? <div className="pt-1">{action}</div> : null}
+      {action ? (
+        <div data-ui-empty-state-action="" className="pt-1">
+          {action}
+        </div>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/lib/library-upload-contract.ts
+++ b/apps/web/src/lib/library-upload-contract.ts
@@ -1,0 +1,54 @@
+export const MAX_LIBRARY_UPLOAD_BYTES = 100 * 1024 * 1024;
+
+// Multipart boundaries and per-file headers are transport overhead, not part
+// of the user's 100 MB allowance. Keep the request itself bounded as an early
+// rejection while leaving room for a large multi-file selection.
+export const MAX_LIBRARY_UPLOAD_REQUEST_BYTES =
+  MAX_LIBRARY_UPLOAD_BYTES + 4 * 1024 * 1024;
+
+type LibraryUploadFile = {
+  name: string;
+  size: number;
+};
+
+export type LibraryUploadValidation =
+  | { ok: true; totalBytes: number }
+  | { ok: false; status: 400 | 413; error: string };
+
+/** Shared browser/API contract: 100 MB total, inclusive, across the batch. */
+export function validateLibraryUploadBatch(
+  files: readonly LibraryUploadFile[],
+): LibraryUploadValidation {
+  if (files.length === 0) {
+    return {
+      ok: false,
+      status: 400,
+      error: "Choose at least one file to import.",
+    };
+  }
+
+  let totalBytes = 0;
+  for (const file of files) {
+    if (!Number.isSafeInteger(file.size) || file.size <= 0) {
+      return {
+        ok: false,
+        status: 400,
+        error:
+          file.size === 0
+            ? `"${file.name}" is empty. Choose a non-empty file.`
+            : `"${file.name}" has an invalid size. Choose the file again.`,
+      };
+    }
+    totalBytes += file.size;
+    if (totalBytes > MAX_LIBRARY_UPLOAD_BYTES) {
+      return {
+        ok: false,
+        status: 413,
+        error:
+          "The selected files exceed the 100 MB import limit. Choose fewer or smaller files.",
+      };
+    }
+  }
+
+  return { ok: true, totalBytes };
+}

--- a/apps/web/src/lib/work-files.ts
+++ b/apps/web/src/lib/work-files.ts
@@ -1,5 +1,6 @@
 import "server-only";
 
+import { createHash } from "node:crypto";
 import { mkdir, readFile, readdir, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { basename, extname, isAbsolute, join, relative, resolve } from "node:path";
 import { ensureOrgWorkspace } from "@neko/llm/work";
@@ -74,27 +75,37 @@ export function libraryOwnerSegment(userId: string | null): string {
 
 /**
  * Direct-to-library upload (no thread): stored under
- * library/uploads/<owner>/. Serving is owner-or-admin gated in the
- * files route, unlike thread uploads which gate on thread access.
+ * library/uploads/<owner>/<content-hash>/. Content-addressing keeps a later
+ * upload with the same cleaned filename from overwriting an earlier source.
+ * Serving is owner-or-admin gated in the files route, unlike thread uploads
+ * which gate on thread access.
  */
 export async function saveLibraryUpload(
   orgId: string,
   userId: string | null,
   file: File,
-): Promise<{ relativePath: string; absolutePath: string; name: string; size: number }> {
+): Promise<{
+  relativePath: string;
+  absolutePath: string;
+  name: string;
+  size: number;
+  contentHash: string;
+}> {
   const roots = await ensureOrgWorkspace(orgId);
   const owner = libraryOwnerSegment(userId);
-  const dir = join(roots.orgRoot, "library", "uploads", owner);
-  await mkdir(dir, { recursive: true });
   const safeName = safeFileName(file.name || "upload.bin");
-  const absolutePath = join(dir, safeName);
   const buffer = Buffer.from(await file.arrayBuffer());
+  const contentHash = createHash("sha256").update(buffer).digest("hex");
+  const dir = join(roots.orgRoot, "library", "uploads", owner, contentHash);
+  await mkdir(dir, { recursive: true });
+  const absolutePath = join(dir, safeName);
   await writeFile(absolutePath, buffer);
   return {
-    relativePath: join("library", "uploads", owner, safeName),
+    relativePath: join("library", "uploads", owner, contentHash, safeName),
     absolutePath,
     name: safeName,
     size: buffer.byteLength,
+    contentHash,
   };
 }
 

--- a/apps/web/test/api/library-upload.test.ts
+++ b/apps/web/test/api/library-upload.test.ts
@@ -1,0 +1,190 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MAX_LIBRARY_UPLOAD_BYTES,
+  MAX_LIBRARY_UPLOAD_REQUEST_BYTES,
+} from "@/lib/library-upload-contract";
+
+const mocks = vi.hoisted(() => ({
+  actor: vi.fn(),
+  createDocument: vi.fn(),
+  enqueue: vi.fn(),
+  formData: vi.fn(),
+  orgId: vi.fn(),
+  save: vi.fn(),
+}));
+
+vi.mock("@/lib/actor", () => ({ getCurrentActor: mocks.actor }));
+vi.mock("@/lib/db", () => ({ getOrgId: mocks.orgId }));
+vi.mock("@neko/db/jobs", () => ({
+  QUEUE: { LIBRARY_DISTILL: "library_distill" },
+  enqueue: mocks.enqueue,
+}));
+vi.mock("@neko/llm/work", () => ({
+  createLibraryDocument: mocks.createDocument,
+}));
+vi.mock("@/lib/work-files", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/work-files")>(
+    "@/lib/work-files",
+  );
+  return { ...actual, saveLibraryUpload: mocks.save };
+});
+
+function sizedFile(name: string, size: number): File {
+  const value = new File(["x"], name, { type: "application/pdf" });
+  Object.defineProperty(value, "size", { configurable: true, value: size });
+  return value;
+}
+
+function request(
+  files: File[],
+  options: { field?: "file" | "files"; contentLength?: number } = {},
+): Request {
+  const form = new FormData();
+  for (const value of files) form.append(options.field ?? "files", value);
+  mocks.formData.mockResolvedValue(form);
+  const headers = new Headers();
+  if (options.contentLength !== undefined) {
+    headers.set("content-length", String(options.contentLength));
+  }
+  return { headers, formData: mocks.formData } as unknown as Request;
+}
+
+describe("/api/library/upload", () => {
+  let POST: typeof import("@/app/api/library/upload/route").POST;
+
+  beforeAll(async () => {
+    ({ POST } = await import("@/app/api/library/upload/route"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.actor.mockResolvedValue({ userId: "user-1", role: "member" });
+    mocks.orgId.mockResolvedValue("org-1");
+    mocks.save.mockImplementation(
+      async (_orgId: string, _userId: string, file: File) => ({
+        name: file.name,
+        size: file.size,
+        relativePath: `library/uploads/user-1/${"a".repeat(64)}/${file.name}`,
+        absolutePath: `/tmp/${file.name}`,
+        contentHash: "a".repeat(64),
+      }),
+    );
+    let id = 0;
+    mocks.createDocument.mockImplementation(async () => {
+      id += 1;
+      return {
+        document: { id: `document-${id}`, status: "uploaded" },
+        created: true,
+      };
+    });
+    mocks.enqueue.mockResolvedValue(undefined);
+  });
+
+  it("imports one file at exactly 100 MB", async () => {
+    const response = await POST(
+      request([sizedFile("annual-report.pdf", MAX_LIBRARY_UPLOAD_BYTES)], {
+        contentLength: MAX_LIBRARY_UPLOAD_REQUEST_BYTES,
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.save).toHaveBeenCalledOnce();
+    expect(mocks.createDocument).toHaveBeenCalledOnce();
+    expect(mocks.enqueue).toHaveBeenCalledOnce();
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      documents: [{ document: { id: "document-1" }, created: true }],
+    });
+  });
+
+  it("imports multiple files in one request when their total is 100 MB", async () => {
+    const response = await POST(
+      request([
+        sizedFile("sales.pdf", 60 * 1024 * 1024),
+        sizedFile("operations.pdf", 40 * 1024 * 1024),
+      ]),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.formData).toHaveBeenCalledOnce();
+    expect(mocks.save).toHaveBeenCalledTimes(2);
+    expect(mocks.createDocument).toHaveBeenCalledTimes(2);
+    expect(mocks.enqueue).toHaveBeenCalledTimes(2);
+    await expect(response.json()).resolves.toMatchObject({
+      ok: true,
+      documents: [
+        { document: { id: "document-1" }, created: true },
+        { document: { id: "document-2" }, created: true },
+      ],
+    });
+  });
+
+  it("rejects an aggregate payload one byte over 100 MB before writing", async () => {
+    const response = await POST(
+      request([
+        sizedFile("sales.pdf", 60 * 1024 * 1024),
+        sizedFile("operations.pdf", 40 * 1024 * 1024 + 1),
+      ]),
+    );
+
+    expect(response.status).toBe(413);
+    expect(mocks.save).not.toHaveBeenCalled();
+    expect(mocks.createDocument).not.toHaveBeenCalled();
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      error: expect.stringContaining("100 MB"),
+    });
+  });
+
+  it("validates the complete batch before writing any file", async () => {
+    const response = await POST(
+      request([
+        sizedFile("valid.pdf", 10),
+        sizedFile("malware.exe", 10),
+      ]),
+    );
+
+    expect(response.status).toBe(415);
+    expect(mocks.save).not.toHaveBeenCalled();
+    expect(mocks.createDocument).not.toHaveBeenCalled();
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+  });
+
+  it("rejects filenames that collide after cleanup before writing", async () => {
+    const response = await POST(
+      request([
+        sizedFile("sales report.pdf", 10),
+        sizedFile("sales_report.pdf", 10),
+      ]),
+    );
+
+    expect(response.status).toBe(400);
+    expect(mocks.save).not.toHaveBeenCalled();
+    expect(mocks.createDocument).not.toHaveBeenCalled();
+    expect(mocks.enqueue).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      error: expect.stringContaining("sales_report.pdf"),
+    });
+  });
+
+  it("keeps the legacy singular file field compatible", async () => {
+    const response = await POST(
+      request([sizedFile("legacy.pdf", 10)], { field: "file" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mocks.save).toHaveBeenCalledOnce();
+  });
+
+  it("rejects a declared multipart request beyond the bounded allowance", async () => {
+    const response = await POST(
+      request([sizedFile("oversized.pdf", 10)], {
+        contentLength: MAX_LIBRARY_UPLOAD_REQUEST_BYTES + 1,
+      }),
+    );
+
+    expect(response.status).toBe(413);
+    expect(mocks.formData).not.toHaveBeenCalled();
+    expect(mocks.save).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/test/components/ui-system.test.ts
+++ b/apps/web/test/components/ui-system.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { Button, IconButton } from "@/components/ui/Button";
 import { Checkbox } from "@/components/ui/Checkbox";
 import { Disclosure } from "@/components/ui/Disclosure";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { FieldInput } from "@/components/ui/Field";
 import { LocalDateTime } from "@/components/ui/LocalDateTime";
 import { Segment, SegmentedControl, Tab, Tabs } from "@/components/ui/Tabs";
@@ -85,6 +86,20 @@ describe("shared UI contracts", () => {
     expect(disclosure).toContain("<details");
     expect(disclosure).toContain("<summary");
     expect(disclosure).toContain('data-ui-disclosure=""');
+  });
+
+  it("exposes stable empty-state slots for surface-specific layouts", () => {
+    const empty = renderToStaticMarkup(
+      createElement(EmptyState, {
+        title: "No concepts",
+        body: "Imported knowledge appears here.",
+      }),
+    );
+
+    expect(empty).toContain('data-ui-empty-state=""');
+    expect(empty).toContain('data-ui-empty-state-copy=""');
+    expect(empty).toContain('data-ui-empty-state-title=""');
+    expect(empty).toContain('data-ui-empty-state-body=""');
   });
 
   it("renders deterministic timestamp fallbacks before client localization", () => {

--- a/apps/web/test/lib/library-upload-contract.test.ts
+++ b/apps/web/test/lib/library-upload-contract.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_LIBRARY_UPLOAD_BYTES,
+  validateLibraryUploadBatch,
+} from "@/lib/library-upload-contract";
+
+const file = (name: string, size: number) => ({ name, size });
+
+describe("library upload contract", () => {
+  it("accepts one file that uses the full 100 MB allowance", () => {
+    expect(
+      validateLibraryUploadBatch([
+        file("annual-report.pdf", MAX_LIBRARY_UPLOAD_BYTES),
+      ]),
+    ).toEqual({ ok: true, totalBytes: MAX_LIBRARY_UPLOAD_BYTES });
+  });
+
+  it("accepts multiple files that together use the full allowance", () => {
+    expect(
+      validateLibraryUploadBatch([
+        file("sales.pdf", 60 * 1024 * 1024),
+        file("operations.pdf", 40 * 1024 * 1024),
+      ]),
+    ).toEqual({ ok: true, totalBytes: MAX_LIBRARY_UPLOAD_BYTES });
+  });
+
+  it("rejects a batch one byte over the aggregate allowance", () => {
+    expect(
+      validateLibraryUploadBatch([
+        file("sales.pdf", 60 * 1024 * 1024),
+        file("operations.pdf", 40 * 1024 * 1024 + 1),
+      ]),
+    ).toEqual({
+      ok: false,
+      status: 413,
+      error:
+        "The selected files exceed the 100 MB import limit. Choose fewer or smaller files.",
+    });
+  });
+
+  it("rejects empty files before an import starts", () => {
+    expect(validateLibraryUploadBatch([file("empty.pdf", 0)])).toEqual({
+      ok: false,
+      status: 400,
+      error: '"empty.pdf" is empty. Choose a non-empty file.',
+    });
+  });
+});

--- a/apps/web/test/lib/work-files.test.ts
+++ b/apps/web/test/lib/work-files.test.ts
@@ -9,6 +9,7 @@ import {
   readRunArtifact,
   readWorkFile,
   safeFileName,
+  saveLibraryUpload,
   saveWorkUpload,
 } from "@/lib/work-files";
 
@@ -145,6 +146,59 @@ describe("saveWorkUpload + readWorkFile round-trip", () => {
     expect(saved.name).not.toContain("..");
 
     await expect(readWorkFile("org-test", "secrets/foo.txt")).rejects.toThrow();
+  }, 30_000);
+});
+
+describe("saveLibraryUpload", () => {
+  it("writes once and returns the hash of the persisted bytes", async () => {
+    const home = await mkdtemp(join(tmpdir(), "neko-library-upload-"));
+    cleanupPaths.push(home);
+    process.env.HOME = home;
+
+    const payload = Buffer.from("durable library knowledge");
+    const saved = await saveLibraryUpload(
+      "org-test",
+      "user-1",
+      new File([payload], "knowledge.pdf", { type: "application/pdf" }),
+    );
+
+    expect(saved.size).toBe(payload.byteLength);
+    expect(saved.contentHash).toBe(
+      "88b05ad9db9ac17bb7271644404856607de0883623c626fab14fcc61d59f5eb7",
+    );
+    expect(saved.relativePath).toBe(
+      `library/uploads/user-1/${saved.contentHash}/knowledge.pdf`,
+    );
+    await expect(readFile(saved.absolutePath)).resolves.toEqual(payload);
+  }, 30_000);
+
+  it("does not overwrite an earlier source with the same filename", async () => {
+    const home = await mkdtemp(join(tmpdir(), "neko-library-upload-"));
+    cleanupPaths.push(home);
+    process.env.HOME = home;
+
+    const first = await saveLibraryUpload(
+      "org-test",
+      "user-1",
+      new File(["first source"], "knowledge.pdf", {
+        type: "application/pdf",
+      }),
+    );
+    const second = await saveLibraryUpload(
+      "org-test",
+      "user-1",
+      new File(["second source"], "knowledge.pdf", {
+        type: "application/pdf",
+      }),
+    );
+
+    expect(first.absolutePath).not.toBe(second.absolutePath);
+    await expect(readFile(first.absolutePath, "utf8")).resolves.toBe(
+      "first source",
+    );
+    await expect(readFile(second.absolutePath, "utf8")).resolves.toBe(
+      "second source",
+    );
   }, 30_000);
 });
 

--- a/apps/web/test/next-config.test.ts
+++ b/apps/web/test/next-config.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import nextConfig from "../next.config";
+import { MAX_LIBRARY_UPLOAD_REQUEST_BYTES } from "@/lib/library-upload-contract";
+
+describe("Next request body contract", () => {
+  it("preserves the complete Library multipart request through Proxy", () => {
+    expect(nextConfig.experimental?.proxyClientMaxBodySize).toBe(
+      MAX_LIBRARY_UPLOAD_REQUEST_BYTES,
+    );
+  });
+});

--- a/packages/llm/src/library/distill.ts
+++ b/packages/llm/src/library/distill.ts
@@ -37,7 +37,7 @@ async function defaultLlm(orgId: string): Promise<DistillLlm> {
   ]);
   const llm = await buildLlm(orgId);
   const librarian = ax(
-    `librarianPrompt:string "librarian instructions plus one uploaded document" -> libraryOperations:string "a single neko_library fenced code block containing a JSON array of ops"`,
+    `librarianPrompt:string "librarian instructions plus one uploaded document" -> libraryOperations:string "a single neko_library fenced JSON array of flat objects discriminated by op"`,
     {
       description:
         "You are a meticulous librarian. Follow the instructions in the prompt exactly and respond with only the fenced neko_library block.",

--- a/packages/llm/src/library/fence.ts
+++ b/packages/llm/src/library/fence.ts
@@ -1,15 +1,18 @@
 // Parses distiller-emitted `neko_library` fences into concept operations,
 // mirroring the neko_memory fence pattern in agent-backends/memory-fence.ts.
 //
-// Fence shape:
+// Canonical fence shape:
 //   ```neko_library
 //   [
-//     { "upsert": { "path": "policies/refund-policy.md", "type": "Policy",
-//                   "title": "Refund policy", "description": "...",
-//                   "tags": ["finance"], "body": "..." } },
-//     { "skip": { "reason": "one-off working data, not durable knowledge" } }
+//     { "op": "upsert", "path": "policies/refund-policy.md", "type": "Policy",
+//       "title": "Refund policy", "description": "...",
+//       "tags": ["finance"], "body": "..." },
+//     { "op": "skip", "reason": "one-off working data, not durable knowledge" }
 //   ]
 //   ```
+//
+// The original wrapped shape (`{ "upsert": { ... } }`) remains accepted for
+// compatibility with already-authored fixtures and provider responses.
 //
 // Multiple upserts are allowed (one document can yield several concepts).
 // A `skip` op marks the source document as triaged-out. Anything not
@@ -83,17 +86,25 @@ function parseUpsert(value: unknown): LibraryUpsertOp | null {
   };
 }
 
+function parseSkip(value: unknown): LibrarySkipOp | null {
+  if (!value || typeof value !== "object") return null;
+  const reason = (value as Record<string, unknown>).reason;
+  if (!isStr(reason) || reason.trim().length === 0) return null;
+  return { kind: "skip", reason: reason.trim() };
+}
+
 function parseItem(item: unknown): LibraryOp | null {
   if (!item || typeof item !== "object") return null;
   const o = item as Record<string, unknown>;
+
+  // Canonical model-facing contract: flat objects discriminated by `op`.
+  if (o.op === "upsert") return parseUpsert(o);
+  if (o.op === "skip") return parseSkip(o);
+  if ("op" in o) return null;
+
+  // Backward compatibility for the original wrapped representation.
   if ("upsert" in o) return parseUpsert(o.upsert);
-  if ("skip" in o) {
-    const skip = o.skip;
-    if (skip && typeof skip === "object" && isStr((skip as Record<string, unknown>).reason)) {
-      return { kind: "skip", reason: String((skip as Record<string, unknown>).reason) };
-    }
-    return null;
-  }
+  if ("skip" in o) return parseSkip(o.skip);
   return null;
 }
 

--- a/packages/llm/src/library/prompts.ts
+++ b/packages/llm/src/library/prompts.ts
@@ -55,6 +55,14 @@ export function buildDistillPrompt(input: DistillPromptInput): string {
     '  (contract end, policy review date), set `stale_after` (YYYY-MM-DD)',
     "  on the op so the concept is retired automatically. Omit it",
     "  otherwise — never guess a date.",
+    "- Use exactly these JSON object shapes; every object is flat and `op`",
+    "  is the discriminator:",
+    '  Upsert: {"op": "upsert", "path": "policies/refund-policy.md",',
+    '  "type": "Policy", "title": "Refund policy", "description": "...",',
+    '  "tags": ["finance"], "body": "reference markdown",',
+    '  "stale_after": "YYYY-MM-DD"}',
+    '  Skip: {"op": "skip", "reason": "one-off working data"}',
+    "  Do not wrap the fields inside an `upsert` or `skip` object.",
     "",
     "Current catalog:",
     catalog,
@@ -68,7 +76,7 @@ export function buildDistillPrompt(input: DistillPromptInput): string {
     "---END DOCUMENT---",
     "",
     "Respond with a single ```neko_library fence containing a JSON array of",
-    "ops, and nothing else.",
+    "the flat operation objects above, and nothing else.",
   ]
     .filter((line) => line !== "")
     .join("\n");

--- a/packages/llm/test/library-distill.test.ts
+++ b/packages/llm/test/library-distill.test.ts
@@ -71,14 +71,13 @@ const FENCE_REPLY = [
   "```neko_library",
   JSON.stringify([
     {
-      upsert: {
-        path: "policies/refund-policy.md",
-        type: "Policy",
-        title: "Refund policy",
-        description: "Refund windows and approval limits.",
-        tags: ["finance"],
-        body: "Refunds within 30 days; >$500 needs CFO approval.",
-      },
+      op: "upsert",
+      path: "policies/refund-policy.md",
+      type: "Policy",
+      title: "Refund policy",
+      description: "Refund windows and approval limits.",
+      tags: ["finance"],
+      body: "Refunds within 30 days; >$500 needs CFO approval.",
     },
   ]),
   "```",
@@ -128,6 +127,9 @@ describe("runLibraryDistill", () => {
     const prompt = llm.mock.calls[0][0] as string;
     expect(prompt).toContain("refund-policy.md");
     expect(prompt).toContain("Customers may request refunds");
+    expect(prompt).toContain('"op": "upsert"');
+    expect(prompt).toContain('"op": "skip"');
+    expect(prompt).toContain("Use exactly these JSON object shapes");
   });
 
   it("passes the existing catalog so the librarian updates instead of duplicating", async () => {
@@ -221,4 +223,3 @@ describe("runLibraryDistill", () => {
     expect(llm).not.toHaveBeenCalled();
   });
 });
-

--- a/packages/llm/test/library-fence.test.ts
+++ b/packages/llm/test/library-fence.test.ts
@@ -42,6 +42,55 @@ describe("extractLibraryFences", () => {
     expect(ops).toEqual([{ kind: "skip", reason: "one-off data" }]);
   });
 
+  it("parses flat discriminator ops emitted by the librarian", () => {
+    const { ops } = extractLibraryFences(
+      fence(
+        JSON.stringify([
+          {
+            op: "upsert",
+            path: "presentations/sales-overview.md",
+            type: "Notes",
+            title: "Sales overview",
+            description: "Positioning and capabilities from the sales deck.",
+            tags: ["sales"],
+            body: "# Sales overview\n\nDurable product positioning.",
+          },
+          { op: "skip", reason: "one-off working data" },
+        ]),
+      ),
+    );
+    expect(ops).toEqual([
+      {
+        kind: "upsert",
+        path: "presentations/sales-overview.md",
+        type: "Notes",
+        title: "Sales overview",
+        description: "Positioning and capabilities from the sales deck.",
+        tags: ["sales"],
+        body: "# Sales overview\n\nDurable product positioning.",
+        stale_after: undefined,
+      },
+      { kind: "skip", reason: "one-off working data" },
+    ]);
+  });
+
+  it("drops unknown flat operation discriminators", () => {
+    const { ops } = extractLibraryFences(
+      fence(
+        JSON.stringify([
+          {
+            op: "delete",
+            path: "presentations/sales-overview.md",
+            type: "Notes",
+            title: "Sales overview",
+            body: "Must not be accepted.",
+          },
+        ]),
+      ),
+    );
+    expect(ops).toEqual([]);
+  });
+
   it("drops upserts with traversal or reserved paths", () => {
     const bad = [
       "../escape.md",


### PR DESCRIPTION
## Summary

- make flat `op`-discriminated objects the explicit librarian JSON contract
- parse that production shape while retaining the original wrapped representation for compatibility
- reject unknown operations and continue applying existing path/content validation
- show the model concrete flat `upsert` and `skip` examples
- accept one or multiple Library documents totaling up to 100 MB in one request
- preserve valid 100 MB requests through Next Proxy, whose default body clone limit is only 10 MB
- validate the complete batch before writing and keep the original singular `file` API field compatible
- hash the bytes while persisting and use content-addressed paths so a later same-name upload cannot overwrite an earlier source
- replace the broken narrow centered Library empty states with the shared, responsive section layout used across Library, Memory, and Skills

## Production evidence

After deploying v2.36.1, retrying the affected PDF passed Ax signature construction and reached Gemini 3.7 Flash. Gemini returned a valid `neko_library` fence whose item had keys `op`, `path`, `type`, `title`, and `body`. The parser only accepted `{ "upsert": { ... } }`, so it discarded the valid item and marked the document failed with `librarian returned no parseable neko_library ops`.

The prompt previously named `upsert` and `skip` semantically but never specified their JSON representation.

## UI reuse map

| Surface need | Existing component or token | Verification |
| --- | --- | --- |
| Choose one or multiple Library documents | Existing hidden native file picker with its documented `data-ui-bespoke-reason` | Selection and aggregate-boundary tests; desktop and phone Library inspection |
| Start an import and show in-flight state | Shared `Button` plus the existing `uploading` disabled state | `pnpm ui:check`; live disabled-state and focus-ring inspection |
| Explain a rejected batch | Existing `.library-error` `role="alert"` region with next-step copy | Client-contract and route rejection tests; rendered error-state inspection |
| Describe the allowance | Existing Library section hierarchy and semantic text tokens | Desktop and phone geometry/computed-style inspection |
| Present an empty knowledge section | Shared `EmptyState` with stable `data-ui-empty-state-*` slots | Populated, loading, error, and empty Library states; Memory and Skills sibling routes |

## Validation

- `pnpm --filter @neko/llm exec vitest run test/ax-signatures.test.ts test/library-fence.test.ts test/library-distill.test.ts` — 20 passed, including explicit `query` and `response` rejection
- `pnpm --filter @neko/llm test` — 705 passed, 146 environment-gated skips
- focused Web upload/storage/UI/config suite — 35 passed
- `pnpm --filter @neko/web test` — 323 passed, 107 database-gated skips
- `pnpm --filter @neko/web lint`
- `pnpm --filter @neko/web typecheck`
- `pnpm -r --if-present typecheck` — all 13 participating workspace projects passed
- `pnpm ui:check`
- `pnpm --filter @neko/web build`
- `git diff --check`
- rendered Library inspection at 1280 px and 390 px: populated, loading, error, empty, keyboard focus, and uploading-disabled states; no horizontal overflow
- rendered shared empty-state inspection on Memory and Skills

## Existing processing limits

This PR increases the direct Library intake allowance; it does not remove the downstream extraction budget:

- supported direct-upload formats remain CSV, DOCX, HTML, JSON, Markdown, PDF, PPTX, TSV, TXT, and XLSX
- binary extraction returns at most 400,000 characters
- the librarian model currently receives the first 60,000 extracted characters per document
- OCR fallback currently scans the first 10 PDF pages

