### PR TITLE
feat(work): stream native provider progress

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -156,31 +156,47 @@ COPY --from=graphjin-bin /usr/local/bin/graphjin /usr/local/bin/graphjin
 
 # ─── 2b. agent runtime: Hermes (sandbox only) ──────────────────────────
 FROM npm-runtime AS agent-base
-ARG HERMES_AGENT_REF=a91a57fa5a13d516c38b07a141a9ce8a3daabeb0
+ARG HERMES_AGENT_REF=29112bef099274229cadff79cdff7bf7b99c4b77
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      git python3 python3-pip \
+      git patch python3 python3-pip \
     && rm -rf /var/lib/apt/lists/*
 # Hermes uses Debian's system Python instead of downloading a second Python
-# distribution. It remains pinned while its Gemini/MCP compatibility patches
-# are required.
+# distribution. Hermes 0.21 intentionally blocks wheel builds, so install its
+# exact source revision into an isolated editable environment (the supported
+# upstream layout) and keep the checkout immutable inside the image.
 RUN curl -LsSf --retry 5 --retry-delay 5 --retry-all-errors https://astral.sh/uv/install.sh \
-      | env UV_INSTALL_DIR=/usr/local/bin sh -s -- --no-modify-path \
-    && UV_TOOL_DIR=/usr/local/uv/tools \
-       UV_TOOL_BIN_DIR=/usr/local/bin \
+      | env UV_INSTALL_DIR=/usr/local/bin UV_NO_MODIFY_PATH=1 sh \
+    && mkdir -p /usr/local/lib/hermes-agent \
+    && git -C /usr/local/lib/hermes-agent init \
+    && git -C /usr/local/lib/hermes-agent remote add origin https://github.com/NousResearch/hermes-agent.git \
+    && git -C /usr/local/lib/hermes-agent fetch --depth 1 origin "$HERMES_AGENT_REF" \
+    && git -C /usr/local/lib/hermes-agent checkout --detach FETCH_HEAD \
+    && test "$(git -C /usr/local/lib/hermes-agent rev-parse HEAD)" = "$HERMES_AGENT_REF" \
+    && rm -rf /usr/local/lib/hermes-agent/.git
+COPY scripts/patches/hermes-acp-reasoning-config.patch /tmp/hermes-acp-reasoning-config.patch
+COPY scripts/patches/hermes-acp-interim-messages.patch /tmp/hermes-acp-interim-messages.patch
+COPY scripts/patches/hermes-acp-anthropic-reasoning.patch /tmp/hermes-acp-anthropic-reasoning.patch
+RUN --mount=type=cache,id=hermes-uv,target=/tmp/uv-cache \
+    patch --batch --forward --fuzz=0 -d /usr/local/lib/hermes-agent -p1 < /tmp/hermes-acp-reasoning-config.patch \
+    && patch --batch --forward --fuzz=0 -d /usr/local/lib/hermes-agent -p1 < /tmp/hermes-acp-interim-messages.patch \
+    && patch --batch --forward --fuzz=0 -d /usr/local/lib/hermes-agent -p1 < /tmp/hermes-acp-anthropic-reasoning.patch \
+    && rm /tmp/hermes-acp-reasoning-config.patch /tmp/hermes-acp-interim-messages.patch /tmp/hermes-acp-anthropic-reasoning.patch \
+    && cd /usr/local/lib/hermes-agent \
+    && UV_PROJECT_ENVIRONMENT=/usr/local/uv/tools/hermes-agent \
        UV_CACHE_DIR=/tmp/uv-cache \
-       uv tool install --python /usr/bin/python3 \
-         --with mcp --with websockets \
-         "hermes-agent[acp] @ git+https://github.com/NousResearch/hermes-agent.git@${HERMES_AGENT_REF}" \
-    && rm -rf /tmp/uv-cache /root/.cache/uv \
-    && sed -i 's/result\.isError/result.is_error/g' \
-         /usr/local/uv/tools/hermes-agent/lib/python3.11/site-packages/tools/mcp_tool.py \
-    && ! grep -q 'result\.isError' \
-         /usr/local/uv/tools/hermes-agent/lib/python3.11/site-packages/tools/mcp_tool.py \
+       uv sync --locked --no-dev --extra acp --extra mcp --extra anthropic \
+    && ln -sf /usr/local/uv/tools/hermes-agent/bin/hermes /usr/local/bin/hermes \
+    && rm -rf /root/.cache/uv \
     && hermes --version \
-    && /usr/local/uv/tools/hermes-agent/bin/python -c "import hermes_cli; assert hermes_cli.__version__ == '0.14.0'" \
+    && /usr/local/uv/tools/hermes-agent/bin/python -c "import hermes_cli; assert hermes_cli.__version__ == '0.21.0'" \
+    && /usr/local/uv/tools/hermes-agent/bin/python -c "import openai; assert openai.__version__, 'Hermes OpenAI provider SDK missing'" \
+    && /usr/local/uv/tools/hermes-agent/bin/python -c "import anthropic; assert anthropic.__version__, 'Hermes Anthropic provider SDK missing'" \
     && /usr/local/uv/tools/hermes-agent/bin/python -c "from mcp.types import CallToolResult; import websockets; result = CallToolResult(content=[]); assert hasattr(result, 'is_error')" \
+    && /usr/local/uv/tools/hermes-agent/bin/python -c "from acp_adapter.session import SessionManager; import inspect; source = inspect.getsource(SessionManager._make_agent); assert 'reasoning_config' in source and 'resolve_reasoning_config' in source, 'Hermes ACP must pass configured reasoning into AIAgent'" \
     && /usr/local/uv/tools/hermes-agent/bin/python -c "from acp_adapter.server import HermesACPAgent; import inspect; source = inspect.getsource(HermesACPAgent.prompt); assert 'usage=usage' in source, 'Hermes ACP prompt response must expose exact turn usage'" \
-    && echo "hermes v0.14 ACP/MCP runtime present"
+    && /usr/local/uv/tools/hermes-agent/bin/python -c "from acp_adapter.events import make_interim_message_cb; from acp_adapter.server import HermesACPAgent; import inspect; source = inspect.getsource(HermesACPAgent.prompt); assert 'interim_assistant_callback' in source and 'pending_streamed_message.append(text)' in source and 'raw_interim_cb(text, already_streamed=False)' in source and 'not streamed_message' not in source; assert callable(make_interim_message_cb), 'Hermes ACP buffered interim callback missing'" \
+    && /usr/local/uv/tools/hermes-agent/bin/python -c "from agent import chat_completion_helpers; from pathlib import Path; source = Path(chat_completion_helpers.__file__).read_text(); assert '_emit_unstreamed_anthropic_reasoning' in source and 'reasoning_was_streamed' in source, 'Hermes ACP Anthropic reasoning fallback missing'" \
+    && echo "hermes v0.21 ACP/MCP runtime present"
 
 # ─── 2c. document toolchain (agent image only) ─────────────────────────
 # Bundled skills (xlsx / pptx / docx / pdf / document-extraction) shell out to

--- a/apps/web/src/app/(work)/work/[threadId]/page.tsx
+++ b/apps/web/src/app/(work)/work/[threadId]/page.tsx
@@ -39,8 +39,23 @@ export default async function WorkThreadPage({
 }: {
   params: Promise<{ threadId: string }>;
 }) {
-  const [{ threadId }, orgId] = await Promise.all([params, getOrgId()]);
-  const thread = await getAuthorizedWorkThread(orgId, threadId);
+  let threadId: string;
+  let thread: Awaited<ReturnType<typeof getAuthorizedWorkThread>>;
+  try {
+    const resolved = await params;
+    threadId = resolved.threadId;
+    const orgId = await getOrgId();
+    thread = await getAuthorizedWorkThread(orgId, threadId);
+  } catch (error) {
+    // WorkScreen owns the operator-facing availability gate. Let it render
+    // that stable state instead of replacing the page with a raw Next.js RSC
+    // or HTML error response when this redirect lookup cannot reach storage.
+    console.error(
+      "[work/thread-page] redirect lookup failed:",
+      error instanceof Error ? error.message : "unknown error",
+    );
+    return null;
+  }
   if (!thread) return null;
   const state = thread.backend_state && typeof thread.backend_state === "object"
     && !Array.isArray(thread.backend_state)

--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -124,12 +124,14 @@ import {
 import { Pill } from "@/components/ui/Pill";
 import { Button, IconButton } from "@/components/ui/Button";
 import { Input, Textarea } from "@/components/ui/Field";
+import { Disclosure } from "@/components/ui/Disclosure";
 import { renderComponent, renderChildren } from "@/a2ui/renderer";
 import { applyMessage, getRootComponent, setDataModelValue } from "@/a2ui/surface";
 import { buildActionFollowUp } from "@/a2ui/action";
 import type { SurfaceState, A2UIMessage } from "@/a2ui/types";
 import { useWorkShell } from "../work-shell-context";
 import { formatSavedShort } from "@/lib/hours-saved";
+import { presentWorkFailure } from "@/lib/work-failure";
 
 type AnswerVital = {
   label: string;
@@ -166,12 +168,20 @@ export type WorkEvent =
   // reconstructs the full assistant text. Mirrors `AgentEvent.message` in
   // packages/llm/src/agent-backend.ts.
   | { type: "message"; role: "user" | "assistant"; content: string }
+  | { type: "interim"; id: string; content: string; source: "hermes_interim_assistant" }
   | { type: "tool_start"; id: string; name: string; input?: unknown }
   | { type: "tool_delta"; id: string; delta: unknown }
   | { type: "tool_end"; id: string; result?: unknown; error?: string }
   | { type: "surface"; messages: A2UIMessage[] }
   | { type: "artifact"; artifact: { path: string; label: string; mimeType?: string } }
   | { type: "status"; message: string }
+  | {
+      type: "progress";
+      id: string;
+      content: string;
+      source: "provider_summary";
+      provider: "google-gemini" | "anthropic";
+    }
   | { type: "error"; message: string }
   | {
       type: "capability_denied";
@@ -985,6 +995,7 @@ export default function WorkScreen() {
     if (activeThreadIdRef.current !== threadId) return;
 
     setSending(false);
+    setStreamError(null);
     updateActiveRunId(null);
     await loadThread(threadId);
     window.setTimeout(() => {
@@ -1356,9 +1367,7 @@ export default function WorkScreen() {
           })
         ) : null}
 
-        {streamError ? (
-          <div className="work-stream-error" role="alert">{streamError}</div>
-        ) : null}
+        {streamError ? <WorkFailureNotice message={streamError} /> : null}
         <div ref={endRef} />
       </div>
 
@@ -1934,6 +1943,8 @@ type ApprovalItem = {
 
 type TimelineItem =
   | { kind: "text"; content: string }
+  | { kind: "interim"; id: string; content: string }
+  | { kind: "progress"; id: string; content: string }
   | { kind: "tools"; tools: ToolItem[] }
   | { kind: "surface"; messages: A2UIMessage[] }
   | {
@@ -1979,6 +1990,13 @@ function surfaceIdOf(messages: A2UIMessage[]): string | null {
   return null;
 }
 
+function canonicalAnswerCreateId(message: A2UIMessage): string | null {
+  if (!("createSurface" in message)) return null;
+  return isCanonicalAnswerSurface([message])
+    ? message.createSurface.surfaceId
+    : null;
+}
+
 function isCanonicalAnswerSurface(messages: A2UIMessage[]): boolean {
   const components = surfaceComponents(messages);
   const hasAnswer = [...components.values()].some(
@@ -1990,20 +2008,6 @@ function isCanonicalAnswerSurface(messages: A2UIMessage[]): boolean {
     ),
   );
   return hasAnswer && carriesAnswer;
-}
-
-function canonicalSurfaceContainsNarrative(messages: A2UIMessage[]): boolean {
-  return [...surfaceComponents(messages).values()].some((component) =>
-    [
-      "Markdown",
-      "Table",
-      "Callout",
-      "Text",
-      "Confirmation",
-      "Choice",
-      "ChoicePicker",
-    ].includes(String(component.component)),
-  );
 }
 
 function withVitalProvenance(
@@ -2294,8 +2298,14 @@ export function buildRunTimeline(events: WorkEvent[], runId: string): {
 } {
   const items: TimelineItem[] = [];
   const toolsById = new Map<string, ToolItem>();
+  const progressById = new Map<
+    string,
+    Extract<TimelineItem, { kind: "progress" }>
+  >();
   const approvalToolByRequest = new Map<string, ToolItem>();
   let surfaceItem: Extract<TimelineItem, { kind: "surface" }> | null = null;
+  let canonicalAnswerSurfaceId: string | null = null;
+  const supersededAnswerSurfaceIds = new Set<string>();
   const denialKeys = new Set<string>();
   const sources = new Set<string>();
   const artifacts: RunArtifact[] = [];
@@ -2317,6 +2327,27 @@ export function buildRunTimeline(events: WorkEvent[], runId: string): {
       case "message": {
         if (event.role !== "assistant") break;
         pendingText += event.content;
+        break;
+      }
+      case "interim": {
+        flushTextSegment();
+        items.push({ kind: "interim", id: event.id, content: event.content });
+        break;
+      }
+      case "progress": {
+        flushTextSegment();
+        const existing = progressById.get(event.id);
+        if (existing) {
+          existing.content += event.content;
+          break;
+        }
+        const item: Extract<TimelineItem, { kind: "progress" }> = {
+          kind: "progress",
+          id: event.id,
+          content: event.content,
+        };
+        progressById.set(event.id, item);
+        items.push(item);
         break;
       }
       case "tool_start": {
@@ -2395,7 +2426,44 @@ export function buildRunTimeline(events: WorkEvent[], runId: string): {
           surfaceItem = { kind: "surface", messages: [] };
           items.push(surfaceItem);
         }
-        surfaceItem.messages.push(...event.messages);
+        for (const message of event.messages) {
+          const nextAnswerSurfaceId = canonicalAnswerCreateId(message);
+          if (
+            nextAnswerSurfaceId &&
+            canonicalAnswerSurfaceId &&
+            nextAnswerSurfaceId !== canonicalAnswerSurfaceId
+          ) {
+            // A Work run owns one canonical answer. If the agent retries that
+            // answer with a fresh surface id, treat the later create as a
+            // revision instead of replaying both reports. Other A2UI surfaces
+            // (forms, confirmations, and protocol updates) remain independent.
+            supersededAnswerSurfaceIds.add(canonicalAnswerSurfaceId);
+            surfaceItem.messages = surfaceItem.messages.filter(
+              (existing) =>
+                surfaceIdOf([existing]) !== canonicalAnswerSurfaceId,
+            );
+          }
+          if (nextAnswerSurfaceId) {
+            canonicalAnswerSurfaceId = nextAnswerSurfaceId;
+            supersededAnswerSurfaceIds.delete(nextAnswerSurfaceId);
+          }
+
+          const targetSurfaceId = surfaceIdOf([message]);
+          if (
+            targetSurfaceId &&
+            supersededAnswerSurfaceIds.has(targetSurfaceId)
+          ) {
+            continue;
+          }
+          surfaceItem.messages.push(message);
+
+          if (
+            "deleteSurface" in message &&
+            message.deleteSurface.surfaceId === canonicalAnswerSurfaceId
+          ) {
+            canonicalAnswerSurfaceId = null;
+          }
+        }
         break;
       }
       case "capability_denied": {
@@ -2501,38 +2569,18 @@ export function buildRunTimeline(events: WorkEvent[], runId: string): {
       sourceList,
       deniedNetwork,
     );
-    if (
-      isCanonicalAnswerSurface(surfaceItem.messages) &&
-      canonicalSurfaceContainsNarrative(surfaceItem.messages)
-    ) {
-      // The surface is the complete answer. Tool rows retain the work trace;
-      // model prose anywhere around the surface is duplicate delivery.
-      for (let index = items.length - 1; index >= 0; index -= 1) {
-        if (items[index]?.kind === "text") items.splice(index, 1);
-      }
-    }
   } else if (isDone) {
-    let finalTextStart = items.length;
-    while (finalTextStart > 0 && items[finalTextStart - 1]?.kind === "text") {
-      finalTextStart -= 1;
-    }
-    const finalText = items
-      .slice(finalTextStart)
-      .filter(
-        (item): item is Extract<TimelineItem, { kind: "text" }> =>
-          item.kind === "text",
-      )
-      .map((item) => item.content)
-      .join("");
+    // Plain assistant prose remains conversation. Vitals are additive evidence,
+    // never a replacement surface that turns every answer into a report.
     const fallback = fallbackAnswerSurface(
       runId,
-      finalText,
+      "",
       vitals,
       sourceList,
       deniedNetwork,
     );
     if (fallback.length > 0) {
-      items.splice(finalTextStart, items.length - finalTextStart, {
+      items.push({
         kind: "surface",
         messages: fallback,
       });
@@ -2605,6 +2653,132 @@ function FenceAwareBubble({
   );
 }
 
+function ProviderProgress({
+  content,
+  live,
+}: {
+  content: string;
+  live: boolean;
+}) {
+  const sections = splitProgressSections(content);
+  const inlineSummary = sections.length === 1 && sections[0]?.heading === "Details"
+    ? sections[0].detail
+    : null;
+  return (
+    <div
+      className="work-progress-summary"
+      {...(live ? { role: "status", "aria-live": "polite" as const } : {})}
+    >
+      <span className="work-progress-summary-mark" aria-hidden="true" />
+      <div className="work-progress-summary-copy">
+        <span className="work-progress-summary-label">Progress</span>
+        {inlineSummary ? (
+          <div className="work-markdown">
+            <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={MARKDOWN_COMPONENTS}>
+              {linkifyWorkspacePaths(inlineSummary)}
+            </ReactMarkdown>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1.5">
+            {sections.map((section, index) => (
+              <Disclosure
+                key={`${section.heading}-${index}`}
+                title={section.heading}
+                className="work-progress-disclosure"
+              >
+                {section.detail ? (
+                  <div className="work-markdown">
+                    <ReactMarkdown remarkPlugins={REMARK_PLUGINS} components={MARKDOWN_COMPONENTS}>
+                      {linkifyWorkspacePaths(section.detail)}
+                    </ReactMarkdown>
+                  </div>
+                ) : null}
+              </Disclosure>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+type ProgressSection = { heading: string; detail: string };
+
+function markdownHeading(block: string[]): string | null {
+  if (block.length !== 1) return null;
+  const candidate = block[0].trim();
+  if (candidate.startsWith("#")) {
+    let markerLength = 0;
+    while (markerLength < candidate.length && candidate[markerLength] === "#") {
+      markerLength += 1;
+    }
+    if (markerLength <= 6 && candidate[markerLength] === " ") {
+      return candidate.slice(markerLength + 1).trim() || null;
+    }
+  }
+  for (const marker of ["**", "__"]) {
+    if (
+      candidate.length > marker.length * 2 &&
+      candidate.startsWith(marker) &&
+      candidate.endsWith(marker)
+    ) {
+      return candidate.slice(marker.length, -marker.length).trim() || null;
+    }
+  }
+  return null;
+}
+
+function plainProgressHeading(block: string[], hasFollowingBlock: boolean): string | null {
+  if (block.length !== 1 || !hasFollowingBlock) return null;
+  const candidate = block[0].trim();
+  if (!candidate || candidate.length > 80) return null;
+  if ([".", "?", "!", ":", ";", ","].some((mark) => candidate.endsWith(mark))) {
+    return null;
+  }
+  if (["{", "[", "`", "-", "*", ">"].some((mark) => candidate.startsWith(mark))) {
+    return null;
+  }
+  const words = candidate.split(" ").filter(Boolean);
+  return words.length >= 2 && words.length <= 10 ? candidate : null;
+}
+
+export function splitProgressSections(content: string): ProgressSection[] {
+  const lines = content.split("\n").map((line) =>
+    line.endsWith("\r") ? line.slice(0, -1) : line,
+  );
+  const blocks: string[][] = [];
+  let pending: string[] = [];
+  for (const line of lines) {
+    if (line.trim()) {
+      pending.push(line);
+    } else if (pending.length) {
+      blocks.push(pending);
+      pending = [];
+    }
+  }
+  if (pending.length) blocks.push(pending);
+  if (!blocks.length) return [{ heading: "Details", detail: "" }];
+
+  const sections: ProgressSection[] = [];
+  let current: ProgressSection | null = null;
+  for (let index = 0; index < blocks.length; index += 1) {
+    const block = blocks[index];
+    const heading = markdownHeading(block) ??
+      plainProgressHeading(block, index + 1 < blocks.length);
+    if (heading) {
+      if (current) sections.push(current);
+      current = { heading, detail: "" };
+      continue;
+    }
+    const text = block.join("\n");
+    if (!current) current = { heading: "Details", detail: text };
+    else current.detail = current.detail ? `${current.detail}\n\n${text}` : text;
+  }
+  if (current) sections.push(current);
+
+  return sections;
+}
+
 function RunTimeline({
   threadId,
   run,
@@ -2624,19 +2798,30 @@ function RunTimeline({
     [events, run?.id],
   );
   const hasSurface = presentation.items.some((item) => item.kind === "surface");
-  const persistedSurface = useMemo(
+  const hasText = presentation.items.some((item) => item.kind === "text");
+  const hasError = presentation.items.some((item) => item.kind === "error");
+  const fallbackFailure = presentWorkFailure(fallbackContent);
+  const fallbackIsTechnicalFailure =
+    !pending && !hasText && !run?.error && fallbackFailure.technical;
+  const persistedText =
+    !pending &&
+    !hasText &&
+    !fallbackIsTechnicalFailure &&
+    fallbackContent.trim()
+      ? fallbackContent
+      : "";
+  const persistedVitals = useMemo(
     () =>
-      !pending && !hasSurface && fallbackContent.trim()
+      !pending && !hasSurface
         ? fallbackAnswerSurface(
             run?.id ?? "persisted",
-            fallbackContent,
+            "",
             presentation.vitals,
             presentation.sources,
             presentation.items.some((item) => item.kind === "capability"),
           )
         : [],
     [
-      fallbackContent,
       hasSurface,
       pending,
       presentation.items,
@@ -2646,17 +2831,46 @@ function RunTimeline({
     ],
   );
   const hasContent =
-    presentation.items.length > 0 || persistedSurface.length > 0;
+    presentation.items.length > 0 ||
+    Boolean(persistedText) ||
+    persistedVitals.length > 0;
 
   return (
     <div className="work-timeline flex flex-col gap-2.5 mt-1">
       {presentation.items.map((item, index) => {
         if (item.kind === "text") {
+          const failure = presentWorkFailure(item.content);
+          if (failure.technical) {
+            return (
+              <WorkFailureNotice
+                key={`text-error-${index}`}
+                message={item.content}
+              />
+            );
+          }
           return (
             <FenceAwareBubble
               key={`text-${index}`}
               keyPrefix={`text-${index}`}
               raw={item.content}
+            />
+          );
+        }
+        if (item.kind === "interim") {
+          return (
+            <FenceAwareBubble
+              key={`interim-${item.id}-${index}`}
+              keyPrefix={`interim-${item.id}-${index}`}
+              raw={item.content}
+            />
+          );
+        }
+        if (item.kind === "progress") {
+          return (
+            <ProviderProgress
+              key={`progress-${item.id}-${index}`}
+              content={item.content}
+              live={pending}
             />
           );
         }
@@ -2692,15 +2906,22 @@ function RunTimeline({
             />
           );
         }
-        return (
-          <div key={`error-${index}`} className="border border-warn/40 bg-warn-soft text-warn-ink rounded-2xl px-3 py-2.5 text-ui-body-sm">
-            {item.message}
-          </div>
-        );
+        return <WorkFailureNotice key={`error-${index}`} message={item.message} />;
       })}
 
-      {persistedSurface.length > 0 ? (
-        <SurfaceBlock messages={persistedSurface} />
+      {fallbackIsTechnicalFailure ? (
+        <WorkFailureNotice message={fallbackContent} />
+      ) : null}
+
+      {persistedText ? (
+        <FenceAwareBubble
+          keyPrefix="persisted-answer"
+          raw={persistedText}
+        />
+      ) : null}
+
+      {persistedVitals.length > 0 ? (
+        <SurfaceBlock messages={persistedVitals} />
       ) : null}
 
       {pending ? (
@@ -2709,7 +2930,9 @@ function RunTimeline({
           <span>{presentation.lastStatus ?? "Running…"}</span>
         </div>
       ) : null}
-      {!pending && run?.error ? <div className="border border-warn/40 bg-warn-soft text-warn-ink rounded-2xl px-3 py-2.5 text-ui-body-sm">{run.error}</div> : null}
+      {!pending && run?.error && !hasError ? (
+        <WorkFailureNotice message={run.error} />
+      ) : null}
       {!pending && hasContent ? (
         <AnswerRunFooter
           run={run}
@@ -2719,6 +2942,26 @@ function RunTimeline({
           onFollowup={(prompt) => insertComposerRef.current?.(prompt)}
         />
       ) : null}
+    </div>
+  );
+}
+
+function WorkFailureNotice({ message }: { message: string }) {
+  const failure = presentWorkFailure(message);
+  return (
+    <div
+      className="rounded-2xl border border-warn/40 bg-warn-soft px-3 py-2.5 text-ui-body-sm text-warn-ink"
+      role="alert"
+    >
+      <p className="font-semibold">{failure.summary}</p>
+      <Disclosure
+        title="Technical details"
+        className="mt-2 border-warn/40 bg-card/70"
+      >
+        <p className="break-words font-mono text-ui-caption text-text2">
+          {failure.detail}
+        </p>
+      </Disclosure>
     </div>
   );
 }

--- a/apps/web/src/app/api/work/runs/[runId]/cancel/route.ts
+++ b/apps/web/src/app/api/work/runs/[runId]/cancel/route.ts
@@ -1,11 +1,18 @@
 import { NextResponse } from "next/server";
 import { abortRun } from "@/lib/neko-run-registry";
 import { getOrgId } from "@/lib/db";
+import {
+  appendWorkRunEvent,
+  cancelWorkRunIfActive,
+} from "@/lib/work-store";
 import { getAuthorizedWorkRun } from "@/lib/work-thread-auth";
 
 type RouteContext = {
   params: Promise<{ runId: string }>;
 };
+
+const INTERRUPTED_RUN_REASON =
+  "Interrupted — the process running the agent is no longer available. Retry to run it again.";
 
 export async function POST(_: Request, context: RouteContext) {
   const { runId } = await context.params;
@@ -13,6 +20,32 @@ export async function POST(_: Request, context: RouteContext) {
   if (!run) {
     return NextResponse.json({ error: "Run not found" }, { status: 404 });
   }
-  const ok = abortRun(runId);
-  return NextResponse.json({ ok });
+  const aborted = abortRun(runId);
+  if (aborted) {
+    return NextResponse.json({ ok: true, recovered: false });
+  }
+
+  // In-process controllers disappear on a hard restart. The durable run row
+  // survives, so Stop must still be able to recover it instead of returning a
+  // misleading success response while the UI remains stuck indefinitely.
+  const recovered = await cancelWorkRunIfActive(runId, INTERRUPTED_RUN_REASON);
+  if (recovered) {
+    await appendWorkRunEvent({
+      orgId: run.org_id,
+      threadId: run.thread_id,
+      runId,
+      event: { type: "done", result: { status: "cancelled" } },
+    });
+  }
+
+  const alreadyTerminal = [
+    "completed",
+    "failed",
+    "cancelled",
+    "needs_input",
+  ].includes(run.status);
+  return NextResponse.json({
+    ok: recovered || alreadyTerminal,
+    recovered,
+  });
 }

--- a/apps/web/src/app/api/work/threads/[threadId]/runs/route.ts
+++ b/apps/web/src/app/api/work/threads/[threadId]/runs/route.ts
@@ -4,7 +4,7 @@ import {
   ensureHostConfigProvisioned,
 } from "@neko/llm";
 import {
-  agentRuntimeDepsFromEnv,
+  agentRuntimeDepsFromConfig,
   createWorkRun,
   ensureAgentBroker,
   finishWorkRun,
@@ -98,7 +98,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
   // Derive the agent-sandbox env (model egress, gateway provider, key alias)
   // before creating the run. If gateway sync is temporarily unavailable, the
   // memoized provision attempt is cleared and the caller can retry cleanly.
-  await ensureHostConfigProvisioned(orgId);
+  const agentRuntime = await ensureHostConfigProvisioned(orgId);
 
   const run = await createWorkRun(orgId, threadId, backend.id, actor);
   const runTelemetry = createWebHarnessObserver(run.id);
@@ -162,7 +162,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       pluginActions,
       observer: runTelemetry.observer,
     },
-    agentRuntimeDepsFromEnv(broker),
+    agentRuntimeDepsFromConfig(agentRuntime, broker),
   )
     .then(async (result) => {
       await observeSafely(runTelemetry.observer, {

--- a/apps/web/src/app/api/workflows/[workflowId]/runs/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/runs/route.ts
@@ -6,7 +6,7 @@ import {
   finishWorkRun,
   getWorkRun,
   registerAgentBrokerEventSink,
-  workflowRuntimeDepsFromEnv,
+  workflowRuntimeDepsFromConfig,
 } from "@neko/llm/work";
 import {
   finishWorkflowRun,
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     typeof body.userMessage === "string" ? body.userMessage.trim() : undefined;
 
   const orgId = await getOrgId();
-  await ensureHostConfigProvisioned(orgId);
+  const agentRuntime = await ensureHostConfigProvisioned(orgId);
 
   let prepared;
   try {
@@ -107,7 +107,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
           pluginActions,
           observer: runTelemetry.observer,
         },
-        workflowRuntimeDepsFromEnv(broker),
+        workflowRuntimeDepsFromConfig(agentRuntime, broker),
       );
       await observeSafely(runTelemetry.observer, {
         kind: "output.contract",

--- a/apps/web/src/app/styles/_work.css
+++ b/apps/web/src/app/styles/_work.css
@@ -245,6 +245,43 @@
   animation: spin 1s linear infinite;
   color: var(--accent);
 }
+.work-progress-summary {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  max-width: min(780px, 86%);
+  padding: 5px 4px;
+  color: var(--text2);
+  text-align: left;
+}
+.work-progress-summary-mark {
+  width: 7px;
+  height: 7px;
+  margin-top: 7px;
+  border-radius: 50%;
+  background: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+  flex-shrink: 0;
+}
+.work-progress-summary-copy {
+  min-width: 0;
+}
+.work-progress-summary-label {
+  display: block;
+  margin-bottom: 2px;
+  color: var(--text3);
+  font-size: var(--type-label);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.work-progress-summary .work-markdown {
+  font-size: var(--type-body-sm);
+  line-height: var(--leading-body);
+}
+.work-progress-summary .work-markdown > * + * {
+  margin-top: 5px;
+}
 
 /* Host-authored capability denial. This is deliberately architectural rather
    than alarm-card chrome: a hard rule, the exact blocked endpoint, and a
@@ -434,6 +471,7 @@
 .work-tool-group-head {
   display: inline-flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 8px;
   width: auto;
   align-self: flex-start;
@@ -518,6 +556,7 @@
 .work-tool-row-head {
   display: flex;
   align-items: center;
+  justify-content: flex-start;
   gap: 10px;
   width: 100%;
   background: transparent;

--- a/apps/web/src/lib/provider-settings.ts
+++ b/apps/web/src/lib/provider-settings.ts
@@ -25,6 +25,7 @@ import {
   maybeDecryptSecret,
   maybeEncryptSecret,
 } from "@neko/llm/secrets";
+import { resolveHermesProviderRuntime } from "@neko/llm/provider-runtime";
 
 export type PublicProviderConfig =
   | {
@@ -210,6 +211,18 @@ function validateConfig(config: EditableProviderConfig): string[] {
     }
   }
 
+  if (errors.length === 0 && config.scope === "primary") {
+    try {
+      resolveHermesProviderRuntime({
+        provider: config.provider,
+        model: config.model,
+        config: config.config,
+      });
+    } catch (error) {
+      errors.push(error instanceof Error ? error.message : "Invalid provider configuration.");
+    }
+  }
+
   return errors;
 }
 
@@ -311,7 +324,11 @@ function mergeDraft(
     return {
       scope: "primary",
       provider,
-      model: draft.model?.trim() || existing.model || getDefaultPrimaryModel(provider),
+      model:
+        draft.model?.trim() ||
+        (providerChanged
+          ? getDefaultPrimaryModel(provider)
+          : existing.model || getDefaultPrimaryModel(provider)),
       label: draft.label ?? existing.label ?? null,
       enabled: draft.enabled ?? existing.enabled,
       config: providerChanged ? { ...(draft.config ?? {}) } : { ...existing.config, ...(draft.config ?? {}) },
@@ -334,7 +351,11 @@ function mergeDraft(
   return {
     scope: "research",
     provider,
-    model: draft.model?.trim() || existing.model || getDefaultResearchModel(provider),
+    model:
+      draft.model?.trim() ||
+      (providerChanged
+        ? getDefaultResearchModel(provider)
+        : existing.model || getDefaultResearchModel(provider)),
     label: draft.label ?? existing.label ?? null,
     enabled: draft.enabled ?? existing.enabled,
     config: providerChanged ? { ...(draft.config ?? {}) } : { ...existing.config, ...(draft.config ?? {}) },

--- a/apps/web/src/lib/work-failure.ts
+++ b/apps/web/src/lib/work-failure.ts
@@ -1,0 +1,106 @@
+export type WorkFailurePresentation = {
+  summary: string;
+  detail: string;
+  technical: boolean;
+};
+
+function httpStatus(message: string): number | null {
+  if (!message.startsWith("HTTP ")) return null;
+  const separator = message.indexOf(":", 5);
+  const statusText = message.slice(5, separator === -1 ? undefined : separator).trim();
+  const status = Number(statusText);
+  return Number.isInteger(status) && status >= 400 && status <= 599
+    ? status
+    : null;
+}
+
+function isHtmlResponse(message: string): boolean {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("<!doctype html") ||
+    lower.includes("<html") ||
+    lower.includes("<head") ||
+    lower.includes("<body")
+  );
+}
+
+/**
+ * Converts agent/runtime failures into operator-facing copy. Technical bodies
+ * remain available behind a Disclosure, but never become the primary answer.
+ */
+export function presentWorkFailure(message: string): WorkFailurePresentation {
+  const detail = message.trim() || "No technical detail was provided.";
+  const lower = detail.toLowerCase();
+  const status = httpStatus(detail);
+  const html = isHtmlResponse(detail);
+
+  if (
+    lower.includes("valid api key") ||
+    lower.includes("invalid api key") ||
+    lower.includes("authentication failed") ||
+    lower.includes("unauthorized")
+  ) {
+    return {
+      summary:
+        "The model provider rejected its credentials. Check the provider settings, then retry.",
+      detail,
+      technical: true,
+    };
+  }
+
+  if (
+    lower.includes("package is required for the anthropic provider") ||
+    lower.includes("hermes anthropic provider sdk missing")
+  ) {
+    return {
+      summary:
+        "The selected model provider is unavailable in this OpenNeko installation. Update the agent runtime, then retry.",
+      detail,
+      technical: true,
+    };
+  }
+
+  if (status === 404) {
+    return {
+      summary:
+        "The selected model is not available from this provider. Check the model name and account access, then retry.",
+      detail,
+      technical: true,
+    };
+  }
+
+  if (status === 429) {
+    return {
+      summary:
+        "The model provider is temporarily limiting requests. Wait a moment, then retry.",
+      detail,
+      technical: true,
+    };
+  }
+
+  if (html) {
+    return {
+      summary:
+        "OpenNeko could not load this result. Retry it; if the problem continues, check the server logs.",
+      detail:
+        "The server returned an HTML error response. Its contents are omitted from the conversation.",
+      technical: true,
+    };
+  }
+
+  if (status !== null || lower.startsWith("internal error:")) {
+    return {
+      summary:
+        "OpenNeko could not complete this run. Retry it; if the problem continues, check the agent setup.",
+      detail,
+      technical: true,
+    };
+  }
+
+  return {
+    summary:
+      "OpenNeko could not complete this run. Retry it; if the problem continues, check the technical details.",
+    detail,
+    technical: false,
+  };
+}

