### PR TITLE
fix: adapt librarian CPU cap to host capacity

### DIFF
--- a/apps/openneko/assets/compose/core.yml
+++ b/apps/openneko/assets/compose/core.yml
@@ -515,7 +515,9 @@ services:
       TRANSFORMERS_OFFLINE: "1"
       DOCLING_ARTIFACTS_PATH: /opt/docling/models
     read_only: true
-    cpus: 4.0
+    # The CLI sets this to min(host CPUs, 4). The one-CPU fallback keeps raw
+    # Compose use portable when the supervisor is not involved.
+    cpus: ${OPENNEKO_LIBRARIAN_CPUS:-1.0}
     mem_limit: 4g
     pids_limit: 256
     cap_drop:

--- a/apps/openneko/assets/compose_parity_test.go
+++ b/apps/openneko/assets/compose_parity_test.go
@@ -23,7 +23,7 @@ type composeParityService struct {
 	Entrypoint  []string                           `yaml:"entrypoint"`
 	Restart     string                             `yaml:"restart"`
 	ReadOnly    bool                               `yaml:"read_only"`
-	CPUs        float64                            `yaml:"cpus"`
+	CPUs        string                             `yaml:"cpus"`
 	MemLimit    string                             `yaml:"mem_limit"`
 	PidsLimit   int                                `yaml:"pids_limit"`
 	CapDrop     []string                           `yaml:"cap_drop"`
@@ -56,7 +56,7 @@ func TestLibrarianIsVendoredBoundedAndRequired(t *testing.T) {
 		if !ok {
 			t.Fatalf("%s compose is missing librarian", label)
 		}
-		if !librarian.ReadOnly || librarian.CPUs != 4 || librarian.MemLimit != "4g" || librarian.PidsLimit != 256 {
+		if !librarian.ReadOnly || librarian.CPUs != "${OPENNEKO_LIBRARIAN_CPUS:-1.0}" || librarian.MemLimit != "4g" || librarian.PidsLimit != 256 {
 			t.Fatalf("%s librarian limits are incomplete: %+v", label, librarian)
 		}
 		if !reflect.DeepEqual(librarian.CapDrop, []string{"ALL"}) {

--- a/apps/openneko/internal/cli/openshell_test.go
+++ b/apps/openneko/internal/cli/openshell_test.go
@@ -68,6 +68,40 @@ func TestConfigurePinnedLibrarianImagePreservesOverride(t *testing.T) {
 	}
 }
 
+func TestConfigureLibrarianCPULimitTracksHostCapacity(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		hostCPUs int
+		want     string
+	}{
+		{name: "invalid host count", hostCPUs: 0, want: "1"},
+		{name: "single CPU host", hostCPUs: 1, want: "1"},
+		{name: "production VM", hostCPUs: 2, want: "2"},
+		{name: "maximum", hostCPUs: 4, want: "4"},
+		{name: "larger host", hostCPUs: 16, want: "4"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(librarianCPULimitEnv, "")
+			if err := configureLibrarianCPULimit(tc.hostCPUs); err != nil {
+				t.Fatal(err)
+			}
+			if got := os.Getenv(librarianCPULimitEnv); got != tc.want {
+				t.Fatalf("%s = %q, want %q", librarianCPULimitEnv, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestConfigureLibrarianCPULimitPreservesOverride(t *testing.T) {
+	t.Setenv(librarianCPULimitEnv, "1.5")
+	if err := configureLibrarianCPULimit(8); err != nil {
+		t.Fatal(err)
+	}
+	if got := os.Getenv(librarianCPULimitEnv); got != "1.5" {
+		t.Fatalf("%s override changed: %q", librarianCPULimitEnv, got)
+	}
+}
+
 func TestOpenShellStateDirOverride(t *testing.T) {
 	// macOS with nothing set → under $HOME (OrbStack maps only $HOME into its VM).
 	if got := openShellStateDirOverride("darwin", "/Users/x", ""); got != "/Users/x/.openneko/openshell" {

--- a/apps/openneko/internal/cli/start.go
+++ b/apps/openneko/internal/cli/start.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
@@ -114,6 +115,9 @@ func bringUpStack(ctx context.Context, cmd *cobra.Command, mode compose.Mode, op
 		_ = os.Setenv("OPENNEKO_VERSION", imageVersion)
 	}
 	if err := configurePinnedLibrarianImage(os.Getenv("OPENNEKO_VERSION")); err != nil {
+		return err
+	}
+	if err := configureLibrarianCPULimit(runtime.NumCPU()); err != nil {
 		return err
 	}
 
@@ -251,6 +255,24 @@ func configurePinnedLibrarianImage(imageVersion string) error {
 		}
 	}
 	return os.Setenv("OPENNEKO_LIBRARIAN_IMAGE", pinned)
+}
+
+const librarianCPULimitEnv = "OPENNEKO_LIBRARIAN_CPUS"
+
+// configureLibrarianCPULimit keeps the extractor bounded without requiring
+// more CPUs than Docker can allocate on the current host. Operators can still
+// provide an explicit fractional or lower limit through the environment.
+func configureLibrarianCPULimit(hostCPUs int) error {
+	if strings.TrimSpace(os.Getenv(librarianCPULimitEnv)) != "" {
+		return nil
+	}
+	if hostCPUs < 1 {
+		hostCPUs = 1
+	}
+	if hostCPUs > 4 {
+		hostCPUs = 4
+	}
+	return os.Setenv(librarianCPULimitEnv, strconv.Itoa(hostCPUs))
 }
 
 // agentImageRef resolves the agent sandbox image: an explicit override wins,

--- a/apps/openneko/internal/cli/upgrade.go
+++ b/apps/openneko/internal/cli/upgrade.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"regexp"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -124,6 +125,9 @@ func runUpgrade(ctx context.Context, cmd *cobra.Command, opts upgradeOptions) er
 		}
 	}()
 	if err := configurePinnedLibrarianImage(target); err != nil {
+		return err
+	}
+	if err := configureLibrarianCPULimit(runtime.NumCPU()); err != nil {
 		return err
 	}
 

--- a/compose.yml
+++ b/compose.yml
@@ -595,7 +595,9 @@ services:
       TRANSFORMERS_OFFLINE: "1"
       DOCLING_ARTIFACTS_PATH: /opt/docling/models
     read_only: true
-    cpus: 4.0
+    # The CLI sets this to min(host CPUs, 4). The one-CPU fallback keeps raw
+    # Compose use portable when the supervisor is not involved.
+    cpus: ${OPENNEKO_LIBRARIAN_CPUS:-1.0}
     mem_limit: 4g
     pids_limit: 256
     cap_drop:


### PR DESCRIPTION
## Summary
- make the librarian CPU cap configurable through `OPENNEKO_LIBRARIAN_CPUS`
- automatically select the lesser of the host CPU count and the existing four-CPU ceiling for CLI-managed starts and upgrades
- retain a safe one-CPU fallback for raw Compose usage
- add regression coverage for 1-, 2-, 4-, and larger-CPU hosts plus explicit fractional overrides

## Why
The v2.39.0 production deployment reached the VM but Docker rejected the librarian because Compose requested 4 CPUs on a 2-CPU host. This keeps the service resource-bounded without making the stack require a four-CPU machine.

## Verification
- `go test ./...` from `apps/openneko`
- root Compose renders `cpus: 2` with `OPENNEKO_LIBRARIAN_CPUS=2`
- packaged Compose renders `cpus: 1.5` with an explicit override
- `git diff --check`