--- a/apps/web/src/lib/work-store.ts
+++ b/apps/web/src/lib/work-store.ts
@@ -15,6 +15,7 @@ export {
   createWorkRun,
   markWorkRunRunning,
   finishWorkRun,
+  cancelWorkRunIfActive,
   createWorkMessage,
   saveAssistantWorkMessage,
   appendWorkRunEvent,

--- a/apps/web/test/api/work-runs.test.ts
+++ b/apps/web/test/api/work-runs.test.ts
@@ -21,8 +21,10 @@ import {
   pool,
   processing_job,
   work_run,
+  work_run_event,
   work_thread,
 } from "@neko/db";
+import { finishWorkRun } from "@neko/llm/work";
 
 const { mockGetOrgId, mockEnqueue, mockResolveBackend } = vi.hoisted(() => ({
   mockGetOrgId: vi.fn(),
@@ -74,6 +76,18 @@ async function callRunsPost(
     parsed = text;
   }
   return { status: res.status, body: parsed };
+}
+
+async function callCancelPost(
+  POST: typeof import("@/app/api/work/runs/[runId]/cancel/route").POST,
+  runId: string,
+): Promise<{ status: number; body: unknown }> {
+  const res = await POST(new Request("http://localhost:3000/test", {
+    method: "POST",
+  }), {
+    params: Promise.resolve({ runId }),
+  });
+  return { status: res.status, body: await res.json() };
 }
 
 describeIfDb("/api/work/threads/[threadId]/runs POST", () => {
@@ -163,4 +177,51 @@ describeIfDb("/api/work/threads/[threadId]/runs POST", () => {
   // throws" removed: there's no enqueue path on this route anymore.
   // Backend failures inside the fire-and-forget runChatTurn are exercised
   // by the worker-side run-chat-turn integration tests instead.
+
+  it("recovers a running run whose in-process controller was lost", async () => {
+    const [{ id: runId }] = await db()
+      .insert(work_run)
+      .values({
+        org_id: orgId,
+        thread_id: threadId,
+        backend: "hermes",
+        status: "running",
+      })
+      .returning({ id: work_run.id });
+    const { POST: cancel } = await import(
+      "@/app/api/work/runs/[runId]/cancel/route"
+    );
+
+    const res = await callCancelPost(cancel, runId);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, recovered: true });
+    const [stored] = await db()
+      .select({
+        status: work_run.status,
+        error: work_run.error,
+        finishedAt: work_run.finished_at,
+      })
+      .from(work_run)
+      .where(eq(work_run.id, runId));
+    expect(stored?.status).toBe("cancelled");
+    expect(stored?.error).toContain("process running the agent is no longer available");
+    expect(stored?.finishedAt).toBeInstanceOf(Date);
+
+    const events = await db()
+      .select({ kind: work_run_event.kind, payload: work_run_event.payload })
+      .from(work_run_event)
+      .where(eq(work_run_event.run_id, runId));
+    expect(events).toEqual([
+      { kind: "done", payload: { type: "done", result: { status: "cancelled" } } },
+    ]);
+
+    // A detached completion cannot revive a run after cancellation.
+    await finishWorkRun(runId, "completed", null);
+    const [afterLateFinish] = await db()
+      .select({ status: work_run.status })
+      .from(work_run)
+      .where(eq(work_run.id, runId));
+    expect(afterLateFinish?.status).toBe("cancelled");
+  });
 });

--- a/apps/web/test/lib/work-failure.test.ts
+++ b/apps/web/test/lib/work-failure.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { presentWorkFailure } from "../../src/lib/work-failure";
+
+describe("Work failure presentation", () => {
+  it("replaces provider credential bodies with an actionable summary", () => {
+    const failure = presentWorkFailure(
+      'HTTP 400: [{ "error": { "message": "Please pass a valid API key" } }]',
+    );
+
+    expect(failure.summary).toContain("provider rejected its credentials");
+    expect(failure.technical).toBe(true);
+    expect(failure.detail).toContain("HTTP 400");
+  });
+
+  it("explains a missing managed provider dependency without asking the operator to pip install", () => {
+    const failure = presentWorkFailure(
+      "Internal error: The 'anthropic' package is required for the Anthropic provider.",
+    );
+
+    expect(failure.summary).toContain("unavailable in this OpenNeko installation");
+    expect(failure.summary).not.toContain("pip install");
+    expect(failure.technical).toBe(true);
+  });
+
+  it("never includes an HTML response body in the rendered technical detail", () => {
+    const failure = presentWorkFailure(
+      "HTTP 500: <!doctype html><html><body>framework trace</body></html>",
+    );
+
+    expect(failure.summary).toContain("could not load this result");
+    expect(failure.detail).not.toContain("<html");
+    expect(failure.detail).toContain("contents are omitted");
+  });
+
+  it("does not mistake ordinary assistant prose for a transport failure", () => {
+    const failure = presentWorkFailure(
+      "Revenue increased in August after the enterprise renewal closed.",
+    );
+
+    expect(failure.technical).toBe(false);
+  });
+});

--- a/apps/web/test/work-run-timeline.test.ts
+++ b/apps/web/test/work-run-timeline.test.ts
@@ -1,6 +1,9 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   buildRunTimeline,
+  splitProgressSections,
   type WorkEvent,
 } from "../src/app/(work)/work/work-screen";
 
@@ -11,6 +14,269 @@ function toolItems(events: WorkEvent[]) {
 }
 
 describe("work run action timeline", () => {
+  it("keeps shared Button-based tool headers left aligned", async () => {
+    const css = await readFile(
+      fileURLToPath(new URL("../src/app/styles/_work.css", import.meta.url)),
+      "utf8",
+    );
+    const rule = (selector: string) => {
+      const start = css.indexOf(`${selector} {`);
+      return css.slice(start, css.indexOf("}", start) + 1);
+    };
+
+    expect(rule(".work-tool-group-head")).toContain(
+      "justify-content: flex-start",
+    );
+    expect(rule(".work-tool-row-head")).toContain(
+      "justify-content: flex-start",
+    );
+  });
+
+  it("interleaves provider summaries without replacing assistant conversation", () => {
+    const result = buildRunTimeline(
+      [
+        { type: "message", role: "assistant", content: "I’ll check the sales data." },
+        {
+          type: "progress",
+          id: "gemini-summary-1",
+          content: "Comparing won revenue by owner.",
+          source: "provider_summary",
+          provider: "google-gemini",
+        },
+        { type: "tool_start", id: "tool-1", name: "Inspect data" },
+        { type: "tool_end", id: "tool-1", result: { ok: true } },
+        {
+          type: "surface",
+          messages: [
+            {
+              version: "v1.0",
+              createSurface: {
+                surfaceId: "answer-run-1",
+                catalogId: "urn:openneko:catalog:work:v2",
+                components: [
+                  { id: "root", component: "Answer", children: ["copy"] },
+                  { id: "copy", component: "Markdown", text: "Sales ranking" },
+                ],
+              },
+            },
+          ],
+        },
+        { type: "message", role: "assistant", content: "Maya leads by a clear margin." },
+        { type: "done" },
+      ],
+      "run-1",
+    );
+
+    expect(result.items.map((item) => item.kind)).toEqual([
+      "text",
+      "progress",
+      "tools",
+      "surface",
+      "text",
+    ]);
+    expect(result.items.filter((item) => item.kind === "text")).toEqual([
+      { kind: "text", content: "I’ll check the sales data." },
+      { kind: "text", content: "Maya leads by a clear margin." },
+    ]);
+  });
+
+  it("keeps provider progress detail behind its heading", async () => {
+    const source = await readFile(
+      fileURLToPath(new URL("../src/app/(work)/work/work-screen.tsx", import.meta.url)),
+      "utf8",
+    );
+    expect(source).toContain('import { Disclosure } from "@/components/ui/Disclosure";');
+    expect(source).toContain('className="work-progress-disclosure"');
+    expect(source).toContain('function splitProgressSections');
+    expect(source).not.toContain('meta={live && index === sections.length - 1 ? "Live" : undefined}');
+    expect(source).not.toContain('replace(/^#{1,6}\\s+/, "")');
+  });
+
+  it("turns plain provider headings into collapsed progress sections", () => {
+    const content = [
+      "Analyzing Sales Data",
+      "",
+      "I've begun analyzing the sales data.",
+      "",
+      "Comparing Bonus Structures",
+      "",
+      "The bonus structures differ across the top performers.",
+      "",
+      "Calculating Commission Impacts",
+      "",
+      "Commission has the larger impact.",
+      "",
+      "```json",
+      '{"neko_value":{"type":"text"}}',
+      "```",
+    ].join("\n");
+
+    expect(splitProgressSections(content)).toEqual([
+      {
+        heading: "Analyzing Sales Data",
+        detail: "I've begun analyzing the sales data.",
+      },
+      {
+        heading: "Comparing Bonus Structures",
+        detail: "The bonus structures differ across the top performers.",
+      },
+      {
+        heading: "Calculating Commission Impacts",
+        detail: [
+          "Commission has the larger impact.",
+          "",
+          "```json",
+          '{"neko_value":{"type":"text"}}',
+          "```",
+        ].join("\n"),
+      },
+    ]);
+  });
+
+  it("uses standalone strong Markdown as the visible provider heading", () => {
+    expect(
+      splitProgressSections([
+        "**Analyzing Successes and Needs**",
+        "",
+        "The render tool worked; now reviewing the closing blocks.",
+      ].join("\n")),
+    ).toEqual([
+      {
+        heading: "Analyzing Successes and Needs",
+        detail: "The render tool worked; now reviewing the closing blocks.",
+      },
+    ]);
+  });
+
+  it("keeps unstructured provider summaries available for inline display", async () => {
+    expect(splitProgressSections("Checked the latest sales totals.")).toEqual([
+      { heading: "Details", detail: "Checked the latest sales totals." },
+    ]);
+
+    const source = await readFile(
+      fileURLToPath(new URL("../src/app/(work)/work/work-screen.tsx", import.meta.url)),
+      "utf8",
+    );
+    expect(source).toContain('sections[0]?.heading === "Details"');
+    expect(source).toContain("linkifyWorkspacePaths(inlineSummary)");
+  });
+
+  it("keeps plain completed answers as prose and adds vitals only as evidence", () => {
+    const result = buildRunTimeline(
+      [
+        { type: "message", role: "assistant", content: "Maya is the top seller." },
+        {
+          type: "vitals",
+          items: [{ label: "Won revenue", value: "$1.2M", basis: "calculated" }],
+        },
+        { type: "done" },
+      ],
+      "run-1",
+    );
+
+    expect(result.items[0]).toEqual({
+      kind: "text",
+      content: "Maya is the top seller.",
+    });
+    expect(result.items[1]?.kind).toBe("surface");
+  });
+
+  it("replaces an earlier canonical answer when the agent retries with a new surface id", () => {
+    const result = buildRunTimeline(
+      [
+        {
+          type: "surface",
+          messages: [
+            {
+              version: "v1.0",
+              createSurface: {
+                surfaceId: "sales-report-01",
+                catalogId: "urn:openneko:catalog:work:v2",
+                components: [
+                  { id: "root", component: "Answer", title: "Sales performance" },
+                  { id: "table", component: "Table", rows: [] },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          type: "surface",
+          messages: [
+            {
+              version: "v1.0",
+              updateDataModel: {
+                surfaceId: "sales-report-01",
+                path: "/draft",
+                value: true,
+              },
+            },
+            {
+              version: "v1.0",
+              createSurface: {
+                surfaceId: "sales-report-02",
+                catalogId: "urn:openneko:catalog:work:v2",
+                components: [
+                  {
+                    id: "root",
+                    component: "Answer",
+                    title: "Sales performance",
+                    children: ["table"],
+                  },
+                  { id: "table", component: "Table", rows: [] },
+                ],
+              },
+            },
+            {
+              version: "v1.0",
+              updateDataModel: {
+                surfaceId: "sales-report-01",
+                path: "/late",
+                value: true,
+              },
+            },
+          ],
+        },
+      ],
+      "run-1",
+    );
+
+    const surface = result.items.find((item) => item.kind === "surface");
+    expect(surface?.kind).toBe("surface");
+    if (surface?.kind !== "surface") throw new Error("Expected surface");
+    expect(surface.messages).toHaveLength(1);
+    expect(surface.messages[0]).toMatchObject({
+      createSurface: { surfaceId: "sales-report-02" },
+    });
+  });
+
+  it("keeps distinct non-answer surfaces in the same run", () => {
+    const result = buildRunTimeline(
+      ["source-form", "confirmation"].map((surfaceId) => ({
+        type: "surface" as const,
+        messages: [
+          {
+            version: "v1.0" as const,
+            createSurface: {
+              surfaceId,
+              catalogId: "urn:openneko:catalog:work:v2",
+              components: [
+                { id: "root", component: "Answer", children: ["field"] },
+                { id: "field", component: "TextField", label: surfaceId },
+              ],
+            },
+          },
+        ],
+      })),
+      "run-1",
+    );
+
+    const surface = result.items.find((item) => item.kind === "surface");
+    expect(surface?.kind).toBe("surface");
+    if (surface?.kind !== "surface") throw new Error("Expected surface");
+    expect(surface.messages).toHaveLength(2);
+  });
+
   it("keeps auto-approved actions as a single ordinary tool row", () => {
     const items = toolItems([
       { type: "tool_start", id: "tool-1", name: "web_search" },

--- a/apps/worker/src/jobs/work-run.ts
+++ b/apps/worker/src/jobs/work-run.ts
@@ -2,7 +2,7 @@ import { ensureHostConfigProvisioned, type AgentEvent } from "@neko/llm";
 import { enqueue, QUEUE } from "@neko/db/jobs";
 import { db, eq, skill_usage } from "@neko/db";
 import {
-  agentRuntimeDepsFromEnv,
+  agentRuntimeDepsFromConfig,
   appendWorkRunEvent,
   ensureAgentBroker,
   getWorkRun,
@@ -91,7 +91,7 @@ export async function runWorkRun(
   // race with a gateway restart, this is the retry — memoized on success, so
   // the healthy path costs nothing. Without it, channel-triggered runs
   // stayed broken until a settings save or a worker restart.
-  await ensureHostConfigProvisioned(orgId);
+  const agentRuntime = await ensureHostConfigProvisioned(orgId);
 
   const broker = await ensureAgentBroker();
   const unregisterBrokerEvents = registerAgentBrokerEventSink(runId, emit);
@@ -108,7 +108,7 @@ export async function runWorkRun(
         pluginActions,
         observer: runTelemetry.observer,
       },
-      agentRuntimeDepsFromEnv(broker),
+      agentRuntimeDepsFromConfig(agentRuntime, broker),
     );
   } catch (cause) {
     await observeSafely(runTelemetry.observer, {

--- a/apps/worker/src/jobs/workflow-run-fire.ts
+++ b/apps/worker/src/jobs/workflow-run-fire.ts
@@ -9,7 +9,7 @@ import {
   ensureAgentBroker,
   registerAgentBrokerEventSink,
   scrubAgentEvent,
-  workflowRuntimeDepsFromEnv,
+  workflowRuntimeDepsFromConfig,
 } from "@neko/llm/work";
 import {
   boundedWorkflowApiResult,
@@ -396,7 +396,7 @@ export async function runWorkflowRunFire(
         observer: telemetry.observer,
       });
     } else {
-      await ensureHostConfigProvisioned(payload.orgId);
+      const agentRuntime = await ensureHostConfigProvisioned(payload.orgId);
       const pluginActions = includeRecordActionDescriptors(
         getPluginRegistryInstance()?.getRegisteredActionDescriptors() ?? [],
       );
@@ -437,7 +437,7 @@ export async function runWorkflowRunFire(
             pluginActions,
             observer: telemetry.observer,
           },
-          workflowRuntimeDepsFromEnv(broker),
+          workflowRuntimeDepsFromConfig(agentRuntime, broker),
         );
         const ceilingFailure = ceilingGuard?.failure();
         if (ceilingFailure) throw ceilingFailure;

--- a/apps/worker/test/jobs/workflow-run-fire.test.ts
+++ b/apps/worker/test/jobs/workflow-run-fire.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  ensureHostConfigProvisioned: vi.fn(async () => undefined),
+  ensureHostConfigProvisioned: vi.fn(async () => ({ modelHosts: [] })),
   claim: vi.fn(async () => true),
   complete: vi.fn(async () => undefined),
   link: vi.fn(async () => undefined),
@@ -28,7 +28,7 @@ vi.mock("@neko/llm/work", () => ({
   ensureAgentBroker: vi.fn(async () => ({})),
   registerAgentBrokerEventSink: vi.fn(() => () => undefined),
   scrubAgentEvent: vi.fn((_scrubber, event) => event),
-  workflowRuntimeDepsFromEnv: vi.fn(() => ({})),
+  workflowRuntimeDepsFromConfig: vi.fn(() => ({})),
 }));
 
 vi.mock("@neko/llm/workflows", () => ({

--- a/evals/semantic-inventory.yaml
+++ b/evals/semantic-inventory.yaml
@@ -4,6 +4,8 @@ schema_version: openneko.eval.semantic-inventory/v1
 # removes an item without assigning it at least one semantic owner here.
 agent_events:
   message: [OUTPUT-MESSAGE]
+  interim: [OUTPUT-MESSAGE, RUNTIME-STREAM]
+  progress: [OUTPUT-MESSAGE, RUNTIME-STREAM]
   tool_start: [RUNTIME-STREAM]
   tool_delta: [RUNTIME-STREAM]
   tool_end: [RUNTIME-STREAM]

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -10,6 +10,7 @@
     "./agent-runtime": "./src/agent-runtime.ts",
     "./sandbox-runtime": "./src/sandbox-runtime.ts",
     "./config": "./src/config.ts",
+    "./provider-runtime": "./src/provider-runtime.ts",
     "./secrets": "./src/secrets.ts",
     "./work": "./src/work/index.ts",
     "./config-vcs": "./src/config-vcs/public.ts",

--- a/packages/llm/src/agent-backend.ts
+++ b/packages/llm/src/agent-backend.ts
@@ -70,12 +70,27 @@ export type AgentEvent =
   // structured-output payloads (a2ui fences, tool-call JSON, etc.) here — use
   // the `surface` event for cards.
   | { type: "message"; role: "user" | "assistant"; content: string }
+  /** Hermes ACP's provider-neutral, model-authored mid-turn commentary. */
+  | { type: "interim"; id: string; content: string; source: "hermes_interim_assistant" }
   | { type: "tool_start"; id: string; name: string; input?: unknown }
   | { type: "tool_delta"; id: string; delta: unknown }
   | { type: "tool_end"; id: string; result?: unknown; error?: string }
   | { type: "surface"; messages: AgentSurfaceMessage[] }
   | { type: "artifact"; artifact: AgentArtifact }
   | { type: "status"; message: string }
+  | {
+      /**
+       * A provider-authored, user-visible summary of the current model step.
+       * This is never raw hidden reasoning and never comes from a second
+       * inference. Backends must emit it only when the provider explicitly
+       * labels the stream as a thought summary.
+       */
+      type: "progress";
+      id: string;
+      content: string;
+      source: "provider_summary";
+      provider: "google-gemini" | "anthropic";
+    }
   | {
       type: "usage";
       source: "outer" | "inner";

--- a/packages/llm/src/agent-backends/hermes-acp-client.ts
+++ b/packages/llm/src/agent-backends/hermes-acp-client.ts
@@ -15,10 +15,14 @@ export type AcpSessionUpdate =
   | {
       sessionUpdate: "agent_message_chunk";
       content: { type: "text"; text: string };
+      fieldMeta?: unknown;
+      _meta?: unknown;
     }
   | {
       sessionUpdate: "agent_thought_chunk";
       content: { type: "text"; text: string };
+      fieldMeta?: unknown;
+      _meta?: unknown;
     }
   | {
       sessionUpdate: "user_message_chunk";

--- a/packages/llm/src/agent-backends/hermes.ts
+++ b/packages/llm/src/agent-backends/hermes.ts
@@ -5,6 +5,7 @@ import { readFileSync } from "node:fs";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
 import {
   agentTurnTimeoutMs,
   type AgentBackend,
@@ -26,10 +27,60 @@ import {
   createAcpClient,
   type AcpClient,
   type AcpNotification,
+  type AcpSessionUpdate,
 } from "./hermes-acp-client";
 import { extractSurfaceMessages } from "./surface";
 
 export { extractSurfaceMessages } from "./surface";
+
+export type ProviderSummarySource = "google-gemini" | "anthropic";
+
+/**
+ * ACP calls every provider reasoning stream an `agent_thought_chunk`, so the
+ * generated per-org config is the trust boundary. Only providers whose native
+ * API explicitly defines these parts as user-visible summaries are exposed:
+ * Gemini includeThoughts and Anthropic thinking.display="summarized".
+ */
+export function providerThoughtSummarySource(
+  hermesHome: string | undefined,
+): ProviderSummarySource | null {
+  if (!hermesHome) return null;
+  try {
+    const config = parseYaml(
+      readFileSync(join(hermesHome, "config.yaml"), "utf8"),
+    ) as {
+      model?: { default?: unknown; provider?: unknown };
+      agent?: { reasoning_effort?: unknown };
+    } | null;
+    const provider = String(config?.model?.provider ?? "").trim().toLowerCase();
+    const model = String(config?.model?.default ?? "").trim().toLowerCase();
+    const effort = config?.agent?.reasoning_effort;
+    const disabled =
+      effort === false ||
+      ["none", "off", "false", "no", "0"].includes(
+        String(effort ?? "").trim().toLowerCase(),
+      );
+    if (
+      provider === "gemini" &&
+      model.startsWith("gemini") &&
+      effort !== undefined &&
+      !disabled
+    ) {
+      return "google-gemini";
+    }
+    if (
+      provider === "anthropic" &&
+      model.startsWith("claude-") &&
+      effort !== undefined &&
+      !disabled
+    ) {
+      return "anthropic";
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 /** Last error-ish lines of hermes' own agent.log — the file dies with the
  *  sandbox, so a mid-turn death must read it NOW or never. */
@@ -213,10 +264,6 @@ export class HermesBackend implements AgentBackend {
       ? `${prompt}\n\nCurrent user message:\n${userMessage}`
       : prompt;
 
-    if (onEvent) {
-      await onEvent({ type: "status", message: "Hermes is working…" });
-    }
-
     // Streaming turns normally cannot be retried because replaying tool and
     // message events would duplicate visible work. A completely empty ACP
     // turn is the exception: runOnce marks it retryable only when Hermes
@@ -356,6 +403,9 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
   if (orgId) {
     env.HERMES_HOME = hermesHomeForOrg(orgId);
   }
+  const providerSummarySource = providerThoughtSummarySource(
+    env.HERMES_HOME,
+  );
   // A hard native crash (SIGSEGV/SIGABRT in compiled deps) dies without a
   // Python traceback — faulthandler makes it dump one to stderr, which the
   // mid-turn death message below surfaces.
@@ -498,6 +548,8 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
     let surfaceEmittedDuringStream = false;
     let toolActivityObserved = false;
     const pendingValidRenderToolCalls = new Map<string, unknown>();
+    let pendingProviderSummary = "";
+    let providerSummarySequence = 0;
     let eventQueue = Promise.resolve();
     let eventError: Error | undefined;
     const emitQueued = (event: AgentEvent): void => {
@@ -510,6 +562,28 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
         }
       });
     };
+    const flushProviderSummary = (): void => {
+      const content = pendingProviderSummary.trim();
+      pendingProviderSummary = "";
+      if (!content || !onEvent) return;
+      providerSummarySequence += 1;
+      emitQueued({
+        type: "progress",
+        id: `${providerSummarySource}-summary-${sessionId}-${providerSummarySequence}`,
+        content,
+        source: "provider_summary",
+        provider: providerSummarySource!,
+      });
+    };
+    let interimSequence = 0;
+    const interimMeta = (update: AcpSessionUpdate): { alreadyStreamed: boolean } | null => {
+      if (update.sessionUpdate !== "agent_message_chunk") return null;
+      const meta = (update.fieldMeta ?? update._meta) as { hermes?: { interim?: unknown; already_streamed?: unknown } } | undefined;
+      const marker = meta?.hermes;
+      return marker?.interim === true
+        ? { alreadyStreamed: marker.already_streamed === true }
+        : null;
+    };
 
     client.onNotification((notif) => {
       const update = notif.update;
@@ -517,6 +591,20 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
         case "agent_message_chunk": {
           const text = update.content?.text ?? "";
           if (!text) return;
+          const interim = interimMeta(update);
+          if (interim) {
+            if (!interim.alreadyStreamed && onEvent) {
+              interimSequence += 1;
+              emitQueued({
+                type: "interim",
+                id: `hermes-interim-${sessionId}-${interimSequence}`,
+                content: text,
+                source: "hermes_interim_assistant",
+              });
+            }
+            return;
+          }
+          flushProviderSummary();
           accumulatedText += text;
           if (onEvent) {
             const outside = outsideFenceText(accumulatedText);
@@ -529,11 +617,20 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
           return;
         }
         case "agent_thought_chunk": {
-          if (debug) emitQueued({ type: "status", message: "Thinking…" });
+          if (providerSummarySource) {
+            const remaining = 6_000 - pendingProviderSummary.length;
+            if (remaining > 0) {
+              pendingProviderSummary += (update.content?.text ?? "").slice(
+                0,
+                remaining,
+              );
+            }
+          }
           return;
         }
         case "tool_call": {
           toolActivityObserved = true;
+          flushProviderSummary();
           if (!onEvent) return;
           // The brokered neko_ui server is the sole surface emitter. Suppress
           // a successful render's tool pill, but preserve the exact rejected
@@ -631,6 +728,7 @@ async function runOnce(args: RunOnceArgs): Promise<RunOnceOutcome> {
       });
       promptStopReason = promptResponse.stopReason;
       promptUsage = normalizeHermesUsage(promptResponse.usage);
+      flushProviderSummary();
     } catch (e) {
       if (e instanceof AcpProtocolError) {
         promptError = `hermes: ${e.message}`;

--- a/packages/llm/src/config.ts
+++ b/packages/llm/src/config.ts
@@ -121,7 +121,8 @@ export function getPrimaryProviderFields(provider: PrimaryProviderId): SettingsF
           label: "Base URL",
           kind: "url",
           required: true,
-          placeholder: "http://localhost:11434",
+          placeholder: "http://host.docker.internal:11434/v1",
+          help: "Use host.docker.internal for Ollama running on the OpenNeko host, or a remote OpenAI-compatible URL.",
         },
       ];
     case "azure-openai":
@@ -156,7 +157,7 @@ export function getPrimaryProviderFields(provider: PrimaryProviderId): SettingsF
           kind: "text",
           required: true,
           placeholder: "my-gcp-project",
-          help: "Uses Google Application Default Credentials from gcloud or GOOGLE_APPLICATION_CREDENTIALS.",
+          help: "OpenNeko uses host-side Google Application Default Credentials to mint a short-lived token; the agent sandbox never receives the credential.",
         },
         {
           key: "region",

--- a/packages/llm/src/host-provision.ts
+++ b/packages/llm/src/host-provision.ts
@@ -16,10 +16,18 @@ import {
 } from "@neko/db";
 import { maybeDecryptSecret } from "./secrets";
 import { VENDORED_HERMES_MODEL_BINARY } from "./agent-runtime-contract";
+import { isPrimaryProvider } from "./config";
 import { hermesHomeForOrg } from "./hermes-home";
+import { getGoogleToken } from "./llm";
+import {
+  resolveHermesProviderRuntime,
+  type HermesProviderRuntime,
+  type ProviderEndpoint,
+} from "./provider-runtime";
 import {
   ensureOpenShellProvider,
   verifyOpenShellGateway,
+  type AgentRuntimeLaunchConfig,
 } from "./work/sandbox-launcher";
 
 const HERMES_DEFAULT_MAX_TURNS = 25;
@@ -270,40 +278,6 @@ async function provisionGraphjinSourcesMode(orgId: string): Promise<void> {
   }
 }
 
-function mapHermesProvider(neko: string): {
-  provider: string;
-  keyVar: string;
-  needsBaseUrl: boolean;
-} {
-  switch (neko) {
-    case "anthropic":
-      return { provider: "anthropic", keyVar: "ANTHROPIC_API_KEY", needsBaseUrl: false };
-    case "openai":
-      return { provider: "openai", keyVar: "OPENAI_API_KEY", needsBaseUrl: false };
-    case "openrouter":
-      return { provider: "openrouter", keyVar: "OPENROUTER_API_KEY", needsBaseUrl: false };
-    case "google-gemini":
-      return { provider: "gemini", keyVar: "GEMINI_API_KEY", needsBaseUrl: false };
-    case "vertex":
-      return { provider: "custom", keyVar: "OPENAI_API_KEY", needsBaseUrl: true };
-    case "x-grok":
-      return { provider: "openrouter", keyVar: "OPENROUTER_API_KEY", needsBaseUrl: false };
-    case "ollama":
-    case "azure-openai":
-      return {
-        provider: "custom",
-        keyVar: `${neko.toUpperCase().replace(/-/g, "_")}_API_KEY`,
-        needsBaseUrl: true,
-      };
-    default:
-      return {
-        provider: neko,
-        keyVar: `${neko.toUpperCase().replace(/-/g, "_")}_API_KEY`,
-        needsBaseUrl: false,
-      };
-  }
-}
-
 function decryptSecrets(secrets: Record<string, unknown> | null): Record<string, string> {
   if (!secrets) return {};
   const out: Record<string, string> = {};
@@ -376,6 +350,30 @@ function hermesDelegationConfigLines(): string[] {
   ];
 }
 
+export function hermesNativeReasoningConfigLines(nekoProvider: string): string[] {
+  if (nekoProvider === "anthropic" || nekoProvider === "google-gemini") {
+    // Keep native provider summaries consistently enabled during tool-heavy
+    // runs. Lower effort can let a model skip thinking on individual steps,
+    // which makes otherwise active runs appear silent.
+    return ['  reasoning_effort: "high"'];
+  }
+  return [];
+}
+
+export function hermesModelConfigLines(runtime: HermesProviderRuntime): string[] {
+  const lines = [
+    "model:",
+    `  default: "${escapeYamlString(runtime.model)}"`,
+    `  provider: "${runtime.provider}"`,
+    `  base_url: "${escapeYamlString(runtime.baseUrl)}"`,
+  ];
+  if (runtime.apiMode) lines.push(`  api_mode: "${runtime.apiMode}"`);
+  if (runtime.provider === "custom" && runtime.keyEnv) {
+    lines.push(`  api_key: "\${${runtime.keyEnv}}"`);
+  }
+  return lines;
+}
+
 async function provisionHermes(orgId: string): Promise<void> {
   const row = await loadProviderRow(orgId, "primary");
   const hermesHome = hermesHomeForOrg(orgId);
@@ -387,36 +385,35 @@ async function provisionHermes(orgId: string): Promise<void> {
     return;
   }
 
-  const { provider, keyVar, needsBaseUrl } = mapHermesProvider(row.provider);
-  const cfg = (row.config ?? {}) as { url?: string; baseUrl?: string };
-  const baseUrl = cfg.baseUrl || cfg.url;
+  if (!isPrimaryProvider(row.provider)) {
+    throw new Error(`Unsupported primary provider: ${row.provider}`);
+  }
+  const runtime = resolveHermesProviderRuntime({
+    provider: row.provider,
+    model: row.model ?? "",
+    config: row.config,
+  });
   const secrets = decryptSecrets(row.secrets);
   const apiKey = secrets.apiKey;
-  const model = row.model ?? "";
 
   await mkdir(hermesHome, { recursive: true });
 
-  const yamlLines = [
-    "model:",
-    `  default: "${escapeYamlString(model)}"`,
-    `  provider: "${provider}"`,
-  ];
-  if (baseUrl) yamlLines.push(`  base_url: "${escapeYamlString(baseUrl)}"`);
-  if (provider === "custom" && needsBaseUrl && !baseUrl) {
-    console.warn(
-      `[host-provision] hermes: provider=custom but no base_url for ${row.provider}; user must add it in /admin/settings/agent`,
-    );
-  }
+  const yamlLines = hermesModelConfigLines(runtime);
   yamlLines.push("");
   yamlLines.push("agent:");
   yamlLines.push(`  max_turns: ${HERMES_DEFAULT_MAX_TURNS}`);
+  // Hermes translates this into the provider's native thinking controls on
+  // the same request. Gemini receives includeThoughts=true; Anthropic receives
+  // thinking.display="summarized". Neither path makes a second model call or
+  // asks the model to narrate progress in the prompt.
+  yamlLines.push(...hermesNativeReasoningConfigLines(row.provider));
   yamlLines.push("");
   yamlLines.push(...hermesDelegationConfigLines());
   yamlLines.push("");
 
   await atomicWriteFile(join(hermesHome, "config.yaml"), yamlLines.join("\n"));
 
-  const envContent = apiKey ? `${keyVar}=${apiKey}\n` : "";
+  const envContent = apiKey && runtime.keyEnv ? `${runtime.keyEnv}=${apiKey}\n` : "";
   await atomicWriteFile(join(hermesHome, ".env"), envContent, { mode: 0o600 });
   await chmod(join(hermesHome, ".env"), 0o600);
 }
@@ -424,17 +421,6 @@ async function provisionHermes(orgId: string): Promise<void> {
 function escapeYamlString(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }
-
-// API host per neko model-provider when there's no explicit base_url. A handful
-// of providers (NOT the 300 model variants) — derived from the org's config,
-// never hand-set per deployment.
-const PROVIDER_API_HOSTS: Record<string, string> = {
-  "google-gemini": "generativelanguage.googleapis.com",
-  anthropic: "api.anthropic.com",
-  openai: "api.openai.com",
-  openrouter: "openrouter.ai",
-  "x-grok": "openrouter.ai",
-};
 
 /**
  * Derive the agent-sandbox egress from the org's model config: the API host
@@ -444,21 +430,18 @@ const PROVIDER_API_HOSTS: Record<string, string> = {
  */
 function deriveAgentEgress(
   row: StoredRow,
-): { hosts: string[]; keyEnv: string } {
-  const cfg = (row.config ?? {}) as { url?: string; baseUrl?: string };
-  const baseUrl = cfg.baseUrl || cfg.url;
-  let host: string | undefined;
-  if (baseUrl) {
-    try {
-      host = new URL(baseUrl).host;
-    } catch {
-      /* fall through to the provider default */
-    }
+): { endpoints: ProviderEndpoint[]; runtime: HermesProviderRuntime } {
+  if (!isPrimaryProvider(row.provider)) {
+    throw new Error(`Unsupported primary provider: ${row.provider}`);
   }
-  host ??= PROVIDER_API_HOSTS[row.provider];
+  const runtime = resolveHermesProviderRuntime({
+    provider: row.provider,
+    model: row.model ?? "",
+    config: row.config,
+  });
   return {
-    hosts: [...(host ? [host] : []), "models.dev"],
-    keyEnv: mapHermesProvider(row.provider).keyVar,
+    endpoints: [runtime.endpoint, { host: "models.dev" }],
+    runtime,
   };
 }
 
@@ -470,13 +453,10 @@ function deriveAgentEgress(
  * provider create` + hand-set egress env.
  */
 // Operator-supplied provider/host/key/home values win permanently; empty or
-// unset means "derive from the org's provider config". The model executable is
-// intentionally absent: it is a vendored runtime contract, never an operator
-// setting. Values here are snapshotted at module load,
-// BEFORE any provisioning pass mutates process.env — the previous `||=`
-// writes made the FIRST pass's derived values permanent, so a provider
-// switch left the sandbox egress allowlist and key env var pinned to the old
-// provider until the process restarted.
+// unset means "derive from the org's provider config". These values are
+// read-only. Persisted provider settings must never be copied into process.env:
+// Next.js can evaluate route bundles at different times, causing one bundle to
+// mistake another bundle's derived values for operator overrides.
 const OPERATOR_AGENT_ENV = {
   provider: process.env.OPENNEKO_AGENT_MODEL_PROVIDER || "",
   host: process.env.OPENNEKO_AGENT_MODEL_HOST || "",
@@ -484,55 +464,90 @@ const OPERATOR_AGENT_ENV = {
   hermesHome: process.env.OPENNEKO_AGENT_HERMES_HOME || "",
 };
 
-function setAgentEnv(key: string, operator: string, derived: string): void {
-  const value = operator || derived;
-  if (value) process.env[key] = value;
-  else delete process.env[key];
+function modelHosts(value: string): ProviderEndpoint[] {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      if (entry.includes("://")) {
+        const url = new URL(entry);
+        return {
+          host: url.hostname,
+          ...(url.port
+            ? { port: Number(url.port) }
+            : url.protocol === "http:"
+              ? { port: 80 }
+              : {}),
+        };
+      }
+      const hostPort = /^(.*):(\d+)$/.exec(entry);
+      return hostPort
+        ? { host: hostPort[1]!, port: Number(hostPort[2]) }
+        : { host: entry };
+    });
 }
 
-async function provisionOpenShellRuntime(orgId: string): Promise<void> {
+function serializeModelEndpoint(endpoint: ProviderEndpoint): string {
+  return endpoint.port ? `${endpoint.host}:${endpoint.port}` : endpoint.host;
+}
+
+export function gatewayProviderName(orgId: string): string {
+  return `openneko-agent-${createHash("sha256").update(orgId).digest("hex").slice(0, 16)}`;
+}
+
+function agentRuntimeLaunchConfig(args: {
+  orgId: string;
+  derivedEndpoints?: ProviderEndpoint[];
+  derivedKeyEnv?: string;
+  hasApiKey: boolean;
+}): AgentRuntimeLaunchConfig {
+  const derivedEndpoints = args.derivedEndpoints ?? [];
+  const keyEnv = OPERATOR_AGENT_ENV.keyEnv || args.derivedKeyEnv || "";
+  const credentialName =
+    process.env.OPENNEKO_AGENT_MODEL_CREDENTIAL || "api_key";
+  const modelProvider =
+    OPERATOR_AGENT_ENV.provider ||
+    (args.hasApiKey ? gatewayProviderName(args.orgId) : "");
+  const hermesHome =
+    OPERATOR_AGENT_ENV.hermesHome ||
+    (derivedEndpoints.length > 0 ? hermesHomeForOrg(args.orgId) : "");
+
+  return {
+    ...(modelProvider ? { modelProvider } : {}),
+    modelHosts: OPERATOR_AGENT_ENV.host
+      ? modelHosts(OPERATOR_AGENT_ENV.host)
+      : derivedEndpoints,
+    ...(keyEnv
+      ? { keyAliases: [{ from: credentialName, to: keyEnv }] }
+      : {}),
+    ...(hermesHome ? { hermesHomeHostPath: hermesHome } : {}),
+  };
+}
+
+async function provisionOpenShellRuntime(
+  orgId: string,
+): Promise<AgentRuntimeLaunchConfig> {
   const row = await loadProviderRow(orgId, "primary");
   if (!row || !row.enabled) {
-    setAgentEnv(
-      "OPENNEKO_AGENT_MODEL_PROVIDER",
-      OPERATOR_AGENT_ENV.provider,
-      "",
-    );
-    setAgentEnv("OPENNEKO_AGENT_MODEL_HOST", OPERATOR_AGENT_ENV.host, "");
-    setAgentEnv(
-      "OPENNEKO_AGENT_MODEL_KEY_ENV",
-      OPERATOR_AGENT_ENV.keyEnv,
-      "",
-    );
-    setAgentEnv(
-      "OPENNEKO_AGENT_HERMES_HOME",
-      OPERATOR_AGENT_ENV.hermesHome,
-      "",
-    );
-    return;
+    return agentRuntimeLaunchConfig({ orgId, hasApiKey: false });
   }
 
-  const { hosts, keyEnv } = deriveAgentEgress(row);
-  const apiKey = decryptSecrets(row.secrets).apiKey;
-  setAgentEnv(
-    "OPENNEKO_AGENT_MODEL_PROVIDER",
-    OPERATOR_AGENT_ENV.provider,
-    apiKey ? "openneko-agent" : "",
-  );
-  setAgentEnv("OPENNEKO_AGENT_MODEL_HOST", OPERATOR_AGENT_ENV.host, hosts.join(","));
-  setAgentEnv("OPENNEKO_AGENT_MODEL_KEY_ENV", OPERATOR_AGENT_ENV.keyEnv, keyEnv);
-  // hermes reads its model + provider from config.yaml under HERMES_HOME. In the
-  // sandbox that config must be MIRRORED in — the launcher does so when
-  // OPENNEKO_AGENT_HERMES_HOME points at the host home provisionHermes writes.
-  // Without it, in-box hermes finds no config and silently falls back to a
-  // default model that 404s.
-  setAgentEnv(
-    "OPENNEKO_AGENT_HERMES_HOME",
-    OPERATOR_AGENT_ENV.hermesHome,
-    hermesHomeForOrg(orgId),
-  );
+  const { endpoints, runtime } = deriveAgentEgress(row);
+  const apiKey =
+    runtime.credentialSource === "google-adc"
+      ? await getGoogleToken()
+      : runtime.credentialSource === "stored-api-key"
+        ? decryptSecrets(row.secrets).apiKey
+        : undefined;
+  const launchConfig = agentRuntimeLaunchConfig({
+    orgId,
+    derivedEndpoints: endpoints,
+    derivedKeyEnv: runtime.keyEnv,
+    hasApiKey: Boolean(apiKey),
+  });
 
-  if (!apiKey) return;
+  if (!apiKey) return launchConfig;
   // The gateway can be restarting exactly while we register the provider
   // (deploys recreate it alongside the worker). A single failed attempt
   // used to be swallowed upstream, leaving a healthy worker with no
@@ -541,7 +556,7 @@ async function provisionOpenShellRuntime(orgId: string): Promise<void> {
   for (let attempt = 1; attempt <= 3; attempt++) {
     try {
       await ensureOpenShellProvider({
-        providerName: process.env.OPENNEKO_AGENT_MODEL_PROVIDER ?? "openneko-agent",
+        providerName: launchConfig.modelProvider ?? "openneko-agent",
         apiKey,
         gatewayName: process.env.OPENSHELL_GATEWAY || undefined,
         gatewayEndpoint: process.env.OPENSHELL_GATEWAY_ENDPOINT || undefined,
@@ -561,8 +576,9 @@ async function provisionOpenShellRuntime(orgId: string): Promise<void> {
   }
   if (lastError !== undefined) throw lastError;
   console.log(
-    `[host-provision] OpenShell agent runtime self-configured: provider="${process.env.OPENNEKO_AGENT_MODEL_PROVIDER}" egress="${hosts.join(",")}" binary="${VENDORED_HERMES_MODEL_BINARY}" keyEnv=${keyEnv}`,
+    `[host-provision] OpenShell agent runtime self-configured: provider="${launchConfig.modelProvider ?? ""}" egress="${launchConfig.modelHosts?.map(serializeModelEndpoint).join(",") ?? ""}" binary="${VENDORED_HERMES_MODEL_BINARY}" keyEnv=${launchConfig.keyAliases?.[0]?.to ?? ""}`,
   );
+  return launchConfig;
 }
 
 /**
@@ -584,7 +600,8 @@ export async function verifyAgentRuntimeReady(orgId: string): Promise<void> {
 
 type HostProvisionState = {
   appliedRevision?: string;
-  tail: Promise<void>;
+  launchConfig?: AgentRuntimeLaunchConfig;
+  tail: Promise<AgentRuntimeLaunchConfig>;
 };
 
 const provisionedOrgs = new Map<string, HostProvisionState>();
@@ -597,7 +614,9 @@ type ProvisionHostConfigOptions = {
 /** Build a content revision without retaining provider secrets in process
  * state. Every setting that changes the files or sandbox launch contract is
  * covered, including same-provider key rotation. */
-async function hostConfigRevision(orgId: string): Promise<string> {
+async function hostConfigRevision(
+  orgId: string,
+): Promise<{ revision: string; refreshCredential: boolean }> {
   const [providers, sources] = await Promise.all([
     db()
       .select({
@@ -633,9 +652,17 @@ async function hostConfigRevision(orgId: string): Promise<string> {
       .orderBy(desc(data_source.is_default), data_source.created_at),
   ]);
 
-  return createHash("sha256")
-    .update(JSON.stringify({ providers, sources }))
-    .digest("hex");
+  return {
+    revision: createHash("sha256")
+      .update(JSON.stringify({ providers, sources }))
+      .digest("hex"),
+    // Vertex access tokens are short-lived. Re-mint and replace the
+    // gateway-side credential for every run instead of memoizing it like a
+    // static API key. The token remains outside the sandbox.
+    refreshCredential: providers.some(
+      (provider) => provider.scope === "primary" && provider.provider === "vertex",
+    ),
+  };
 }
 
 /**
@@ -647,34 +674,57 @@ async function hostConfigRevision(orgId: string): Promise<string> {
  * worker. Calls for one org are serialized so a key rotation or provider
  * family switch cannot race two writers against the same Hermes files.
  */
-export async function ensureHostConfigProvisioned(orgId: string): Promise<void> {
-  const requestedRevision = await hostConfigRevision(orgId);
+export async function ensureHostConfigProvisioned(
+  orgId: string,
+): Promise<AgentRuntimeLaunchConfig> {
+  const requested = await hostConfigRevision(orgId);
   let state = provisionedOrgs.get(orgId);
   if (!state) {
-    state = { tail: Promise.resolve() };
+    state = {
+      tail: Promise.resolve(
+        agentRuntimeLaunchConfig({ orgId, hasApiKey: false }),
+      ),
+    };
     provisionedOrgs.set(orgId, state);
   }
-  if (state.appliedRevision === requestedRevision) return;
+  if (
+    state.appliedRevision === requested.revision &&
+    state.launchConfig &&
+    !requested.refreshCredential
+  ) {
+    return state.launchConfig;
+  }
 
-  const run = state.tail.catch(() => undefined).then(async () => {
+  const provisionState = state;
+  const run = provisionState.tail.catch(() =>
+    agentRuntimeLaunchConfig({ orgId, hasApiKey: false }),
+  ).then(async () => {
     // Re-read after earlier callers finish. A settings save may have landed
     // while this call was queued, and only the newest revision should win.
-    const currentRevision = await hostConfigRevision(orgId);
-    if (state.appliedRevision === currentRevision) return;
-    await provisionHostConfig(orgId, {
+    const current = await hostConfigRevision(orgId);
+    if (
+      provisionState.appliedRevision === current.revision &&
+      provisionState.launchConfig &&
+      !current.refreshCredential
+    ) {
+      return provisionState.launchConfig;
+    }
+    const launchConfig = await provisionHostConfig(orgId, {
       requireOpenShellSync: true,
       requireHermesSync: true,
     });
-    state.appliedRevision = currentRevision;
+    provisionState.appliedRevision = current.revision;
+    provisionState.launchConfig = launchConfig;
+    return launchConfig;
   });
-  state.tail = run;
-  await run;
+  provisionState.tail = run;
+  return run;
 }
 
 export async function provisionHostConfig(
   orgId: string,
   options: ProvisionHostConfigOptions = {},
-): Promise<void> {
+): Promise<AgentRuntimeLaunchConfig> {
   try {
     await provisionGraphJin(orgId);
   } catch (e) {
@@ -692,8 +742,9 @@ export async function provisionHostConfig(
   }
 
   let openShellError: unknown;
+  let launchConfig = agentRuntimeLaunchConfig({ orgId, hasApiKey: false });
   try {
-    await provisionOpenShellRuntime(orgId);
+    launchConfig = await provisionOpenShellRuntime(orgId);
   } catch (e) {
     openShellError = e;
     console.warn(
@@ -717,4 +768,5 @@ export async function provisionHostConfig(
   if (hermesError && options.requireHermesSync) {
     throw hermesError;
   }
+  return launchConfig;
 }

--- a/packages/llm/src/interaction/from-agent-event.ts
+++ b/packages/llm/src/interaction/from-agent-event.ts
@@ -58,12 +58,16 @@ const mapOne = (event: AgentEvent, gen: IdGen): InteractionEvent[] => {
   switch (event.type) {
     case "message":
       return event.role === "assistant" ? [{ kind: "converse", id: gen(), role: "assistant", text: event.content }] : [];
+    case "interim":
+      return [{ kind: "converse", id: event.id, role: "assistant", text: event.content }];
     case "tool_start":
       return [{ kind: "progress", id: event.id, label: event.name, phase: "start" }];
     case "tool_end":
       return [{ kind: "progress", id: event.id, label: event.id, phase: "end" }];
     case "status":
       return [{ kind: "progress", id: gen(), label: event.message, phase: "start" }];
+    case "progress":
+      return [{ kind: "progress", id: event.id, label: event.content, phase: "start" }];
     case "surface":
       return [informFromSurface(event.messages, gen())];
     case "artifact":

--- a/packages/llm/src/llm.ts
+++ b/packages/llm/src/llm.ts
@@ -10,6 +10,7 @@ import {
 } from "./config";
 import { maybeDecryptSecret } from "./secrets";
 import { GoogleAuth } from "google-auth-library";
+import { vertexOpenAiBaseUrl } from "./provider-runtime";
 
 type ProviderSource = "org" | "env" | "default" | "draft";
 
@@ -211,9 +212,7 @@ export async function getGoogleToken(): Promise<string> {
 }
 
 function buildVertexApiUrl(config: ResolvedPrimaryProviderConfig): string {
-  const projectId = String(config.config.projectId ?? "").trim();
-  const region = String(config.config.region ?? "global").trim() || "global";
-  return `https://aiplatform.googleapis.com/v1/projects/${projectId}/locations/${region}/endpoints/openapi`;
+  return vertexOpenAiBaseUrl(config.config);
 }
 
 function toAxProviderName(provider: PrimaryProviderId): string {

--- a/packages/llm/src/provider-runtime.ts
+++ b/packages/llm/src/provider-runtime.ts
@@ -1,0 +1,202 @@
+import type { PrimaryProviderId } from "./config";
+
+export type ProviderCredentialSource = "stored-api-key" | "google-adc" | "none";
+
+export type ProviderEndpoint = {
+  host: string;
+  port?: number;
+};
+
+export type HermesProviderRuntime = {
+  provider: string;
+  model: string;
+  baseUrl: string;
+  keyEnv?: string;
+  apiMode?: "chat_completions";
+  credentialSource: ProviderCredentialSource;
+  endpoint: ProviderEndpoint;
+};
+
+function requiredConfig(config: Record<string, unknown>, key: string, label: string): string {
+  const value = typeof config[key] === "string" ? config[key].trim() : "";
+  if (!value) throw new Error(`${label} is required.`);
+  return value;
+}
+
+function endpointFromUrl(baseUrl: string): ProviderEndpoint {
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    throw new Error(`Invalid provider Base URL: ${baseUrl}`);
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    throw new Error(`Provider Base URL must use http or https: ${baseUrl}`);
+  }
+  return {
+    host: url.hostname,
+    ...(url.port
+      ? { port: Number(url.port) }
+      : url.protocol === "http:"
+        ? { port: 80 }
+        : {}),
+  };
+}
+
+function fixedRuntime(
+  provider: string,
+  model: string,
+  baseUrl: string,
+  keyEnv: string,
+): HermesProviderRuntime {
+  return {
+    provider,
+    model,
+    baseUrl,
+    keyEnv,
+    credentialSource: "stored-api-key",
+    endpoint: endpointFromUrl(baseUrl),
+  };
+}
+
+function azureBaseUrl(config: Record<string, unknown>): string {
+  const resourceName = requiredConfig(config, "resourceName", "Azure resource name");
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i.test(resourceName)) {
+    throw new Error("Azure resource name contains invalid characters.");
+  }
+  return `https://${resourceName}.openai.azure.com/openai/v1`;
+}
+
+export function vertexOpenAiBaseUrl(config: Record<string, unknown>): string {
+  const projectId = requiredConfig(config, "projectId", "GCP project ID");
+  const region = requiredConfig(config, "region", "Vertex region");
+  if (!/^[a-z0-9][a-z0-9-.:]{0,126}$/i.test(projectId)) {
+    throw new Error("GCP project ID contains invalid characters.");
+  }
+  if (!/^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/i.test(region)) {
+    throw new Error("Vertex region contains invalid characters.");
+  }
+  const host = region === "global" ? "aiplatform.googleapis.com" : `${region}-aiplatform.googleapis.com`;
+  return `https://${host}/v1beta1/projects/${encodeURIComponent(projectId)}/locations/${encodeURIComponent(region)}/endpoints/openapi`;
+}
+
+function ollamaBaseUrl(config: Record<string, unknown>): string {
+  const configured = requiredConfig(config, "url", "Ollama Base URL");
+  let url: URL;
+  try {
+    url = new URL(configured);
+  } catch {
+    throw new Error(`Invalid Ollama Base URL: ${configured}`);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("Ollama Base URL must use http or https.");
+  }
+
+  // The model runs in an OpenShell sandbox, so loopback points at the
+  // sandbox itself. Route host-local Ollama through Docker's host gateway.
+  if (["localhost", "127.0.0.1", "[::1]", "::1"].includes(url.hostname)) {
+    url.hostname = "host.docker.internal";
+  }
+  if (url.pathname === "/" || url.pathname === "") url.pathname = "/v1";
+  return url.toString().replace(/\/$/, "");
+}
+
+/**
+ * OpenNeko's complete Admin-provider -> Hermes 0.21 runtime contract.
+ *
+ * Keep this exhaustive. A provider must not appear in Admin unless it has an
+ * explicit Hermes identity, credential source, base URL and sandbox endpoint.
+ */
+export function resolveHermesProviderRuntime(args: {
+  provider: PrimaryProviderId;
+  model: string;
+  config?: Record<string, unknown> | null;
+}): HermesProviderRuntime {
+  const config = args.config ?? {};
+
+  switch (args.provider) {
+    case "openai":
+      // In Hermes 0.21, bare `openai` is intentionally an OpenRouter alias.
+      return fixedRuntime("openai-api", args.model, "https://api.openai.com/v1", "OPENAI_API_KEY");
+    case "anthropic":
+      return fixedRuntime("anthropic", args.model, "https://api.anthropic.com", "ANTHROPIC_API_KEY");
+    case "google-gemini":
+      return fixedRuntime("gemini", args.model, "https://generativelanguage.googleapis.com/v1beta", "GEMINI_API_KEY");
+    case "azure-openai": {
+      const baseUrl = azureBaseUrl(config);
+      return {
+        ...fixedRuntime(
+          "azure-foundry",
+          requiredConfig(config, "deploymentName", "Azure deployment name"),
+          baseUrl,
+          "AZURE_FOUNDRY_API_KEY",
+        ),
+        apiMode: "chat_completions",
+      };
+    }
+    // Hermes 0.21 does not register these four vendor slugs as runtime
+    // providers. Their APIs are OpenAI-compatible, so route them through the
+    // explicit custom transport instead of letting Hermes fail with
+    // "Unknown provider" before making a request.
+    case "mistral":
+      return {
+        ...fixedRuntime("custom", args.model, "https://api.mistral.ai/v1", "MISTRAL_API_KEY"),
+        apiMode: "chat_completions",
+      };
+    case "groq":
+      return {
+        ...fixedRuntime("custom", args.model, "https://api.groq.com/openai/v1", "GROQ_API_KEY"),
+        apiMode: "chat_completions",
+      };
+    case "cohere":
+      return {
+        ...fixedRuntime(
+          "custom",
+          args.model,
+          "https://api.cohere.ai/compatibility/v1",
+          "COHERE_API_KEY",
+        ),
+        apiMode: "chat_completions",
+      };
+    case "together":
+      return {
+        ...fixedRuntime("custom", args.model, "https://api.together.ai/v1", "TOGETHER_API_KEY"),
+        apiMode: "chat_completions",
+      };
+    case "deepseek":
+      return fixedRuntime("deepseek", args.model, "https://api.deepseek.com/v1", "DEEPSEEK_API_KEY");
+    case "ollama": {
+      const baseUrl = ollamaBaseUrl(config);
+      return {
+        provider: "custom",
+        model: args.model,
+        baseUrl,
+        apiMode: "chat_completions",
+        credentialSource: "none",
+        endpoint: endpointFromUrl(baseUrl),
+      };
+    }
+    case "huggingface":
+      return fixedRuntime("huggingface", args.model, "https://router.huggingface.co/v1", "HF_TOKEN");
+    case "openrouter":
+      return fixedRuntime("openrouter", args.model, "https://openrouter.ai/api/v1", "OPENROUTER_API_KEY");
+    case "reka": {
+      const runtime = fixedRuntime("custom", args.model, "https://api.reka.ai/v1", "REKA_API_KEY");
+      return { ...runtime, apiMode: "chat_completions" };
+    }
+    case "x-grok":
+      return fixedRuntime("xai", args.model, "https://api.x.ai/v1", "XAI_API_KEY");
+    case "vertex": {
+      const baseUrl = vertexOpenAiBaseUrl(config);
+      return {
+        provider: "custom",
+        model: args.model,
+        baseUrl,
+        keyEnv: "VERTEX_ACCESS_TOKEN",
+        apiMode: "chat_completions",
+        credentialSource: "google-adc",
+        endpoint: endpointFromUrl(baseUrl),
+      };
+    }
+  }
+}

--- a/packages/llm/src/work/a2ui-contract.ts
+++ b/packages/llm/src/work/a2ui-contract.ts
@@ -107,10 +107,42 @@ export type RenderInputValidation =
       issues: Array<{ path: string; code: string; message: string }>;
     };
 
+function generatedSurfaceGraphIssues(
+  messages: RenderCardsArgs["messages"],
+): Array<{ path: string; code: string; message: string }> {
+  const issues: Array<{ path: string; code: string; message: string }> = [];
+  messages.forEach((message, index) => {
+    if (!("createSurface" in message)) return;
+    const components = message.createSurface.components;
+    if (!components) return;
+    const root = components.find((component) => component.id === "root");
+    if (!root) {
+      issues.push({
+        path: `messages.${index}.createSurface.components`,
+        code: "missing_root",
+        message: 'A generated surface must contain a component with id "root".',
+      });
+      return;
+    }
+    if (root.component !== "Answer" || components.length === 1) return;
+    if (!Array.isArray(root.children) || root.children.length === 0) {
+      issues.push({
+        path: `messages.${index}.createSurface.components.root.children`,
+        code: "unattached_answer_components",
+        message:
+          "An Answer surface with additional components must attach them through root.children.",
+      });
+    }
+  });
+  return issues;
+}
+
 /** Validate the complete tool argument object. Invalid messages reject the call. */
 export function validateRenderCardsInput(value: unknown): RenderInputValidation {
   const parsed = renderCardsArgsSchema.safeParse(value);
   if (parsed.success) {
+    const issues = generatedSurfaceGraphIssues(parsed.data.messages);
+    if (issues.length > 0) return { success: false, issues };
     return {
       success: true,
       messages: parsed.data.messages as AgentSurfaceMessage[],

--- a/packages/llm/src/work/index.ts
+++ b/packages/llm/src/work/index.ts
@@ -135,6 +135,7 @@ export type {
 } from "./run-chat-turn";
 // Shared OpenShell sandbox launcher (worker channel runs + web interactive chat).
 export {
+  agentRuntimeDepsFromConfig,
   agentRuntimeDepsFromEnv,
   buildModelEgressArgs,
   buildSandboxPolicy,
@@ -145,8 +146,11 @@ export {
   makeSandboxRunCore,
   makeSandboxWorkflowRunCore,
   sandboxAgentBackendForJob,
+  sandboxLauncherOptionsFromConfig,
   stageSandboxWorkspace,
+  workflowRuntimeDepsFromConfig,
   workflowRuntimeDepsFromEnv,
+  type AgentRuntimeLaunchConfig,
   type AgentJobAccess,
   type RunJobAgentBackendInput,
   type StagedSandboxWorkspace,

--- a/packages/llm/src/work/prompt.ts
+++ b/packages/llm/src/work/prompt.ts
@@ -103,15 +103,24 @@ comparison, a table, findings, a decision, a form, or an error-recovery path.
 Its description carries the available components and protocol. Compose an
 interface that fits the current request, using the smallest useful combination
 of narrative, data, layout, inputs, and actions.
-The surface is the canonical answer: after rendering it, do not repeat the
-same prose or figures in the final message. Every claim and figure in the
-surface must come from a successful tool result in this turn or content the
-operator supplied. A failed tool is an error state, not a data source. A short
-prose-only answer may skip the tool. Check the render tool result: if it rejects
-the surface, correct the envelope and retry. Never say a surface was rendered
-unless the tool accepted it.
+The surface supports the conversation; it does not replace your assistant
+message. Give the operator a concise direct answer, interpretation, or focused
+question in natural prose. Do not recite every table row or figure again.
+Every claim and figure in the surface must come from a successful tool result
+in this turn or content the operator supplied. A failed tool is an error state,
+not a data source. A short prose-only answer may skip the tool. Check the render
+tool result: if it rejects the surface, correct the envelope and retry. Never
+say a surface was rendered unless the tool accepted it.
 </rendering>`;
 }
+
+const CONVERSATION_SECTION = `<conversation>
+Treat this as an ongoing working conversation, not a report generator. Respond
+to the operator's actual wording and prior turns, lead with what matters now,
+and use natural prose even when a structured surface carries supporting data.
+When a material choice belongs to the operator, ask a focused question instead
+of silently choosing for them.
+</conversation>`;
 
 function buildClarificationSection(supportsClarificationTool: boolean): string {
   if (!supportsClarificationTool) {
@@ -831,6 +840,7 @@ everything, from "what was last week's revenue?" to "set up a workflow
 that flags churn risk every Monday."
 </role>`,
     operatorProfile ?? "",
+    CONVERSATION_SECTION,
     buildClarificationSection(supportsClarificationTool),
     dataSurface === "customer" ? buildSelectedMentionsSection(workspace) : "",
     dataSurface === "customer" && wantsCards

--- a/packages/llm/src/work/run-chat-turn.ts
+++ b/packages/llm/src/work/run-chat-turn.ts
@@ -110,7 +110,7 @@ export type RunChatTurnDeps = {
   listInstalledSkills: typeof defaultListInstalledSkills;
   /**
    * Runs the agent loop. Production hosts inject the OpenShell sandbox
-   * impl (agentRuntimeDepsFromEnv) — SEC9: the only runtime. The default
+   * impl (agentRuntimeDepsFromConfig) — SEC9: the only runtime. The default
    * (runAgentBackend in-process) exists for tests, which exercise the
    * core without a sandbox. The DB-bound prologue/epilogue stay host-side.
    */

--- a/packages/llm/src/work/sandbox-launcher.ts
+++ b/packages/llm/src/work/sandbox-launcher.ts
@@ -53,7 +53,7 @@ export interface SandboxLauncherOptions {
    * `openshell:resolve:env:…` placeholder) to the env var the backend reads —
    * e.g. {from:"api_key", to:"GEMINI_API_KEY"} for hermes-gemini. The proxy
    * still substitutes the real key on egress, so the box only sees the
-   * placeholder. `to` comes from the hermes provider→key map (mapHermesProvider).
+   * placeholder. `to` comes from the exhaustive Admin-provider runtime contract.
    */
   keyAliases?: ReadonlyArray<{ from: string; to: string }>;
   /**
@@ -72,6 +72,17 @@ export interface SandboxLauncherOptions {
   execTimeoutMs?: number;
   onLog?: (line: string) => void;
 }
+
+/**
+ * Per-org model routing captured from the persisted provider row immediately
+ * before a sandbox run. Keep this separate from process.env: the web and
+ * worker hosts are long-lived, and Next.js may evaluate route bundles at
+ * different times inside the same process.
+ */
+export type AgentRuntimeLaunchConfig = Pick<
+  SandboxLauncherOptions,
+  "modelProvider" | "modelHosts" | "keyAliases" | "hermesHomeHostPath"
+>;
 
 type RunCore = (input: RunAgentBackendInput) => Promise<AgentRunResult>;
 type RunWorkflowCore = (input: RunWorkflowAgentBackendInput) => Promise<AgentRunResult>;
@@ -372,7 +383,16 @@ export async function sandboxAgentBackendForJob(opts: {
   if (needsBroker && !broker) {
     throw new Error("agent job capabilities require the OpenNeko broker");
   }
-  const runCore = makeSandboxJobRunCore(sandboxLauncherOptionsFromEnv(broker));
+  // Resolve the org's persisted provider into an immutable launch snapshot.
+  // Import lazily because host-provision owns the gateway sync and itself
+  // imports this module's OpenShell helpers.
+  const launchConfig = await import("../host-provision").then(
+    ({ ensureHostConfigProvisioned }) =>
+      ensureHostConfigProvisioned(opts.orgId),
+  );
+  const runCore = makeSandboxJobRunCore(
+    sandboxLauncherOptionsFromConfig(launchConfig, broker),
+  );
 
   return {
     id: opts.backend.id,
@@ -635,7 +655,7 @@ function makeSandboxCore(
         `agent sandbox ready: ${name} (backend=${input.backend.id}, kind=${kind}, ` +
           `graphjin=brokered, skill_overrides=${staged.skillOverrides.length})`,
       );
-      await input.emit({ type: "status", message: "Launching agent…" });
+      await input.emit({ type: "status", message: "Agent is working…" });
       return await execAndStream(
         cli,
         gatewayArgs,
@@ -760,11 +780,47 @@ export function agentRuntimeDepsFromEnv(
   };
 }
 
+export function agentRuntimeDepsFromConfig(
+  config: AgentRuntimeLaunchConfig,
+  broker?: SandboxBrokerHandle,
+): Pick<Partial<RunChatTurnDeps>, "runCore"> {
+  return {
+    runCore: makeSandboxRunCore(sandboxLauncherOptionsFromConfig(config, broker)),
+  };
+}
+
 export function workflowRuntimeDepsFromEnv(
   broker?: SandboxBrokerHandle,
 ): Pick<Partial<RunWorkflowTurnDeps>, "runCore"> {
   return {
     runCore: makeSandboxWorkflowRunCore(sandboxLauncherOptionsFromEnv(broker)),
+  };
+}
+
+export function workflowRuntimeDepsFromConfig(
+  config: AgentRuntimeLaunchConfig,
+  broker?: SandboxBrokerHandle,
+): Pick<Partial<RunWorkflowTurnDeps>, "runCore"> {
+  return {
+    runCore: makeSandboxWorkflowRunCore(
+      sandboxLauncherOptionsFromConfig(config, broker),
+    ),
+  };
+}
+
+export function sandboxLauncherOptionsFromConfig(
+  config: AgentRuntimeLaunchConfig,
+  broker?: SandboxBrokerHandle,
+): SandboxLauncherOptions {
+  return {
+    agentImage:
+      process.env.OPENNEKO_AGENT_IMAGE ?? "ghcr.io/open-neko/agent:latest",
+    gatewayName: process.env.OPENSHELL_GATEWAY || undefined,
+    gatewayEndpoint: process.env.OPENSHELL_GATEWAY_ENDPOINT || undefined,
+    ...config,
+    brokerUrl: broker?.url,
+    brokerTokenFor: broker?.tokenFor,
+    brokerRelease: broker?.release,
   };
 }
 
@@ -783,18 +839,12 @@ export function sandboxLauncherOptionsFromEnv(
   // egress, so the box only ever holds the placeholder.
   const keyEnv = process.env.OPENNEKO_AGENT_MODEL_KEY_ENV;
   const credName = process.env.OPENNEKO_AGENT_MODEL_CREDENTIAL || "api_key";
-  return {
-    agentImage: process.env.OPENNEKO_AGENT_IMAGE ?? "ghcr.io/open-neko/agent:latest",
-    gatewayName: process.env.OPENSHELL_GATEWAY || undefined,
-    gatewayEndpoint: process.env.OPENSHELL_GATEWAY_ENDPOINT || undefined,
+  return sandboxLauncherOptionsFromConfig({
     modelProvider: process.env.OPENNEKO_AGENT_MODEL_PROVIDER || undefined,
     modelHosts: hosts.map((host) => ({ host })),
     keyAliases: keyEnv ? [{ from: credName, to: keyEnv }] : undefined,
     hermesHomeHostPath: process.env.OPENNEKO_AGENT_HERMES_HOME || undefined,
-    brokerUrl: broker?.url,
-    brokerTokenFor: broker?.tokenFor,
-    brokerRelease: broker?.release,
-  };
+  }, broker);
 }
 
 // Generic provider profile: holds just the model credential. The proxy

--- a/packages/llm/src/work/secret-scrubber.ts
+++ b/packages/llm/src/work/secret-scrubber.ts
@@ -98,6 +98,7 @@ export function scrubAgentEvent<T>(scrubber: Scrubber, event: T): T {
   const e = event as Record<string, unknown>;
   switch (e.type) {
     case "message":
+    case "interim":
       return {
         ...e,
         content: typeof e.content === "string" ? scrubber(e.content) : e.content,
@@ -129,10 +130,16 @@ export function scrubAgentEvent<T>(scrubber: Scrubber, event: T): T {
         artifact: scrubJson(scrubber, e.artifact),
       } as T;
     case "status":
+    case "progress":
     case "error":
       return {
         ...e,
-        message: typeof e.message === "string" ? scrubber(e.message) : e.message,
+        ...(typeof e.message === "string"
+          ? { message: scrubber(e.message) }
+          : {}),
+        ...(typeof e.content === "string"
+          ? { content: scrubber(e.content) }
+          : {}),
       } as T;
     case "done":
       return {

--- a/packages/llm/src/work/store.ts
+++ b/packages/llm/src/work/store.ts
@@ -5,6 +5,7 @@ import {
   desc,
   eq,
   gte,
+  inArray,
   isNull,
   sql,
   work_message,
@@ -350,7 +351,15 @@ export async function finishWorkRun(
       updated_at: new Date(),
       finished_at: new Date(),
     })
-    .where(eq(work_run.id, runId))
+    // A terminal state is final. This also prevents a detached agent process
+    // from overwriting a cancellation if it returns after the control plane
+    // has already recovered the run.
+    .where(
+      and(
+        eq(work_run.id, runId),
+        inArray(work_run.status, ["queued", "running"]),
+      ),
+    )
     .returning({ orgId: work_run.org_id });
   if (rows[0]) {
     const { recordAuditEvent } = await import("../workflows/audit-chain");
@@ -362,6 +371,44 @@ export async function finishWorkRun(
       payload: { status, error },
     });
   }
+}
+
+/**
+ * Terminalize a queued/running run whose in-process owner is gone.
+ * Returns true only when this call won the terminal-state transition.
+ */
+export async function cancelWorkRunIfActive(
+  runId: string,
+  error: string | null,
+): Promise<boolean> {
+  const now = new Date();
+  const rows = await db()
+    .update(work_run)
+    .set({
+      status: "cancelled",
+      error,
+      updated_at: now,
+      finished_at: now,
+    })
+    .where(
+      and(
+        eq(work_run.id, runId),
+        inArray(work_run.status, ["queued", "running"]),
+      ),
+    )
+    .returning({ orgId: work_run.org_id });
+
+  if (!rows[0]) return false;
+
+  const { recordAuditEvent } = await import("../workflows/audit-chain");
+  await recordAuditEvent({
+    orgId: rows[0].orgId,
+    entityKind: "work_run",
+    entityId: runId,
+    event: "run:cancelled",
+    payload: { status: "cancelled", error },
+  });
+  return true;
 }
 
 // Persist a run's agent-estimated analysis value (server-clamped minutes +

--- a/packages/llm/src/work/tools.ts
+++ b/packages/llm/src/work/tools.ts
@@ -6,7 +6,7 @@ import {
 import { z } from "zod";
 import { writeWorkSkillFiles } from "./skill-files";
 import { RENDER_CARDS_DESCRIPTION } from "./render-catalog";
-import type { AgentEvent, AgentSurfaceMessage } from "../agent-backend";
+import type { AgentEvent } from "../agent-backend";
 import { WORK_MEMORY_KINDS, type WorkMemoryContext } from "./memory-types";
 import type { RiskLevel } from "../workflows";
 import type { AgentControlPlane } from "./control-plane";
@@ -15,6 +15,7 @@ import {
   A2UI_RENDER_TOOL_NAME,
   RENDER_CARDS_INPUT_SHAPE,
   type RenderCardsArgs,
+  validateRenderCardsInput,
 } from "./a2ui-contract";
 import { OPENNEKO_GRAPHJIN_MCP_SERVER_NAME } from "../graphjin/mcp-names";
 
@@ -35,9 +36,25 @@ export function buildRenderCardsServer(
     RENDER_CARDS_DESCRIPTION,
     RENDER_CARDS_INPUT_SHAPE,
     async (args: RenderCardsArgs) => {
+      const validated = validateRenderCardsInput(args);
+      if (!validated.success) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({
+                ok: false,
+                error: "Invalid A2UI surface graph",
+                issues: validated.issues,
+              }),
+            },
+          ],
+        };
+      }
       await emit({
         type: "surface",
-        messages: args.messages as AgentSurfaceMessage[],
+        messages: validated.messages,
       });
       return {
         content: [
@@ -45,7 +62,7 @@ export function buildRenderCardsServer(
             type: "text" as const,
             text: JSON.stringify({
               ok: true,
-              accepted: args.messages.length,
+              accepted: validated.messages.length,
             }),
           },
         ],

--- a/packages/llm/test/helpers/fake-acp-process.ts
+++ b/packages/llm/test/helpers/fake-acp-process.ts
@@ -237,6 +237,40 @@ export function chunkNotification(sessionId: string, text: string) {
   };
 }
 
+export function interimNotification(sessionId: string, text: string) {
+  return {
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: {
+      sessionId,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text },
+        _meta: {
+          hermes: {
+            interim: true,
+            already_streamed: false,
+          },
+        },
+      },
+    },
+  };
+}
+
+export function thoughtNotification(sessionId: string, text: string) {
+  return {
+    jsonrpc: "2.0",
+    method: "session/update",
+    params: {
+      sessionId,
+      update: {
+        sessionUpdate: "agent_thought_chunk",
+        content: { type: "text", text },
+      },
+    },
+  };
+}
+
 export function toolCallNotification(sessionId: string, toolCallId: string, opts: { kind?: string; title?: string; locations?: Array<{ path: string }> } = {}) {
   return {
     jsonrpc: "2.0",

--- a/packages/llm/test/hermes-backend-acp.test.ts
+++ b/packages/llm/test/hermes-backend-acp.test.ts
@@ -1,9 +1,14 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   chunkNotification,
   createMockSpawn,
+  interimNotification,
   makeController,
   NO_RESPONSE,
+  thoughtNotification,
   toolCallNotification,
   toolCallUpdateNotification,
 } from "./helpers/fake-acp-process";
@@ -25,8 +30,24 @@ beforeEach(() => {
   controller.setScript({});
 });
 
-afterEach(() => {
+const temporaryHermesHomes: string[] = [];
+
+async function useHermesConfig(yaml: string): Promise<string> {
+  const home = await mkdtemp(join(tmpdir(), "openneko-hermes-test-"));
+  temporaryHermesHomes.push(home);
+  await writeFile(join(home, "config.yaml"), yaml, "utf8");
+  vi.stubEnv("HERMES_HOME", home);
+  return home;
+}
+
+afterEach(async () => {
   vi.clearAllMocks();
+  vi.unstubAllEnvs();
+  await Promise.all(
+    temporaryHermesHomes.splice(0).map((home) =>
+      rm(home, { recursive: true, force: true }),
+    ),
+  );
 });
 
 const { HermesBackend } = await import("../src/agent-backends/hermes");
@@ -136,6 +157,225 @@ describe("HermesBackend ACP behavior", () => {
       .map((e) => e.content);
     expect(messageContents).toEqual(["a", "b", "c"]);
     expect(result.finalText).toBe("abc");
+  });
+
+  it("keeps Hermes interim commentary separate from the final answer", async () => {
+    const sessionId = "sess-interim";
+    controller.setScript({
+      responders: {
+        "session/new": () => ({ sessionId }),
+        "session/prompt": (_p, ctx) => {
+          ctx.emitNotification(
+            interimNotification(sessionId, "I’ll inspect the sales records first."),
+          );
+          ctx.emitNotification(
+            toolCallNotification(sessionId, "tc-sales", {
+              kind: "read",
+              title: "Inspect sales data",
+            }),
+          );
+          ctx.emitNotification(
+            toolCallUpdateNotification(sessionId, "tc-sales", {
+              status: "completed",
+              rawOutput: "ok",
+            }),
+          );
+          ctx.emitNotification(
+            chunkNotification(sessionId, "Revenue increased over the period."),
+          );
+          return { stopReason: "end_turn" };
+        },
+      },
+    });
+    const events: Array<Record<string, unknown>> = [];
+
+    const result = await new HermesBackend().run({
+      prompt: "p",
+      workspace: FAKE_WORKSPACE,
+      onEvent: (event) => events.push(event as unknown as Record<string, unknown>),
+    });
+
+    expect(events.map((event) => event.type)).toEqual([
+      "interim",
+      "tool_start",
+      "tool_end",
+      "message",
+    ]);
+    expect(events[0]).toMatchObject({
+      type: "interim",
+      content: "I’ll inspect the sales records first.",
+      source: "hermes_interim_assistant",
+    });
+    expect(result.finalText).toBe("Revenue increased over the period.");
+  });
+
+  it("emits Gemini thought summaries as same-call progress before tools and prose", async () => {
+    await useHermesConfig([
+      "model:",
+      '  default: "gemini-3.6-flash"',
+      '  provider: "gemini"',
+      "agent:",
+      '  reasoning_effort: "medium"',
+      "",
+    ].join("\n"));
+    const sessionId = "sess-gemini-summaries";
+    let promptCalls = 0;
+    controller.setScript({
+      responders: {
+        "session/new": () => ({ sessionId }),
+        "session/prompt": (_p, ctx) => {
+          promptCalls += 1;
+          ctx.emitNotification(thoughtNotification(sessionId, "I’m checking "));
+          ctx.emitNotification(thoughtNotification(sessionId, "the sales records."));
+          ctx.emitNotification(
+            toolCallNotification(sessionId, "tc-sales", {
+              kind: "read",
+              title: "Inspect sales data",
+            }),
+          );
+          ctx.emitNotification(
+            toolCallUpdateNotification(sessionId, "tc-sales", {
+              status: "completed",
+              rawOutput: "ok",
+            }),
+          );
+          ctx.emitNotification(
+            thoughtNotification(sessionId, "I found the top performers."),
+          );
+          ctx.emitNotification(chunkNotification(sessionId, "Here are the results."));
+          return { stopReason: "end_turn" };
+        },
+      },
+    });
+    const events: Array<Record<string, unknown>> = [];
+
+    await new HermesBackend().run({
+      prompt: "p",
+      workspace: FAKE_WORKSPACE,
+      onEvent: (event) => events.push(event as unknown as Record<string, unknown>),
+    });
+
+    expect(promptCalls).toBe(1);
+    expect(events.map((event) => event.type)).toEqual([
+      "progress",
+      "tool_start",
+      "tool_end",
+      "progress",
+      "message",
+    ]);
+    expect(events.filter((event) => event.type === "progress")).toEqual([
+      {
+        type: "progress",
+        id: "google-gemini-summary-sess-gemini-summaries-1",
+        content: "I’m checking the sales records.",
+        source: "provider_summary",
+        provider: "google-gemini",
+      },
+      {
+        type: "progress",
+        id: "google-gemini-summary-sess-gemini-summaries-2",
+        content: "I found the top performers.",
+        source: "provider_summary",
+        provider: "google-gemini",
+      },
+    ]);
+  });
+
+  it("emits Anthropic summarized thinking as same-call progress", async () => {
+    await useHermesConfig([
+      "model:",
+      '  default: "claude-sonnet-5"',
+      '  provider: "anthropic"',
+      "agent:",
+      '  reasoning_effort: "medium"',
+      "",
+    ].join("\n"));
+    const sessionId = "sess-anthropic-summaries";
+    controller.setScript({
+      responders: {
+        "session/new": () => ({ sessionId }),
+        "session/prompt": (_p, ctx) => {
+          ctx.emitNotification(thoughtNotification(sessionId, "Checking the quarterly totals."));
+          ctx.emitNotification(
+            toolCallNotification(sessionId, "tc-revenue", {
+              kind: "read",
+              title: "Query revenue",
+            }),
+          );
+          ctx.emitNotification(
+            toolCallUpdateNotification(sessionId, "tc-revenue", {
+              status: "completed",
+              rawOutput: "ok",
+            }),
+          );
+          ctx.emitNotification(thoughtNotification(sessionId, "Comparing quarter-over-quarter changes."));
+          ctx.emitNotification(chunkNotification(sessionId, "Public answer"));
+          return { stopReason: "end_turn" };
+        },
+      },
+    });
+    const events: Array<Record<string, unknown>> = [];
+
+    await new HermesBackend().run({
+      prompt: "p",
+      workspace: FAKE_WORKSPACE,
+      onEvent: (event) => events.push(event as unknown as Record<string, unknown>),
+    });
+
+    expect(events.map((event) => event.type)).toEqual([
+      "progress",
+      "tool_start",
+      "tool_end",
+      "progress",
+      "message",
+    ]);
+    expect(events.filter((event) => event.type === "progress")).toEqual([
+      {
+        type: "progress",
+        id: "anthropic-summary-sess-anthropic-summaries-1",
+        content: "Checking the quarterly totals.",
+        source: "provider_summary",
+        provider: "anthropic",
+      },
+      {
+        type: "progress",
+        id: "anthropic-summary-sess-anthropic-summaries-2",
+        content: "Comparing quarter-over-quarter changes.",
+        source: "provider_summary",
+        provider: "anthropic",
+      },
+    ]);
+  });
+
+  it("does not expose generic ACP reasoning streams from other providers", async () => {
+    await useHermesConfig([
+      "model:",
+      '  default: "gpt-5.4"',
+      '  provider: "openai"',
+      "agent:",
+      '  reasoning_effort: "medium"',
+      "",
+    ].join("\n"));
+    const sessionId = "sess-private-reasoning";
+    controller.setScript({
+      responders: {
+        "session/new": () => ({ sessionId }),
+        "session/prompt": (_p, ctx) => {
+          ctx.emitNotification(thoughtNotification(sessionId, "private reasoning"));
+          ctx.emitNotification(chunkNotification(sessionId, "Public answer"));
+          return { stopReason: "end_turn" };
+        },
+      },
+    });
+    const events: Array<{ type: string }> = [];
+
+    await new HermesBackend().run({
+      prompt: "p",
+      workspace: FAKE_WORKSPACE,
+      onEvent: (event) => events.push(event),
+    });
+
+    expect(events.map((event) => event.type)).toEqual(["message"]);
   });
 
   it("retries a content-free end_turn, then fails instead of completing empty", async () => {

--- a/packages/llm/test/hermes-backend-spawn.test.ts
+++ b/packages/llm/test/hermes-backend-spawn.test.ts
@@ -108,7 +108,7 @@ describe("HermesBackend spawn invariants", () => {
     expect(controller.spawnCalls[0].options.detached).toBe(true);
   });
 
-  it("emits status + message events when onEvent is provided", async () => {
+  it("emits assistant messages without synthetic status when onEvent is provided", async () => {
     controller.setScript({
       notificationsByMethod: {
         "session/prompt": [
@@ -136,8 +136,8 @@ describe("HermesBackend spawn invariants", () => {
       },
     });
     expect(result.status).toBe("completed");
-    expect(events.find((e) => e.type === "status")).toBeDefined();
     expect(events.find((e) => e.type === "message")).toBeDefined();
+    expect(events.find((e) => e.type === "status")).toBeUndefined();
   });
 
   it("returns AgentRunResult (no thrown error) on completed run", async () => {

--- a/packages/llm/test/hermes-install-contract.test.ts
+++ b/packages/llm/test/hermes-install-contract.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const REPO_ROOT = fileURLToPath(new URL("../../../", import.meta.url));
-const HERMES_REF = "a91a57fa5a13d516c38b07a141a9ce8a3daabeb0";
+const HERMES_REF = "29112bef099274229cadff79cdff7bf7b99c4b77";
 
 describe("Hermes install contract", () => {
   it("keeps container and local development on the same exact upstream ref", async () => {
@@ -14,28 +14,64 @@ describe("Hermes install contract", () => {
 
     expect(dockerfile).toContain(`ARG HERMES_AGENT_REF=${HERMES_REF}`);
     expect(installer).toContain(`HERMES_AGENT_REF="\${HERMES_AGENT_REF:-${HERMES_REF}}"`);
-    expect(dockerfile).toContain("uv tool install --python /usr/bin/python3");
-    expect(installer).toContain("uv tool install --force --python 3.11");
-    expect(dockerfile).toContain("--with mcp --with websockets");
-    expect(installer).toContain("--with mcp --with websockets");
-    expect(dockerfile).not.toContain("uv sync --project /usr/local/lib/hermes-agent");
-    expect(installer).not.toContain("uv 0.12 or newer");
-    expect(dockerfile).toContain("hermes_cli.__version__ == '0.14.0'");
-    expect(installer).toContain("HERMES_AGENT_VERSION=\"0.14.0\"");
+    expect(dockerfile).toContain(
+      'git -C /usr/local/lib/hermes-agent fetch --depth 1 origin "$HERMES_AGENT_REF"',
+    );
+    expect(dockerfile).toContain(
+      "UV_PROJECT_ENVIRONMENT=/usr/local/uv/tools/hermes-agent",
+    );
+    expect(dockerfile).toContain(
+      "uv sync --locked --no-dev --extra acp --extra mcp --extra anthropic",
+    );
+    expect(installer).toContain('uv venv --clear "$hermes_tool_root" --python 3.11');
+    expect(installer).toContain(
+      'uv sync --project "$hermes_source_root" --locked --no-dev --extra acp --extra mcp --extra anthropic',
+    );
+    expect(dockerfile).not.toContain("uv tool install");
+    expect(installer).not.toContain("uv tool install");
+    expect(dockerfile).toContain("hermes_cli.__version__ == '0.21.0'");
+    expect(installer).toContain("HERMES_AGENT_VERSION=\"0.21.0\"");
+    expect(dockerfile).toContain("Hermes OpenAI provider SDK missing");
+    expect(installer).toContain("Hermes OpenAI provider SDK missing");
+    expect(dockerfile).toContain("Hermes Anthropic provider SDK missing");
+    expect(installer).toContain("Hermes Anthropic provider SDK missing");
   });
 
-  it("patches v0.14's MCP adapter for the SDK's snake_case is_error field", async () => {
-    const [dockerfile, installer] = await Promise.all([
+  it("patches ACP to pass the configured reasoning effort into AIAgent", async () => {
+    const [dockerfile, installer, patch, interimPatch, anthropicPatch] = await Promise.all([
       readFile(`${REPO_ROOT}Dockerfile`, "utf8"),
       readFile(`${REPO_ROOT}scripts/install-clis.sh`, "utf8"),
+      readFile(
+        `${REPO_ROOT}scripts/patches/hermes-acp-reasoning-config.patch`,
+        "utf8",
+      ),
+      readFile(`${REPO_ROOT}scripts/patches/hermes-acp-interim-messages.patch`, "utf8"),
+      readFile(`${REPO_ROOT}scripts/patches/hermes-acp-anthropic-reasoning.patch`, "utf8"),
     ]);
 
-    expect(dockerfile).toContain("result.is_error");
-    expect(installer).toContain("result.is_error");
-    expect(dockerfile).toContain("hasattr(result, 'is_error')");
-    expect(installer).toContain("hasattr(result, 'is_error')");
+    expect(patch).toContain("resolve_reasoning_config");
+    expect(patch).toContain('"reasoning_config": resolve_reasoning_config');
+    expect(interimPatch).toContain("make_interim_message_cb");
+    expect(interimPatch).toContain("interim_assistant_callback");
+    expect(interimPatch).toContain("pending_streamed_message.append(text)");
+    expect(interimPatch).toContain("raw_interim_cb(text, already_streamed=False)");
+    expect(interimPatch).toContain(
+      '-            and (not streamed_message or result.get("response_transformed"))',
+    );
+    expect(anthropicPatch).toContain("_emit_unstreamed_anthropic_reasoning");
+    expect(anthropicPatch).toContain("reasoning_was_streamed");
+    expect(dockerfile).toContain("hermes-acp-reasoning-config.patch");
+    expect(dockerfile).toContain("hermes-acp-interim-messages.patch");
+    expect(dockerfile).toContain("hermes-acp-anthropic-reasoning.patch");
+    expect(installer).toContain("hermes-acp-reasoning-config.patch");
+    expect(installer).toContain("hermes-acp-interim-messages.patch");
+    expect(installer).toContain("hermes-acp-anthropic-reasoning.patch");
+    expect(dockerfile).toContain("Hermes ACP must pass configured reasoning into AIAgent");
+    expect(installer).toContain("Hermes ACP must pass configured reasoning into AIAgent");
     expect(dockerfile).toContain("assert 'usage=usage' in source");
     expect(installer).toContain("assert 'usage=usage' in source");
+    expect(dockerfile).toContain("Hermes ACP Anthropic reasoning fallback missing");
+    expect(installer).toContain("Hermes ACP Anthropic reasoning fallback missing");
   });
 
   it("disables network-backed lazy installs in the runtime", async () => {

--- a/packages/llm/test/hermes-render-stub.test.ts
+++ b/packages/llm/test/hermes-render-stub.test.ts
@@ -31,6 +31,38 @@ describe("brokered neko_ui render MCP server", () => {
     });
   });
 
+  it("rejects an Answer whose result components are not attached to the root", async () => {
+    await withRenderServer(async (client, emit) => {
+      const result = await client.callTool({
+        name: "render_cards",
+        arguments: {
+          messages: [
+            {
+              version: "v1.0",
+              createSurface: {
+                surfaceId: "sales-report-01",
+                catalogId: "urn:openneko:catalog:work:v2",
+                components: [
+                  { id: "root", component: "Answer", title: "Sales performance" },
+                  { id: "table", component: "Table", rows: [] },
+                ],
+              },
+            },
+          ],
+        },
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toEqual([
+        expect.objectContaining({
+          type: "text",
+          text: expect.stringContaining("unattached_answer_components"),
+        }),
+      ]);
+      expect(emit).not.toHaveBeenCalled();
+    });
+  });
+
   it("emits a valid A2UI v1.0 surface from the one canonical server", async () => {
     const messages = [
       {

--- a/packages/llm/test/host-provision.test.ts
+++ b/packages/llm/test/host-provision.test.ts
@@ -36,7 +36,9 @@ import {
 } from "@neko/db";
 import {
   ensureHostConfigProvisioned,
+  gatewayProviderName,
   hermesHomeForOrg,
+  hermesNativeReasoningConfigLines,
   patchGraphjinSourcesJwtSecret,
   provisionHostConfig,
   shouldReconcileDemoSourceAuthMode,
@@ -190,6 +192,29 @@ describe("shouldReconcileDemoSourceAuthMode", () => {
   });
 });
 
+describe("hermesNativeReasoningConfigLines", () => {
+  it("enables provider-native summaries for Gemini and Anthropic only", () => {
+    expect(hermesNativeReasoningConfigLines("google-gemini")).toEqual([
+      '  reasoning_effort: "high"',
+    ]);
+    expect(hermesNativeReasoningConfigLines("anthropic")).toEqual([
+      '  reasoning_effort: "high"',
+    ]);
+    expect(hermesNativeReasoningConfigLines("openai")).toEqual([]);
+  });
+});
+
+describe("gatewayProviderName", () => {
+  it("isolates gateway credentials by organization without exposing the org id", () => {
+    const first = gatewayProviderName("customer-a");
+    const second = gatewayProviderName("customer-b");
+    expect(first).toMatch(/^openneko-agent-[a-f0-9]{16}$/);
+    expect(second).toMatch(/^openneko-agent-[a-f0-9]{16}$/);
+    expect(first).not.toBe(second);
+    expect(first).not.toContain("customer-a");
+  });
+});
+
 describeIfDb("provisionHostConfig", () => {
   let orgId: string;
   let tempHome: string;
@@ -292,6 +317,7 @@ describeIfDb("provisionHostConfig", () => {
     expect(yaml).toContain('default: "gemini-pro-latest"');
     expect(yaml).toContain('provider: "gemini"');
     expect(yaml).toContain("max_turns:");
+    expect(yaml).toContain('reasoning_effort: "high"');
     expect(yaml).toContain("delegation:");
     expect(yaml).toContain("max_iterations: 50");
     expect(yaml).toContain("max_concurrent_children: 3");
@@ -354,6 +380,7 @@ describeIfDb("provisionHostConfig", () => {
 
     const yaml = await readFile(join(hermesHome, "config.yaml"), "utf8");
     expect(yaml).toContain('provider: "anthropic"');
+    expect(yaml).toContain('reasoning_effort: "high"');
     const env = await readFile(join(hermesHome, ".env"), "utf8");
     expect(env).toContain("ANTHROPIC_API_KEY=sk-ant-test");
   });
@@ -392,12 +419,16 @@ describeIfDb("provisionHostConfig", () => {
       provider: "hermes",
       config: { backend: "hermes" },
     });
-    await expect(provisionHostConfig(orgId)).resolves.toBeUndefined();
+    await expect(provisionHostConfig(orgId)).resolves.toEqual({
+      modelHosts: [],
+    });
     await readFile(graphjinPath(tempHome), "utf8");
   });
 
   it("does not throw when no data source exists (graphjin write skipped)", async () => {
-    await expect(provisionHostConfig(orgId)).resolves.toBeUndefined();
+    await expect(provisionHostConfig(orgId)).resolves.toEqual({
+      modelHosts: [],
+    });
   });
 
   it("repairs an existing packaged-demo AdventureWorks source deterministically", async () => {
@@ -535,9 +566,15 @@ describeIfDb("provisionHostConfig", () => {
       model: "gemini-pro-latest",
       secrets: { apiKey: "key-a" },
     });
-    await provisionHostConfig(orgId);
-    const firstHost = process.env.OPENNEKO_AGENT_MODEL_HOST;
-    expect(firstHost).toBeTruthy();
+    const firstLaunch = await provisionHostConfig(orgId);
+    expect(firstLaunch).toMatchObject({
+      modelProvider: expect.stringMatching(/^openneko-agent-[a-f0-9]{16}$/),
+      modelHosts: [
+        { host: "generativelanguage.googleapis.com" },
+        { host: "models.dev" },
+      ],
+      keyAliases: [{ from: "api_key", to: "GEMINI_API_KEY" }],
+    });
 
     // Operator switches provider; the old `||=` writes pinned the first
     // pass's derived values for the process lifetime, leaving the egress
@@ -549,10 +586,22 @@ describeIfDb("provisionHostConfig", () => {
       model: "claude-opus-4-7",
       secrets: { apiKey: "key-b" },
     });
-    await provisionHostConfig(orgId);
-    expect(process.env.OPENNEKO_AGENT_MODEL_HOST).toBeTruthy();
-    expect(process.env.OPENNEKO_AGENT_MODEL_HOST).not.toBe(firstHost);
-    expect(process.env.OPENNEKO_AGENT_MODEL_KEY_ENV).toContain("ANTHROPIC");
+    const secondLaunch = await provisionHostConfig(orgId);
+    expect(secondLaunch).toMatchObject({
+      modelProvider: expect.stringMatching(/^openneko-agent-[a-f0-9]{16}$/),
+      modelHosts: [
+        { host: "api.anthropic.com" },
+        { host: "models.dev" },
+      ],
+      keyAliases: [{ from: "api_key", to: "ANTHROPIC_API_KEY" }],
+      hermesHomeHostPath: hermesHomeForOrg(orgId),
+    });
+
+    // Persisted org configuration is returned as a run-local snapshot. It
+    // must not contaminate process.env, where a separately bundled Next.js
+    // route could later mistake it for an operator override.
+    expect(process.env.OPENNEKO_AGENT_MODEL_HOST).toBeUndefined();
+    expect(process.env.OPENNEKO_AGENT_MODEL_KEY_ENV).toBeUndefined();
   });
 
   it("keeps direct provisioning best-effort when OpenShell provider sync fails", async () => {
@@ -573,7 +622,9 @@ describeIfDb("provisionHostConfig", () => {
       secrets: { apiKey: "test-gemini-key" },
     });
 
-    await expect(provisionHostConfig(orgId)).resolves.toBeUndefined();
+    await expect(provisionHostConfig(orgId)).resolves.toEqual({
+      modelHosts: [],
+    });
     expect(ensureOpenShellProviderMock).toHaveBeenCalledTimes(3);
 
     const yaml = await readFile(join(hermesHome, "config.yaml"), "utf8");
@@ -672,11 +723,17 @@ describeIfDb("provisionHostConfig", () => {
             eq(llm_provider_config.scope, "primary"),
           ),
         );
-      await ensureHostConfigProvisioned(refreshOrgId);
+      const anthropicLaunch = await ensureHostConfigProvisioned(refreshOrgId);
       expect(ensureOpenShellProviderMock).toHaveBeenLastCalledWith(
         expect.objectContaining({ apiKey: "key-c" }),
       );
-      expect(process.env.OPENNEKO_AGENT_MODEL_KEY_ENV).toBe("ANTHROPIC_API_KEY");
+      expect(anthropicLaunch).toMatchObject({
+        modelHosts: [
+          { host: "api.anthropic.com" },
+          { host: "models.dev" },
+        ],
+        keyAliases: [{ from: "api_key", to: "ANTHROPIC_API_KEY" }],
+      });
 
       // Removing the saved key must not leave the previous gateway provider
       // attached to future sandboxes in this long-lived worker process.
@@ -689,8 +746,8 @@ describeIfDb("provisionHostConfig", () => {
             eq(llm_provider_config.scope, "primary"),
           ),
         );
-      await ensureHostConfigProvisioned(refreshOrgId);
-      expect(process.env.OPENNEKO_AGENT_MODEL_PROVIDER).toBeUndefined();
+      const keylessLaunch = await ensureHostConfigProvisioned(refreshOrgId);
+      expect(keylessLaunch.modelProvider).toBeUndefined();
       await expect(
         readFile(join(hermesHomeForOrg(refreshOrgId), ".env"), "utf8"),
       ).resolves.toBe("");
@@ -739,7 +796,10 @@ describeIfDb("provisionHostConfig", () => {
       expect(ensureOpenShellProviderMock).toHaveBeenCalledTimes(3);
 
       ensureOpenShellProviderMock.mockResolvedValue(undefined);
-      await expect(ensureHostConfigProvisioned(retryOrgId)).resolves.toBeUndefined();
+      await expect(ensureHostConfigProvisioned(retryOrgId)).resolves.toMatchObject({
+        modelProvider: expect.stringMatching(/^openneko-agent-[a-f0-9]{16}$/),
+        keyAliases: [{ from: "api_key", to: "GEMINI_API_KEY" }],
+      });
       expect(ensureOpenShellProviderMock).toHaveBeenCalledTimes(4);
       delete process.env.OPENNEKO_PROVISION_RETRY_BASE_MS;
     } finally {

--- a/packages/llm/test/interaction-from-agent-event.test.ts
+++ b/packages/llm/test/interaction-from-agent-event.test.ts
@@ -13,16 +13,24 @@ describe("toInteractionEvents", () => {
     ]);
   });
 
-  it("maps tool + status to progress", () => {
+  it("maps tool, runtime status, and provider summary to progress", () => {
     const events: AgentEvent[] = [
       { type: "tool_start", id: "t1", name: "graphjin_query" },
       { type: "tool_end", id: "t1" },
       { type: "status", message: "Thinking" },
+      {
+        type: "progress",
+        id: "summary-1",
+        content: "Checking the sales totals.",
+        source: "provider_summary",
+        provider: "google-gemini",
+      },
     ];
     expect(toInteractionEvents(events)).toEqual([
       { kind: "progress", id: "t1", label: "graphjin_query", phase: "start" },
       { kind: "progress", id: "t1", label: "t1", phase: "end" },
       { kind: "progress", id: "ie-1", label: "Thinking", phase: "start" },
+      { kind: "progress", id: "summary-1", label: "Checking the sales totals.", phase: "start" },
     ]);
   });
 

--- a/packages/llm/test/provider-runtime.test.ts
+++ b/packages/llm/test/provider-runtime.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from "vitest";
+import { PRIMARY_PROVIDER_OPTIONS, type PrimaryProviderId } from "../src/config";
+import { resolveHermesProviderRuntime } from "../src/provider-runtime";
+import { hermesModelConfigLines } from "../src/host-provision";
+
+const configByProvider: Partial<Record<PrimaryProviderId, Record<string, unknown>>> = {
+  "azure-openai": {
+    resourceName: "customer-openai",
+    deploymentName: "production-gpt",
+  },
+  ollama: { url: "http://localhost:11434" },
+  vertex: { projectId: "customer-ai", region: "us-central1" },
+};
+
+const expected = {
+  openai: ["openai-api", "OPENAI_API_KEY", "api.openai.com", undefined],
+  anthropic: ["anthropic", "ANTHROPIC_API_KEY", "api.anthropic.com", undefined],
+  "google-gemini": ["gemini", "GEMINI_API_KEY", "generativelanguage.googleapis.com", undefined],
+  "azure-openai": ["azure-foundry", "AZURE_FOUNDRY_API_KEY", "customer-openai.openai.azure.com", undefined],
+  mistral: ["custom", "MISTRAL_API_KEY", "api.mistral.ai", undefined],
+  groq: ["custom", "GROQ_API_KEY", "api.groq.com", undefined],
+  cohere: ["custom", "COHERE_API_KEY", "api.cohere.ai", undefined],
+  together: ["custom", "TOGETHER_API_KEY", "api.together.ai", undefined],
+  deepseek: ["deepseek", "DEEPSEEK_API_KEY", "api.deepseek.com", undefined],
+  ollama: ["custom", undefined, "host.docker.internal", 11434],
+  huggingface: ["huggingface", "HF_TOKEN", "router.huggingface.co", undefined],
+  openrouter: ["openrouter", "OPENROUTER_API_KEY", "openrouter.ai", undefined],
+  reka: ["custom", "REKA_API_KEY", "api.reka.ai", undefined],
+  "x-grok": ["xai", "XAI_API_KEY", "api.x.ai", undefined],
+  vertex: ["custom", "VERTEX_ACCESS_TOKEN", "us-central1-aiplatform.googleapis.com", undefined],
+} satisfies Record<PrimaryProviderId, [string, string | undefined, string, number | undefined]>;
+
+describe("resolveHermesProviderRuntime", () => {
+  it("defines the complete Hermes, credential and egress contract for every Admin provider", () => {
+    expect(Object.keys(expected).sort()).toEqual(
+      PRIMARY_PROVIDER_OPTIONS.map(({ value }) => value).sort(),
+    );
+
+    for (const { value: provider } of PRIMARY_PROVIDER_OPTIONS) {
+      const runtime = resolveHermesProviderRuntime({
+        provider,
+        model: "test-model",
+        config: configByProvider[provider],
+      });
+      const [hermesProvider, keyEnv, host, port] = expected[provider];
+      expect(runtime.provider, provider).toBe(hermesProvider);
+      expect(runtime.keyEnv, provider).toBe(keyEnv);
+      expect(runtime.endpoint, provider).toEqual({
+        host,
+        ...(port ? { port } : {}),
+      });
+      expect(runtime.baseUrl, provider).toMatch(/^https?:\/\//);
+    }
+  });
+
+  it("renders a complete Hermes model block for every Admin provider", () => {
+    for (const { value: provider } of PRIMARY_PROVIDER_OPTIONS) {
+      const runtime = resolveHermesProviderRuntime({
+        provider,
+        model: "test-model",
+        config: configByProvider[provider],
+      });
+      const yaml = hermesModelConfigLines(runtime).join("\n");
+      expect(yaml, provider).toContain(`provider: "${runtime.provider}"`);
+      expect(yaml, provider).toContain(`base_url: "${runtime.baseUrl}"`);
+      if (runtime.provider === "custom" && runtime.keyEnv) {
+        expect(yaml, provider).toContain(`api_key: "\${${runtime.keyEnv}}"`);
+      } else {
+        expect(yaml, provider).not.toContain("api_key:");
+      }
+      expect(yaml, provider).not.toContain("REAL_SECRET");
+    }
+  });
+
+  it("uses the Azure deployment name as the wire model", () => {
+    const runtime = resolveHermesProviderRuntime({
+      provider: "azure-openai",
+      model: "friendly-model-label",
+      config: configByProvider["azure-openai"],
+    });
+    expect(runtime.model).toBe("production-gpt");
+    expect(runtime.baseUrl).toBe(
+      "https://customer-openai.openai.azure.com/openai/v1",
+    );
+  });
+
+  it("normalizes host-local Ollama and preserves its explicit port", () => {
+    const runtime = resolveHermesProviderRuntime({
+      provider: "ollama",
+      model: "llama3.2",
+      config: { url: "http://127.0.0.1:11434" },
+    });
+    expect(runtime.baseUrl).toBe("http://host.docker.internal:11434/v1");
+    expect(runtime.endpoint).toEqual({ host: "host.docker.internal", port: 11434 });
+    expect(runtime.credentialSource).toBe("none");
+  });
+
+  it("routes global Vertex through the global endpoint", () => {
+    const runtime = resolveHermesProviderRuntime({
+      provider: "vertex",
+      model: "publisher/model",
+      config: { projectId: "customer-ai", region: "global" },
+    });
+    expect(runtime.baseUrl).toBe(
+      "https://aiplatform.googleapis.com/v1beta1/projects/customer-ai/locations/global/endpoints/openapi",
+    );
+    expect(runtime.endpoint).toEqual({ host: "aiplatform.googleapis.com" });
+    expect(runtime.credentialSource).toBe("google-adc");
+  });
+
+  it("rejects endpoint-bearing providers whose endpoint fields are unsafe", () => {
+    expect(() =>
+      resolveHermesProviderRuntime({
+        provider: "azure-openai",
+        model: "gpt",
+        config: { resourceName: "customer.example.com/path", deploymentName: "gpt" },
+      }),
+    ).toThrow("invalid characters");
+    expect(() =>
+      resolveHermesProviderRuntime({
+        provider: "ollama",
+        model: "llama",
+        config: { url: "file:///tmp/ollama.sock" },
+      }),
+    ).toThrow("must use http or https");
+  });
+});

--- a/packages/llm/test/sandbox-launcher.test.ts
+++ b/packages/llm/test/sandbox-launcher.test.ts
@@ -86,6 +86,7 @@ vi.mock("node:child_process", () => ({ spawn: h.spawn }));
 const jobCapture = vi.hoisted(() => ({
   jobs: [] as Array<Record<string, unknown>>,
   policies: [] as Array<ReturnType<typeof JSON.parse>>,
+  hermesEnvs: [] as string[],
 }));
 vi.mock("node:fs/promises", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs/promises")>();
@@ -106,6 +107,12 @@ vi.mock("node:fs/promises", async (importOriginal) => {
           /* ignore non-JSON writes */
         }
       }
+      if (
+        typeof p === "string" &&
+        p.endsWith("hermes-home/.env")
+      ) {
+        jobCapture.hermesEnvs.push(String(data));
+      }
       return (actual.writeFile as (...a: unknown[]) => Promise<void>)(p, data, ...rest);
     },
   };
@@ -119,6 +126,7 @@ const {
   buildSandboxPolicy,
   buildScopedEgressArgs,
   ensureOpenShellProvider,
+  sandboxLauncherOptionsFromConfig,
   sandboxLauncherOptionsFromEnv,
   stageSandboxWorkspace,
   verifyOpenShellGateway,
@@ -138,6 +146,41 @@ describe("sandboxLauncherOptionsFromEnv", () => {
         { host: "models.dev" },
       ]);
       expect(options).not.toHaveProperty("modelEgress");
+    } finally {
+      vi.unstubAllEnvs();
+    }
+  });
+});
+
+describe("sandboxLauncherOptionsFromConfig", () => {
+  it("uses the run-local provider snapshot instead of stale process globals", () => {
+    vi.stubEnv(
+      "OPENNEKO_AGENT_MODEL_HOST",
+      "generativelanguage.googleapis.com,models.dev",
+    );
+    vi.stubEnv("OPENNEKO_AGENT_MODEL_KEY_ENV", "GEMINI_API_KEY");
+    vi.stubEnv("OPENNEKO_AGENT_MODEL_PROVIDER", "stale-gemini-provider");
+    vi.stubEnv("OPENNEKO_AGENT_HERMES_HOME", "/tmp/stale-gemini-home");
+    try {
+      const options = sandboxLauncherOptionsFromConfig({
+        modelProvider: "openneko-agent",
+        modelHosts: [
+          { host: "api.anthropic.com" },
+          { host: "models.dev" },
+        ],
+        keyAliases: [{ from: "api_key", to: "ANTHROPIC_API_KEY" }],
+        hermesHomeHostPath: "/tmp/current-anthropic-home",
+      });
+
+      expect(options).toMatchObject({
+        modelProvider: "openneko-agent",
+        modelHosts: [
+          { host: "api.anthropic.com" },
+          { host: "models.dev" },
+        ],
+        keyAliases: [{ from: "api_key", to: "ANTHROPIC_API_KEY" }],
+        hermesHomeHostPath: "/tmp/current-anthropic-home",
+      });
     } finally {
       vi.unstubAllEnvs();
     }
@@ -395,6 +438,7 @@ describe("makeSandboxRunCore", () => {
     h.state.execLines = undefined;
     jobCapture.jobs.length = 0;
     jobCapture.policies.length = 0;
+    jobCapture.hermesEnvs.length = 0;
   });
   afterEach(() => vi.restoreAllMocks());
 
@@ -443,6 +487,10 @@ describe("makeSandboxRunCore", () => {
     expect(events.filter((event) => event.type === "message")).toEqual([
       expect.objectContaining({ type: "message", content: "hi" }),
     ]);
+    expect(events.filter((event) => event.type === "status").at(-1)).toEqual({
+      type: "status",
+      message: "Agent is working…",
+    });
     // result parsed from the RESULT line:
     expect(result).toEqual({ status: "completed", finalText: "hi there", backendState: { t: 1 } });
     // create used the agent image; preflight and exec ran the deployed
@@ -808,6 +856,14 @@ describe("makeSandboxRunCore", () => {
     expect(execCall?.args.join(" ")).toContain(
       "HERMES_HOME='/sandbox/org-1/runs/run-1/.openneko/hermes-home'",
     );
+    expect(jobCapture.hermesEnvs).toEqual([""]);
+    expect(
+      JSON.stringify({
+        calls: h.calls,
+        jobs: jobCapture.jobs,
+        policies: jobCapture.policies,
+      }),
+    ).not.toContain("REAL_SECRET");
   });
 });
 

--- a/packages/llm/test/secret-scrubber.test.ts
+++ b/packages/llm/test/secret-scrubber.test.ts
@@ -4,6 +4,7 @@ import {
   escapeRegex,
   isNoopScrubber,
   REDACTED_PLACEHOLDER,
+  scrubAgentEvent,
   scrubJson,
 } from "../src/work/secret-scrubber";
 
@@ -87,6 +88,27 @@ describe("scrubJson", () => {
     const input = { msg: "xoxb-secret-1" };
     scrubJson(scrub, input);
     expect(input.msg).toBe("xoxb-secret-1");
+  });
+});
+
+describe("scrubAgentEvent", () => {
+  it("scrubs provider progress summaries before persistence", () => {
+    const scrub = createScrubber(["secret-value-123"]);
+    expect(
+      scrubAgentEvent(scrub, {
+        type: "progress",
+        id: "gemini-summary-1",
+        content: "Checking secret-value-123 now",
+        source: "provider_summary",
+        provider: "google-gemini",
+      }),
+    ).toEqual({
+      type: "progress",
+      id: "gemini-summary-1",
+      content: "Checking [REDACTED] now",
+      source: "provider_summary",
+      provider: "google-gemini",
+    });
   });
 });
 

--- a/packages/llm/test/work-prompt.test.ts
+++ b/packages/llm/test/work-prompt.test.ts
@@ -151,6 +151,20 @@ describe("buildWorkPrompt clarification contract", () => {
   });
 });
 
+describe("buildWorkPrompt conversation contract", () => {
+  it("keeps prose conversational without prompting the model for progress", () => {
+    const prompt = build("hermes", {
+      wantsCards: true,
+      supportsCardTool: true,
+    });
+    expect(prompt).toContain("ongoing working conversation");
+    expect(prompt).toContain("surface supports the conversation");
+    expect(prompt).toContain("concise direct answer");
+    expect(prompt).not.toMatch(/emit (?:an )?(?:interim|progress) update/i);
+    expect(prompt).not.toMatch(/before (?:each|every) tool/i);
+  });
+});
+
 describe("buildWorkPrompt skill catalog", () => {
   it("includes compact discovery metadata and a path for on-demand instructions", () => {
     const prompt = build("hermes", {

--- a/scripts/install-clis.sh
+++ b/scripts/install-clis.sh
@@ -12,11 +12,13 @@
 #   ./scripts/install-clis.sh --skip-hermes  # graphjin only
 set -euo pipefail
 
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+REPO_ROOT="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
 GRAPHJIN_VERSION="${GRAPHJIN_VERSION:-3.20.47}"
 # Pin Hermes to the same ref baked into the Dockerfile so local-dev installs
-# match what ships in the container image. v2026.5.16 / v0.14.0.
-HERMES_AGENT_REF="${HERMES_AGENT_REF:-a91a57fa5a13d516c38b07a141a9ce8a3daabeb0}"
-HERMES_AGENT_VERSION="0.14.0"
+# match what ships in the container image. v2026.8.31 / v0.21.0.
+HERMES_AGENT_REF="${HERMES_AGENT_REF:-29112bef099274229cadff79cdff7bf7b99c4b77}"
+HERMES_AGENT_VERSION="0.21.0"
 
 SKIP_GRAPHJIN=false
 SKIP_HERMES=false
@@ -64,59 +66,115 @@ if ! $SKIP_GRAPHJIN && ! have graphjin; then
 fi
 
 # ─── hermes (Nous Research) ────────────────────────────────────────────
-# Hermes v0.14.0 supports a normal uv tool install. Check the active executable
-# so running this installer also replaces an existing v0.20 installation.
+# Hermes 0.21 deliberately blocks wheel builds. Install the pinned checkout in
+# editable mode, matching its supported source layout and the Docker image.
+# Check the active executable so this also replaces an older installation.
 hermes_matches_version() {
-  have hermes && hermes --version 2>/dev/null | grep -Eq '(^|[^0-9])0\.14\.0([^0-9]|$)'
+  have hermes && hermes --version 2>/dev/null | grep -Eq '(^|[^0-9])0\.21\.0([^0-9]|$)'
 }
 
 if ! $SKIP_HERMES && ! hermes_matches_version; then
   log "installing hermes (Nous Research) @ ${HERMES_AGENT_REF:0:8}"
   if [ "$os" = linux ] && have apt-get; then
     sudo apt-get update -qq
-    sudo apt-get install -y -qq python3 python3-venv python3-dev libffi-dev git build-essential ripgrep ffmpeg
+    sudo apt-get install -y -qq python3 python3-venv python3-dev libffi-dev git patch build-essential ripgrep ffmpeg
   fi
   if ! have uv; then
     log "installing uv"
     if [ "$os" = macos ] && have brew; then
       brew install uv
     else
-      curl -LsSf https://astral.sh/uv/install.sh | sudo env UV_INSTALL_DIR=/usr/local/bin sh -s -- --no-modify-path
+      curl -LsSf https://astral.sh/uv/install.sh | sudo env UV_INSTALL_DIR=/usr/local/bin UV_NO_MODIFY_PATH=1 sh
     fi
   fi
 
-  uv tool install --force --python 3.11 \
-    --with mcp --with websockets \
-    "hermes-agent[acp] @ git+https://github.com/NousResearch/hermes-agent.git@${HERMES_AGENT_REF}"
+  hermes_tools_dir="$(uv tool dir)"
+  hermes_tool_root="$hermes_tools_dir/hermes-agent"
+  hermes_source_root="$hermes_tools_dir/hermes-agent-openneko-${HERMES_AGENT_VERSION}-${HERMES_AGENT_REF:0:12}-patchset2"
+  hermes_bin_dir="$(uv tool dir --bin)"
+  case "$hermes_tools_dir" in
+    ""|"/") echo "refusing unsafe uv tool directory: $hermes_tools_dir" >&2; exit 1 ;;
+  esac
+  mkdir -p "$hermes_tools_dir" "$hermes_bin_dir"
+  if [ ! -d "$hermes_source_root/.git" ]; then
+    if [ -e "$hermes_source_root" ]; then
+      echo "hermes source path exists but is not a managed checkout: $hermes_source_root" >&2
+      exit 1
+    fi
+    git init "$hermes_source_root"
+    git -C "$hermes_source_root" remote add origin https://github.com/NousResearch/hermes-agent.git
+    git -C "$hermes_source_root" fetch --depth 1 origin "$HERMES_AGENT_REF"
+    git -C "$hermes_source_root" checkout --detach FETCH_HEAD
+  fi
+  if [ "$(git -C "$hermes_source_root" rev-parse HEAD)" != "$HERMES_AGENT_REF" ]; then
+    echo "managed hermes checkout is not pinned to $HERMES_AGENT_REF" >&2
+    exit 1
+  fi
+  if ! grep -q '"reasoning_config": resolve_reasoning_config' "$hermes_source_root/acp_adapter/session.py"; then
+    patch --batch --forward --fuzz=0 -d "$hermes_source_root" -p1 \
+      < "$REPO_ROOT/scripts/patches/hermes-acp-reasoning-config.patch"
+  fi
+  if ! grep -q 'make_interim_message_cb' "$hermes_source_root/acp_adapter/events.py"; then
+    patch --batch --forward --fuzz=0 -d "$hermes_source_root" -p1 \
+      < "$REPO_ROOT/scripts/patches/hermes-acp-interim-messages.patch"
+  fi
+  if ! grep -q '_emit_unstreamed_anthropic_reasoning' "$hermes_source_root/agent/chat_completion_helpers.py"; then
+    patch --batch --forward --fuzz=0 -d "$hermes_source_root" -p1 \
+      < "$REPO_ROOT/scripts/patches/hermes-acp-anthropic-reasoning.patch"
+  fi
+  uv venv --clear "$hermes_tool_root" --python 3.11
+  UV_PROJECT_ENVIRONMENT="$hermes_tool_root" \
+    uv sync --project "$hermes_source_root" --locked --no-dev --extra acp --extra mcp --extra anthropic
+  ln -sf "$hermes_tool_root/bin/hermes" "$hermes_bin_dir/hermes"
 
-  hermes_tool_root="$(uv tool dir)/hermes-agent"
-  hermes_python="$hermes_tool_root/bin/python"
-  hermes_mcp_tool="$hermes_tool_root/lib/python3.11/site-packages/tools/mcp_tool.py"
-  if [ ! -f "$hermes_mcp_tool" ]; then
-    echo "hermes v${HERMES_AGENT_VERSION} MCP adapter was not installed at $hermes_mcp_tool" >&2
-    exit 1
-  fi
-  if grep -q 'result\.isError' "$hermes_mcp_tool"; then
-    sed -i.bak 's/result\.isError/result.is_error/g' "$hermes_mcp_tool"
-    rm -f "$hermes_mcp_tool.bak"
-  fi
-  if grep -q 'result\.isError' "$hermes_mcp_tool"; then
-    echo "hermes v${HERMES_AGENT_VERSION} MCP adapter compatibility patch failed" >&2
-    exit 1
-  fi
   hash -r
   if ! hermes_matches_version; then
     echo "hermes install completed but v${HERMES_AGENT_VERSION} is not active on PATH" >&2
     exit 1
   fi
+elif ! $SKIP_HERMES; then
+  log "hermes already matches v${HERMES_AGENT_VERSION}"
+fi
+
+if ! $SKIP_HERMES; then
+  hermes_tool_root="$(uv tool dir)/hermes-agent"
+  hermes_python="$hermes_tool_root/bin/python"
+  hermes_site="$("$hermes_python" -c 'import pathlib, acp_adapter; print(pathlib.Path(acp_adapter.__file__).resolve().parent.parent)')"
+  hermes_session="$hermes_site/acp_adapter/session.py"
+  if [ ! -f "$hermes_session" ]; then
+    echo "hermes v${HERMES_AGENT_VERSION} ACP session adapter was not installed at $hermes_session" >&2
+    exit 1
+  fi
+  if ! grep -q '"reasoning_config": resolve_reasoning_config' "$hermes_session"; then
+    patch --batch --forward --fuzz=0 -d "$hermes_site" -p1 \
+      < "$REPO_ROOT/scripts/patches/hermes-acp-reasoning-config.patch"
+  fi
+  hermes_events="$hermes_site/acp_adapter/events.py"
+  if ! grep -q 'make_interim_message_cb' "$hermes_events"; then
+    patch --batch --forward --fuzz=0 -d "$hermes_site" -p1 \
+      < "$REPO_ROOT/scripts/patches/hermes-acp-interim-messages.patch"
+  fi
+  hermes_chat_helpers="$hermes_site/agent/chat_completion_helpers.py"
+  if ! grep -q '_emit_unstreamed_anthropic_reasoning' "$hermes_chat_helpers"; then
+    patch --batch --forward --fuzz=0 -d "$hermes_site" -p1 \
+      < "$REPO_ROOT/scripts/patches/hermes-acp-anthropic-reasoning.patch"
+  fi
   "$hermes_python" -c \
     "import hermes_cli; assert hermes_cli.__version__ == '${HERMES_AGENT_VERSION}'"
   "$hermes_python" -c \
+    "import openai; assert openai.__version__, 'Hermes OpenAI provider SDK missing'"
+  "$hermes_python" -c \
+    "import anthropic; assert anthropic.__version__, 'Hermes Anthropic provider SDK missing'"
+  "$hermes_python" -c \
     "from mcp.types import CallToolResult; result = CallToolResult(content=[]); assert hasattr(result, 'is_error')"
   "$hermes_python" -c \
+    "from acp_adapter.session import SessionManager; import inspect; source = inspect.getsource(SessionManager._make_agent); assert 'reasoning_config' in source and 'resolve_reasoning_config' in source, 'Hermes ACP must pass configured reasoning into AIAgent'"
+  "$hermes_python" -c \
     "from acp_adapter.server import HermesACPAgent; import inspect; source = inspect.getsource(HermesACPAgent.prompt); assert 'usage=usage' in source, 'Hermes ACP prompt response must expose exact turn usage'"
-elif ! $SKIP_HERMES; then
-  log "hermes already matches v${HERMES_AGENT_VERSION}"
+  "$hermes_python" -c \
+    "from acp_adapter.events import make_interim_message_cb; from acp_adapter.server import HermesACPAgent; import inspect; source = inspect.getsource(HermesACPAgent.prompt); assert 'interim_assistant_callback' in source and 'pending_streamed_message.append(text)' in source and 'raw_interim_cb(text, already_streamed=False)' in source and 'not streamed_message' not in source; assert callable(make_interim_message_cb), 'Hermes ACP buffered interim callback missing'"
+  "$hermes_python" -c \
+    "from agent import chat_completion_helpers; from pathlib import Path; source = Path(chat_completion_helpers.__file__).read_text(); assert '_emit_unstreamed_anthropic_reasoning' in source and 'reasoning_was_streamed' in source, 'Hermes ACP Anthropic reasoning fallback missing'"
 fi
 
 log "done. installed:"

--- a/scripts/patches/hermes-acp-anthropic-reasoning.patch
+++ b/scripts/patches/hermes-acp-anthropic-reasoning.patch
@@ -1,0 +1,66 @@
+--- a/agent/chat_completion_helpers.py
++++ b/agent/chat_completion_helpers.py
+@@ -4657,6 +4657,7 @@
+         stream's socket without closing the shared client mid-flight (#67142).
+         """
+         has_tool_use = False
++        reasoning_was_streamed = False
+         # Zero-event guard parity with the chat_completions path: track
+         # whether the provider delivered ANY stream event. On an eventless
+         # stream the real Anthropic SDK's get_final_message() raises
+@@ -4780,6 +4781,7 @@
+                             thinking_text = getattr(delta, "thinking", "")
+                             if thinking_text:
+                                 _fire_first_delta()
++                                reasoning_was_streamed = True
+                                 agent._fire_reasoning_delta(thinking_text)
+             if not agent._interrupt_requested:
+                 raw_stream = _stream_context["stream"]
+@@ -4831,6 +4833,31 @@
+                     return True
+             return False
+
++        def _emit_unstreamed_anthropic_reasoning(message) -> None:
++            """Deliver completed Anthropic summaries when no delta was forwarded.
++
++            Some Anthropic SDK/model combinations preserve summarized thinking
++            on the completed Message but do not yield a ``thinking_delta`` to
++            Hermes' ACP consumer. The generic response builder assumes every
++            streamed request already delivered reasoning and suppresses its
++            fallback, leaving ACP silent. Recover the provider summary here,
++            before the tool event, while deduplicating the normal delta path.
++            """
++            nonlocal reasoning_was_streamed
++            if reasoning_was_streamed or message is None or not agent.reasoning_callback:
++                return
++            try:
++                reasoning_text = agent._extract_reasoning(message)
++            except Exception:
++                logger.debug(
++                    "Failed to extract completed Anthropic reasoning for ACP",
++                    exc_info=True,
++                )
++                return
++            if reasoning_text:
++                agent._fire_reasoning_delta(reasoning_text)
++                reasoning_was_streamed = True
++
+         if (
+             base_final_message is not None
+             and not getattr(base_final_message, "content", None)
+@@ -4847,6 +4874,7 @@
+                     "block was still incomplete; treating as a "
+                     "mid-tool-call stream drop (#80498)."
+                 )
++            _emit_unstreamed_anthropic_reasoning(base_final_message)
+             return base_final_message
+         final_message = accumulator.response(base_final_message)
+         if (
+@@ -4863,6 +4891,7 @@
+                 "block was still incomplete; treating as a "
+                 "mid-tool-call stream drop (#80498)."
+             )
++        _emit_unstreamed_anthropic_reasoning(final_message)
+         return final_message
+
+     def _call():

--- a/scripts/patches/hermes-acp-interim-messages.patch
+++ b/scripts/patches/hermes-acp-interim-messages.patch
@@ -1,0 +1,113 @@
+--- a/acp_adapter/events.py
++++ b/acp_adapter/events.py
+@@ -14,7 +14,7 @@
+ from typing import Any, Callable, Deque, Dict
+
+ import acp
+-from acp.schema import AgentPlanUpdate, PlanEntry
++from acp.schema import AgentMessageChunk, AgentPlanUpdate, PlanEntry, TextContentBlock
+
+ from .tools import (
+     build_tool_complete,
+@@ -279,0 +280,25 @@
++
++
++def make_interim_message_cb(
++    conn: acp.Client,
++    session_id: str,
++    loop: asyncio.AbstractEventLoop,
++) -> Callable:
++    """Stream Hermes' real mid-turn assistant commentary over standard ACP."""
++
++    def _interim(text: str, *, already_streamed: bool = False) -> None:
++        if not text:
++            return
++        update = AgentMessageChunk(
++            session_update="agent_message_chunk",
++            content=TextContentBlock(type="text", text=text),
++            field_meta={
++                "hermes": {
++                    "interim": True,
++                    "already_streamed": bool(already_streamed),
++                }
++            },
++        )
++        _send_update(conn, session_id, loop, update)
++
++    return _interim
+--- a/acp_adapter/server.py
++++ b/acp_adapter/server.py
+@@ -65,7 +65,7 @@
+ from acp_adapter.auth import TERMINAL_SETUP_AUTH_METHOD_ID, build_auth_methods, detect_provider
+ from acp_adapter.events import (
+     _build_plan_update_from_todo_result,
+-    make_message_cb,
++    make_interim_message_cb,
+     make_step_cb,
+     make_thinking_cb,
+     make_tool_progress_cb,
+@@ -1941,7 +1941,7 @@
+         previous_approval_cb = None
+         edit_approval_requester = None
+
+-        streamed_message = False
++        pending_streamed_message: list[str] = []
+
+         if conn:
+             tool_progress_cb = make_tool_progress_cb(
+@@ -1950,13 +1950,24 @@
+             )
+             reasoning_cb = make_thinking_cb(conn, session_id, loop)
+             step_cb = make_step_cb(conn, session_id, loop, tool_call_ids, tool_call_meta)
+-            message_cb = make_message_cb(conn, session_id, loop)
+
+-            def stream_delta_cb(text: str) -> None:
+-                nonlocal streamed_message
++            def stream_delta_cb(text: str | None) -> None:
++                # Provider text arrives before Hermes knows whether this model
++                # response is final prose or commentary attached to a tool call.
++                # Buffer it until Hermes classifies the completed response so
++                # ACP never publishes interim text as a final assistant message.
+                 if text:
+-                    streamed_message = True
+-                message_cb(text)
++                    pending_streamed_message.append(text)
++
++            raw_interim_cb = make_interim_message_cb(conn, session_id, loop)
++
++            def interim_cb(text: str, *, already_streamed: bool = False) -> None:
++                if not text:
++                    return
++                # All pending deltas belong to the response Hermes has just
++                # classified as interim. They were intentionally not sent.
++                pending_streamed_message.clear()
++                raw_interim_cb(text, already_streamed=False)
+
+             approval_cb = make_approval_callback(conn.request_permission, loop, session_id)
+             try:
+@@ -1974,6 +1985,7 @@
+             reasoning_cb = None
+             step_cb = None
+             stream_delta_cb = None
++            interim_cb = None
+             approval_cb = None
+
+         agent = state.agent
+@@ -1985,6 +1997,7 @@
+         agent.reasoning_callback = reasoning_cb
+         agent.step_callback = step_cb
+         agent.stream_delta_callback = stream_delta_cb
++        agent.interim_assistant_callback = interim_cb
+
+         # Approval callback is per-thread (thread-local, GHSA-qg5c-hvr5-hjgr).
+         # Set it INSIDE _run_agent so the TLS write happens in the executor
+@@ -2175 +2188,0 @@
+-            and (not streamed_message or result.get("response_transformed"))
+@@ -2177,4 +2189,3 @@
+-            # Deliver the final response when streaming did not already send it,
+-            # or when a plugin hook transformed the response after streaming
+-            # finished (e.g. transform_llm_output) — otherwise the appended /
+-            # rewritten text never reaches the client.
++            # Provider text is buffered until Hermes classifies each completed
++            # response. Interim responses were emitted by interim_cb; the
++            # completed turn response is emitted exactly once here.

--- a/scripts/patches/hermes-acp-reasoning-config.patch
+++ b/scripts/patches/hermes-acp-reasoning-config.patch
@@ -1,0 +1,21 @@
+diff --git a/acp_adapter/session.py b/acp_adapter/session.py
+index 870ec95..1eee8d3 100644
+--- a/acp_adapter/session.py
++++ b/acp_adapter/session.py
+@@ -8,7 +8,7 @@ history.
+ """
+ from __future__ import annotations
+
+-from hermes_constants import get_hermes_home
++from hermes_constants import get_hermes_home, resolve_reasoning_config
+
+ import copy
+ import json
+@@ -642,6 +642,7 @@ class SessionManager:
+             "session_id": session_id,
+             "session_db": self._get_db(),
+             "model": model or default_model,
++            "reasoning_config": resolve_reasoning_config(config, model or default_model),
+         }
+
+         try:


### PR DESCRIPTION
## Summary

- upgrade and pin Hermes Agent 0.21 with strict ACP patches for configured reasoning and provider-neutral interim assistant messages
- surface native Gemini thought summaries and Hermes interim commentary without synthetic progress prompts or an additional model channel
- interleave progress, tools, prose, and A2UI results in the Work timeline; collapse provider detail under its authored headings
- reject malformed generated Answer surfaces and reconcile duplicate Answer retries during replay

## Verification

- `pnpm --filter @neko/llm exec vitest run test/hermes-backend-acp.test.ts test/interaction-from-agent-event.test.ts test/secret-scrubber.test.ts test/host-provision.test.ts test/work-prompt.test.ts test/hermes-install-contract.test.ts` (77 passed, 19 environment skips)
- `pnpm --filter @neko/web exec vitest run test/work-run-timeline.test.ts` (13 passed)
- worker and web TypeScript checks
- focused web lint and `pnpm ui:check`
- strict `--fuzz=0` dry-run for both Hermes patches
- `docker build --target agent -t openneko-agent:dev .`
- live Work verification at desktop width, including collapsed and expanded provider progress

## Notes

- No second model invocation is introduced.
- Phone-width live visual verification remains outstanding; the progress UI uses the existing shared `Disclosure` primitive.