### PR TITLE
fix: cache startup knowledge, preserve solo identity, and trace run phases

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -62,6 +62,30 @@ jobs:
     name: Web design system
     runs-on: ubuntu-latest
 
+    # Solo-mode pages resolve a persisted identity, just like installed instances.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: neko
+          POSTGRES_PASSWORD: secret
+          POSTGRES_DB: neko
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U neko"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      OPENNEKO_PG_ENV_OVERRIDE: "1"
+      NEKO_PG_HOST: 127.0.0.1
+      NEKO_PG_PORT: "5432"
+      NEKO_PG_USER: neko
+      NEKO_PG_PASSWORD: secret
+      NEKO_PG_DATABASE: neko
+      NEKO_PG_SSLMODE: disable
+
     steps:
       - uses: actions/checkout@v6
         with:
@@ -83,6 +107,15 @@ jobs:
 
       - name: Install
         run: AX_SKIP_SKILL_INSTALL=1 pnpm install --frozen-lockfile
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: apps/openneko/go.mod
+          cache-dependency-path: apps/openneko/go.sum
+
+      - name: Migrate visual-test database
+        working-directory: apps/openneko
+        run: go run ./cmd/openneko migrate
 
       - name: Install Chromium
         run: pnpm --filter @neko/web exec playwright install --with-deps chromium

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -146,6 +146,10 @@ jobs:
         id: tag
         run: echo "value=${{ github.event.inputs.tag || github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve built source commit
+        id: source-commit
+        run: echo "value=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
       - name: Compute arch-safe platform key (amd64 / arm64)
         id: archkey
         run: echo "value=${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}" >> "$GITHUB_OUTPUT"
@@ -166,6 +170,9 @@ jobs:
         with:
           context: .
           file: ${{ matrix.file || './Dockerfile' }}
+          build-args: |
+            OPENNEKO_VERSION=${{ steps.tag.outputs.value }}
+            OPENNEKO_COMMIT=${{ steps.source-commit.outputs.value }}
           target: ${{ matrix.target }}
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=ghcr.io/open-neko/${{ matrix.image }},push-by-digest=true,name-canonical=true,push=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -390,6 +390,10 @@ CMD ["--listen", ":5003", "--upstream", "http://127.0.0.1:5004", "--", "node", "
 # ─── 5a. web runtime ───────────────────────────────────────────────────
 # Web remains a trusted OpenShell control plane; the agent runtime is not here.
 FROM runtime-base AS web
+ARG OPENNEKO_VERSION=unknown
+ARG OPENNEKO_COMMIT=unknown
+ENV OPENNEKO_VERSION=$OPENNEKO_VERSION OPENNEKO_COMMIT=$OPENNEKO_COMMIT
+LABEL org.opencontainers.image.revision=$OPENNEKO_COMMIT org.opencontainers.image.version=$OPENNEKO_VERSION
 WORKDIR /app
 # Writable HOME under /tmp so the entrypoint can materialize config on
 # read-only container filesystems. PORT=8080 matches the common PaaS
@@ -442,6 +446,10 @@ RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
 # and approved schema diff/sync require the shared pinned GraphJin CLI; this
 # parent supplies it without inheriting Hermes or the document toolchain.
 FROM graphjin-node-runtime AS worker
+ARG OPENNEKO_VERSION=unknown
+ARG OPENNEKO_COMMIT=unknown
+ENV OPENNEKO_VERSION=$OPENNEKO_VERSION OPENNEKO_COMMIT=$OPENNEKO_COMMIT
+LABEL org.opencontainers.image.revision=$OPENNEKO_COMMIT org.opencontainers.image.version=$OPENNEKO_VERSION
 WORKDIR /app
 # Minimal extraction toolchain for the library distiller ("the librarian"),
 # which shells out to the bundled document-extraction script on this host:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,14 +6,17 @@ have stale implementation status; verify them against current source.
 
 ## RBAC-1: connect effective access revisions to warm sandbox reuse
 
-**Pending — required before normal user-scoped sandbox reuse can be enabled.**
+**Pending — required for reuse with fine-grained or multi-user access. Solo admin reuse is enabled.**
 Updated 12 September 2026 alongside the warm sandbox implementation.
 
 Generic prewarming defaults to one slot. Assigned reuse is scoped to
 **organisation + user**, across chats, with a **three-minute idle timeout**.
 Every turn gets a fresh Hermes child/session, current staged context and a fresh
-broker token. Missing access revisions currently disable assigned reuse; they do
-not disable generic prewarming.
+broker token. Solo deployments retain their sole active admin's sandbox, using
+their persisted local admin account ID. Solo upgrades adopt or create that account
+automatically; email is required only before enabling SSO, which links the same ID. Their idle timeout starts after the turn finishes. Other actors require an access revision; generic
+prewarming remains available without one. Expired generic spares replenish
+automatically while the host is alive.
 
 ### Revision contract
 

--- a/apps/openneko/assets/migrations/0073_solo_admin_identity.sql
+++ b/apps/openneko/assets/migrations/0073_solo_admin_identity.sql
@@ -1,0 +1,4 @@
+-- The owner is resolved lazily only after confirming auth is off. Never infer
+-- a solo identity for an existing SSO installation during schema migration.
+alter table organization add column if not exists solo_admin_user_id text
+  references app_user(id) on delete set null;

--- a/apps/web/src/app/(work)/work/work-screen.tsx
+++ b/apps/web/src/app/(work)/work/work-screen.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { acknowledgeWorkStartup, markWorkStartup } from "@/lib/work-startup-timing";
+
 import "@/a2ui/components";
 import {
   ArrowUp,
@@ -760,6 +762,7 @@ export default function WorkScreen() {
   }
 
   async function sendMessage() {
+    const submittedAt = performance.now();
     const trimmed = draft.trim();
     if (!trimmed && files.length === 0) return;
 
@@ -805,7 +808,7 @@ export default function WorkScreen() {
     setDraftMentions([]);
     setMention(null);
 
-    await postAndStreamRun(threadId, message);
+    await postAndStreamRun(threadId, message, submittedAt);
   }
 
   // Submit a follow-up turn directly (no composer round-trip) — the landing
@@ -888,7 +891,7 @@ export default function WorkScreen() {
     await postAndStreamRun(threadId, text);
   }
 
-  async function postAndStreamRun(threadId: string, message: string) {
+  async function postAndStreamRun(threadId: string, message: string, submittedAt = performance.now()) {
     // Every entry point must expose the live-run controls. Retry/edit reloads
     // the truncated thread first, and that reload clears `sending` when no
     // earlier run remains in flight.
@@ -911,6 +914,7 @@ export default function WorkScreen() {
       runId: string;
       actorRole?: RunRecord["actorRole"];
     };
+    acknowledgeWorkStartup(threadId, runId, submittedAt);
     if (!mountedRef.current) return;
 
     updateActiveRunId(runId);
@@ -1039,6 +1043,7 @@ export default function WorkScreen() {
         close: () => settle("closed"),
       };
 
+      es.onopen = () => markWorkStartup(runId, "streamOpenMs");
       es.onmessage = (msgEvent) => {
         let event: WorkEvent;
         try {
@@ -1048,6 +1053,9 @@ export default function WorkScreen() {
         }
         if (event.type === "hello") return;
         applyIncomingEvent(runId, event);
+        markWorkStartup(runId, "firstEventMs");
+        if ((event.type === "message" && event.role === "assistant" && event.content) || event.type === "surface") markWorkStartup(runId, "firstOutputMs");
+        if (event.type === "done") markWorkStartup(runId, "doneMs");
         if (event.type === "done") settle("done");
       };
       es.onerror = () => {

--- a/apps/web/src/app/admin/users/UsersClient.tsx
+++ b/apps/web/src/app/admin/users/UsersClient.tsx
@@ -34,11 +34,11 @@ export interface AdminUserRow {
  * change roles, and disable/enable accounts. The API enforces the
  * last-active-admin guard; errors from it surface inline.
  */
-export function UsersClient({ users }: { users: AdminUserRow[] }) {
+export function UsersClient({ users, identitySetup = false }: { users: AdminUserRow[]; identitySetup?: boolean }) {
   const router = useRouter();
   const [email, setEmail] = useState("");
   const [name, setName] = useState("");
-  const [role, setRole] = useState<"member" | "admin">("member");
+  const [role, setRole] = useState<"member" | "admin">(identitySetup ? "admin" : "member");
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
@@ -83,6 +83,7 @@ export function UsersClient({ users }: { users: AdminUserRow[] }) {
         email,
         name: name.trim().length > 0 ? name : undefined,
         role,
+        ...(identitySetup ? { updateSoloAccount: true } : {}),
       }),
     });
     if (ok) {
@@ -116,15 +117,16 @@ export function UsersClient({ users }: { users: AdminUserRow[] }) {
         </div>
       ) : null}
 
-      <div className="mb-4 max-w-[520px]">
+      {!identitySetup && <div className="mb-4 max-w-[520px]">
         <SearchInput
           label="Search users"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
           placeholder="Search users by name, email, role, or status"
         />
-      </div>
+      </div>}
 
+      {identitySetup && <p className="mb-4 text-sm text-text2">Use the email you will sign in with if you enable SSO later.</p>}
       <form
         onSubmit={createUser}
         className="mb-6 grid grid-cols-[minmax(220px,1.4fr)_minmax(180px,1fr)_minmax(130px,0.6fr)_auto] items-end gap-3 max-[820px]:grid-cols-2 max-[520px]:grid-cols-1"
@@ -132,6 +134,9 @@ export function UsersClient({ users }: { users: AdminUserRow[] }) {
         <Field label="Email" htmlFor="new-user-email">
           <Input
             id="new-user-email"
+            name="email"
+            autoComplete="email"
+            spellCheck={false}
             type="email"
             required
             value={email}
@@ -142,6 +147,8 @@ export function UsersClient({ users }: { users: AdminUserRow[] }) {
         <Field label="Name (optional)" htmlFor="new-user-name">
           <Input
             id="new-user-name"
+            name="name"
+            autoComplete="name"
             type="text"
             value={name}
             onChange={(event) => setName(event.target.value)}
@@ -151,6 +158,7 @@ export function UsersClient({ users }: { users: AdminUserRow[] }) {
         <Field label="Role" htmlFor="new-user-role">
           <NativeSelect
             id="new-user-role"
+            disabled={identitySetup}
             value={role}
             onChange={(event) =>
               setRole(event.target.value === "admin" ? "admin" : "member")
@@ -161,7 +169,7 @@ export function UsersClient({ users }: { users: AdminUserRow[] }) {
           </NativeSelect>
         </Field>
         <Button type="submit" variant="primary" disabled={busy === "create"}>
-          {busy === "create" ? "Adding…" : "Add user"}
+          {busy === "create" ? "Saving…" : identitySetup ? "Save email" : "Add user"}
         </Button>
       </form>
 
@@ -169,7 +177,7 @@ export function UsersClient({ users }: { users: AdminUserRow[] }) {
         <p className="text-sm text-text2">
           {query
             ? "No users match this search."
-            : "No users yet. Add one above to allow them to sign in."}
+            : identitySetup ? "Your account already exists. Adding an email is optional until you enable SSO." : "No users yet. Add one above to allow them to sign in."}
         </p>
       ) : (
         <div className="overflow-x-auto">

--- a/apps/web/src/app/admin/users/page.tsx
+++ b/apps/web/src/app/admin/users/page.tsx
@@ -1,5 +1,5 @@
 import { connection } from "next/server";
-import { app_user, asc, db, eq } from "@neko/db";
+import { app_user, asc, db, eq, isUnclaimedSoloEmail } from "@neko/db";
 import { getCurrentActor } from "@/lib/actor";
 import { getOrgId } from "@/lib/db";
 import { getPluginStatus } from "@/lib/auth";
@@ -30,9 +30,10 @@ export default async function AdminUsersPage() {
     getPluginStatus(),
   ]);
 
+  const identitySetup = users.some((user) => user.id === actor.userId && isUnclaimedSoloEmail(user.email));
   const rows: AdminUserRow[] = users.map((user) => ({
     id: user.id,
-    email: user.email,
+    email: isUnclaimedSoloEmail(user.email) ? "Email not set" : user.email,
     name: user.name,
     role: user.role,
     disabled: Boolean(user.disabledAt),
@@ -47,7 +48,7 @@ export default async function AdminUsersPage() {
       subtitle={
         pluginStatus.authProvider
           ? `Multi-user mode via ${pluginStatus.authProvider}.`
-          : "Solo mode: this deployment grants admin access by default."
+          : "Solo mode uses your local admin account."
       }
       back={{ href: "/admin", label: "Admin" }}
       wide
@@ -55,11 +56,11 @@ export default async function AdminUsersPage() {
       <section className="settings-card">
         <div className="settings-card-head">
           <div>
-            <h2 className="settings-card-title">Users</h2>
+            <h2 className="settings-card-title">{identitySetup ? "Your admin email" : "Users"}</h2>
             <p className="settings-card-copy">
-              Provision users before their first sign-in, assign roles, and
-              disable accounts. Providers without automatic provisioning
-              (e.g. magic link) only ever sign in users listed here.
+              {identitySetup
+                ? "Your local account is ready to use. Add your email before enabling SSO; your work stays with this account."
+                : "Provision users before their first sign-in, assign roles, and disable accounts. Providers without automatic provisioning (e.g. magic link) only ever sign in users listed here."}
             </p>
           </div>
           <div className="settings-source">
@@ -67,7 +68,7 @@ export default async function AdminUsersPage() {
           </div>
         </div>
 
-        <UsersClient users={rows} />
+        <UsersClient users={rows} identitySetup={identitySetup} />
       </section>
     </AdminShell>
   );

--- a/apps/web/src/app/api/admin/users/route.ts
+++ b/apps/web/src/app/api/admin/users/route.ts
@@ -12,7 +12,7 @@
 
 import { randomBytes } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
-import { and, app_user, db, eq, sql } from "@neko/db";
+import { and, app_user, db, eq, sql, organization, isUnclaimedSoloEmail } from "@neko/db";
 import { isDenied, requireAdminActor } from "@/lib/admin-auth";
 import { getOrgId } from "@/lib/db";
 
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
   const actor = await requireAdminActor();
   if (isDenied(actor)) return actor;
 
-  let body: { email?: unknown; name?: unknown; role?: unknown };
+  let body: { email?: unknown; name?: unknown; role?: unknown; updateSoloAccount?: unknown };
   try {
     body = await request.json();
   } catch {
@@ -67,16 +67,31 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const id = `usr_${randomBytes(9).toString("base64url")}`;
+  let id = `usr_${randomBytes(9).toString("base64url")}`;
   try {
-    await db().insert(app_user).values({
-      id,
-      sub: null,
-      email,
-      name,
-      org_id: orgId,
-      role,
+    const created = await db().transaction(async (tx) => {
+      await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${"openneko.app_user:" + orgId}))`);
+      if (body.updateSoloAccount === true) {
+        const [org] = await tx.select({ owner: organization.solo_admin_user_id }).from(organization)
+          .where(eq(organization.id, orgId)).limit(1);
+        const [owner] = await tx.select({ email: app_user.email, sub: app_user.sub }).from(app_user)
+          .where(and(eq(app_user.org_id, orgId), eq(app_user.id, actor.userId!))).limit(1);
+        if (org?.owner !== actor.userId || !owner || owner.sub || !isUnclaimedSoloEmail(owner.email) || role !== "admin") return false;
+        id = actor.userId!;
+        await tx.update(app_user).set({ email, name, updated_at: new Date() }).where(eq(app_user.id, id));
+        return true;
+      }
+      await tx.insert(app_user).values({
+        id,
+        sub: null,
+        email,
+        name,
+        org_id: orgId,
+        role,
+      });
+      return true;
     });
+    if (!created) return NextResponse.json({ error: "This account cannot be updated here. Reload the page." }, { status: 409 });
   } catch (e) {
     // app_user_org_email_unique: a concurrent provision (double-click,
     // second admin tab) won the race between our lookup and this insert.
@@ -93,6 +108,6 @@ export async function POST(request: NextRequest) {
   }
   return NextResponse.json(
     { user: { id, email, name, role } },
-    { status: 201 },
+    { status: body.updateSoloAccount === true ? 200 : 201 },
   );
 }

--- a/apps/web/src/app/api/auth/session/route.ts
+++ b/apps/web/src/app/api/auth/session/route.ts
@@ -7,11 +7,11 @@
  */
 
 import { NextResponse } from "next/server";
-import { getCurrentUser } from "@/lib/auth";
+import { getCurrentUser, getAuthProvider } from "@/lib/auth";
 import { getCurrentActor } from "@/lib/actor";
 
 export async function GET() {
   const user = await getCurrentUser();
   const actor = user ? await getCurrentActor() : null;
-  return NextResponse.json({ user, role: actor?.role ?? null });
+  return NextResponse.json({ user, role: actor?.role ?? null, authEnabled: Boolean(await getAuthProvider()) });
 }

--- a/apps/web/src/app/api/v1/workflows/[workflowId]/runs/[runId]/artifact/route.ts
+++ b/apps/web/src/app/api/v1/workflows/[workflowId]/runs/[runId]/artifact/route.ts
@@ -1,3 +1,5 @@
+import { startupEvent, startupPhase, withStartupTrace } from "@neko/telemetry/startup";
+import { randomUUID } from "node:crypto";
 import { createReadStream } from "node:fs";
 import { Readable } from "node:stream";
 import { NextRequest, NextResponse } from "next/server";
@@ -19,18 +21,35 @@ type RouteContext = {
 };
 
 export async function GET(request: NextRequest, context: RouteContext) {
+  const { runId } = await context.params;
+  return withStartupTrace({ requestId: randomUUID(), workflowRunId: runId }, () => startupPhase("workflow.http_artifact", async () => {
+    const response = await getWorkflow(request, context);
+    startupEvent("workflow.http_response", { statusCode: response.status });
+    return response;
+  }));
+}
+
+async function getWorkflow(request: NextRequest, context: RouteContext) {
   const fingerprint = workflowApiFingerprint(request);
   try {
-    await enforceWorkflowApiEdgeThrottle(fingerprint);
+    await startupPhase("workflow.api_throttle", async () => enforceWorkflowApiEdgeThrottle(fingerprint));
     const { workflowId, runId } = await context.params;
     const token = parseWorkflowApiBearer(request.headers.get("authorization"));
-    const artifact = await getWorkflowApiArtifact({
+    const artifact = await startupPhase("workflow.api_artifact", async () => getWorkflowApiArtifact({
       workflowId,
       runId,
       token: token ?? "",
       clientFingerprint: fingerprint,
-    });
-    const body = Readable.toWeb(createReadStream(artifact.absolutePath));
+    }));
+    const source = createReadStream(artifact.absolutePath);
+    const started = performance.now();
+    let outcome = "cancelled";
+    source.once("end", () => { outcome = "completed"; });
+    source.once("error", () => { outcome = "failed"; });
+    source.once("close", () => startupEvent("workflow.artifact_stream", {
+      outcome, durationMs: performance.now() - started, bytesRead: source.bytesRead,
+    }));
+    const body = Readable.toWeb(source);
     return new NextResponse(body as ReadableStream, {
       headers: {
         "Content-Type": artifact.contentType,

--- a/apps/web/src/app/api/v1/workflows/[workflowId]/runs/[runId]/route.ts
+++ b/apps/web/src/app/api/v1/workflows/[workflowId]/runs/[runId]/route.ts
@@ -1,3 +1,5 @@
+import { startupEvent, startupPhase, withStartupTrace } from "@neko/telemetry/startup";
+import { randomUUID } from "node:crypto";
 import { NextRequest } from "next/server";
 import {
   enforceWorkflowApiEdgeThrottle,
@@ -18,17 +20,26 @@ type RouteContext = {
 };
 
 export async function GET(request: NextRequest, context: RouteContext) {
+  const { runId } = await context.params;
+  return withStartupTrace({ requestId: randomUUID(), workflowRunId: runId }, () => startupPhase("workflow.http_status", async () => {
+    const response = await getWorkflow(request, context);
+    startupEvent("workflow.http_response", { statusCode: response.status });
+    return response;
+  }));
+}
+
+async function getWorkflow(request: NextRequest, context: RouteContext) {
   const fingerprint = workflowApiFingerprint(request);
   try {
-    await enforceWorkflowApiEdgeThrottle(fingerprint);
+    await startupPhase("workflow.api_throttle", async () => enforceWorkflowApiEdgeThrottle(fingerprint));
     const { workflowId, runId } = await context.params;
     const token = parseWorkflowApiBearer(request.headers.get("authorization"));
-    const run = await getWorkflowApiRunStatus({
+    const run = await startupPhase("workflow.api_status", async () => getWorkflowApiRunStatus({
       workflowId,
       runId,
       token: token ?? "",
       clientFingerprint: fingerprint,
-    });
+    }));
     return workflowApiJson(
       {
         ...run,

--- a/apps/web/src/app/api/v1/workflows/[workflowId]/runs/route.ts
+++ b/apps/web/src/app/api/v1/workflows/[workflowId]/runs/route.ts
@@ -1,3 +1,5 @@
+import { startupEvent, startupPhase, withStartupTrace } from "@neko/telemetry/startup";
+import { randomUUID } from "node:crypto";
 import { NextRequest } from "next/server";
 import {
   WorkflowApiError,
@@ -32,9 +34,17 @@ function parseMode(request: NextRequest): WorkflowApiExecutionMode {
 }
 
 export async function POST(request: NextRequest, context: RouteContext) {
+  return withStartupTrace({ requestId: randomUUID() }, () => startupPhase("workflow.http_submit", async () => {
+    const response = await postWorkflow(request, context);
+    startupEvent("workflow.http_response", { statusCode: response.status });
+    return response;
+  }));
+}
+
+async function postWorkflow(request: NextRequest, context: RouteContext) {
   const fingerprint = workflowApiFingerprint(request);
   try {
-    await enforceWorkflowApiEdgeThrottle(fingerprint);
+    await startupPhase("workflow.api_throttle", async () => enforceWorkflowApiEdgeThrottle(fingerprint));
     const { workflowId } = await context.params;
     const mode = parseMode(request);
     const contentType = request.headers.get("content-type")?.split(";")[0]?.trim();
@@ -45,17 +55,18 @@ export async function POST(request: NextRequest, context: RouteContext) {
         415,
       );
     }
-    const value = await readWorkflowApiJsonBody(request);
+    const value = await startupPhase("workflow.api_read_body", async () => readWorkflowApiJsonBody(request));
     const token = parseWorkflowApiBearer(request.headers.get("authorization"));
     const idempotencyKey = request.headers.get("idempotency-key");
-    const admitted = await admitWorkflowApiRun({
+    const admitted = await startupPhase("workflow.api_admit", async () => admitWorkflowApiRun({
       workflowId,
       token: token ?? "",
       idempotencyKey: idempotencyKey ?? "",
       mode,
       value,
       clientFingerprint: fingerprint,
-    });
+    }));
+    startupEvent("workflow.api_admitted", { workflowRunId: admitted.runId, mode: admitted.mode, replay: admitted.replay, outcome: admitted.status });
     return workflowApiJson(
       {
         runId: admitted.runId,

--- a/apps/web/src/app/api/work/threads/[threadId]/runs/[runId]/events/route.ts
+++ b/apps/web/src/app/api/work/threads/[threadId]/runs/[runId]/events/route.ts
@@ -1,3 +1,4 @@
+import { startupEvent, startupPhase, withStartupTrace } from "@neko/telemetry/startup";
 import { NextRequest } from "next/server";
 import type { AgentEvent } from "@neko/llm";
 import { createNotifyClient, type NotifyClient } from "@neko/db";
@@ -36,6 +37,11 @@ function comment(text: string): Uint8Array {
 
 export async function GET(request: NextRequest, context: RouteContext) {
   const { threadId, runId } = await context.params;
+  return withStartupTrace({ threadId, runId }, () => startupPhase("sse.subscribe", () => getEvents(request, context)));
+}
+
+async function getEvents(request: NextRequest, context: RouteContext) {
+  const { threadId, runId } = await context.params;
   const url = new URL(request.url);
   const lastEventIdHeader = request.headers.get("last-event-id");
   // Accept both `afterId` (new) and `afterSeq` (legacy) to keep older
@@ -60,6 +66,9 @@ export async function GET(request: NextRequest, context: RouteContext) {
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       const t0 = Date.now();
+      const started = performance.now();
+      let firstEvent = true;
+      let firstOutput = true;
       let closed = false;
       let lastSentId = afterId;
       const sentIds = new Set<number>();
@@ -77,7 +86,10 @@ export async function GET(request: NextRequest, context: RouteContext) {
         if (id <= afterId) return;
         if (sentIds.has(id)) return;
         sentIds.add(id);
+        if (closed) return;
         safeEnqueue(frame(event, id));
+        if (firstEvent) { firstEvent = false; startupEvent("sse.first_event", { durationMs: performance.now() - started, afterId }); }
+        if (firstOutput && ((event.type === "message" && event.role === "assistant" && event.content) || event.type === "surface")) { firstOutput = false; startupEvent("sse.first_output", { durationMs: performance.now() - started, afterId }); }
         if (id > lastSentId) lastSentId = id;
       };
 
@@ -104,7 +116,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
       let listenClient: NotifyClient | null = null;
       try {
-        listenClient = await createNotifyClient("work_run_event");
+        listenClient = await startupPhase("sse.listen", () => createNotifyClient("work_run_event"));
         listenClient.on((channel, payload) => {
           if (channel === "work_run_event" && payload === runId) {
             wakeFromNotify();
@@ -124,15 +136,15 @@ export async function GET(request: NextRequest, context: RouteContext) {
         }),
       );
 
+      startupEvent("sse.hello", { durationMs: performance.now() - started, afterId });
+      let firstRead = true;
       let keepaliveTimer = Date.now();
 
       try {
         while (!closed) {
-          const newEvents = await getWorkRunEventsAfter(
-            orgId,
-            runId,
-            lastSentId,
-          );
+          const read = () => getWorkRunEventsAfter(orgId, runId, lastSentId);
+          const newEvents = firstRead ? await startupPhase("sse.initial_db_read", read) : await read();
+          firstRead = false;
           for (const { id, event } of newEvents) {
             sendIfNew(event, id);
           }

--- a/apps/web/src/app/api/work/threads/[threadId]/runs/[runId]/timing/route.ts
+++ b/apps/web/src/app/api/work/threads/[threadId]/runs/[runId]/timing/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest } from "next/server";
+import { startupEvent, withStartupTrace } from "@neko/telemetry/startup";
+import { getOrgId } from "@/lib/db";
+import { getAuthorizedWorkThread } from "@/lib/work-thread-auth";
+import { getWorkRun } from "@/lib/work-store";
+
+export const runtime = "nodejs";
+const allowed = new Set(["acknowledgementMs", "streamOpenMs", "firstEventMs", "firstOutputMs", "paintOpportunityMs", "doneMs", "documentVisible"]);
+export async function POST(request: NextRequest, context: { params: Promise<{ threadId: string; runId: string }> }) {
+  const { threadId, runId } = await context.params;
+  const orgId = await getOrgId();
+  if (!await getAuthorizedWorkThread(orgId, threadId)) return new Response(null, { status: 404 });
+  const run = await getWorkRun(orgId, runId);
+  if (!run || run.thread_id !== threadId) return new Response(null, { status: 404 });
+  const body: unknown = await request.json().catch(() => null);
+  if (!body || typeof body !== "object" || Array.isArray(body)) return new Response(null, { status: 400 });
+  const values = Object.entries(body);
+  if (!values.length || values.some(([key, value]) => !allowed.has(key) || typeof value !== "number" || !Number.isFinite(value) || value < 0 || value > (key === "documentVisible" ? 1 : 3_600_000))) return new Response(null, { status: 400 });
+  withStartupTrace({ threadId, runId }, () => startupEvent("browser.startup", { origin: "client_reported", ...Object.fromEntries(values) }));
+  return new Response(null, { status: 204 });
+}

--- a/apps/web/src/app/api/work/threads/[threadId]/runs/route.ts
+++ b/apps/web/src/app/api/work/threads/[threadId]/runs/route.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+import { bindStartupRun, startupEvent, startupPhase, withStartupTrace } from "@neko/telemetry/startup";
 import { NextRequest, NextResponse } from "next/server";
 import {
   resolveAgentBackend,
@@ -46,15 +48,25 @@ export const dynamic = "force-dynamic";
 
 export async function POST(request: NextRequest, context: RouteContext) {
   const { threadId } = await context.params;
+  return withStartupTrace({ requestId: randomUUID(), threadId }, () => startupPhase("http.submit", async () => {
+    const response = await postRun(request, context);
+    startupEvent("http.response", { statusCode: response.status });
+    return response;
+  }));
+}
+
+async function postRun(request: NextRequest, context: RouteContext) {
+  const telemetryStartedAt = Date.now();
+  const { threadId } = await context.params;
   const body = await request.json().catch(() => ({}));
   const message = typeof body.message === "string" ? body.message.trim() : "";
   if (!message) {
     return NextResponse.json({ error: "message is required" }, { status: 400 });
   }
 
-  const orgId = await getOrgId();
-  const actor = await getCurrentActor();
-  const thread = await getAuthorizedWorkThread(orgId, threadId, actor);
+  const orgId = await startupPhase("http.organization", () => getOrgId());
+  const actor = await startupPhase("http.identity", () => getCurrentActor());
+  const thread = await startupPhase("http.authorize", () => getAuthorizedWorkThread(orgId, threadId, actor));
   if (!thread) {
     return NextResponse.json({ error: "Thread not found" }, { status: 404 });
   }
@@ -94,19 +106,29 @@ export async function POST(request: NextRequest, context: RouteContext) {
   }
 
   // Memory writes are agent-driven through the brokered memory MCP tool.
-  const backend = await resolveAgentBackend(orgId);
+  const backend = await startupPhase("config.backend", () => resolveAgentBackend(orgId));
 
   // Derive the agent-sandbox env (model egress, gateway provider, key alias)
   // before creating the run. If gateway sync is temporarily unavailable, the
   // memoized provision attempt is cleared and the caller can retry cleanly.
-  const agentRuntime = await ensureHostConfigProvisioned(orgId);
+  const agentRuntime = await startupPhase("config.provision", () => ensureHostConfigProvisioned(orgId));
 
-  const run = await createWorkRun(orgId, threadId, backend.id, actor);
+  const [pluginActions, packActions] = await Promise.all([
+    startupPhase("context.plugin_actions", () => getPluginActionDescriptors()),
+    startupPhase("context.pack_actions", () => listPackActionDescriptors(orgId)),
+  ]);
+
+  // The agent loop runs in an OpenShell sandbox (SEC9: the only runtime).
+  // The web server stays the control plane, launches the box, and relays
+  // events over the existing SSE.
+  const broker = await startupPhase("broker.ready", () => ensureAgentBroker());
+
+  const run = await startupPhase("run.create", () => createWorkRun(orgId, threadId, backend.id, actor));
   const runTelemetry = createWebHarnessObserver(run.id);
   const telemetryOperationId = `work:${run.id}`;
-  const telemetryStartedAt = Date.now();
   await observeSafely(runTelemetry.observer, {
     kind: "run.start",
+    timestamp: new Date(telemetryStartedAt).toISOString(),
     operationId: telemetryOperationId,
     attributes: {
       "openneko.run.kind": "production",
@@ -117,16 +139,18 @@ export async function POST(request: NextRequest, context: RouteContext) {
     },
   });
 
+  await bindStartupRun(run.id, runTelemetry.observer);
+
   if (!thread.title) {
     await touchWorkThread(threadId, { title: suggestWorkThreadTitle(message) });
   }
-  await createWorkMessage({
+  await startupPhase("run.save_user_message", () => createWorkMessage({
     orgId,
     threadId,
     runId: run.id,
     role: "user",
     content: message,
-  });
+  }));
 
   const abortController = new AbortController();
   registerRun({
@@ -143,15 +167,6 @@ export async function POST(request: NextRequest, context: RouteContext) {
     runId: run.id,
   });
 
-  const [pluginActions, packActions] = await Promise.all([
-    getPluginActionDescriptors(),
-    listPackActionDescriptors(orgId),
-  ]);
-
-  // The agent loop runs in an OpenShell sandbox (SEC9: the only runtime).
-  // The web server stays the control plane, launches the box, and relays
-  // events over the existing SSE.
-  const broker = await ensureAgentBroker();
   const unregisterBrokerEvents = registerAgentBrokerEventSink(run.id, emit);
 
   void runChatTurn(
@@ -236,6 +251,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       unregisterRun(run.id);
     });
 
+  startupEvent("http.ack_ready", { durationMs: Date.now() - telemetryStartedAt, execution: "in_process" });
   return NextResponse.json({
     runId: run.id,
     threadId,

--- a/apps/web/src/app/api/workflows/[workflowId]/runs/route.ts
+++ b/apps/web/src/app/api/workflows/[workflowId]/runs/route.ts
@@ -1,3 +1,5 @@
+import { bindStartupRun, startupEvent, startupPhase, withStartupTrace } from "@neko/telemetry/startup";
+import { randomUUID } from "node:crypto";
 import { NextRequest, NextResponse } from "next/server";
 import { db, eq, workflow_run } from "@neko/db";
 import { ensureHostConfigProvisioned } from "@neko/llm";
@@ -31,22 +33,31 @@ type RouteContext = {
 };
 
 export async function POST(request: NextRequest, context: RouteContext) {
+  return withStartupTrace({ requestId: randomUUID() }, () => startupPhase("workflow.http_submit", async () => {
+    const response = await postWorkflow(request, context);
+    startupEvent("workflow.http_response", { statusCode: response.status });
+    return response;
+  }));
+}
+
+async function postWorkflow(request: NextRequest, context: RouteContext) {
+  const telemetryStartedAt = Date.now();
   const { workflowId } = await context.params;
   const body = await request.json().catch(() => ({}));
   const userMessage =
     typeof body.userMessage === "string" ? body.userMessage.trim() : undefined;
 
   const orgId = await getOrgId();
-  const agentRuntime = await ensureHostConfigProvisioned(orgId);
+  const agentRuntime = await startupPhase("config.provision", async () => ensureHostConfigProvisioned(orgId));
 
   let prepared;
   try {
-    prepared = await prepareWorkflowRun({
+    prepared = await startupPhase("workflow.prepare", async () => prepareWorkflowRun({
       orgId,
       workflowId,
       triggerKind: "manual",
       triggerPayload: { userMessage: userMessage ?? null },
-    });
+    }));
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     return NextResponse.json({ error: msg }, { status: 400 });
@@ -69,9 +80,9 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
   const runTelemetry = createWebHarnessObserver(prepared.workRunId);
   const telemetryOperationId = `workflow:${prepared.workRunId}`;
-  const telemetryStartedAt = Date.now();
   await observeSafely(runTelemetry.observer, {
     kind: "run.start",
+    timestamp: new Date(telemetryStartedAt).toISOString(),
     operationId: telemetryOperationId,
     attributes: {
       "openneko.run.kind": "production",
@@ -88,11 +99,14 @@ export async function POST(request: NextRequest, context: RouteContext) {
     },
   });
 
+  await bindStartupRun(prepared.workRunId, runTelemetry.observer, telemetryOperationId);
+  startupEvent("workflow.link", { workflowRunId: prepared.workflowRun.id, threadId: prepared.threadId });
+
   void (async () => {
     let unregisterBrokerEvents: () => void = () => undefined;
     try {
-      const pluginActions = await getPluginActionDescriptors();
-      const broker = await ensureAgentBroker();
+      const pluginActions = await startupPhase("context.plugin_actions", async () => getPluginActionDescriptors());
+      const broker = await startupPhase("broker.ready", async () => ensureAgentBroker());
       unregisterBrokerEvents = registerAgentBrokerEventSink(
         prepared.workRunId,
         emit,

--- a/apps/web/src/components/AppHeader.tsx
+++ b/apps/web/src/components/AppHeader.tsx
@@ -52,8 +52,9 @@ export default function AppHeader({ back, children }: AppHeaderProps) {
         if (cancelled || !res.ok) return;
         const data = (await res.json()) as {
           user: { id: string; email: string; name: string | null } | null;
+          authEnabled?: boolean;
         };
-        if (data.user) setUser({ email: data.user.email });
+        if (data.user && data.authEnabled !== false) setUser({ email: data.user.email });
       } catch {
         // best-effort
       }

--- a/apps/web/src/components/AppRail.tsx
+++ b/apps/web/src/components/AppRail.tsx
@@ -338,11 +338,12 @@ export default function AppRail() {
         if (cancelled || !res.ok) return;
         const data = (await res.json()) as {
           user: { id: string; email: string; name: string | null } | null;
+          authEnabled?: boolean;
           role: "admin" | "member" | null;
         };
         if (data.user) {
           setUser({ email: data.user.email, name: data.user.name });
-          setSessionMode(data.role === "member" ? "member" : "admin");
+          setSessionMode(data.authEnabled === false ? "solo" : data.role === "member" ? "member" : "admin");
         } else {
           setSessionMode("solo");
         }
@@ -617,7 +618,7 @@ export default function AppRail() {
                 </span>
               </span>
             </Link>
-            <Button
+            {sessionMode !== "solo" && <Button
               variant="ghost"
               type="button"
               className="app-rail-signout"
@@ -626,7 +627,7 @@ export default function AppRail() {
               title={`Sign out ${user.email}`}
             >
               <LogOut aria-hidden="true" strokeWidth={2} />
-            </Button>
+            </Button>}
           </div>
         ) : null}
       </div>

--- a/apps/web/src/components/records/AppChatSidebar.tsx
+++ b/apps/web/src/components/records/AppChatSidebar.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { acknowledgeWorkStartup, markWorkStartup } from "@/lib/work-startup-timing";
+
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
 import {
@@ -232,6 +234,7 @@ export function AppChatSidebar({
         `/api/work/threads/${threadId}/runs/${runId}/events`,
       );
       eventSourceRef.current = source;
+      source.onopen = () => markWorkStartup(runId, "streamOpenMs");
       source.onmessage = (messageEvent) => {
         let event: ChatEvent;
         try {
@@ -240,6 +243,9 @@ export function AppChatSidebar({
           return;
         }
         if (event.type === "hello") return;
+        markWorkStartup(runId, "firstEventMs");
+        if ((event.type === "message" && event.role === "assistant" && event.content) || event.type === "surface") markWorkStartup(runId, "firstOutputMs");
+        if (event.type === "done") markWorkStartup(runId, "doneMs");
         if (
           event.type === "message" &&
           event.role === "assistant" &&
@@ -423,6 +429,7 @@ export function AppChatSidebar({
   }
 
   async function submit(event: FormEvent<HTMLFormElement>) {
+    const submittedAt = performance.now();
     event.preventDefault();
     const message = draft.trim();
     if (!message || sending) return;
@@ -480,6 +487,7 @@ export function AppChatSidebar({
         throw new Error(payload.error ?? "Could not send the message");
       }
       const payload = (await response.json()) as { runId: string };
+      acknowledgeWorkStartup(threadId, payload.runId, submittedAt);
       const now = new Date().toISOString();
       setBundle((current) =>
         current

--- a/apps/web/src/lib/actor.ts
+++ b/apps/web/src/lib/actor.ts
@@ -5,7 +5,7 @@ import { getCurrentUser } from "@/lib/auth";
 /**
  * getCurrentUser without a request-scope requirement: outside a Next
  * request (tests, jobs) `cookies()` throws — treat that as "no session"
- * (solo profile), exactly like a missing cookie.
+ * without granting anonymous admin access.
  */
 export async function getCurrentUserSafe(): Promise<Awaited<
   ReturnType<typeof getCurrentUser>
@@ -17,19 +17,14 @@ export async function getCurrentUserSafe(): Promise<Awaited<
   }
 }
 
-/**
- * K1: resolve the acting principal for a web-initiated run. With the auth
- * plugin off (solo profile) there is no session user — the operator IS
- * the admin. With auth on, the session user's role is snapshotted here at
- * run start.
- */
+/** Solo and SSO work both carry the persisted acting user's ID. */
 export async function getCurrentActor(): Promise<RunActor> {
   const user = await getCurrentUserSafe();
-  if (!user) return { userId: null, role: "admin" };
+  if (!user) return { userId: null, role: "member" };
   const [row] = await db()
     .select({ role: app_user.role })
     .from(app_user)
     .where(eq(app_user.id, user.id))
     .limit(1);
-  return { userId: user.id, role: row?.role === "member" ? "member" : "admin" };
+  return { userId: user.id, role: row?.role === "admin" ? "admin" : "member" };
 }

--- a/apps/web/src/lib/admin-auth.ts
+++ b/apps/web/src/lib/admin-auth.ts
@@ -10,8 +10,7 @@ export function adminOnlyJson(): NextResponse {
 /**
  * Admin gate for OpenNeko-native administration routes.
  *
- * getCurrentActor preserves solo/userless mode as admin while SSO is NOT
- * configured. Once SSO sign-in is live (a provider is ready on
+ * Solo resolves its persisted local admin automatically. Once SSO sign-in is live (a provider is ready on
  * /admin/auth/status), a request without a valid session is NOT the solo
  * operator — it's an unauthenticated visitor — and is denied. The proxy
  * exempts the SSO setup surfaces from the session gate precisely so this

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -35,6 +35,8 @@ import { cookies } from "next/headers";
 import {
   and,
   app_user,
+  getOrCreateSoloAdmin,
+  isUnclaimedSoloEmail,
   db,
   eq,
   inArray,
@@ -436,7 +438,7 @@ export async function upsertUserFromIdentity(
         role: app_user.role,
       })
       .from(app_user)
-      .where(and(eq(app_user.org_id, orgId), eq(app_user.email, identity.email)))
+      .where(and(eq(app_user.org_id, orgId), sql`lower(${app_user.email}) = ${identity.email.trim().toLowerCase()}`))
       .limit(1);
     if (byEmail[0] && !byEmail[0].sub) {
       const role = mapped.role ?? byEmail[0].role;
@@ -783,7 +785,7 @@ function decodeReturnPath(encoded: string): string {
 }
 
 /**
- * Resolve the current session (cookie → DB lookup → user). Returns
+ * Resolve the local solo account, or the SSO session (cookie → DB lookup → user). Returns
  * null when no session, an expired session, or a session whose user
  * row has been deleted (IT deprovisioned them in the IdP and a
  * background sweep deleted the row). Pages calling this can choose
@@ -794,6 +796,12 @@ export async function getCurrentUser(): Promise<{
   email: string;
   name: string | null;
 } | null> {
+  // Solo authentication still resolves to a real account. Never infer a
+  // another user as the operator once SSO is live.
+  if (!(await getAuthProvider())) {
+    const owner = await getOrCreateSoloAdmin(await getOrgId());
+    return owner ? { id: owner.id, email: isUnclaimedSoloEmail(owner.email) ? "" : owner.email, name: owner.name } : null;
+  }
   const jar = await cookies();
   const token = jar.get(SESSION_COOKIE_NAME)?.value;
   if (!token) return null;

--- a/apps/web/src/lib/work-startup-timing.ts
+++ b/apps/web/src/lib/work-startup-timing.ts
@@ -1,0 +1,34 @@
+// Browser durations share one monotonic clock; never subtract browser/server timestamps.
+type Timing = { threadId: string; started: number; values: Record<string, number>; output: boolean };
+const pending = new Map<string, Timing>();
+function report(runId: string, timing: Timing): void {
+  void fetch(`/api/work/threads/${timing.threadId}/runs/${runId}/timing`, {
+    method: "POST", headers: { "content-type": "application/json" }, keepalive: true,
+    body: JSON.stringify(timing.values),
+  }).catch(() => {});
+}
+export function acknowledgeWorkStartup(threadId: string, runId: string, started: number): void {
+  // Bounded when a user navigates away before receiving output.
+  if (pending.size >= 32) pending.delete(pending.keys().next().value!);
+  const timing = { threadId, started, values: { acknowledgementMs: performance.now() - started }, output: false };
+  pending.set(runId, timing);
+  report(runId, timing);
+}
+export function markWorkStartup(runId: string, phase: "streamOpenMs" | "firstEventMs" | "firstOutputMs" | "doneMs"): void {
+  const timing = pending.get(runId);
+  if (!timing || timing.values[phase] !== undefined) return;
+  timing.values[phase] = performance.now() - timing.started;
+  if (phase === "firstOutputMs") {
+    timing.output = true;
+    // This is a paint opportunity after dispatching the React update, not proof of visible pixels.
+    requestAnimationFrame(() => requestAnimationFrame(() => {
+      timing.values.paintOpportunityMs = performance.now() - timing.started;
+      timing.values.documentVisible = document.visibilityState === "visible" ? 1 : 0;
+      report(runId, timing);
+      pending.delete(runId);
+    }));
+  } else if (phase === "doneMs" && !timing.output) {
+    report(runId, timing);
+    pending.delete(runId);
+  }
+}

--- a/apps/web/src/lib/work-thread-auth.ts
+++ b/apps/web/src/lib/work-thread-auth.ts
@@ -10,8 +10,8 @@ type WorkRunRow = NonNullable<Awaited<ReturnType<typeof getWorkRun>>>;
 /**
  * Web Ask history is personal for every human role. Being an admin grants
  * configuration authority, not access to another person's conversation. The
- * solo profile has a null user id, so it can access only its own null-owned
- * local threads. Channel threads never use these web routes.
+ * solo profile has a persisted owner ID; its legacy null-owned web threads
+ * are assigned to that owner during the automatic upgrade. Channel threads never use these web routes.
  */
 export function canAccessWorkThread(
   actor: RunActor,

--- a/apps/web/test/api/admin-users.test.ts
+++ b/apps/web/test/api/admin-users.test.ts
@@ -6,10 +6,11 @@ const mocks = vi.hoisted(() => ({
   selectResults: [] as Row[][],
   inserted: [] as Row[],
   updates: [] as Row[],
+  actorId: "admin-1" as string | null,
 }));
 
 vi.mock("@/lib/admin-auth", () => ({
-  requireAdminActor: async () => ({ userId: "admin-1", role: "admin" }),
+  requireAdminActor: async () => ({ userId: mocks.actorId, role: "admin" }),
   isDenied: () => false,
 }));
 
@@ -26,6 +27,8 @@ vi.mock("@neko/db", () => {
     }),
   });
   return {
+    organization: { solo_admin_user_id: "owner" },
+    isUnclaimedSoloEmail: (email: string) => email.endsWith("@solo.openneko.invalid"),
     app_user: {
       id: "id",
       org_id: "org_id",
@@ -35,6 +38,11 @@ vi.mock("@neko/db", () => {
       $inferInsert: {},
     },
     db: () => ({
+      transaction: async (fn: (tx: unknown) => Promise<unknown>) => fn({
+        execute: async () => {}, select: chain,
+        update: () => ({ set: (value: Row) => ({ where: async () => { mocks.updates.push(value); } }) }),
+        insert: () => ({ values: async (values: Row) => { mocks.inserted.push(values); } }),
+      }),
       select: chain,
       insert: () => ({
         values: async (values: Row) => {
@@ -84,6 +92,18 @@ describe("POST /api/admin/users", () => {
     mocks.selectResults = [];
     mocks.inserted = [];
     mocks.updates = [];
+    mocks.actorId = "admin-1";
+  });
+
+  it("adds the solo owner's email in place without creating another account", async () => {
+    mocks.selectResults = [[], [{ owner: "admin-1" }], [{ email: "local@solo.openneko.invalid", sub: null }]];
+    const res = await POST(postRequest({ email: "owner@example.com", role: "admin", updateSoloAccount: true }) as never);
+    expect(res.status).toBe(200);
+    expect((await res.json()).user.id).toBe("admin-1");
+    expect(mocks.updates[0]).toMatchObject({ email: "owner@example.com" });
+    expect(mocks.inserted).toEqual([]);
+    mocks.selectResults = [[], [{ owner: "someone-else" }], [{ email: "local@solo.openneko.invalid", sub: null }]];
+    expect((await POST(postRequest({ email: "another@example.com", role: "admin", updateSoloAccount: true }) as never)).status).toBe(409);
   });
 
   it("provisions a user with a lowercased email and no sub", async () => {
@@ -130,6 +150,7 @@ describe("PATCH /api/admin/users/[userId]", () => {
     mocks.selectResults = [];
     mocks.inserted = [];
     mocks.updates = [];
+    mocks.actorId = "admin-1";
   });
 
   it("refuses to demote the last active admin", async () => {

--- a/apps/web/test/api/settings-install-policy.test.ts
+++ b/apps/web/test/api/settings-install-policy.test.ts
@@ -1,7 +1,7 @@
 /**
  * /api/settings/install-policy contract tests.
  *
- * Covers: solo/userless admin => 200, non-admin => 403,
+ * Covers: persisted solo admin => 200, non-admin => 403,
  * admin => 200 read + write,
  * partial PATCH semantics, validation error on http: marketplace URL,
  * official marketplace is always preserved.
@@ -23,7 +23,7 @@ import {
   deleteTestOrg,
   uniqueOrgId,
 } from "@neko/db/test-helpers";
-import { app_user, db, pool } from "@neko/db";
+import { app_user, getOrCreateSoloAdmin, db, pool } from "@neko/db";
 import { callRoute } from "../_helpers/route";
 
 const { mockGetOrgId, mockGetCurrentUser } = vi.hoisted(() => ({
@@ -89,8 +89,8 @@ describeIfDb("/api/settings/install-policy", () => {
     await pool().end();
   });
 
-  it("GET returns DEFAULT_POLICY in solo/userless admin mode", async () => {
-    mockGetCurrentUser.mockResolvedValue(null);
+  it("GET returns DEFAULT_POLICY in persisted solo admin mode", async () => {
+    mockGetCurrentUser.mockResolvedValue(await getOrCreateSoloAdmin(orgId));
     const res = await callRoute(GET);
     expect(res.status).toBe(200);
     const body = res.body as {

--- a/apps/web/test/api/settings-skill-learn.test.ts
+++ b/apps/web/test/api/settings-skill-learn.test.ts
@@ -1,7 +1,7 @@
 /**
  * /api/settings/skill-learn contract tests.
  *
- * Covers: solo/userless admin => 200 default off, non-admin => 403,
+ * Covers: persisted solo admin => 200 default off, non-admin => 403,
  * admin => 200 read + write, persist across GET, reject non-boolean.
  */
 
@@ -21,7 +21,7 @@ import {
   deleteTestOrg,
   uniqueOrgId,
 } from "@neko/db/test-helpers";
-import { app_user, db, eq, pool, skill_learn_org } from "@neko/db";
+import { app_user, getOrCreateSoloAdmin, db, eq, pool, skill_learn_org } from "@neko/db";
 import { callRoute } from "../_helpers/route";
 
 const { mockGetOrgId, mockGetCurrentUser } = vi.hoisted(() => ({
@@ -86,7 +86,7 @@ describeIfDb("/api/settings/skill-learn", () => {
   });
 
   it("GET returns learning off when no org row exists", async () => {
-    mockGetCurrentUser.mockResolvedValue(null);
+    mockGetCurrentUser.mockResolvedValue(await getOrCreateSoloAdmin(orgId));
     const res = await callRoute(GET);
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ enabled: false, source: "default" });

--- a/apps/web/test/api/setup-finish.test.ts
+++ b/apps/web/test/api/setup-finish.test.ts
@@ -21,7 +21,7 @@ import {
   seedProvider,
   uniqueOrgId,
 } from "@neko/db/test-helpers";
-import { app_user, db, eq, organization, pool } from "@neko/db";
+import { app_user, getOrCreateSoloAdmin, db, eq, organization, pool } from "@neko/db";
 import { callRoute } from "../_helpers/route";
 
 const { mockGetOrgId, mockGetCurrentUser, mockRequireAgentRuntimeReady } = vi.hoisted(() => ({
@@ -78,7 +78,7 @@ describeIfDb("/settings/finish", () => {
     orgId = uniqueOrgId("api-finish");
     await createTestOrg(orgId);
     mockGetOrgId.mockResolvedValue(orgId);
-    mockGetCurrentUser.mockResolvedValue(null);
+    mockGetCurrentUser.mockResolvedValue(await getOrCreateSoloAdmin(orgId));
     mockRequireAgentRuntimeReady.mockResolvedValue(undefined);
   });
 

--- a/apps/web/test/api/work-startup-timing.test.ts
+++ b/apps/web/test/api/work-startup-timing.test.ts
@@ -1,0 +1,20 @@
+import { beforeEach, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+const state = vi.hoisted(() => ({ authorized: true, threadId: "thread" }));
+vi.mock("@/lib/db", () => ({ getOrgId: async () => "org" }));
+vi.mock("@/lib/work-thread-auth", () => ({ getAuthorizedWorkThread: async () => state.authorized ? {} : null }));
+vi.mock("@/lib/work-store", () => ({ getWorkRun: async () => ({ thread_id: state.threadId }) }));
+import { POST } from "@/app/api/work/threads/[threadId]/runs/[runId]/timing/route";
+beforeEach(() => { state.authorized = true; state.threadId = "thread"; vi.restoreAllMocks(); });
+const send = (body: unknown) => POST(new NextRequest("http://localhost/timing", { method: "POST", body: JSON.stringify(body) }), { params: Promise.resolve({ threadId: "thread", runId: "run" }) });
+it("accepts bounded timings only for an authorized run and never logs arbitrary data", async () => {
+  const log = vi.spyOn(console, "log").mockImplementation(() => {});
+  expect((await send({ acknowledgementMs: 10, firstOutputMs: 23 })).status).toBe(204);
+  expect(JSON.parse(log.mock.calls[0][0])).toMatchObject({ runId: "run", threadId: "thread", origin: "client_reported", firstOutputMs: 23 });
+  for (const body of [{ prompt: "private" }, { firstOutputMs: -1 }, { firstOutputMs: "5" }, { firstOutputMs: 3_600_001 }, [], null]) expect((await send(body)).status).toBe(400);
+  state.authorized = false;
+  expect((await send({ firstOutputMs: 2 })).status).toBe(404);
+  state.authorized = true; state.threadId = "another";
+  expect((await send({ firstOutputMs: 2 })).status).toBe(404);
+  expect(log).toHaveBeenCalledTimes(1);
+});

--- a/apps/web/test/api/workflow-api-public.test.ts
+++ b/apps/web/test/api/workflow-api-public.test.ts
@@ -203,3 +203,14 @@ describe("public workflow API routes", () => {
     });
   });
 });
+
+it("correlates admission phases without exposing credentials or input", async () => {
+  const log = vi.spyOn(console, "log").mockImplementation(() => {});
+  try {
+    await POST(postRequest(), postContext);
+    const entries = log.mock.calls.map(call => JSON.parse(String(call[0])));
+    expect(entries).toEqual(expect.arrayContaining([expect.objectContaining({ phase: "workflow.api_admitted", workflowRunId: "run-a", replay: false }), expect.objectContaining({ phase: "workflow.api_admit", ok: true, durationMs: expect.any(Number) })]));
+    expect(new Set(entries.map(entry => entry.requestId)).size).toBe(1);
+    expect(JSON.stringify(entries)).not.toMatch(/workflow-token|request-0001|orderId/);
+  } finally { log.mockRestore(); }
+});

--- a/apps/web/test/api/workflow-artifact-timing.test.ts
+++ b/apps/web/test/api/workflow-artifact-timing.test.ts
@@ -1,0 +1,25 @@
+import { expect, it, vi } from "vitest";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { NextRequest } from "next/server";
+const state = vi.hoisted(() => ({ path: "" }));
+vi.mock("@neko/llm/workflows", () => ({
+  enforceWorkflowApiEdgeThrottle: async () => {},
+  getWorkflowApiArtifact: async () => ({ absolutePath: state.path, bytes: 3, fileName: "result.csv", contentType: "text/csv" }),
+  parseWorkflowApiBearer: () => "credential",
+  workflowApiClientFingerprint: () => "fingerprint",
+}));
+import { GET } from "@/app/api/v1/workflows/[workflowId]/runs/[runId]/artifact/route";
+it("preserves streamed bytes and records completion without the artifact path", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "workflow-timing-"));
+  const log = vi.spyOn(console, "log").mockImplementation(() => {});
+  try {
+    state.path = join(dir, "result.csv");
+    await writeFile(state.path, "x\n1");
+    const response = await GET(new NextRequest("http://localhost/artifact"), { params: Promise.resolve({ workflowId: "workflow", runId: "run" }) });
+    expect(await response.text()).toBe("x\n1");
+    await vi.waitFor(() => expect(log.mock.calls.map(call => JSON.parse(String(call[0])))).toEqual(expect.arrayContaining([expect.objectContaining({ phase: "workflow.artifact_stream", workflowRunId: "run", outcome: "completed", bytesRead: 3 })])));
+    expect(JSON.stringify(log.mock.calls)).not.toContain(state.path);
+  } finally { log.mockRestore(); await rm(dir, { recursive: true, force: true }); }
+});

--- a/apps/web/test/lib/actor-identity.test.ts
+++ b/apps/web/test/lib/actor-identity.test.ts
@@ -1,0 +1,19 @@
+import { beforeEach, expect, it, vi } from "vitest";
+const state = vi.hoisted(() => ({ user: null as { id: string } | null, provider: false, rows: [] as unknown[] }));
+vi.mock("@/lib/auth", () => ({ getCurrentUser: async () => state.user, getAuthProvider: async () => state.provider ? {} : null }));
+vi.mock("@neko/db", () => ({ app_user: {}, eq: vi.fn(), getOrgId: async () => "org", db: () => ({ select: () => ({ from: () => ({ where: () => ({ limit: async () => state.rows }) }) }) }) }));
+import { getCurrentActor } from "@/lib/actor";
+import { GET as session } from "@/app/api/auth/session/route";
+beforeEach(() => { state.user = null; state.provider = false; state.rows = []; });
+it("uses the persisted owner immediately and grants no anonymous admin fallback", async () => {
+  expect(await getCurrentActor()).toEqual({ userId: null, role: "member" });
+  state.user = { id: "usr_owner" }; state.rows = [{ role: "admin" }];
+  expect(await getCurrentActor()).toEqual({ userId: "usr_owner", role: "admin" });
+});
+
+it("reports solo identity separately from sign-in state for the navigation", async () => {
+  state.user = { id: "usr_owner" }; state.rows = [{ role: "admin" }];
+  expect(await (await session()).json()).toMatchObject({ user: { id: "usr_owner" }, authEnabled: false });
+  state.provider = true;
+  expect(await (await session()).json()).toMatchObject({ user: { id: "usr_owner" }, authEnabled: true });
+});

--- a/apps/web/test/lib/solo-identity.test.ts
+++ b/apps/web/test/lib/solo-identity.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({ rows: [] as Record<string, unknown>[][], updates: [] as unknown[], inserts: [] as unknown[], token: undefined as string | undefined }));
+vi.mock("next/headers", () => ({ cookies: async () => ({ get: () => state.token ? { value: state.token } : undefined }) }));
+vi.mock("@/lib/db", () => ({ getOrgId: async () => "org" }));
+vi.mock("@neko/llm/work", () => ({ upsertOperatorProfile: vi.fn() }));
+vi.mock("@neko/db", async (original) => {
+  const actual = await original<Record<string, unknown>>();
+  const runner = {
+    select: () => ({ from: () => ({ where: () => ({ limit: async () => state.rows.shift() ?? [] }) }) }),
+    execute: async () => {},
+    update: () => ({ set: (value: unknown) => ({ where: async () => { state.updates.push(value); } }) }),
+    insert: () => ({ values: async (value: unknown) => { state.inserts.push(value); } }),
+    delete: () => ({ where: async () => {} }),
+  };
+  return { ...actual, getOrCreateSoloAdmin: vi.fn(async () => state.rows.shift()?.[0] ?? null), db: () => ({ ...runner, transaction: async (fn: (tx: typeof runner) => unknown) => fn(runner) }) };
+});
+import { _resetAuthProviderCache, encodeSession, getCurrentUser, upsertUserFromIdentity } from "@/lib/auth";
+
+const owner = { id: "usr_owner", email: "owner@example.com", name: "Owner", role: "admin", sub: null, disabledAt: null };
+function provider(live: boolean) {
+  _resetAuthProviderCache();
+  vi.stubGlobal("fetch", vi.fn(async () => Response.json({ provider: live ? { pluginName: "oidc" } : null })));
+}
+beforeEach(() => { state.rows = []; state.updates = []; state.inserts = []; state.token = undefined; provider(false); });
+afterEach(() => { vi.unstubAllGlobals(); _resetAuthProviderCache(); });
+
+it("uses the persisted solo owner without requiring a cookie or redirect", async () => {
+  state.rows = [[owner], [owner]];
+  expect(await getCurrentUser()).toEqual({ id: owner.id, email: owner.email, name: owner.name });
+  expect((await getCurrentUser())?.id).toBe(owner.id);
+});
+
+it("links SSO to the solo account without creating a second identity, and requires a session once live", async () => {
+  provider(true);
+  expect(await getCurrentUser()).toBeNull();
+  state.rows = [[], [owner]];
+  const linked = await upsertUserFromIdentity({ sub: "idp-owner", email: "Owner@Example.com", name: "Owner" });
+  expect(linked.id).toBe(owner.id);
+  expect(state.updates[0]).toMatchObject({ sub: "idp-owner", role: "admin" });
+  expect(state.inserts).toEqual([]);
+  state.token = encodeSession({ userId: owner.id, email: owner.email, name: owner.name, expiresAt: Math.floor(Date.now() / 1000) + 60 });
+  state.rows = [[{ id: owner.id, email: owner.email, name: owner.name }]];
+  expect((await getCurrentUser())?.id).toBe(owner.id);
+});

--- a/apps/web/test/lib/work-startup-timing.test.ts
+++ b/apps/web/test/lib/work-startup-timing.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { acknowledgeWorkStartup, markWorkStartup } from "@/lib/work-startup-timing";
+afterEach(() => vi.unstubAllGlobals());
+it("reports acknowledgement and first paint opportunity once, ignores resumed runs", () => {
+  const fetch = vi.fn().mockResolvedValue({});
+  const frames: FrameRequestCallback[] = [];
+  vi.stubGlobal("fetch", fetch);
+  vi.stubGlobal("document", { visibilityState: "visible" });
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => frames.push(callback));
+  markWorkStartup("resumed", "firstEventMs");
+  expect(fetch).not.toHaveBeenCalled();
+  acknowledgeWorkStartup("thread", "run", performance.now());
+  markWorkStartup("run", "streamOpenMs");
+  markWorkStartup("run", "firstEventMs");
+  markWorkStartup("run", "firstOutputMs");
+  markWorkStartup("run", "firstOutputMs");
+  expect(fetch).toHaveBeenCalledTimes(1);
+  frames.shift()!(0); frames.shift()!(0);
+  expect(fetch).toHaveBeenCalledTimes(2);
+  const body = JSON.parse(fetch.mock.calls[1][1].body);
+  expect(body).toMatchObject({ acknowledgementMs: expect.any(Number), streamOpenMs: expect.any(Number), firstEventMs: expect.any(Number), firstOutputMs: expect.any(Number), paintOpportunityMs: expect.any(Number), documentVisible: 1 });
+  markWorkStartup("run", "doneMs");
+  expect(fetch).toHaveBeenCalledTimes(2);
+});

--- a/apps/worker/AGENT_STARTUP.md
+++ b/apps/worker/AGENT_STARTUP.md
@@ -93,7 +93,141 @@ The [user-scoped warm pool experiment](benchmarks/2026-09-12-user-warm-pool.md)
 implements generic prewarming enabled by default (one slot), user reuse, and a
 three-minute idle timeout. Set `OPENNEKO_AGENT_WARM_POOL_SIZE=0` to disable it.
 
-Future RBAC work must complete [RBAC-1 in the roadmap](../../ROADMAP.md#rbac-1-connect-effective-access-revisions-to-warm-sandbox-reuse)
-before wiring assigned user reuse into normal web and worker runs. It documents
+Solo admin runs reuse their assigned sandbox by default. Userless runs use the
+recorded solo owner's persisted ID. Web requests automatically adopt or create
+that account, with no setup redirect or required email. The three-minute idle timeout starts after completion; active turns do
+not consume it. Expired generic spares replenish automatically while the host is
+alive. Changed model/provider or access configuration still invalidates reuse.
+
+## Knowledge cache
+
+JWT datasource knowledge is stored as one atomic snapshot in the shared agent
+home. The worker checks GraphJin's active catalog revision every 60 seconds and
+rebuilds only when it changes. Chat turns use the cached snapshot without a
+GraphJin request; a missing snapshot is built once on demand. Revision metadata
+is read as admin, while catalog content remains service-scoped. Source identity
+and pack-format changes invalidate the snapshot. A recompile during fetching
+discards the incomplete revision and retries; a refresh failure retains the last
+complete snapshot for that same source. Sandbox staging materializes only the
+snapshot's six knowledge files, never cache metadata or temporary builds.
+
+An isolated diagnostic against `neko-vm` on 12 September measured a 13,515 ms
+cold build (41 HTTP calls), a 20 ms cached read (zero HTTP calls), and a 22 ms
+unchanged-revision check (one HTTP call). This used the patched cache in a
+temporary directory; it did not deploy the patch or change the live cache.
+
+Multi-user RBAC work must complete [RBAC-1 in the roadmap](../../ROADMAP.md#rbac-1-connect-effective-access-revisions-to-warm-sandbox-reuse)
+before enabling assigned reuse for actors with fine-grained grants. It documents
 the opaque revision string, the separate SHA-256 fingerprint, invalidation rules
 and acceptance checks.
+
+## Solo admin identity
+
+Migration 0073 adds `organization.solo_admin_user_id`. On the first solo request,
+the existing unambiguous active local admin is adopted; otherwise a local admin
+row is created automatically under the same per-org lock used by SSO sign-ins.
+Its internal `.invalid` address is not a mailbox and is hidden from the UI.
+The saved owner ID remains stable when more users are added. No setup redirect,
+email entry, or manual database update is required to keep using the installation.
+Explicitly disabling the recorded owner is still honored.
+
+The Users form can save a real email on that same owner row, preserving work and
+personal connection ownership. An auth provider remains pending while this local
+owner has no real email, preventing activation from locking out the admin. Once
+saved, the existing case-insensitive SSO email match attaches the IdP subject to
+the same ID. Already-active SSO installations do not bootstrap a solo identity.
+During first ownership assignment, existing null-owned web Ask threads are moved
+to the owner atomically so history stays visible. Channel/workflow threads and
+threads with an existing owner are excluded; historical run/audit actors remain
+unchanged.
+
+Validation covers concurrent upgrades, adoption, additional users, disabled
+owners, email completion without changing ID, and SSO readiness. The UI reuses
+Users' Field/Input/NativeSelect/Button and existing navigation. Solo mode exposes
+its identity separately from sign-in state, so it does not show a sign-out action.
+
+Upgrade UI checked at 1280px and 390px: optional email form, persisted account
+visible before email entry, 44px phone targets, visible focus, no page overflow,
+and no solo sign-out action. Saving email kept the same user ID and one user row.
+SSO readiness and identity linking are covered by server tests; full external IdP
+login and the unrelated Records service were not exercised in this test stack.
+
+### Startup timing coverage
+
+Web Ask executes in the web process. Channel jobs execute in the worker queue;
+only the latter report `queue.wait` from the enqueue timestamp (including elapsed retry time on retried jobs). Old queued jobs
+without that timestamp have unavailable queue timing, not a fabricated zero.
+
+Both paths write JSON `startup_timing` records with request/run/thread IDs,
+version, commit, process ID, timestamp, monotonic elapsed time and phase duration.
+`run.link` connects HTTP phases before a run exists to the eventual run ID.
+Release web/worker images embed the checked-out commit and release version;
+unversioned local images honestly report `unknown`.
+
+| Area | Captured phases / decisions |
+| --- | --- |
+| HTTP | submit, organization, identity, authorization, backend/provisioning, run creation, user-message persistence, acknowledgement ready |
+| Worker | queue wait, run lookup, provisioning, pack actions, broker readiness |
+| Shared turn | mark running, load thread, workspace, knowledge prefetch/read, identity and authorization revision, GraphJin config, compaction, memory, skills, persona, fallback plugin catalog |
+| Knowledge | snapshot read/age, hit/miss/coalesced wait, revision checks, individual catalog requests, rebuild, atomic publish, refresh failure and stale availability; 60-second background refresh |
+| Sandbox | acquire, staging, cold creation, configuration binding, provider/policy attachment, execution, download, deletion; assigned/generic hits, cold misses, model/auth/config changes, dead slots, concurrent users, idle expiry and spare replenishment |
+| Streaming | SSE subscription, LISTEN setup, initial DB read, hello, first event and first assistant output enqueued |
+| Browser | submit through acknowledgement (including new-thread/upload preparation), stream open, first event, first assistant output and subsequent paint opportunity; terminal run without output |
+
+Timed phases pair start/end observations on exceptions too. With a run observer,
+they feed the existing OTel exporter and persisted summary `phases` (bounded at
+128 entries). Decision events and browser reports are structured logs. OTel
+export still requires the existing collector configuration; logs do not.
+
+Browser durations use only the browser's monotonic clock and are explicitly
+`client_reported`. The reporting endpoint authorizes the thread/run and permits
+only fixed numeric fields. A double animation frame is a **paint opportunity**,
+not proof of visible pixels; hidden tabs can defer it. Resumed runs do not invent
+a submission timestamp. Browser metrics are best effort if the tab closes.
+SSE timings with nonzero `afterId` describe replay/reconnection, not original
+startup. Do not add nested or parallel phase durations together.
+
+The existing outer model observation measures the agent loop; its first-output
+marker is explicitly tagged as agent output, **not provider TTFT**. Run-level
+first output includes the HTTP/worker prelude when a startup trace is present. Provider-internal scheduling/token timings are
+not exposed by the ACP event contract. Tool/delegation spans and usage continue
+through the existing agent-event observer. Prompts, SQL, catalog content, tokens
+and raw configuration are excluded from startup metrics; revisions are hashed.
+
+To compare turns, filter container JSON logs by `type == "startup_timing"`, then
+by `runId` (or `requestId` for a rejected/pre-run request). Compare the same
+version/commit and execution path, grouping sandbox outcomes and cache outcomes
+before calculating median/p95. Use `elapsedMs` for milestone timing and
+`durationMs` for individual phases. Join background eviction/replenishment logs
+by pool/slot; their originating run ID does not mean they blocked that run.
+
+### Workflows, metrics and workflow API calls
+
+The same timing helper also covers:
+
+- Manual workflow HTTP setup; scheduled, subscription, watcher and API workflow
+  claims/preparation; backend/workspace/memory/knowledge setup; sandbox phases;
+  compiled batch execution and result persistence. Preflight spans attach to
+  the workflow root, not a fabricated chat run.
+- Metric job loading, DB reads, provisioning, knowledge and isolated workspace
+  setup, agent execution or deterministic saved-query HTTP execution, progress
+  writes and snapshot/status persistence.
+- Public workflow API throttling/body parsing, credential verification, batch
+  input staging, the admission transaction (including idempotency/quota checks),
+  replay outcome, admission-to-dispatch wait, enqueue, worker execution, status
+  polling, artifact authorization/setup and file-stream completion/cancellation.
+  Stream completion means bytes handed off by the server, not client receipt.
+- Other jobs using the shared processing-job handler get a dispatch envelope and
+  running/succeeded/failed persistence phases. Their internal steps retain their
+  existing instrumentation; this does not claim every internal operation is timed.
+
+Workflow API HTTP request IDs link to canonical `workflowRunId`; worker records
+link it to the underlying `runId` and thread. Metric records carry `jobId`.
+Queue stamps are added at enqueue for work, workflow and metric executions.
+API workflow queue time includes admission/dispatch delay; scheduled executions
+use enqueue time. Retries include elapsed time since enqueue. Old payloads with
+no timestamp have unavailable queue timing. Phase logs include setup before an
+observer exists and cleanup after a persisted run summary; use dispatch/refresh
+logs for the complete handler envelope, not the sum of nested spans. Workflow
+credentials, idempotency keys, request input, query text and result data are not
+included in the timing records.

--- a/apps/worker/benchmarks/2026-09-12-user-warm-pool.md
+++ b/apps/worker/benchmarks/2026-09-12-user-warm-pool.md
@@ -25,7 +25,7 @@ real launcher, `runChatTurn`, broker, Hermes and Gemini 3.5 Flash Lite.
 - Each turn still uses `session/new`; OpenNeko already supplies conversation
   history in its prompt. This does not retain an ACP conversation between chats.
 
-The generic pool is replenished on demand, not continuously after idle expiry.
+The generic pool now replenishes automatically after idle expiry while the host is alive.
 It is local to each host process. Web and worker processes therefore have separate
 pools, and generic misses can still incur preparation work. Assigned idle slots
 are not evicted early to make room: memory planning must include the number of
@@ -38,8 +38,9 @@ queue or a ten-user capacity certification.
 principal comes from the stored run actor, never the browser or agent. The future
 authorization service must return a revision covering every effective source,
 pack/plugin, memory and library grant. Returning null disables assigned reuse.
-No production caller supplies this hook yet, so enabling generic prewarming alone
-does not enable cross-chat reuse in the web UI.
+No production caller supplies this hook yet. Solo deployments now enable reuse
+for their recorded solo owner without it, using the persisted app-user ID. Web
+requests automatically adopt or create this owner during upgrade. Multi-user deployments still require the hook.
 
 The live demo has an admin actor with no user ID. The benchmark supplies explicit
 synthetic cache principals and revisions to test reuse/invalidation while running
@@ -145,5 +146,6 @@ the feature in the normal web process or supply a production authorization hook.
 
 Runtime defaults: `OPENNEKO_AGENT_WARM_POOL_SIZE=1` and
 `OPENNEKO_AGENT_WARM_IDLE_MS=180000`. Set the pool size to zero to disable generic
-prewarming. Assigned user reuse still requires the trusted authorization-revision
-hook described above. The running demo web process was left unchanged.
+prewarming. Solo admin reuse is enabled by default; other actors require the
+trusted authorization-revision hook described above. The benchmark itself left
+the running demo web process unchanged.

--- a/apps/worker/src/admin-server.ts
+++ b/apps/worker/src/admin-server.ts
@@ -87,6 +87,8 @@ export interface AuthHandlerSurface {
    * gate with zero provisioned admins locks everyone out.
    */
   hasProvisionedAdmin?(): Promise<boolean>;
+  /** A bootstrapped solo owner must supply a real email before sign-in activates. */
+  soloAdminNeedsEmail?(): Promise<boolean>;
   /** Write (string) or delete (null) one auth-plugin env value. */
   setAuthSecret?(key: string, value: string | null): Promise<void>;
   beginAuth(params: {
@@ -1017,15 +1019,15 @@ async function handleAuthStatus(
   // that the deployment stays in single-operator mode so the admin can
   // reach the setup UI. Usable means: every required env var is set,
   // AND (for manual-provisioning providers like magic link) at least
-  // one active admin user is provisioned — otherwise flipping the gate
+  // one active admin user is provisioned. Any bootstrapped solo owner must
+  // also have a real email before switching to sign-in — otherwise the gate
   // would lock everyone out with no way back in.
   const missingEnv =
     auth.getAuthEnvGaps?.() ?? (auth.authSignInReady() ? [] : null);
   const envComplete = missingEnv !== null && missingEnv.length === 0;
   const manual = (info.provisioning ?? "automatic") === "manual";
-  const needsAdminUser = manual
-    ? !(await (auth.hasProvisionedAdmin?.() ?? Promise.resolve(true)))
-    : false;
+  const needsAdminUser = (await auth.soloAdminNeedsEmail?.()) === true ||
+    (manual && !(await (auth.hasProvisionedAdmin?.() ?? Promise.resolve(true))));
   const ready = envComplete && !needsAdminUser;
   const summary = {
     pluginName: info.pluginName,

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,10 +1,12 @@
+import { withStartupTrace, startupPhase, startupEvent } from "@neko/telemetry/startup";
+import { soloAdminNeedsEmail } from "@neko/db";
 import { dispatchEmbeddingJobs, runEmbeddingIndexJob, type EmbeddingIndexPayload } from "@neko/llm";
 import "dotenv/config";
 
 import { randomUUID } from "node:crypto";
 import { readFile, realpath, stat } from "node:fs/promises";
 import { createServer } from "node:http";
-import { resolve, sep } from "node:path";
+import { join, resolve, sep } from "node:path";
 import pg from "pg";
 import type PgBoss from "pg-boss";
 import {
@@ -93,7 +95,7 @@ import {
   type PluginActionSeed,
 } from "@neko/llm/workflows";
 import { resolveDeclarativePackActionAdapter, registerPackConnectionPreflight } from "./packs/declarative-action-runtime.js";
-import { ensureOrgWorkspace, reportDeploymentProfile } from "@neko/llm/work";
+import { ensureOrgWorkspace, getOrgAgentRoot, reportDeploymentProfile } from "@neko/llm/work";
 import { ensureQueueExists } from "./pg-boss-helpers.js";
 import { PluginRegistry } from "./plugins/plugin-registry.js";
 import { setPluginRegistryInstance } from "./plugins/registry-instance.js";
@@ -346,19 +348,20 @@ function makeHandler<P extends ProcessingJobPayload>(
 ) {
   return async (jobs: PgBoss.Job<P>[]) => {
     const results = await Promise.allSettled(
-      jobs.map(async (job) => {
+      jobs.map(job => withStartupTrace({ jobId: job.data.processingJobId, runId: job.data.processingJobId }, () => startupPhase("job.dispatch", async () => {
+        if (Number.isFinite(job.data.queuedAt)) startupEvent("queue.wait", { durationMs: Math.max(0, Date.now() - job.data.queuedAt!), basis: "since_enqueue_including_retries", jobKind: job.name });
         const { processingJobId, orgId } = job.data;
         console.log(
           `[worker] running ${job.name} job=${processingJobId} org=${orgId}`,
         );
-        await markRunning(processingJobId);
+        await startupPhase("job.mark_running", () => markRunning(processingJobId));
         try {
           await fn(processingJobId, orgId, job.data);
-          await markSucceeded(processingJobId);
+          await startupPhase("job.mark_succeeded", () => markSucceeded(processingJobId));
           console.log(`[worker] job ${processingJobId} succeeded`);
         } catch (e) {
           const msg = e instanceof Error ? e.message : String(e);
-          await markFailed(processingJobId, msg);
+          await startupPhase("job.mark_failed", () => markFailed(processingJobId, msg));
           if (e instanceof UpstreamProviderError) {
             console.warn(
               `[worker] job ${processingJobId} upstream provider unavailable; skipping pg-boss retry: ${msg}`,
@@ -371,7 +374,7 @@ function makeHandler<P extends ProcessingJobPayload>(
           if (e instanceof Error && e.stack) console.warn(e.stack);
           throw e;
         }
-      }),
+      }))),
     );
     const firstFailure = results.find((r) => r.status === "rejected");
     if (firstFailure && firstFailure.status === "rejected") {
@@ -493,6 +496,7 @@ const server = createServer(
         pluginRegistry?.getAuthConfiguredEnvKeys() ?? [],
       getAuthDeclaredEnvKeys: () =>
         pluginRegistry?.getAuthDeclaredEnvKeys() ?? [],
+      soloAdminNeedsEmail: async () => soloAdminNeedsEmail(await getOrgId()),
       hasProvisionedAdmin: async () => {
         const [row] = await db()
           .select({ id: app_user.id })
@@ -907,6 +911,26 @@ await seedOpenNekoOpsWorkflow(ADMIN_ORG_ID);
     );
   }
 }
+
+// Web and worker share the agent-home volume. Only this sweep checks revisions;
+// warm turns read the last complete snapshot without waiting on GraphJin.
+let knowledgeRefreshRunning = false;
+const refreshKnowledgeCaches = async () => {
+  if (knowledgeRefreshRunning) return;
+  knowledgeRefreshRunning = true;
+  try {
+    const sources = await db().selectDistinct({ orgId: data_source.org_id })
+      .from(data_source).where(eq(data_source.auth_mode, "jwt"));
+    for (const { orgId } of sources) {
+      const result = await withStartupTrace({ requestId: `knowledge-refresh:${orgId}:${Date.now()}` }, () => startupPhase("knowledge.background_refresh", () => prefetchKnowledgeForOrg(orgId, join(getOrgAgentRoot(orgId), "knowledge"), { refresh: true })));
+      if (!result.ok) console.warn(`[worker] knowledge cache refresh failed for ${orgId}: ${result.error}`);
+    }
+  } catch (error) {
+    console.warn("[worker] knowledge cache sweep failed:", error);
+  } finally { knowledgeRefreshRunning = false; }
+};
+const knowledgeRefreshTimer = setInterval(() => { void refreshKnowledgeCaches(); }, 60_000);
+knowledgeRefreshTimer.unref();
 
 const concurrency = await resolveAgentConcurrency(ADMIN_ORG_ID);
 console.log(
@@ -1646,6 +1670,7 @@ const shutdown = async (signal: string) => {
   clearInterval(libraryCleanupTimer);
   clearInterval(libraryRecoveryTimer);
   clearInterval(packOAuthRefreshTimer);
+  clearInterval(knowledgeRefreshTimer);
   workflowScheduler.stop();
   workflowApiDispatcher.stop();
   channelInbound.stop();

--- a/apps/worker/src/jobs/metric-refresh.ts
+++ b/apps/worker/src/jobs/metric-refresh.ts
@@ -1,3 +1,4 @@
+import { bindStartupRun, startupPhase, withStartupTrace } from "@neko/telemetry/startup";
 import {
   and,
   data_source,
@@ -37,14 +38,18 @@ import {
  *      (slug, title, why, chartHint, role). Creates a metric row with
  *      source='chat', active=false, then writes the snapshot against it.
  */
-export async function runMetricRefresh(jobId: string, orgId: string) {
-  await updateProgress(jobId, "Loading card");
+export function runMetricRefresh(jobId: string, orgId: string) {
+  return withStartupTrace({ runId: jobId, jobId, rootOperationId: `metric:${jobId}` }, () => startupPhase("metric.refresh", () => runMetricRefreshTraced(jobId, orgId)));
+}
 
-  const jobRows = await db()
+async function runMetricRefreshTraced(jobId: string, orgId: string) {
+  await startupPhase("job.progress", async () => updateProgress(jobId, "Loading card"));
+
+  const jobRows = await startupPhase("metric.db_read", async () => db()
     .select({ trigger_payload: processing_job.trigger_payload })
     .from(processing_job)
     .where(and(eq(processing_job.id, jobId), eq(processing_job.org_id, orgId)))
-    .limit(1);
+    .limit(1));
   const payload = jobRows[0]?.trigger_payload as
     | {
         metricId?: string;
@@ -74,7 +79,7 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
 
   if (payload.metricId) {
     // Path 1: bootstrap card — load from metric table.
-    const cards = await db()
+    const cards = await startupPhase("metric.db_read", async () => db()
       .select({
         id: metric.id,
         role: metric.role,
@@ -87,8 +92,8 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
         definition_hash: metric.definition_hash,
       })
       .from(metric)
-      .where(and(eq(metric.id, payload.metricId), eq(metric.org_id, orgId)))
-      .limit(1);
+      .where(and(eq(metric.id, payload.metricId!), eq(metric.org_id, orgId)))
+      .limit(1));
     const card = cards[0];
     if (!card) throw new Error(`metric ${payload.metricId} not found`);
     metricRowId = card.id;
@@ -115,7 +120,7 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
     const why = payload.why || payload.question;
     const chartHint = (payload.chartHint ?? "bar") as MetricAgentInput["chartHint"];
 
-    const existingRows = await db()
+    const existingRows = await startupPhase("metric.db_read", async () => db()
       .select({ id: metric.id })
       .from(metric)
       .where(
@@ -125,7 +130,7 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
           eq(metric.slug, slug),
         ),
       )
-      .limit(1);
+      .limit(1));
     const existingId = existingRows[0]?.id;
 
     if (existingId) {
@@ -136,7 +141,7 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
       // at the first job's id, and the status route returns payload=null. The
       // last_refresh_status reset moves the card back to "pending" so the
       // dashboard re-skeletons while the new run is in flight.
-      await db()
+      await startupPhase("metric.persist", async () => db()
         .update(metric)
         .set({
           created_by_job: jobId,
@@ -144,9 +149,9 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
           last_refresh_error: null,
           last_refresh_job_id: jobId,
         })
-        .where(eq(metric.id, existingId));
+        .where(eq(metric.id, existingId)));
     } else {
-      const ins = await db()
+      const ins = await startupPhase("metric.persist", async () => db()
         .insert(metric)
         .values({
           org_id: orgId,
@@ -161,7 +166,7 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
           last_refresh_status: "pending",
           last_refresh_job_id: jobId,
         })
-        .returning({ id: metric.id });
+        .returning({ id: metric.id }));
       const newId = ins[0]?.id;
       if (!newId) throw new Error("failed to insert chat metric row");
       metricRowId = newId;
@@ -194,7 +199,7 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
     return;
   }
 
-  await updateProgress(jobId, "Running agent");
+  await startupPhase("job.progress", async () => updateProgress(jobId, "Running agent"));
   // Stamp metric.last_refresh_status on BOTH the success and failure paths
   // so the briefing API can render a Retry button without joining
   // processing_job (which only knows the job id, not the metric id). The
@@ -207,6 +212,7 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
   try {
     let result: MetricAgentResult;
     runTelemetry = createWorkerHarnessObserver(jobId);
+    await bindStartupRun(jobId, runTelemetry.observer, `metric:${jobId}`);
     if (payload.classification) {
       await observeSafely(runTelemetry.observer, {
         kind: "model.request",
@@ -242,15 +248,15 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
         },
       });
     }
-    await ensureHostConfigProvisioned(orgId);
-    result = await runMetricAgent({
+    await startupPhase("config.provision", async () => ensureHostConfigProvisioned(orgId));
+    result = await startupPhase("metric.agent", async () => runMetricAgent({
       ...input,
       jobId,
-      observer: runTelemetry.observer,
+      observer: runTelemetry!.observer,
       observationAttributes: {
         "openneko.job.kind": "metric_refresh",
       },
-    });
+    }));
 
     const validationError = validateResult(result);
     await observeSafely(runTelemetry.observer, {
@@ -265,15 +271,15 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
       throw new Error(`metric agent output invalid: ${validationError}`);
     }
 
-    await updateProgress(jobId, "Saving snapshot");
+    await startupPhase("job.progress", async () => updateProgress(jobId, "Saving snapshot"));
 
-    await db().insert(metric_snapshot).values({
+    await startupPhase("metric.persist", async () => db().insert(metric_snapshot).values({
       metric_id: metricRowId,
       status: result.mood,
       payload: result,
-    });
+    }));
 
-    await db()
+    await startupPhase("metric.persist", async () => db()
       .update(metric)
       .set({
         last_refresh_status: "ok",
@@ -281,7 +287,7 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
         last_refresh_job_id: jobId,
         updated_at: new Date(),
       })
-      .where(eq(metric.id, metricRowId));
+      .where(eq(metric.id, metricRowId)));
 
     console.log(
       `[metric_refresh] org=${orgId} metric=${input.slug} mood=${result.mood} "${result.headlineMetric}"`,
@@ -298,7 +304,7 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
       });
     }
     const msg = e instanceof Error ? e.message : String(e);
-    await db()
+    await startupPhase("metric.persist", async () => db()
       .update(metric)
       .set({
         last_refresh_status: "failed",
@@ -306,7 +312,7 @@ export async function runMetricRefresh(jobId: string, orgId: string) {
         last_refresh_job_id: jobId,
         updated_at: new Date(),
       })
-      .where(eq(metric.id, metricRowId));
+      .where(eq(metric.id, metricRowId)));
     throw e;
   } finally {
     if (runTelemetry) {
@@ -366,11 +372,12 @@ async function runDeterministicMetricRefresh(input: {
       "openneko.metric.execution_mode": "saved_query",
     },
   });
+  await bindStartupRun(input.jobId, telemetry.observer, `metric:${input.jobId}`);
   try {
     const definition = parseMetricDefinition(input.definition);
-    await updateProgress(input.jobId, "Running reviewed saved query");
-    const boundSource = await packArtifactSource(input.orgId, "metric", input.metricId);
-    const [fallbackSource] = boundSource ? [] : await db()
+    await startupPhase("job.progress", async () => updateProgress(input.jobId, "Running reviewed saved query"));
+    const boundSource = await startupPhase("metric.source", async () => packArtifactSource(input.orgId, "metric", input.metricId));
+    const [fallbackSource] = boundSource ? [] : await startupPhase("metric.db_read", async () => db()
       .select({
         graphqlUrl: data_source.graphql_url,
         authMode: data_source.auth_mode,
@@ -378,22 +385,22 @@ async function runDeterministicMetricRefresh(input: {
       .from(data_source)
       .where(and(eq(data_source.org_id, input.orgId), eq(data_source.enabled, true)))
       .orderBy(desc(data_source.is_default), data_source.created_at)
-      .limit(1);
+      .limit(1));
     const source = boundSource ?? fallbackSource;
     if (!source?.graphqlUrl) throw new Error("saved-query metric has no enabled GraphJin source");
 
-    const [previous] = await db()
+    const [previous] = await startupPhase("metric.db_read", async () => db()
       .select({ value: metric_snapshot.value })
       .from(metric_snapshot)
       .where(eq(metric_snapshot.metric_id, input.metricId))
       .orderBy(desc(metric_snapshot.captured_at))
-      .limit(1);
+      .limit(1));
     const previousValue = previous?.value === null || previous?.value === undefined
       ? null
       : Number(previous.value);
     const baseline = previousValue !== null && Number.isFinite(previousValue) ? previousValue : null;
     const now = new Date();
-    const response = await graphjinQuery<Record<string, unknown>>({
+    const response = await startupPhase("metric.saved_query", async () => graphjinQuery<Record<string, unknown>>({
       baseUrl: graphjinEndpoint(source.graphqlUrl),
       query: definition.execution.document,
       variables: buildSavedQueryVariables(input.definition, now),
@@ -410,7 +417,7 @@ async function runDeterministicMetricRefresh(input: {
           }
         : {}),
       signal: AbortSignal.timeout(30_000),
-    });
+    }));
     if (response.errors?.length) {
       throw new Error(`saved-query metric failed: ${response.errors.map((error) => error.message).join("; ")}`);
     }
@@ -432,9 +439,9 @@ async function runDeterministicMetricRefresh(input: {
     });
     if (validationError) throw new Error(`saved-query metric output invalid: ${validationError}`);
 
-    await updateProgress(input.jobId, "Saving deterministic snapshot");
+    await startupPhase("job.progress", async () => updateProgress(input.jobId, "Saving deterministic snapshot"));
     const durationMs = Date.now() - startedAt;
-    await db().insert(metric_snapshot).values({
+    await startupPhase("metric.persist", async () => db().insert(metric_snapshot).values({
       metric_id: input.metricId,
       value: mapped.value === null ? null : String(mapped.value),
       value_json: mapped.valueJson,
@@ -446,8 +453,8 @@ async function runDeterministicMetricRefresh(input: {
       source_freshness_at: mapped.sourceFreshnessAt,
       duration_ms: durationMs,
       error_class: null,
-    });
-    await db()
+    }));
+    await startupPhase("metric.persist", async () => db()
       .update(metric)
       .set({
         last_refresh_status: "ok",
@@ -455,14 +462,14 @@ async function runDeterministicMetricRefresh(input: {
         last_refresh_job_id: input.jobId,
         updated_at: new Date(),
       })
-      .where(eq(metric.id, input.metricId));
+      .where(eq(metric.id, input.metricId)));
     console.log(
       `[metric_refresh] org=${input.orgId} metric=${input.slug} mode=saved_query mood=${mapped.result.mood} durationMs=${durationMs}`,
     );
   } catch (error) {
     failure = error;
     const message = error instanceof Error ? error.message : String(error);
-    await db()
+    await startupPhase("metric.persist", async () => db()
       .update(metric)
       .set({
         last_refresh_status: "failed",
@@ -470,7 +477,7 @@ async function runDeterministicMetricRefresh(input: {
         last_refresh_job_id: input.jobId,
         updated_at: new Date(),
       })
-      .where(eq(metric.id, input.metricId));
+      .where(eq(metric.id, input.metricId)));
     await observeSafely(telemetry.observer, {
       kind: "error",
       operationId: `metric:${input.jobId}:saved-query-error`,

--- a/apps/worker/src/jobs/work-run.ts
+++ b/apps/worker/src/jobs/work-run.ts
@@ -1,3 +1,4 @@
+import { bindStartupRun, startupEvent, startupPhase, withStartupTrace } from "@neko/telemetry/startup";
 import { ensureHostConfigProvisioned, type AgentEvent } from "@neko/llm";
 import { enqueue, QUEUE } from "@neko/db/jobs";
 import { db, eq, skill_usage } from "@neko/db";
@@ -24,10 +25,15 @@ import {
 } from "../telemetry.js";
 import { observeSafely } from "@neko/telemetry";
 
-export async function runWorkRun(
+export async function runWorkRun(jobId: string, orgId: string, payload: Parameters<typeof runWorkRunTraced>[2]): Promise<void> {
+  return withStartupTrace({ runId: payload.runId, threadId: payload.threadId }, () => runWorkRunTraced(jobId, orgId, payload));
+}
+
+async function runWorkRunTraced(
   jobId: string,
   orgId: string,
   payload: {
+    queuedAt?: number;
     runId: string;
     threadId: string;
     message: string;
@@ -39,7 +45,8 @@ export async function runWorkRun(
   const { runId, threadId, message, channel, channelPlugin, recipient } =
     payload;
 
-  const run = await getWorkRun(orgId, runId);
+  if (Number.isFinite(payload.queuedAt)) startupEvent("queue.wait", { durationMs: Math.max(0, Date.now() - payload.queuedAt!), execution: "worker_queue", basis: "since_enqueue_including_retries" });
+  const run = await startupPhase("run.lookup", () => getWorkRun(orgId, runId));
   if (!run) {
     console.warn(
       `[work-run] run ${runId} not found for thread ${threadId}; skipping stale job`,
@@ -51,6 +58,7 @@ export async function runWorkRun(
   const startedAt = Date.now();
   await observeSafely(runTelemetry.observer, {
     kind: "run.start",
+    measurements: { coverage: "unavailable", ...(Number.isFinite(payload.queuedAt) ? { queueDurationMs: Math.max(0, Date.now() - payload.queuedAt!) } : {}) },
     operationId,
     attributes: {
       "openneko.run.kind": "production",
@@ -59,6 +67,8 @@ export async function runWorkRun(
       "openneko.delivery.channel": channel ?? "web",
     },
   });
+
+  await bindStartupRun(runId, runTelemetry.observer);
 
   // Snapshot the scrubber once per run. fs.watch on the secrets file
   // rebuilds the registry's scrubber, so a future run picks up rotated
@@ -84,21 +94,22 @@ export async function runWorkRun(
     await appendWorkRunEvent({ orgId, threadId, runId, event: scrubbed });
   };
 
-  const pluginActions = includeRecordActionDescriptors(
-    getPluginRegistryInstance()?.getRegisteredActionDescriptors() ?? [],
-  );
-  const packActions = await listPackActionDescriptors(orgId);
-
-  // Same gate the workflow job runs: if the boot-time provider sync lost a
-  // race with a gateway restart, this is the retry — memoized on success, so
-  // the healthy path costs nothing. Without it, channel-triggered runs
-  // stayed broken until a settings save or a worker restart.
-  const agentRuntime = await ensureHostConfigProvisioned(orgId);
-
-  const broker = await ensureAgentBroker();
-  const unregisterBrokerEvents = registerAgentBrokerEventSink(runId, emit);
+  let unregisterBrokerEvents = () => {};
   let result;
   try {
+    const pluginActions = includeRecordActionDescriptors(
+      getPluginRegistryInstance()?.getRegisteredActionDescriptors() ?? [],
+    );
+    const packActions = await startupPhase("context.pack_actions", () => listPackActionDescriptors(orgId));
+
+    // Same gate the workflow job runs: if the boot-time provider sync lost a
+    // race with a gateway restart, this is the retry — memoized on success, so
+    // the healthy path costs nothing. Without it, channel-triggered runs
+    // stayed broken until a settings save or a worker restart.
+    const agentRuntime = await startupPhase("config.provision", () => ensureHostConfigProvisioned(orgId));
+
+    const broker = await startupPhase("broker.ready", () => ensureAgentBroker());
+    unregisterBrokerEvents = registerAgentBrokerEventSink(runId, emit);
     result = await runChatTurn(
       {
         orgId,

--- a/apps/worker/src/jobs/workflow-run-fire.ts
+++ b/apps/worker/src/jobs/workflow-run-fire.ts
@@ -1,3 +1,4 @@
+import { bindStartupRun, startupEvent, startupPhase, withStartupTrace } from "@neko/telemetry/startup";
 import type { WorkflowRunFirePayload } from "@neko/db/jobs";
 import {
   ensureHostConfigProvisioned,
@@ -173,7 +174,7 @@ async function emitRunTelemetry(input: {
   }
   if (input.apiClaim) {
     await persistWorkflowApiTelemetry({
-      admissionId: input.apiClaim.id,
+      admissionId: input.apiClaim!.id,
       workflowRunId: input.prepared.workflowRun.id,
       summary,
     });
@@ -269,7 +270,7 @@ async function runApiBatch(input: {
   });
   const finalText = `Processed ${result.progress.finalRows} batch records into one CSV artifact.`;
   await input.emit({ type: "message", role: "assistant", content: finalText });
-  await finishWorkflowApiAdmission({
+  await startupPhase("workflow.api_finalize", async () => finishWorkflowApiAdmission({
     admissionId: input.claim.id,
     workflowRunId: input.claim.workflowRunId,
     workRunId: input.claim.workRunId,
@@ -282,21 +283,25 @@ async function runApiBatch(input: {
     },
     artifactPath: result.artifactPath,
     progress: result.progress,
-  });
+  }));
   await input.emit({ type: "done", result: { status: "completed" } });
   return { status: "completed", finalText };
 }
 
-export async function runWorkflowRunFire(
+export function runWorkflowRunFire(payload: WorkflowRunFirePayload): Promise<void> {
+  return withStartupTrace({ requestId: payload.apiAdmissionId ?? payload.scheduleFiringId, workflowRunId: payload.workflowRunId }, () => startupPhase("workflow.dispatch", () => runWorkflowRunFireTraced(payload)));
+}
+
+async function runWorkflowRunFireTraced(
   payload: WorkflowRunFirePayload,
 ): Promise<void> {
   const scheduleFiringId = payload.scheduleFiringId;
   if (scheduleFiringId) {
-    const claimed = await claimWorkflowScheduleFiring({
+    const claimed = await startupPhase("workflow.claim_schedule", async () => claimWorkflowScheduleFiring({
       firingId: scheduleFiringId,
       orgId: payload.orgId,
       workflowId: payload.workflowId,
-    });
+    }));
     if (!claimed) {
       console.log(
         `[workflow-run-fire] duplicate delivery ignored firing=${scheduleFiringId}`,
@@ -315,16 +320,16 @@ export async function runWorkflowRunFire(
 
   try {
     if (payload.triggerKind === "api") {
-      apiClaim = await claimApiPayload(payload);
+      apiClaim = await startupPhase("workflow.claim_api", async () => claimApiPayload(payload));
       if (!apiClaim) return;
-      prepared = await loadPreparedWorkflowRun({
+      prepared = await startupPhase("workflow.load_prepared", async () => loadPreparedWorkflowRun({
         orgId: payload.orgId,
         workflowId: payload.workflowId,
-        workflowRunId: apiClaim.workflowRunId,
-      });
+        workflowRunId: apiClaim!.workflowRunId,
+      }));
     } else {
-      await ensureHostConfigProvisioned(payload.orgId);
-      prepared = await prepareWorkflowRun({
+      await startupPhase("config.provision", async () => ensureHostConfigProvisioned(payload.orgId));
+      prepared = await startupPhase("workflow.prepare", async () => prepareWorkflowRun({
         orgId: payload.orgId,
         workflowId: payload.workflowId,
         triggerKind: payload.triggerKind,
@@ -334,7 +339,7 @@ export async function runWorkflowRunFire(
         triggeredBySubscriptionId: payload.triggeredBySubscriptionId,
         triggeredByOutputId: payload.triggeredByOutputId,
         triggeredByObservationId: payload.triggeredByObservationId,
-      });
+      }));
     }
 
     if (scheduleFiringId) {
@@ -356,11 +361,11 @@ export async function runWorkflowRunFire(
 
     telemetry = createWorkerHarnessObserver(prepared.workRunId);
     const operationId = `workflow:${prepared.workRunId}`;
-    const queueDurationMs = Math.max(
+    const queueDurationMs = !apiClaim && !Number.isFinite(payload.queuedAt) ? undefined : Math.max(
       0,
       startedAt -
         (apiClaim?.admittedAt.getTime() ??
-          prepared.workflowRun.createdAt.getTime()),
+          (payload.queuedAt ?? startedAt)),
     );
     await observeSafely(telemetry.observer, {
       kind: "run.start",
@@ -373,7 +378,7 @@ export async function runWorkflowRunFire(
         "openneko.workflow_run.id": prepared.workflowRun.id,
         "openneko.trigger.kind": payload.triggerKind,
         ...(apiClaim
-          ? { "openneko.api.execution_mode": apiClaim.mode }
+          ? { "openneko.api.execution_mode": apiClaim!.mode }
           : {}),
       },
       measurements: {
@@ -383,28 +388,31 @@ export async function runWorkflowRunFire(
       },
     });
 
+    await bindStartupRun(prepared.workRunId, telemetry.observer, operationId);
+    startupEvent("workflow.execution", { workflowRunId: prepared.workflowRun.id, triggerKind: payload.triggerKind, queueTimingAvailable: Boolean(apiClaim || payload.queuedAt), queueDurationMs: apiClaim || payload.queuedAt ? queueDurationMs : undefined });
+
     let result: {
       status: "completed" | "failed" | "cancelled" | "needs_input";
       finalText: string;
       error?: string;
     };
     if (apiClaim?.mode === "batch") {
-      result = await runApiBatch({
-        claim: apiClaim,
-        prepared,
-        emit,
-        observer: telemetry.observer,
-      });
+      result = await startupPhase("workflow.batch", async () => runApiBatch({
+        claim: apiClaim!,
+        prepared: prepared!,
+        emit: emit!,
+        observer: telemetry!.observer,
+      }));
     } else {
-      const agentRuntime = await ensureHostConfigProvisioned(payload.orgId);
+      const agentRuntime = await startupPhase("config.provision", async () => ensureHostConfigProvisioned(payload.orgId));
       const pluginActions = includeRecordActionDescriptors(
         getPluginRegistryInstance()?.getRegisteredActionDescriptors() ?? [],
       );
-      const broker = await ensureAgentBroker();
+      const broker = await startupPhase("broker.ready", async () => ensureAgentBroker());
       const abort = new AbortController();
       const unregister = registerAgentCanceller(() => abort.abort());
       const ceilingGuard = apiClaim
-        ? createApiCeilingGuard({ claim: apiClaim, abort, emit })
+        ? createApiCeilingGuard({ claim: apiClaim!, abort, emit })
         : null;
       const maxRuntimeTimer = apiClaim && ceilingGuard
         ? setTimeout(
@@ -415,7 +423,7 @@ export async function runWorkflowRunFire(
                   "The API run exceeded its runtime ceiling.",
                 ),
               ),
-            apiClaim.limits.maxRuntimeSeconds * 1_000,
+            apiClaim!.limits.maxRuntimeSeconds * 1_000,
           )
         : null;
       maxRuntimeTimer?.unref();
@@ -429,7 +437,7 @@ export async function runWorkflowRunFire(
           {
             prepared,
             userMessage: apiClaim
-              ? apiInputMessage(apiClaim.requestPayload)
+              ? apiInputMessage(apiClaim!.requestPayload)
               : payload.userMessage,
             mode: "headless",
             emit: guardedEmit,
@@ -447,21 +455,21 @@ export async function runWorkflowRunFire(
         unregister();
       }
       if (apiClaim) {
-        await finishWorkflowApiAdmission({
-          admissionId: apiClaim.id,
-          workflowRunId: apiClaim.workflowRunId,
-          workRunId: apiClaim.workRunId,
+        await startupPhase("workflow.api_finalize", async () => finishWorkflowApiAdmission({
+          admissionId: apiClaim!.id,
+          workflowRunId: apiClaim!.workflowRunId,
+          workRunId: apiClaim!.workRunId,
           status: result.status,
           summary: result.finalText.slice(0, 4_000) || null,
           terminalResult: boundedWorkflowApiResult(
             result.finalText,
-            apiClaim.limits.maxResultBytes,
+            apiClaim!.limits.maxResultBytes,
           ),
           error: result.error ?? null,
           errorCode:
             result.status === "completed" ? null : `workflow_${result.status}`,
           progress: { stage: result.status },
-        });
+        }));
       }
     }
 
@@ -516,8 +524,8 @@ export async function runWorkflowRunFire(
         measurements: {
           durationMs: Date.now() - startedAt,
           queueDurationMs: apiClaim
-            ? Math.max(0, startedAt - apiClaim.admittedAt.getTime())
-            : 0,
+            ? Math.max(0, startedAt - apiClaim!.admittedAt.getTime())
+            : Number.isFinite(payload.queuedAt) ? Math.max(0, startedAt - payload.queuedAt!) : undefined,
           coverage: "unavailable",
         },
       });
@@ -529,10 +537,10 @@ export async function runWorkflowRunFire(
         error instanceof WorkflowApiRunCeilingExceeded
           ? error.code
           : "workflow_failed";
-      await finishWorkflowApiAdmission({
-        admissionId: apiClaim.id,
-        workflowRunId: apiClaim.workflowRunId,
-        workRunId: apiClaim.workRunId,
+      await startupPhase("workflow.api_finalize", async () => finishWorkflowApiAdmission({
+        admissionId: apiClaim!.id,
+        workflowRunId: apiClaim!.workflowRunId,
+        workRunId: apiClaim!.workRunId,
         status: "failed",
         error:
           error instanceof Error
@@ -540,7 +548,7 @@ export async function runWorkflowRunFire(
             : "Workflow API execution failed.",
         errorCode: code,
         progress: { stage: "failed" },
-      }).catch((finishError) => {
+      })).catch((finishError) => {
         console.error(
           `[workflow-run-fire] could not finalize API run=${apiClaim?.workflowRunId}: ${finishError instanceof Error ? finishError.message : String(finishError)}`,
         );

--- a/apps/worker/src/workflow-api-dispatcher.ts
+++ b/apps/worker/src/workflow-api-dispatcher.ts
@@ -1,3 +1,4 @@
+import { startupEvent, startupPhase, withStartupTrace } from "@neko/telemetry/startup";
 import { enqueue, QUEUE, type WorkflowRunFirePayload } from "@neko/db/jobs";
 import {
   expireWorkflowApiResults,
@@ -75,7 +76,10 @@ export async function runWorkflowApiDispatcherTick(input: {
         queueAttempt: admission.attempts,
       };
       try {
-        const queueJobId = await deps.enqueue(payload, admission);
+        const queueJobId = await withStartupTrace({ workflowRunId: admission.workflowRunId, runId: admission.workRunId, threadId: admission.threadId }, () => {
+          startupEvent("workflow.admission_wait", { durationMs: Math.max(0, now.getTime() - admission.admittedAt.getTime()) });
+          return startupPhase("workflow.enqueue", () => deps.enqueue(payload, admission));
+        });
         if (!queueJobId) throw new Error("queue_rejected");
         await deps.markEnqueued(admission.id, queueJobId, now);
         dispatched += 1;

--- a/apps/worker/test/admin-server.test.ts
+++ b/apps/worker/test/admin-server.test.ts
@@ -652,7 +652,7 @@ describe("worker admin /admin/auth/*", () => {
     }
   });
 
-  it("GET /admin/auth/status keeps a manual-provisioning provider pending until an admin user exists", async () => {
+  it.each(["manual", "automatic"] as const)("GET /admin/auth/status keeps %s setup pending until the admin is ready", async (provisioning) => {
     let hasAdmin = false;
     const handler = createAdminHandler({
       auth: {
@@ -660,10 +660,11 @@ describe("worker admin /admin/auth/*", () => {
         getAuthEnvGaps: () => [],
         getAuthConfiguredEnvKeys: () => ["MAGIC_LINK_FROM", "RESEND_API_KEY"],
         hasProvisionedAdmin: async () => hasAdmin,
+        soloAdminNeedsEmail: async () => provisioning === "automatic" && !hasAdmin,
         getAuthProvider: () => ({
           pluginName: "@open-neko/plugin-magic-link",
           providerLabel: "Email link",
-          provisioning: "manual",
+          provisioning,
           loginHintRequired: true,
         }),
         beginAuth: async () => ({ authorizationUrl: "https://x" }),

--- a/apps/worker/test/jobs/metric-refresh.test.ts
+++ b/apps/worker/test/jobs/metric-refresh.test.ts
@@ -192,6 +192,7 @@ describeIfDb("runMetricRefresh", () => {
           schemaVersion: "openneko.harness-run-summary/v1",
           runId: jobId,
           status: "completed",
+          phases: expect.arrayContaining([expect.objectContaining({ name: "metric.db_read", ok: true }), expect.objectContaining({ name: "metric.persist", ok: true })]),
         },
       });
     });

--- a/apps/worker/test/jobs/work-run.test.ts
+++ b/apps/worker/test/jobs/work-run.test.ts
@@ -25,6 +25,8 @@ import {
 } from "@neko/db/test-helpers";
 import {
   action_policy,
+  app_user,
+  organization,
   and,
   asc,
   db,
@@ -150,6 +152,33 @@ describeIfDb("runChatTurn", () => {
 
   afterAll(async () => {
     await pool().end();
+  });
+
+  it.each([false, true])("passes the solo admin identity to runCore with a local user row=%s", async (hasLocalUser) => {
+    vi.stubEnv("OPENNEKO_PROFILE", "solo");
+    try {
+      const localUserId = `${orgId}-admin`;
+      if (hasLocalUser) await db().insert(app_user).values({
+        id: localUserId, org_id: orgId, email: "admin@example.test", role: "admin",
+      });
+      if (hasLocalUser) await db().update(organization).set({ solo_admin_user_id: localUserId }).where(eq(organization.id, orgId));
+      const thread = await insertWorkThread(orgId);
+      const run = await insertWorkRun({ orgId, threadId: thread.id });
+      await db().update(work_run).set({ actor_role: "admin" }).where(eq(work_run.id, run.id));
+      const runCore = vi.fn(async () => ({ status: "completed" as const, finalText: "Done." }));
+      await runChatTurn({
+        orgId, threadId: thread.id, runId: run.id, message: "Hello", emit: async () => {},
+      }, makeDeps({ runCore }));
+      if (hasLocalUser) expect(runCore).toHaveBeenCalledWith(expect.objectContaining({
+        sandboxUser: {
+          principalId: localUserId,
+          authorizationRevision: "solo-admin-v1",
+        },
+      }));
+      else expect((runCore.mock.calls as unknown[][])[0][0]).not.toHaveProperty("sandboxUser");
+    } finally {
+      vi.unstubAllEnvs();
+    }
   });
 
   it("happy path: writes events in id-monotonic order, finalizes work_run completed, emits done", async () => {
@@ -415,7 +444,10 @@ describeIfDb("runChatTurn", () => {
       }),
     );
 
-    expect(memory.observations.map((item) => item.kind)).toEqual([
+    const startup = memory.observations.filter(item => String(item.attributes["openneko.stage"]).startsWith("startup."));
+    expect(startup.filter(item => item.kind === "stage.end").map(item => item.attributes["openneko.stage"])).toEqual(expect.arrayContaining(["startup.run.mark_running", "startup.run.load_thread", "startup.workspace.prepare", "startup.context.skills", "startup.identity.sandbox"]));
+    expect(startup.filter(item => item.kind === "stage.start")).toHaveLength(startup.filter(item => item.kind === "stage.end").length);
+    expect(memory.observations.filter(item => !String(item.attributes["openneko.stage"]).startsWith("startup.")).map((item) => item.kind)).toEqual([
       "stage.start",
       "model.request",
       "tool.start",

--- a/apps/worker/test/jobs/workflow-run-fire.test.ts
+++ b/apps/worker/test/jobs/workflow-run-fire.test.ts
@@ -124,7 +124,7 @@ describe("workflow schedule firing consumer", () => {
     expect(mocks.release).not.toHaveBeenCalled();
     expect(mocks.persistRunTelemetry).toHaveBeenCalledWith(
       prepared.workflowRun.id,
-      expect.objectContaining({ status: "completed" }),
+      expect.objectContaining({ status: "completed", phases: expect.arrayContaining([expect.objectContaining({ name: "workflow.prepare", ok: true }), expect.objectContaining({ name: "config.provision", ok: true })]) }),
     );
   });
 

--- a/db/migrations/0073_solo_admin_identity.sql
+++ b/db/migrations/0073_solo_admin_identity.sql
@@ -1,0 +1,4 @@
+-- The owner is resolved lazily only after confirming auth is off. Never infer
+-- a solo identity for an existing SSO installation during schema migration.
+alter table organization add column if not exists solo_admin_user_id text
+  references app_user(id) on delete set null;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21,6 +21,7 @@ export {
   type RecordsMigrationResult,
 } from "./records-migrate";
 export { createNotifyClient, type NotifyClient } from "./notify";
+export { getOrCreateSoloAdmin, isUnclaimedSoloEmail, soloAdminNeedsEmail } from "./solo-admin";
 export { getOrgId, _resetOrgIdCacheForTesting } from "./org";
 export {
   readLocalConfig,

--- a/packages/db/src/jobs.ts
+++ b/packages/db/src/jobs.ts
@@ -43,6 +43,7 @@ export const QUEUE = {
 export type QueueName = (typeof QUEUE)[keyof typeof QUEUE];
 
 export type ProcessingJobPayload = {
+  queuedAt?: number;
   processingJobId: string;
   orgId: string;
 };
@@ -52,6 +53,7 @@ export type MetricRefreshPayload = ProcessingJobPayload & {
 };
 
 export type WorkRunPayload = ProcessingJobPayload & {
+  queuedAt?: number;
   /** work_run.id — the row the worker will update. */
   runId: string;
   /** work_thread.id this run belongs to. */
@@ -85,6 +87,7 @@ export type ChannelDeliverPayload = {
 };
 
 export type WorkflowRunFirePayload = {
+  queuedAt?: number;
   orgId: string;
   workflowId: string;
   triggerKind: "manual" | "cron" | "subscription" | "watcher" | "api";
@@ -236,7 +239,7 @@ export async function enqueue<T extends object>(
 ): Promise<string | null> {
   await ensureQueue(queue);
   const b = await boss();
-  return b.send(queue, data as object, { ...DEFAULT_SEND_OPTS, ...(opts ?? {}) });
+  return b.send(queue, (queue === QUEUE.WORK_RUN || queue === QUEUE.METRIC_REFRESH || queue === QUEUE.WORKFLOW_RUN_FIRE) ? { ...(data as object), queuedAt: Date.now() } : data as object, { ...DEFAULT_SEND_OPTS, ...(opts ?? {}) });
 }
 
 export async function stopBoss(): Promise<void> {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1,5 +1,6 @@
 import { relations, sql } from "drizzle-orm";
 import {
+  type AnyPgColumn,
   bigserial,
   boolean,
   check,
@@ -42,6 +43,7 @@ export const organization = pgTable(
     domain: text("domain"),
     status: text("status").notNull().default("active"),
     setup_complete_at: ts("setup_complete_at"),
+    solo_admin_user_id: text("solo_admin_user_id").references((): AnyPgColumn => app_user.id, { onDelete: "set null" }),
     created_at: ts("created_at").notNull().defaultNow(),
     updated_at: ts("updated_at").notNull().defaultNow(),
   },

--- a/packages/db/src/solo-admin.ts
+++ b/packages/db/src/solo-admin.ts
@@ -1,0 +1,61 @@
+import { randomBytes } from "node:crypto";
+import { and, eq, isNull, sql } from "drizzle-orm";
+import { db } from "./index";
+import { app_user, organization, work_thread, workflow_run } from "./schema";
+
+export function isUnclaimedSoloEmail(email: string): boolean {
+  return email.endsWith("@solo.openneko.invalid");
+}
+
+async function readOwner(orgId: string, runner = db()) {
+  const [row] = await runner.select({
+    id: app_user.id, email: app_user.email, name: app_user.name,
+    role: app_user.role, disabledAt: app_user.disabled_at,
+  }).from(organization).innerJoin(app_user, eq(organization.solo_admin_user_id, app_user.id))
+    .where(and(eq(organization.id, orgId), eq(app_user.org_id, orgId))).limit(1);
+  return row;
+}
+
+/** Call only after the auth gate confirms this is a solo installation. */
+export async function getOrCreateSoloAdmin(orgId: string) {
+  const existing = await readOwner(orgId);
+  if (existing) return existing.role === "admin" && !existing.disabledAt ? existing : null;
+  return db().transaction(async (tx) => {
+    await tx.execute(sql`select pg_advisory_xact_lock(hashtext(${"openneko.app_user:" + orgId}))`);
+    const [org] = await tx.select({ owner: organization.solo_admin_user_id })
+      .from(organization).where(eq(organization.id, orgId)).limit(1);
+    if (!org) throw new Error("Organization not found");
+    let ownerId = org.owner;
+    if (!ownerId) {
+      const candidates = await tx.select({ id: app_user.id }).from(app_user)
+        .where(and(eq(app_user.org_id, orgId), eq(app_user.role, "admin"), isNull(app_user.sub), isNull(app_user.disabled_at)))
+        .limit(2);
+      // Adopt an unambiguous existing local admin. Otherwise persist a dedicated
+      // local operator rather than attributing their work to an arbitrary user.
+      ownerId = candidates.length === 1 ? candidates[0].id : `usr_${randomBytes(9).toString("base64url")}`;
+      if (candidates.length !== 1) await tx.insert(app_user).values({
+        id: ownerId, org_id: orgId, role: "admin", name: "Solo administrator",
+        email: `${ownerId}@solo.openneko.invalid`,
+      });
+      await tx.update(organization).set({ solo_admin_user_id: ownerId }).where(eq(organization.id, orgId));
+      // These are exactly the unowned local chats visible to the old solo
+      // principal. Move ownership atomically so assigning an ID cannot hide them.
+      // Keep channel/workflow histories and already-owned chats untouched.
+      await tx.update(work_thread).set({ created_by_user_id: ownerId }).where(and(
+        eq(work_thread.org_id, orgId), eq(work_thread.channel, "web"),
+        isNull(work_thread.created_by_user_id),
+        sql`not exists (select 1 from ${workflow_run} where ${workflow_run.thread_id} = ${work_thread.id})`,
+      ));
+    }
+    const [owner] = await tx.select({ id: app_user.id, email: app_user.email, name: app_user.name,
+      role: app_user.role, disabledAt: app_user.disabled_at }).from(app_user)
+      .where(and(eq(app_user.id, ownerId), eq(app_user.org_id, orgId))).limit(1);
+    return owner?.role === "admin" && !owner.disabledAt ? owner : null;
+  });
+}
+
+/** SSO setup must collect a real mailbox before switching this owner to sign-in. */
+export async function soloAdminNeedsEmail(orgId: string): Promise<boolean> {
+  const owner = await readOwner(orgId);
+  return Boolean(owner && isUnclaimedSoloEmail(owner.email));
+}

--- a/packages/db/test/integration/org-bootstrap.test.ts
+++ b/packages/db/test/integration/org-bootstrap.test.ts
@@ -54,6 +54,7 @@ describeIfDb("getOrgId bootstrap", () => {
         domain text,
         status text not null default 'active',
         setup_complete_at timestamptz,
+        solo_admin_user_id text,
         created_at timestamptz not null default now(),
         updated_at timestamptz not null default now()
       )`);

--- a/packages/db/test/integration/solo-admin.test.ts
+++ b/packages/db/test/integration/solo-admin.test.ts
@@ -1,0 +1,54 @@
+import { expect, it } from "vitest";
+import { and, app_user, db, eq, getOrCreateSoloAdmin, isUnclaimedSoloEmail, soloAdminNeedsEmail, work_thread, work_run, workflow_definition, workflow_run } from "../../src";
+import { dbReachable, withTestOrg } from "./_helpers";
+const reachable = await dbReachable();
+
+it.skipIf(!reachable)("upgrades a userless installation once under concurrent requests and retains its owner as users are added", async () => {
+  await withTestOrg(async (orgId) => {
+    const [oldChat] = await db().insert(work_thread).values({ org_id: orgId, channel: "web", title: "Existing solo chat" }).returning();
+    const [channelChat] = await db().insert(work_thread).values({ org_id: orgId, channel: "telegram", title: "Channel chat" }).returning();
+    const [workflowChat] = await db().insert(work_thread).values({ org_id: orgId, channel: "web" }).returning();
+    const [definition] = await db().insert(workflow_definition).values({ org_id: orgId, name: "Scheduled job" }).returning();
+    const [run] = await db().insert(work_run).values({ org_id: orgId, thread_id: workflowChat.id, backend: "hermes", actor_role: "service" }).returning();
+    await db().insert(workflow_run).values({ org_id: orgId, workflow_id: definition.id, thread_id: workflowChat.id, work_run_id: run.id, trigger_kind: "cron" });
+    const owners = await Promise.all(Array.from({ length: 8 }, () => getOrCreateSoloAdmin(orgId)));
+    const owner = owners[0]!;
+    expect(new Set(owners.map((row) => row?.id)).size).toBe(1);
+    const chats = await db().select().from(work_thread).where(eq(work_thread.org_id, orgId));
+    expect(chats.find(row => row.id === oldChat.id)?.created_by_user_id).toBe(owner.id);
+    expect(chats.find(row => row.id === channelChat.id)?.created_by_user_id).toBeNull();
+    expect(chats.find(row => row.id === workflowChat.id)?.created_by_user_id).toBeNull();
+    expect(isUnclaimedSoloEmail(owner.email)).toBe(true);
+    expect(await soloAdminNeedsEmail(orgId)).toBe(true);
+    await db().insert(app_user).values({ id: `${orgId}-other`, org_id: orgId, role: "admin", email: "other@example.test" });
+    expect((await getOrCreateSoloAdmin(orgId))?.id).toBe(owner.id);
+    await db().update(app_user).set({ email: "owner@example.test" }).where(eq(app_user.id, owner.id));
+    expect(await soloAdminNeedsEmail(orgId)).toBe(false);
+    expect((await getOrCreateSoloAdmin(orgId))?.id).toBe(owner.id);
+    await db().update(app_user).set({ disabled_at: new Date() }).where(eq(app_user.id, owner.id));
+    expect(await getOrCreateSoloAdmin(orgId)).toBeNull();
+  }, "solo-empty");
+});
+
+it.skipIf(!reachable)("adopts an existing local admin and never chooses an arbitrary admin in ambiguous legacy data", async () => {
+  await withTestOrg(async (orgId) => {
+    const originalId = `${orgId}-admin`;
+    await db().insert(app_user).values({ id: originalId, org_id: orgId, role: "admin", email: "owner@example.test" });
+    const [personalChat] = await db().insert(work_thread).values({ org_id: orgId, created_by_user_id: originalId }).returning();
+    expect((await getOrCreateSoloAdmin(orgId))?.id).toBe(originalId);
+    expect((await db().select().from(work_thread).where(eq(work_thread.id, personalChat.id)))[0].created_by_user_id).toBe(originalId);
+    expect(await soloAdminNeedsEmail(orgId)).toBe(false);
+    await db().insert(app_user).values({ id: `${orgId}-member`, org_id: orgId, role: "member", email: "member@example.test" });
+    expect((await getOrCreateSoloAdmin(orgId))?.id).toBe(originalId);
+  }, "solo-existing");
+  await withTestOrg(async (orgId) => {
+    for (const id of ["a", "b"]) await db().insert(app_user).values({ id: `${orgId}-${id}`, org_id: orgId, role: "admin", email: `${id}@example.test` });
+    const [otherChat] = await db().insert(work_thread).values({ org_id: orgId, created_by_user_id: `${orgId}-a` }).returning();
+    const owner = await getOrCreateSoloAdmin(orgId);
+    expect((await db().select().from(work_thread).where(eq(work_thread.id, otherChat.id)))[0].created_by_user_id).toBe(`${orgId}-a`);
+    expect(owner?.id).not.toBe(`${orgId}-a`);
+    expect(owner?.id).not.toBe(`${orgId}-b`);
+    const rows = await db().select().from(app_user).where(and(eq(app_user.org_id, orgId), eq(app_user.id, owner!.id)));
+    expect(rows).toHaveLength(1);
+  }, "solo-ambiguous");
+});

--- a/packages/llm/src/knowledge-cache.ts
+++ b/packages/llm/src/knowledge-cache.ts
@@ -1,0 +1,109 @@
+import { mkdir, mkdtemp, readFile, rename, rm, writeFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { startupEvent, startupPhase } from "@neko/telemetry/startup";
+import type { PrefetchKnowledgeResult } from "./knowledge-pack";
+
+const CACHE_FILE = ".knowledge-snapshot.json";
+export const KNOWLEDGE_FILES = ["tables.json", "namespaces.json", "insights.json", "syntax.json", "INDEX.md", "mode.json"] as const;
+type Snapshot = {
+  format: 1;
+  source: string;
+  revision: string;
+  builtAt?: number;
+  files: Record<(typeof KNOWLEDGE_FILES)[number], string>;
+};
+const pending = new Map<string, Promise<PrefetchKnowledgeResult>>();
+
+export async function removeKnowledgeSnapshot(root: string): Promise<void> {
+  await rm(join(root, CACHE_FILE), { force: true });
+}
+
+export async function readKnowledgeSnapshot(root: string): Promise<Snapshot | null> {
+  try {
+    const value = JSON.parse(await readFile(join(root, CACHE_FILE), "utf8")) as Snapshot;
+    if (value.format !== 1 || typeof value.source !== "string" || typeof value.revision !== "string") return null;
+    for (const file of KNOWLEDGE_FILES) {
+      if (typeof value.files[file] !== "string") return null;
+      if (file.endsWith(".json")) JSON.parse(value.files[file]);
+    }
+    value.builtAt ??= (await stat(join(root, CACHE_FILE))).mtimeMs;
+    return value;
+  } catch { return null; }
+}
+
+async function publish(root: string, snapshot: Snapshot): Promise<void> {
+  await mkdir(root, { recursive: true });
+  const temp = await mkdtemp(join(root, ".publish-"));
+  try {
+    await writeFile(join(temp, CACHE_FILE), JSON.stringify(snapshot));
+    await rename(join(temp, CACHE_FILE), join(root, CACHE_FILE));
+  } finally { await rm(temp, { recursive: true, force: true }); }
+}
+
+/** Never expose the old datasource's files when its replacement cannot be loaded. */
+export async function clearKnowledgeSnapshot(root: string, source: string, mode: string): Promise<void> {
+  const files = Object.fromEntries(KNOWLEDGE_FILES.map(file => [file,
+    file === "mode.json" ? JSON.stringify({ mode }) : file === "INDEX.md" ? "" : "{}",
+  ])) as Snapshot["files"];
+  await publish(root, { format: 1, source, revision: "", files });
+}
+
+function result(snapshot: Snapshot): PrefetchKnowledgeResult {
+  return { ok: true, files: KNOWLEDGE_FILES.slice(0, 4).map(file => ({
+    file, bytes: Buffer.byteLength(snapshot.files[file]),
+  })) };
+}
+
+/** One complete snapshot, atomically replaced only after a stable revision is fetched. */
+export async function refreshKnowledgeSnapshot(args: {
+  root: string;
+  source: string;
+  mode: string;
+  refresh?: boolean;
+  revision: () => Promise<string>;
+  build: (directory: string) => Promise<PrefetchKnowledgeResult>;
+}): Promise<PrefetchKnowledgeResult> {
+  const cached = await startupPhase("knowledge.snapshot_read", () => readKnowledgeSnapshot(args.root));
+  const cacheMeta = { snapshotAgeMs: cached?.builtAt ? Math.max(0, Date.now() - cached.builtAt) : undefined,
+    revision: cached?.revision ? createHash("sha256").update(cached.revision).digest("hex").slice(0, 16) : undefined,
+    backgroundRefresh: args.refresh === true };
+
+  // Warm callers do not wait for the worker's in-flight background refresh.
+  if (cached?.source === args.source && cached.revision && !args.refresh) { startupEvent("knowledge.cache", { ...cacheMeta, outcome: "hit" }); return result(cached); }
+  const key = JSON.stringify([args.root, args.source]);
+  const existing = pending.get(key);
+  if (existing) { startupEvent("knowledge.cache", { ...cacheMeta, outcome: "coalesced" }); return startupPhase("knowledge.refresh_wait", () => existing); }
+  startupEvent("knowledge.cache", { ...cacheMeta, outcome: args.refresh ? "revision_check" : "miss", reason: !cached ? "absent" : cached.source !== args.source ? "source_changed" : "refresh_required" });
+  const operation = (async () => {
+    try {
+      if (cached?.source !== args.source) await clearKnowledgeSnapshot(args.root, args.source, args.mode);
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const revision = await startupPhase("knowledge.revision_check", args.revision);
+        if (!revision) throw new Error("GraphJin returned no catalog revision");
+        if (cached?.source === args.source && cached.revision === revision) { startupEvent("knowledge.cache", { ...cacheMeta, outcome: "revision_unchanged" }); return result(cached); }
+        const temp = await mkdtemp(join(args.root, ".build-"));
+        try {
+          const built = await startupPhase("knowledge.rebuild", () => args.build(temp));
+          if (!built.ok) throw new Error(built.error ?? "knowledge build failed");
+          const files = Object.fromEntries(await Promise.all(KNOWLEDGE_FILES.map(async file => {
+            const text = await readFile(join(temp, file), "utf8");
+            if (file.endsWith(".json")) JSON.parse(text);
+            return [file, text];
+          }))) as Snapshot["files"];
+          if (await startupPhase("knowledge.revision_check", args.revision) !== revision) continue;
+          const snapshot: Snapshot = { format: 1, source: args.source, revision, files, builtAt: Date.now() };
+          await startupPhase("knowledge.publish", () => publish(args.root, snapshot));
+          startupEvent("knowledge.cache", { outcome: "rebuilt", revision: createHash("sha256").update(revision).digest("hex").slice(0, 16), snapshotAgeMs: 0 });
+          return result(snapshot);
+        } finally { await rm(temp, { recursive: true, force: true }); }
+      }
+      throw new Error("GraphJin catalog changed during knowledge refresh; retrying on the next sweep");
+    } catch (error) {
+      startupEvent("knowledge.cache", { ...cacheMeta, outcome: "refresh_failed", staleAvailable: cached?.source === args.source && Boolean(cached.revision), errorType: error instanceof Error ? error.name : "unknown" });
+      return { ok: false, files: [], error: error instanceof Error ? error.message : String(error) };
+    }
+  })();
+  pending.set(key, operation);
+  try { return await operation; } finally { pending.delete(key); }
+}

--- a/packages/llm/src/knowledge-pack.ts
+++ b/packages/llm/src/knowledge-pack.ts
@@ -1,5 +1,7 @@
+import { startupPhase } from "@neko/telemetry/startup";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { clearKnowledgeSnapshot, readKnowledgeSnapshot, refreshKnowledgeSnapshot, removeKnowledgeSnapshot } from "./knowledge-cache";
 
 export const KNOWLEDGE_SECTIONS = [
   { section: "tables?limit=500", file: "tables.json", label: "tables" },
@@ -120,12 +122,15 @@ async function readOrEmpty(path: string): Promise<string> {
 export async function readKnowledgePack(
   knowledge: KnowledgePackPaths,
 ): Promise<KnowledgePackContents> {
+  const snapshot = await readKnowledgeSnapshot(knowledge.knowledgeRoot);
+  const read = (file: keyof NonNullable<typeof snapshot>["files"], fallback: string) =>
+    snapshot ? Promise.resolve(snapshot.files[file]) : readOrEmpty(fallback);
   const [tables, namespaces, insights, syntax, modeRaw] = await Promise.all([
-    readOrEmpty(knowledge.files.tables),
-    readOrEmpty(knowledge.files.namespaces),
-    readOrEmpty(knowledge.files.insights),
-    readOrEmpty(knowledge.files.syntax),
-    readOrEmpty(knowledge.files.mode),
+    read("tables.json", knowledge.files.tables),
+    read("namespaces.json", knowledge.files.namespaces),
+    read("insights.json", knowledge.files.insights),
+    read("syntax.json", knowledge.files.syntax),
+    read("mode.json", knowledge.files.mode),
   ]);
   let mode: KnowledgeMode = "legacy";
   try {
@@ -303,7 +308,7 @@ export async function prefetchAgenticKnowledgePack(args: {
   fetchImpl?: typeof fetch;
 }): Promise<PrefetchKnowledgeResult> {
   const doFetch = args.fetchImpl ?? fetch;
-  const query: CatalogQueryFn = async (q) => {
+  const query: CatalogQueryFn = async (q) => startupPhase("knowledge.catalog_request", async () => {
     const res = await doFetch(args.graphqlUrl, {
       method: "POST",
       headers: {
@@ -311,13 +316,14 @@ export async function prefetchAgenticKnowledgePack(args: {
         authorization: `Bearer ${args.token}`,
       },
       body: JSON.stringify({ query: q }),
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
     });
     if (!res.ok) throw new Error(`gj_catalog HTTP ${res.status}`);
     return (await res.json()) as {
       data: unknown;
       errors?: Array<{ message: string }>;
     };
-  };
+  });
 
   await mkdir(args.destDir, { recursive: true });
   try {
@@ -598,10 +604,12 @@ export async function prefetchAgenticKnowledgePack(args: {
 export async function prefetchKnowledgeForOrg(
   orgId: string,
   destDir: string,
+  options: { refresh?: boolean } = {},
 ): Promise<PrefetchKnowledgeResult & { mode: KnowledgeMode }> {
   const { data_source, db, desc, eq } = await import("@neko/db");
   const [src] = await db()
     .select({
+      id: data_source.id,
       authMode: data_source.auth_mode,
       mcpUrl: data_source.mcp_url,
       graphqlUrl: data_source.graphql_url,
@@ -611,21 +619,44 @@ export async function prefetchKnowledgeForOrg(
     .orderBy(desc(data_source.is_default), data_source.created_at)
     .limit(1);
   if (!src?.mcpUrl && !src?.graphqlUrl) {
+    await clearKnowledgeSnapshot(destDir, "none", "legacy");
     return { ok: false, files: [], error: "no data source configured", mode: "legacy" };
   }
   if (src.authMode === "jwt") {
     const { mintGraphjinToken } = await import("./graphjin/token");
-    const result = await prefetchAgenticKnowledgePack({
-      graphqlUrl:
-        src.graphqlUrl || graphqlUrlFromMcpUrl(src.mcpUrl as string),
-      token: mintGraphjinToken({ orgId, userId: null, role: "service" }),
-      destDir,
+    const graphqlUrl = src.graphqlUrl || graphqlUrlFromMcpUrl(src.mcpUrl as string);
+    const result = await refreshKnowledgeSnapshot({
+      root: destDir, mode: "agentic", refresh: options.refresh,
+      source: JSON.stringify([orgId, src.id, graphqlUrl, src.authMode, "service", 1]),
+      revision: async () => {
+        // Revision metadata is admin-only; knowledge content remains service-scoped.
+        const response = await fetch(graphqlUrl, {
+          method: "POST",
+          headers: { "content-type": "application/json", authorization: `Bearer ${mintGraphjinToken({ orgId, userId: null, role: "admin" })}` },
+          body: JSON.stringify({ query: 'query { gj_config(id: "current") { catalog_revision } }' }),
+          signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+        });
+        const body = await response.json();
+        if (!response.ok || body.errors?.length) throw new Error("GraphJin catalog revision unavailable");
+        const row = Array.isArray(body.data?.gj_config) ? body.data.gj_config[0] : body.data?.gj_config;
+        if (typeof row?.catalog_revision !== "string") throw new Error("GraphJin returned no catalog revision");
+        return row.catalog_revision;
+      },
+      build: directory => prefetchAgenticKnowledgePack({
+        graphqlUrl, token: mintGraphjinToken({ orgId, userId: null, role: "service" }), destDir: directory,
+      }),
     });
     return { ...result, mode: "agentic" };
+  }
+  // Legacy discovery has no revision contract. Clear a previous JWT snapshot
+  // before writing its legacy replacement so readers never use the old source.
+  if (await readKnowledgeSnapshot(destDir)) {
+    await clearKnowledgeSnapshot(destDir, "legacy", "legacy");
   }
   const result = await prefetchKnowledgePack({
     discoveryUrl: discoveryUrlFromMcpUrl((src.mcpUrl ?? src.graphqlUrl) as string),
     destDir,
   });
+  if (result.ok) await removeKnowledgeSnapshot(destDir);
   return { ...result, mode: "legacy" };
 }

--- a/packages/llm/src/metric-agent.ts
+++ b/packages/llm/src/metric-agent.ts
@@ -1,3 +1,4 @@
+import { startupPhase, withStartupTrace } from "@neko/telemetry/startup";
 import { data_source, db, desc, eq } from "@neko/db";
 import { observeSafely, type HarnessObserver } from "@neko/telemetry";
 import {
@@ -110,11 +111,16 @@ export type MetricAgentResult = {
 };
 
 
-export async function runMetricAgent(
+export function runMetricAgent(input: MetricAgentInput): Promise<MetricAgentResult> {
+  return withStartupTrace({ runId: input.jobId ?? input.slug, rootOperationId: `metric:${input.jobId ?? input.slug}`, observer: input.observer }, () => runMetricAgentTraced(input));
+}
+
+async function runMetricAgentTraced(
   input: MetricAgentInput,
 ): Promise<MetricAgentResult> {
+  const observedStartedAt = Date.now();
   const graphjinPath = input.graphjinPath ?? "direct";
-  const sources = await db()
+  const sources = await startupPhase("metric.db_read", async () => db()
     .select({
       graphql_url: data_source.graphql_url,
       mcp_url: data_source.mcp_url,
@@ -122,7 +128,7 @@ export async function runMetricAgent(
     .from(data_source)
     .where(eq(data_source.org_id, input.orgId))
     .orderBy(desc(data_source.is_default), data_source.created_at)
-    .limit(1);
+    .limit(1));
   const source = sources[0];
   const requiredUrl =
     graphjinPath === "agent" ? source?.graphql_url : source?.mcp_url;
@@ -136,15 +142,15 @@ export async function runMetricAgent(
     `[metric-agent] org=${input.orgId} role=${input.role} slug=${input.slug} graphjinPath=${graphjinPath}`,
   );
 
-  const knowledgeWorkspace = await ensureWorkWorkspace(
+  const knowledgeWorkspace = await startupPhase("workspace.prepare", async () => ensureWorkWorkspace(
     input.orgId,
     "metric-agent",
     input.jobId ?? input.slug,
-  );
-  const refreshResult = await prefetchKnowledgeForOrg(
+  ));
+  const refreshResult = await startupPhase("knowledge.prefetch", async () => prefetchKnowledgeForOrg(
     input.orgId,
     knowledgeWorkspace.knowledgeRoot,
-  );
+  ));
   if (refreshResult.ok) {
     const totalBytes = refreshResult.files.reduce((n, f) => n + f.bytes, 0);
     console.log(
@@ -155,17 +161,16 @@ export async function runMetricAgent(
       `[metric-agent] org=${input.orgId} slug=${input.slug} knowledge refresh failed (${refreshResult.error}); proceeding with on-disk pack`,
     );
   }
-  const knowledge = await readKnowledgePack(
+  const knowledge = await startupPhase("knowledge.read_pack", async () => readKnowledgePack(
     knowledgePackPaths(knowledgeWorkspace.knowledgeRoot),
-  );
+  ));
 
-  const backend = await resolveAgentBackend(input.orgId);
+  const backend = await startupPhase("config.backend", async () => resolveAgentBackend(input.orgId));
   const debug = input.debug === true;
-  const isolated = await ensureIsolatedJobWorkspace(
+  const isolated = await startupPhase("workspace.isolate", async () => ensureIsolatedJobWorkspace(
     `metric-${input.jobId ?? input.slug}`,
-  );
+  ));
   const operationId = `metric:${input.jobId ?? input.slug}`;
-  const observedStartedAt = Date.now();
   const observe = async (
     event: Parameters<HarnessObserver["observe"]>[0],
   ): Promise<void> => observeSafely(input.observer, event);
@@ -178,6 +183,7 @@ export async function runMetricAgent(
   const toolCalls: Record<string, number> = {};
   await observe({
     kind: "run.start",
+    timestamp: new Date(observedStartedAt).toISOString(),
     operationId,
     attributes: {
       "openneko.run.kind": "production",
@@ -192,9 +198,9 @@ export async function runMetricAgent(
     // Preload the top-5 global memories so pinned operator rules show up
     // verbatim. Anything narrower (per-card semantic match) is reachable
     // through the sandbox's search-only memory broker capability.
-    const memoryContext = await formatGlobalMemoryPromptContext(input.orgId);
+    const memoryContext = await startupPhase("context.memory", async () => formatGlobalMemoryPromptContext(input.orgId));
     const supportsMemorySearch = backend.capabilities.mcpTools;
-    const sandboxedBackend = await sandboxAgentBackendForJob({
+    const sandboxedBackend = await startupPhase("sandbox.backend", async () => sandboxAgentBackendForJob({
       backend,
       orgId: input.orgId,
       runId: input.jobId ?? input.slug,
@@ -204,7 +210,7 @@ export async function runMetricAgent(
         graphjinAgent: graphjinPath === "agent",
         memorySearch: supportsMemorySearch,
       },
-    });
+    }));
 
     const basePrompt = buildMetricPrompt({
       input,

--- a/packages/llm/src/work/agent-event-telemetry.ts
+++ b/packages/llm/src/work/agent-event-telemetry.ts
@@ -1,3 +1,4 @@
+import { startupElapsedMs } from "@neko/telemetry/startup";
 import type { HarnessObserver } from "@neko/telemetry";
 import { observeSafely } from "@neko/telemetry";
 import type { AgentEvent } from "../agent-backend";
@@ -56,6 +57,7 @@ export function createAgentEventTelemetry(input: {
       const firstOutputMs = Date.now() - agentStartedAt;
       await observe({
         kind: "model.first_chunk",
+        attributes: { "openneko.timing.basis": "agent_first_output", "openneko.timing.provider_ttft": false },
         operationId: modelOperationId,
         parentOperationId: stageOperationId,
         measurements: { firstOutputMs, coverage: "unavailable" },
@@ -63,7 +65,7 @@ export function createAgentEventTelemetry(input: {
       await observe({
         kind: "run.first_output",
         operationId: input.operationId,
-        measurements: { firstOutputMs, coverage: "unavailable" },
+        measurements: { firstOutputMs: startupElapsedMs() ?? firstOutputMs, coverage: "unavailable" },
       });
     }
     if (event.type === "tool_start") {

--- a/packages/llm/src/work/personas.ts
+++ b/packages/llm/src/work/personas.ts
@@ -1,4 +1,5 @@
-import { and, db, eq, operator_profile, work_run } from "@neko/db";
+import { and, app_user, organization, db, eq, operator_profile, work_run } from "@neko/db";
+import { resolveDeploymentProfile } from "./deployment-profile";
 
 /**
  * CV3 — personas. The agent reads a compiled, persona-shaped brief as an
@@ -124,6 +125,26 @@ export async function getWorkRunActor(
     )
     .limit(1);
   return row ?? { userId: null, role: null };
+}
+
+/** Reuse is keyed to the persisted solo admin account. */
+export async function getSoloSandboxUser(
+  orgId: string,
+  actor: { userId: string | null; role: string | null },
+): Promise<{ principalId: string; authorizationRevision: string } | null> {
+  if (resolveDeploymentProfile() !== "solo" || actor.role !== "admin") return null;
+  const [org] = await db().select({ owner: organization.solo_admin_user_id })
+    .from(organization).where(eq(organization.id, orgId)).limit(1);
+  if (!org?.owner || (actor.userId && actor.userId !== org.owner)) return null;
+  const users = await db().select({ id: app_user.id, role: app_user.role, disabledAt: app_user.disabled_at, sub: app_user.sub })
+    .from(app_user).where(and(eq(app_user.org_id, orgId), eq(app_user.id, org.owner))).limit(1);
+  if (!users[0] || users[0].role !== "admin" || users[0].disabledAt || users[0].sub) return null;
+  return {
+    principalId: users[0].id,
+    // Solo admin has unrestricted org access; fine-grained grants still use
+    // the authorization-revision hook. Launch configuration is hashed separately.
+    authorizationRevision: "solo-admin-v1",
+  };
 }
 
 /** Compiled prompt block. Empty string when there's nothing to say. */

--- a/packages/llm/src/work/run-chat-turn.ts
+++ b/packages/llm/src/work/run-chat-turn.ts
@@ -1,3 +1,4 @@
+import { startupPhase, startupEvent, withStartupTrace } from "@neko/telemetry/startup";
 import { getGraphjinConfigSettingsForOrg } from "@neko/db";
 import type {
   AgentChatMessage,
@@ -40,6 +41,7 @@ import {
   buildOperatorProfileSection,
   getOperatorProfile,
   getWorkRunActor,
+  getSoloSandboxUser,
 } from "./personas";
 import { buildWorkPrompt } from "./prompt";
 import { compactIfNeeded, type ThreadCompaction } from "./compact-transcript";
@@ -118,7 +120,7 @@ export type RunChatTurnOptions = {
 // Tests can substitute any of these without touching the call site. Production
 // callers pass nothing and get the real implementations.
 export type RunChatTurnDeps = {
-  /** Trusted authorization service hook. Omit to disable assigned sandbox reuse.
+  /** Trusted authorization service hook. Without it, only solo admins reuse sandboxes.
    * Revision must cover sources, packs/plugins, memories and library grants. */
   sandboxAuthorizationRevision?: (input: {
     orgId: string; threadId: string; userId: string; role: string | null;
@@ -228,7 +230,11 @@ export function extractNetworkPolicyDenial(
   };
 }
 
-export async function runChatTurn(
+export function runChatTurn(opts: RunChatTurnOptions, deps: Partial<RunChatTurnDeps> = {}): Promise<RunChatTurnResult> {
+  return withStartupTrace({ runId: opts.runId, threadId: opts.threadId, observer: opts.observer }, () => runChatTurnTraced(opts, deps));
+}
+
+async function runChatTurnTraced(
   opts: RunChatTurnOptions,
   deps: Partial<RunChatTurnDeps> = {},
 ): Promise<RunChatTurnResult> {
@@ -244,9 +250,9 @@ export async function runChatTurn(
     deps.listInstalledSkills ?? defaultListInstalledSkills;
   const runCore = deps.runCore ?? runAgentBackend;
 
-  await markWorkRunRunning(runId);
+  await startupPhase("run.mark_running", () => markWorkRunRunning(runId));
 
-  const bundle = await getWorkThreadBundle(orgId, threadId);
+  const bundle = await startupPhase("run.load_thread", () => getWorkThreadBundle(orgId, threadId));
   if (!bundle) {
     const errMsg = "Thread deleted before run start.";
     await finishWorkRun(runId, "failed", errMsg);
@@ -265,13 +271,13 @@ export async function runChatTurn(
     ? "records"
     : "customer";
 
-  const backend = await resolveAgentBackend(orgId);
-  const workspace = await ensureWorkWorkspace(orgId, threadId, runId);
+  const backend = await startupPhase("config.backend", () => resolveAgentBackend(orgId));
+  const workspace = await startupPhase("workspace.prepare", () => ensureWorkWorkspace(orgId, threadId, runId));
 
   // Knowledge layering: agentic deployments (auth_mode=jwt) get the slim
   // gj_catalog bootstrap; legacy ones keep the broad discovery dumps.
   if (dataSurface === "customer") {
-    const refresh = await prefetchKnowledgeForOrg(orgId, workspace.knowledgeRoot);
+    const refresh = await startupPhase("knowledge.prefetch", () => prefetchKnowledgeForOrg(orgId, workspace.knowledgeRoot));
     if (!refresh.ok) {
       console.warn(
         `[work-run] org=${orgId} knowledge refresh failed (${refresh.error}); proceeding with on-disk pack`,
@@ -280,9 +286,10 @@ export async function runChatTurn(
   }
   const knowledge = dataSurface === "records"
     ? { mode: "legacy" as const, tables: "{}", namespaces: "{}", insights: "{}", syntax: "{}" }
-    : await readKnowledgePack(knowledgePackPaths(workspace.knowledgeRoot));
+    : await startupPhase("knowledge.read_pack", () => readKnowledgePack(knowledgePackPaths(workspace.knowledgeRoot)));
 
   let assistantText = "";
+  let firstOutputLogged = false;
   let needsInputEvent: Extract<
     AgentEvent,
     { type: "needs_input" }
@@ -320,6 +327,10 @@ export async function runChatTurn(
     toolRecorder.observe(event);
     await eventTelemetry.observeEvent(event);
     await emit(event);
+    if (((event.type === "message" && event.role === "assistant" && event.content) || event.type === "surface") && !firstOutputLogged) {
+      firstOutputLogged = true;
+      startupEvent("run.first_assistant_output", {});
+    }
     const denial = extractNetworkPolicyDenial(event);
     if (denial) {
       const key = `${denial.host}:${denial.port ?? 443}`;
@@ -353,7 +364,7 @@ export async function runChatTurn(
 
   // K1 actor drives the brokered GraphJin identity, persona (CV3), and
   // memory layer (CV2). GraphJin credentials never enter the agent sandbox.
-  const actor = await getWorkRunActor(runId);
+  const actor = await startupPhase("identity.resolve", () => getWorkRunActor(runId));
 
   try {
     if (dataSurface === "customer" && !backend.capabilities.mcpTools) {
@@ -383,7 +394,7 @@ export async function runChatTurn(
     const supportsPluginManagerTool =
       customerSurface && backend.capabilities.mcpTools;
     const sourceConfigSettings = dataSurface === "customer"
-      ? await getGraphjinConfigSettingsForOrg(orgId)
+      ? await startupPhase("config.graphjin", () => getGraphjinConfigSettingsForOrg(orgId))
       : { sourceConfigEnabled: false };
     const supportsSourceConfigTool =
       backend.capabilities.mcpTools &&
@@ -403,12 +414,12 @@ export async function runChatTurn(
         bundle.thread.backendState as { compaction?: ThreadCompaction }
       ).compaction;
       retainedCompaction = prior;
-      const compacted = await compactIfNeeded({
+      const compacted = await startupPhase("context.compaction", () => compactIfNeeded({
         messages: bundle.messages,
         prior,
         orgId,
         now: new Date().toISOString(),
-      });
+      }));
       priorSummary = compacted.summary;
       transcriptRows = compacted.kept;
       newCompaction = compacted.newCompaction;
@@ -429,7 +440,7 @@ export async function runChatTurn(
 
     const [memoryContext, installedSkills, profile] = await Promise.all([
       customerSurface
-        ? formatWorkMemoryPromptContext(
+        ? startupPhase("context.memory", () => formatWorkMemoryPromptContext(
             {
               orgId,
               threadId,
@@ -439,14 +450,14 @@ export async function runChatTurn(
             // Use the latest user message as the retrieval query so we pull
             // memories semantically close to what the operator just asked.
             { contextQuery: message, contextLimit: 5 },
-          )
+          ))
         : Promise.resolve(""),
-      listInstalledSkills(workspace.skillsRoot).then((skills) =>
+      startupPhase("context.skills", () => listInstalledSkills(workspace.skillsRoot)).then((skills) =>
         customerSurface
           ? skills
           : skills.filter((skill) => skill.name === "records"),
       ),
-      getOperatorProfile(orgId, actor.userId),
+      startupPhase("context.persona", () => getOperatorProfile(orgId, actor.userId)),
     ]);
     const operatorProfile = buildOperatorProfileSection(profile);
     let pluginCatalog: PluginCatalog | undefined;
@@ -460,9 +471,7 @@ export async function runChatTurn(
       mayNeedCapabilityRecovery
     ) {
       try {
-        pluginCatalog = await (opts.controlPlane ?? inProcessControlPlane).listPlugins({
-          orgId,
-        });
+        pluginCatalog = await startupPhase("context.plugin_catalog", () => (opts.controlPlane ?? inProcessControlPlane).listPlugins({ orgId }));
       } catch (error) {
         console.warn(
           `[work-run] marketplace lookup failed: ${error instanceof Error ? error.message : error}`,
@@ -506,12 +515,15 @@ export async function runChatTurn(
       inputBytes: Buffer.byteLength(`${prompt}\n\n${message}`, "utf8"),
     });
     const authorizationRevision = actor.userId && deps.sandboxAuthorizationRevision
-      ? await deps.sandboxAuthorizationRevision({ orgId, threadId, userId: actor.userId, role: actor.role })
+      ? await startupPhase("identity.authorization_revision", () => deps.sandboxAuthorizationRevision!({ orgId, threadId, userId: actor.userId!, role: actor.role }))
       : null;
+    const sandboxUser = deps.sandboxAuthorizationRevision
+      ? actor.userId && authorizationRevision
+        ? { principalId: actor.userId, authorizationRevision }
+        : null
+      : await startupPhase("identity.sandbox", () => getSoloSandboxUser(orgId, actor));
     const result = await runCore({
-      ...(actor.userId && authorizationRevision ? {
-        sandboxUser: { principalId: actor.userId, authorizationRevision },
-      } : {}),
+      ...(sandboxUser ? { sandboxUser } : {}),
       backend,
       prompt,
       userMessage: message,

--- a/packages/llm/src/work/sandbox-launcher.ts
+++ b/packages/llm/src/work/sandbox-launcher.ts
@@ -1,3 +1,4 @@
+import { startupEvent, startupPhase } from "@neko/telemetry/startup";
 import { createHash, randomUUID } from "node:crypto";
 import { SandboxPool, type WarmSlot } from "./sandbox-pool";
 import { spawn } from "node:child_process";
@@ -21,6 +22,7 @@ import { VENDORED_HERMES_MODEL_BINARY } from "../agent-runtime-contract";
 import type { RunBinding } from "./broker";
 import type { RunChatTurnDeps } from "./run-chat-turn";
 import { copySkillOverrides } from "./workspace";
+import { KNOWLEDGE_FILES, readKnowledgeSnapshot } from "../knowledge-cache";
 
 // Wire protocol shared with the in-image entrypoint. The agent runs in a
 // separate container, so these can't share a module at runtime — they MUST
@@ -306,11 +308,13 @@ export async function stageSandboxWorkspace(
   ) as AgentWorkspace;
 
   await mkdir(stageOrgRoot, { recursive: true });
+  const knowledge = await readKnowledgeSnapshot(workspace.knowledgeRoot);
   await Promise.all([
-    copyDirectoryIfPresent(
-      workspace.knowledgeRoot,
-      stagedWorkspace.knowledgeRoot,
-    ),
+    knowledge
+      ? mkdir(stagedWorkspace.knowledgeRoot, { recursive: true }).then(() => Promise.all(
+        KNOWLEDGE_FILES.map(file => writeFile(path.join(stagedWorkspace.knowledgeRoot, file), knowledge.files[file])),
+      ))
+      : copyDirectoryIfPresent(workspace.knowledgeRoot, stagedWorkspace.knowledgeRoot),
     copyDirectoryIfPresent(
       workspace.threadUploadsRoot,
       stagedWorkspace.threadUploadsRoot,
@@ -483,6 +487,7 @@ function makeSandboxCore(
   let pool = warmSize > 0 && kind === "work" ? warmPools.get(poolKey) : undefined;
   if (warmSize > 0 && kind === "work" && !pool) {
     pool = new SandboxPool({ size: warmSize, idleMs,
+      onEvent: attributes => startupEvent("sandbox.pool", { poolId: createHash("sha256").update(poolKey).digest("hex").slice(0, 16), ...attributes }),
       create: newWarmSlot, onError: () => log("warm sandbox preparation failed") });
     warmPools.set(poolKey, pool);
     pool.replenish();
@@ -505,7 +510,7 @@ function makeSandboxCore(
       const start = performance.now();
       let ok = false;
       try {
-        const value = await operation();
+        const value = await startupPhase(`sandbox.${phase}`, operation);
         ok = true;
         return value;
       } finally {
@@ -692,6 +697,8 @@ function makeSandboxCore(
         // derive it from a prompt, agent backendState, or a browser claim.
         const session = reuse?.principalId && reuse.authorizationRevision ? {
           key: JSON.stringify([input.orgId, reuse.principalId]),
+          modelScope: createHash("sha256").update(JSON.stringify([opts.modelProvider, input.backend.id, input.backend.configuredIdentity])).digest("hex"),
+          authorizationScope: createHash("sha256").update(reuse.authorizationRevision).digest("hex"),
           scope: createHash("sha256").update(JSON.stringify([
             reuse.authorizationRevision, opts.modelProvider, opts.modelHosts,
             opts.keyAliases, opts.env, input.backend.id, input.backend.configuredIdentity,
@@ -701,7 +708,7 @@ function makeSandboxCore(
             hermesStage ? await readFile(path.join(hermesStage, "config.yaml"), "utf8") : null,
           ])).digest("hex"),
         } : undefined;
-        lease = await pool.acquire(session);
+        lease = await startupPhase("sandbox.acquire", () => pool!.acquire(session));
         warmSlot = lease.slot ?? await timed("warm_miss", newWarmSlot);
         name = warmSlot.name;
         sandboxCreated = true;
@@ -1427,7 +1434,7 @@ async function createWarmSandbox(o: {
     "--", "/usr/local/uv/tools/hermes-agent/bin/python", "/app/hermes-warm.py", "serve",
     String(Math.ceil(o.idleMs / 1000))], { stdio: ["ignore", "pipe", "pipe"] });
   let alive = true;
-  child.on("close", () => { alive = false; });
+  const closed = new Promise<void>(resolve => child.on("close", () => { alive = false; resolve(); }));
   child.stderr.resume();
   const destroy = async () => {
     try {
@@ -1450,7 +1457,7 @@ async function createWarmSandbox(o: {
       child.once("close", () => done(new Error("warm sandbox exited before readiness")));
     });
     child.stdout.resume();
-    return { name, alive: () => alive, destroy };
+    return { name, alive: () => alive, destroy, closed };
   } catch (error) {
     await destroy().catch(() => {});
     throw error;

--- a/packages/llm/src/work/sandbox-pool.ts
+++ b/packages/llm/src/work/sandbox-pool.ts
@@ -3,10 +3,13 @@ export type WarmSlot = {
   name: string;
   alive: () => boolean;
   destroy: () => Promise<void>;
+  closed?: Promise<void>;
 };
 type IdleSlot = {
   slot: WarmSlot;
   scope: string;
+  modelScope?: string;
+  authorizationScope?: string;
   timer: ReturnType<typeof setTimeout>;
 };
 
@@ -22,21 +25,37 @@ export class SandboxPool {
     idleMs: number;
     create: () => Promise<WarmSlot>;
     onError: (error: unknown) => void;
+    onEvent?: (attributes: Record<string, unknown>) => void;
   }) {}
+
+  private event(attributes: Record<string, unknown>): void {
+    try { this.options.onEvent?.(attributes); } catch {}
+  }
 
   replenish(): void {
     if (this.stopped) return;
     this.generic = this.generic.filter(slot => slot.alive());
     while (this.generic.length + this.pending < this.options.size) {
       this.pending++;
+      const started = performance.now();
       void this.options.create().then(async slot => {
+        this.event({ outcome: "spare_ready", background: true, slot: slot.name, durationMs: performance.now() - started });
         if (this.stopped) await slot.destroy();
-        else this.generic.push(slot);
-      }).catch(this.options.onError).finally(() => { this.pending--; });
+        else {
+          this.generic.push(slot);
+          void slot.closed?.then(() => {
+            const index = this.generic.indexOf(slot);
+            if (index < 0) return; // Assigned slots follow their user's idle timeout.
+            this.event({ outcome: "evicted", reason: "generic_closed", background: true, slot: slot.name });
+            this.generic.splice(index, 1);
+            this.replenish();
+          });
+        }
+      }).catch(error => { this.event({ outcome: "spare_failed", background: true, durationMs: performance.now() - started }); this.options.onError(error); }).finally(() => { this.pending--; });
     }
   }
 
-  async acquire(user?: { key: string; scope: string }): Promise<{
+  async acquire(user?: { key: string; scope: string; modelScope?: string; authorizationScope?: string }): Promise<{
     slot?: WarmSlot;
     reused: boolean;
     release: (slot: WarmSlot | undefined, healthy: boolean) => Promise<void>;
@@ -46,6 +65,7 @@ export class SandboxPool {
     if (retain) this.busy.add(retain.key);
     let slot: WarmSlot | undefined;
     let reused = false;
+    let reason = !user ? "no_identity" : !retain ? "user_busy" : "no_assigned_slot";
     const old = retain && this.idle.get(retain.key);
     if (old && retain) {
       clearTimeout(old.timer);
@@ -54,6 +74,8 @@ export class SandboxPool {
         slot = old.slot;
         reused = true;
       } else {
+        reason = old.scope === retain.scope ? "assigned_dead" : old.modelScope !== retain.modelScope ? "model_changed" : old.authorizationScope !== retain.authorizationScope ? "authorization_changed" : "config_changed";
+        this.event({ outcome: "evicted", reason, slot: old.slot.name });
         try {
           await old.slot.destroy();
         } catch (error) {
@@ -66,6 +88,7 @@ export class SandboxPool {
       const candidate = this.generic.shift()!;
       if (candidate.alive()) slot = candidate;
     }
+    this.event({ outcome: reused ? "assigned_hit" : slot ? "generic_hit" : "cold", reason: reused ? "scope_match" : reason, slot: slot?.name });
     this.replenish();
     let released = false;
     return {
@@ -74,15 +97,20 @@ export class SandboxPool {
         if (released) return;
         released = true;
         if (retain) this.busy.delete(retain.key);
+        // A spare can expire while a long turn runs. Refill before the next request.
+        this.replenish();
         if (!used) return;
         if (!this.stopped && retain && healthy && used.alive()) {
           const timer = setTimeout(() => {
+            this.event({ outcome: "evicted", reason: "assigned_idle_timeout", slot: used.name, idleMs: this.options.idleMs });
             this.idle.delete(retain.key);
             void used.destroy().catch(this.options.onError);
           }, this.options.idleMs);
           timer.unref();
-          this.idle.set(retain.key, { slot: used, scope: retain.scope, timer });
+          this.event({ outcome: "retained", slot: used.name, idleMs: this.options.idleMs });
+          this.idle.set(retain.key, { slot: used, scope: retain.scope, modelScope: retain.modelScope, authorizationScope: retain.authorizationScope, timer });
         } else {
+          this.event({ outcome: "discarded", reason: this.stopped ? "shutdown" : !retain ? "disposable" : !healthy ? "unhealthy" : "closed" });
           await used.destroy();
         }
       },

--- a/packages/llm/src/workflows/api-admission.ts
+++ b/packages/llm/src/workflows/api-admission.ts
@@ -1,3 +1,4 @@
+import { startupPhase } from "@neko/telemetry/startup";
 import { randomUUID } from "node:crypto";
 import {
   mkdir,
@@ -490,10 +491,10 @@ export async function admitWorkflowApiRun(input: {
 }): Promise<WorkflowApiAdmissionResult> {
   const now = input.now ?? new Date();
   const idempotencyKey = validateWorkflowApiIdempotencyKey(input.idempotencyKey);
-  const verified = await verifyWorkflowApiAccessToken(
+  const verified = await startupPhase("workflow.api_authenticate", async () => verifyWorkflowApiAccessToken(
     input.workflowId,
     input.token,
-  );
+  ));
   if (!verified) {
     throw new WorkflowApiError(
       "invalid_credentials",
@@ -517,16 +518,16 @@ export async function admitWorkflowApiRun(input: {
   const admissionId = randomUUID();
   let stagedPath: string | null = null;
   if (input.mode === "batch") {
-    stagedPath = await stageBatchInput({
+    stagedPath = await startupPhase("workflow.api_stage_input", async () => stageBatchInput({
       orgId: verified.orgId,
       workRunId,
       records: initialValidation.records ?? [],
-    });
+    }));
   }
 
   let created = false;
   try {
-    const result = await withSerializableTransaction(async (client) => {
+    const result = await startupPhase("workflow.api_transaction", async () => withSerializableTransaction(async (client) => {
       const access = await lockWorkflowApiAccess(client, input.workflowId);
       const tokenMatches = verifyWorkflowApiTokenDigest(
         input.token,
@@ -729,7 +730,7 @@ export async function admitWorkflowApiRun(input: {
         statusUrl: `/api/v1/workflows/${access.workflow_id}/runs/${workflowRunId}`,
         expiresAt,
       } satisfies WorkflowApiAdmissionResult;
-    });
+    }));
 
     if (created) {
       await recordAuditEvent({

--- a/packages/llm/src/workflows/run-workflow-turn.ts
+++ b/packages/llm/src/workflows/run-workflow-turn.ts
@@ -1,3 +1,4 @@
+import { startupPhase, withStartupTrace } from "@neko/telemetry/startup";
 import { pool } from "@neko/db";
 import type { AgentEvent } from "../agent-backend";
 import type { HarnessObserver } from "@neko/telemetry";
@@ -75,14 +76,14 @@ export async function prepareWorkflowRun(
 ): Promise<PreparedWorkflowRun> {
   const resolveAgentBackend =
     deps.resolveAgentBackend ?? defaultResolveAgentBackend;
-  const workflow = await getWorkflow(opts.orgId, opts.workflowId);
+  const workflow = await startupPhase("workflow.load", async () => getWorkflow(opts.orgId, opts.workflowId));
   if (!workflow) {
     throw new Error(`Workflow ${opts.workflowId} not found for org ${opts.orgId}.`);
   }
   if (!workflow.enabled) {
     throw new Error(`Workflow ${workflow.name} is disabled.`);
   }
-  const backend = await resolveAgentBackend(opts.orgId);
+  const backend = await startupPhase("config.backend", async () => resolveAgentBackend(opts.orgId));
   let actor: { userId: string | null; role: "admin" | "member" | "service" } = { userId: null, role: "service" };
   if (workflow.ownerUserId) {
     const owner = await pool().query<{ role: string }>("select role from app_user where org_id=$1 and id=$2 and disabled_at is null", [opts.orgId, workflow.ownerUserId]);
@@ -94,9 +95,9 @@ export async function prepareWorkflowRun(
   // persisted (the sidebar lists only "web" threads).
   const threadId =
     opts.threadId ??
-    (await createWorkThread(opts.orgId, workflow.name, "workflow")).id;
-  const created = await createWorkRun(opts.orgId, threadId, backend.id, actor);
-  const workflowRun = await createWorkflowRun({
+    (await startupPhase("workflow.create_thread", async () => createWorkThread(opts.orgId, workflow.name, "workflow"))).id;
+  const created = await startupPhase("workflow.create_work_run", async () => createWorkRun(opts.orgId, threadId, backend.id, actor));
+  const workflowRun = await startupPhase("workflow.create_run", async () => createWorkflowRun({
     orgId: opts.orgId,
     workflowId: opts.workflowId,
     threadId,
@@ -109,7 +110,7 @@ export async function prepareWorkflowRun(
     triggeredBySubscriptionId: opts.triggeredBySubscriptionId,
     triggeredByOutputId: opts.triggeredByOutputId,
     triggeredByObservationId: opts.triggeredByObservationId,
-  });
+  }));
   return {
     workflow,
     workflowRun,
@@ -198,7 +199,11 @@ function synthesizeSeedMessage(
   return `Begin executing the "${workflow.name}" workflow.`;
 }
 
-export async function runWorkflowTurn(
+export function runWorkflowTurn(opts: RunWorkflowTurnOptions, deps: Partial<RunWorkflowTurnDeps> = {}): Promise<RunWorkflowTurnResult> {
+  return withStartupTrace({ runId: opts.prepared.workRunId, threadId: opts.prepared.threadId, workflowRunId: opts.prepared.workflowRun.id, rootOperationId: `workflow:${opts.prepared.workRunId}`, observer: opts.observer }, () => runWorkflowTurnTraced(opts, deps));
+}
+
+async function runWorkflowTurnTraced(
   opts: RunWorkflowTurnOptions,
   deps: Partial<RunWorkflowTurnDeps> = {},
 ): Promise<RunWorkflowTurnResult> {
@@ -213,8 +218,8 @@ export async function runWorkflowTurn(
     deps.formatGlobalMemoryPromptContext ?? defaultFormatGlobalMemoryPromptContext;
   const runCore = deps.runCore ?? defaultRunWorkflowAgentBackend;
 
-  const backend = await resolveAgentBackend(orgId);
-  await markWorkRunRunning(workRunId);
+  const backend = await startupPhase("config.backend", async () => resolveAgentBackend(orgId));
+  await startupPhase("run.mark_running", async () => markWorkRunRunning(workRunId));
 
   let assistantText = "";
   let needsInput = false;
@@ -233,7 +238,7 @@ export async function runWorkflowTurn(
     await emit(event);
   };
 
-  const workspace = await ensureWorkWorkspace(orgId, threadId, workRunId);
+  const workspace = await startupPhase("workspace.prepare", async () => ensureWorkWorkspace(orgId, threadId, workRunId));
 
   try {
     if (!backend.capabilities.mcpTools) {
@@ -246,11 +251,11 @@ export async function runWorkflowTurn(
       message: `Starting workflow "${workflow.name}" (${triggerKind})…`,
     });
 
-    const memoryContext = await formatGlobalMemoryPromptContext(orgId);
+    const memoryContext = await startupPhase("context.memory", async () => formatGlobalMemoryPromptContext(orgId));
 
-    const knowledge = await readKnowledgePack(
+    const knowledge = await startupPhase("knowledge.read_pack", async () => readKnowledgePack(
       knowledgePackPaths(workspace.knowledgeRoot),
-    );
+    ));
 
     const prompt = buildWorkflowRunnerPrompt({
       workflow,
@@ -329,12 +334,12 @@ export async function runWorkflowTurn(
       (result.status === "completed"
         ? "Looked at the data; nothing to flag."
         : null);
-    await finishWorkflowRun({
+    await startupPhase("workflow.persist_result", async () => finishWorkflowRun({
       workflowRunId: workflowRun.id,
       status: result.status,
       summary,
       error: result.error ?? null,
-    });
+    }));
 
     if (persistedText) {
       await saveAssistantWorkMessage({
@@ -366,12 +371,12 @@ export async function runWorkflowTurn(
         usageMissingReason: "workflow paused for operator input",
       });
       await finishWorkRun(workRunId, "failed", null);
-      await finishWorkflowRun({
+      await startupPhase("workflow.persist_result", async () => finishWorkflowRun({
         workflowRunId: workflowRun.id,
         status: "needs_input",
         summary: assistantText.slice(0, 4000) || null,
         error: null,
-      });
+      }));
       await wrappedEmit({ type: "done", result: { status: "needs_input" } });
       return {
         status: "needs_input",
@@ -402,12 +407,12 @@ export async function runWorkflowTurn(
 
     await wrappedEmit({ type: "error", message: errMsg });
     await finishWorkRun(workRunId, status, aborted ? null : errMsg);
-    await finishWorkflowRun({
+    await startupPhase("workflow.persist_result", async () => finishWorkflowRun({
       workflowRunId: workflowRun.id,
       status,
       summary: assistantText.slice(0, 4000) || null,
       error: aborted ? null : errMsg,
-    });
+    }));
     await wrappedEmit({ type: "done", result: { status } });
     if (!aborted) throw error;
     return {

--- a/packages/llm/test/knowledge-cache.test.ts
+++ b/packages/llm/test/knowledge-cache.test.ts
@@ -1,0 +1,86 @@
+import { mkdtemp, readdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { KNOWLEDGE_FILES, readKnowledgeSnapshot, refreshKnowledgeSnapshot } from "../src/knowledge-cache";
+import { knowledgePackPaths, readKnowledgePack } from "../src/knowledge-pack";
+
+let root: string;
+beforeEach(async () => { root = await mkdtemp(join(tmpdir(), "knowledge-cache-test-")); });
+afterEach(async () => { await rm(root, { recursive: true, force: true }); });
+
+function fixture() {
+  const state = { revision: "r1", fail: false };
+  const revision = vi.fn(async () => state.revision);
+  const build = vi.fn(async (directory: string) => {
+    if (state.fail) return { ok: false, files: [], error: "unreachable" };
+    await Promise.all(KNOWLEDGE_FILES.map(file => writeFile(join(directory, file),
+      file === "INDEX.md" ? "index" : file === "mode.json" ? '{"mode":"agentic"}' : JSON.stringify({ revision: state.revision }),
+    )));
+    return { ok: true, files: [] };
+  });
+  return { state, args: { root, source: "org/source/service/v1", mode: "agentic", revision, build } };
+}
+
+it("shares cold preparation, serves warm snapshots without GraphJin, and replaces only changed revisions", async () => {
+  const { args, state } = fixture();
+  expect((await Promise.all([refreshKnowledgeSnapshot(args), refreshKnowledgeSnapshot(args)])).every(r => r.ok)).toBe(true);
+  expect(args.build).toHaveBeenCalledTimes(1);
+  args.revision.mockClear();
+  await refreshKnowledgeSnapshot(args);
+  expect(args.revision).not.toHaveBeenCalled();
+  await refreshKnowledgeSnapshot({ ...args, refresh: true });
+  expect(args.build).toHaveBeenCalledTimes(1);
+  state.revision = "r2";
+  await refreshKnowledgeSnapshot({ ...args, refresh: true });
+  expect(args.build).toHaveBeenCalledTimes(2);
+  const pack = await readKnowledgePack(knowledgePackPaths(root));
+  expect(pack.mode).toBe("agentic");
+  expect(pack.tables).toContain("r2");
+  expect(await readdir(root)).toEqual([".knowledge-snapshot.json"]);
+});
+
+it("serves the last complete snapshot while a background replacement is in flight", async () => {
+  const { args, state } = fixture();
+  await refreshKnowledgeSnapshot(args);
+  state.revision = "r2";
+  let release!: () => void;
+  const gate = new Promise<void>(resolve => { release = resolve; });
+  let started!: () => void;
+  const starting = new Promise<void>(resolve => { started = resolve; });
+  const build = args.build;
+  const refresh = refreshKnowledgeSnapshot({ ...args, refresh: true,
+    build: async dir => { started(); await gate; return build(dir); },
+  });
+  await starting;
+  expect((await refreshKnowledgeSnapshot(args)).ok).toBe(true);
+  expect((await readKnowledgeSnapshot(root))?.revision).toBe("r1");
+  release();
+  expect((await refresh).ok).toBe(true);
+  expect((await readKnowledgeSnapshot(root))?.revision).toBe("r2");
+});
+
+it("keeps a good snapshot on refresh failure but does not reuse another source's knowledge", async () => {
+  const { args, state } = fixture();
+  await refreshKnowledgeSnapshot(args);
+  state.revision = "r2";
+  state.fail = true;
+  expect((await refreshKnowledgeSnapshot({ ...args, refresh: true })).ok).toBe(false);
+  expect((await readKnowledgeSnapshot(root))?.revision).toBe("r1");
+  expect((await refreshKnowledgeSnapshot({ ...args, source: "different-source" })).ok).toBe(false);
+  expect((await readKnowledgePack(knowledgePackPaths(root))).tables).toBe("{}");
+});
+
+it("discards a build when the graph recompiles during fetching and retries the new revision", async () => {
+  const { args, state } = fixture();
+  const build = args.build;
+  let first = true;
+  expect((await refreshKnowledgeSnapshot({ ...args, build: async dir => {
+    const result = await build(dir);
+    if (first) { first = false; state.revision = "r2"; }
+    return result;
+  } })).ok).toBe(true);
+  expect(build).toHaveBeenCalledTimes(2);
+  expect((await readKnowledgeSnapshot(root))?.revision).toBe("r2");
+  expect((await readKnowledgePack(knowledgePackPaths(root))).tables).toContain("r2");
+});

--- a/packages/llm/test/sandbox-launcher.test.ts
+++ b/packages/llm/test/sandbox-launcher.test.ts
@@ -4,6 +4,7 @@ import {
   mkdir,
   mkdtemp,
   readFile,
+  readdir,
   rm,
   writeFile,
 } from "node:fs/promises";
@@ -14,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentEvent, AgentWorkspace } from "../src/agent-backend";
 import type { RunAgentBackendInput } from "../src/work/agent-core";
 import { GRAPHJIN_DIRECT_GOVERNED_POLICY } from "../src/work/graphjin-tool-policy";
+import { KNOWLEDGE_FILES, refreshKnowledgeSnapshot } from "../src/knowledge-cache";
 import type { RunWorkflowAgentBackendInput } from "../src/workflows/agent-core";
 
 /**
@@ -388,6 +390,22 @@ describe("buildSandboxPolicy", () => {
 });
 
 describe("stageSandboxWorkspace", () => {
+  it("materializes one cached snapshot without old files or cache metadata", async () => {
+    const root = await mkdtemp(join(tmpdir(), "knowledge-stage-test-"));
+    try {
+      const workspace = fullWorkspace(join(root, "org"));
+      await refreshKnowledgeSnapshot({ root: workspace.knowledgeRoot, source: "source", mode: "agentic",
+        revision: async () => "r1", build: async dir => {
+          await Promise.all(KNOWLEDGE_FILES.map(file => writeFile(join(dir, file), file === "INDEX.md" ? "index" : '{"current":true}')));
+          return { ok: true, files: [] };
+        },
+      });
+      await writeFile(join(workspace.knowledgeRoot, "tables.json"), '{"obsolete":true}');
+      const staged = await stageSandboxWorkspace(workspace, join(root, "stage"));
+      expect((await readdir(staged.workspace.knowledgeRoot)).sort()).toEqual([...KNOWLEDGE_FILES].sort());
+      expect(await readFile(join(staged.workspace.knowledgeRoot, "tables.json"), "utf8")).toBe('{"current":true}');
+    } finally { await rm(root, { recursive: true, force: true }); }
+  });
   it("exposes only the current run, current thread uploads, knowledge, and skill overrides", async () => {
     const root = await mkdtemp(join(tmpdir(), "sandbox-stage-source-"));
     const stage = await mkdtemp(join(tmpdir(), "sandbox-stage-dest-"));

--- a/packages/llm/test/sandbox-pool.test.ts
+++ b/packages/llm/test/sandbox-pool.test.ts
@@ -1,11 +1,59 @@
 import { afterEach, expect, it, vi } from 'vitest';
 import { SandboxPool, type WarmSlot } from '../src/work/sandbox-pool';
 afterEach(() => vi.useRealTimers());
+it('replenishes an expired generic spare without waiting for another user request', async () => {
+  let expire!: () => void;
+  const create = vi.fn(async () => ({
+    name: 'spare', alive: () => true, destroy: vi.fn(async () => {}),
+    closed: new Promise<void>(resolve => { expire = resolve; }),
+  }));
+  const pool = new SandboxPool({ size: 1, idleMs: 180_000, create, onError: error => { throw error; } });
+  pool.replenish();
+  await vi.waitFor(() => expect(create).toHaveBeenCalledTimes(1));
+  // Let the ready slot enter the pool before simulating its sandbox-side expiry.
+  await new Promise(resolve => setImmediate(resolve));
+  expire();
+  await vi.waitFor(() => expect(create).toHaveBeenCalledTimes(2));
+  await pool.close();
+  expire();
+  await new Promise(resolve => setImmediate(resolve));
+  expect(create).toHaveBeenCalledTimes(2);
+});
+it('keeps a long-running user slot until three minutes after release and replaces expired spares', async () => {
+  vi.useFakeTimers();
+  let count = 0;
+  const create = vi.fn(async () => {
+    const expires = Date.now() + 180_000;
+    return { name: String(++count), alive: () => Date.now() < expires, destroy: vi.fn(async () => {}) };
+  });
+  const pool = new SandboxPool({ size: 1, idleMs: 180_000, create, onError: error => { throw error; } });
+  pool.replenish();
+  await vi.advanceTimersByTimeAsync(0);
+  const session = { key: 'org/solo-admin', scope: 'solo-admin-v1' };
+  const first = await pool.acquire(session);
+  // Active Hermes children do not expire; only the unused generic spare does.
+  first.slot!.alive = () => true;
+  await vi.advanceTimersByTimeAsync(224_000);
+  expect(first.slot!.destroy).not.toHaveBeenCalled();
+  await first.release(first.slot, true);
+  expect(create).toHaveBeenCalledTimes(3);
+  await vi.advanceTimersByTimeAsync(12_000);
+  const second = await pool.acquire(session);
+  expect(second.reused).toBe(true);
+  expect(second.slot).toBe(first.slot);
+  await second.release(second.slot, true);
+  await vi.advanceTimersByTimeAsync(179_999);
+  expect(first.slot!.destroy).not.toHaveBeenCalled();
+  await vi.advanceTimersByTimeAsync(1);
+  expect(first.slot!.destroy).toHaveBeenCalledTimes(1);
+  await pool.close();
+});
 it('keeps assignments private, expires idle slots, and destroys changed/failed scopes', async () => {
   vi.useFakeTimers();
   let count = 0;
   const slots: WarmSlot[] = [];
-  const pool = new SandboxPool({ size: 1, idleMs: 1000,
+  const onEvent = vi.fn();
+  const pool = new SandboxPool({ size: 1, idleMs: 1000, onEvent,
     create: async () => { const slot = { name: String(++count), alive: () => true, destroy: vi.fn(async () => {}) }; slots.push(slot); return slot; },
     onError: error => { throw error; } });
   pool.replenish();
@@ -33,5 +81,9 @@ it('keeps assignments private, expires idle slots, and destroys changed/failed s
   expect(bob.reused).toBe(false);
   await bob.release(bob.slot!, false);
   expect(bob.slot!.destroy).toHaveBeenCalled();
+  expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ outcome: "assigned_hit" }));
+  expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ reason: "user_busy" }));
+  expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ reason: "config_changed" }));
+  expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ reason: "assigned_idle_timeout" }));
   await pool.close();
 });

--- a/packages/llm/test/solo-sandbox-user.test.ts
+++ b/packages/llm/test/solo-sandbox-user.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  owner: null as string | null,
+  users: [] as Array<{ id: string; role: string; disabledAt: Date | null; sub?: string | null }>,
+}));
+vi.mock("@neko/db", () => ({
+  organization: { id: "org", solo_admin_user_id: "owner" },
+  app_user: { id: "id", org_id: "org_id", role: "role", disabled_at: "disabled_at", sub: "sub" },
+  operator_profile: {}, work_run: {}, and: vi.fn(), eq: vi.fn(),
+  db: () => ({ select: () => ({ from: (table: { solo_admin_user_id?: string }) => ({ where: () => ({
+    limit: async () => table.solo_admin_user_id ? [{ owner: state.owner }] : state.users.filter(u => u.id === state.owner),
+  }) }) }) }),
+}));
+
+import { getSoloSandboxUser } from "../src/work/personas";
+
+afterEach(() => { state.users = []; state.owner = null; vi.unstubAllEnvs(); });
+
+it("retains the solo admin identity and excludes detached and disabled actors while retaining the owner as users are added", async () => {
+  vi.stubEnv("OPENNEKO_PROFILE", "solo");
+  const admin = { userId: null, role: "admin" };
+  expect(await getSoloSandboxUser("org-a", admin)).toBeNull();
+  expect(await getSoloSandboxUser("org-a", { ...admin, role: "member" })).toBeNull();
+  state.owner = "alice";
+  state.users = [{ id: "alice", role: "admin", disabledAt: null }];
+  expect(await getSoloSandboxUser("org-a", admin)).toMatchObject({ principalId: "alice" });
+  state.users[0].sub = "sso-alice";
+  expect(await getSoloSandboxUser("org-a", admin)).toBeNull();
+  state.users[0].sub = null;
+  const alice = { userId: "alice", role: "admin" };
+  expect(await getSoloSandboxUser("org-a", alice)).toMatchObject({ principalId: "alice" });
+  state.users[0].disabledAt = new Date();
+  expect(await getSoloSandboxUser("org-a", alice)).toBeNull();
+  state.users[0].disabledAt = null;
+  state.users.push({ id: "bob", role: "member", disabledAt: null });
+  expect(await getSoloSandboxUser("org-a", alice)).toMatchObject({ principalId: "alice" });
+  state.users = [];
+  vi.stubEnv("OPENNEKO_PROFILE", "team");
+  expect(await getSoloSandboxUser("org-a", admin)).toBeNull();
+});

--- a/packages/telemetry/package.json
+++ b/packages/telemetry/package.json
@@ -7,7 +7,8 @@
   "types": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./node": "./src/node.ts"
+    "./node": "./src/node.ts",
+    "./startup": "./src/startup.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/telemetry/src/startup.ts
+++ b/packages/telemetry/src/startup.ts
@@ -1,0 +1,90 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
+import { performance } from "node:perf_hooks";
+import { observeSafely } from "./observer";
+import { sanitizeAttributes } from "./redaction";
+import type { HarnessObserver, ObservationInput } from "./types";
+
+type StartupContext = {
+  started?: number;
+  requestId?: string;
+  runId?: string;
+  rootOperationId?: string;
+  workflowRunId?: string;
+  jobId?: string;
+  threadId?: string;
+  observer?: HarnessObserver;
+  pending?: ObservationInput[];
+};
+const current = new AsyncLocalStorage<{ trace: StartupContext; parent?: string }>();
+
+export function withStartupTrace<T>(context: StartupContext, operation: () => T): T {
+  return current.run({ trace: { started: performance.now(), ...current.getStore()?.trace, ...context, pending: [] } }, operation);
+}
+
+/** Link pre-run HTTP phases to the eventual run without creating a run before validation. */
+export async function bindStartupRun(runId: string, observer: HarnessObserver, rootOperationId = `work:${runId}`): Promise<void> {
+  const context = current.getStore()?.trace;
+  if (!context) return;
+  context.runId = runId;
+  context.rootOperationId = rootOperationId;
+  context.observer = observer;
+  startupEvent("run.link", {});
+  for (const observation of context.pending ?? []) await observeSafely(observer, {
+    ...observation, parentOperationId: observation.parentOperationId ?? rootOperationId,
+  });
+  context.pending = [];
+}
+
+export function startupElapsedMs(): number | undefined {
+  const started = current.getStore()?.trace.started;
+  return started === undefined ? undefined : Math.max(0, performance.now() - started);
+}
+
+function metadata() {
+  const context = current.getStore()?.trace;
+  return {
+    requestId: context?.requestId, runId: context?.runId, threadId: context?.threadId,
+    workflowRunId: context?.workflowRunId, jobId: context?.jobId,
+    version: process.env.OPENNEKO_VERSION ?? process.env.NEXT_PUBLIC_APP_VERSION ?? "unknown",
+    commit: process.env.OPENNEKO_COMMIT ?? process.env.GIT_COMMIT ?? "unknown",
+    pid: process.pid,
+    elapsedMs: startupElapsedMs(),
+  };
+}
+
+function log(phase: string, values: Record<string, unknown>): void {
+  try { console.log(JSON.stringify({ type: "startup_timing", timestamp: new Date().toISOString(), ...metadata(), phase, ...sanitizeAttributes(values) })); } catch {}
+}
+
+async function observe(input: ObservationInput): Promise<void> {
+  const context = current.getStore()?.trace;
+  if (context?.observer) await observeSafely(context.observer, input);
+  else if (context?.pending && context.pending.length < 128) context.pending.push(input);
+}
+
+export function startupEvent(phase: string, attributes: Record<string, unknown>): void {
+  log(phase, { event: true, ...attributes });
+}
+
+/** Monotonic durations, paired spans on failure too; instrumentation never changes the result. */
+export async function startupPhase<T>(phase: string, operation: () => Promise<T>, attributes: Record<string, unknown> = {}): Promise<T> {
+  const context = current.getStore()?.trace;
+  const operationId = `startup:${randomUUID()}`;
+  const parentOperationId = current.getStore()?.parent ?? (context?.rootOperationId ?? (context?.runId ? `work:${context.runId}` : undefined));
+  const started = performance.now();
+  const startedAt = new Date().toISOString();
+  const attrs = sanitizeAttributes({ "openneko.stage": `startup.${phase}`, ...attributes });
+  await observe({ kind: "stage.start", operationId, parentOperationId, timestamp: startedAt, attributes: attrs });
+  let ok = false;
+  try {
+    const result = await current.run({ trace: context ?? {}, parent: operationId }, operation);
+    ok = true;
+    return result;
+  } finally {
+    const durationMs = Math.max(0, performance.now() - started);
+    log(phase, { ...attributes, durationMs, ok, startedAt, operationId, parentOperationId });
+    await observe({ kind: "stage.end", operationId, parentOperationId: parentOperationId ?? (context?.rootOperationId ?? (context?.runId ? `work:${context.runId}` : undefined)), status: ok ? "ok" : "error", attributes: attrs,
+      measurements: { durationMs, coverage: "unavailable" } });
+  }
+}

--- a/packages/telemetry/src/summary.ts
+++ b/packages/telemetry/src/summary.ts
@@ -24,6 +24,7 @@ export type HarnessRunSummary = {
     queueMs?: number;
     firstOutputMs?: number;
   };
+  phases?: Array<{ name: string; durationMs: number; ok: boolean }>;
   io?: {
     inputBytes?: number;
     outputBytes?: number;
@@ -80,6 +81,12 @@ export class HarnessRunSummaryAccumulator implements ObservationSink {
 
   emit(observation: HarnessObservation): void {
     const attrs = observation.attributes;
+    const phase = attrs["openneko.stage"];
+    if (observation.kind === "stage.end" && typeof phase === "string" && phase.startsWith("startup.") && observation.measurements?.durationMs !== undefined) {
+      this.value.phases ??= [];
+      if (this.value.phases.length < 128) this.value.phases.push({ name: phase.slice(8), durationMs: observation.measurements.durationMs, ok: observation.status !== "error" });
+    }
+    this.value.durations.queueMs ??= observation.measurements?.queueDurationMs;
     this.value.traceId ??= observation.traceId;
     this.value.backend ??= asString(attrs["openneko.backend"]);
     this.value.provider ??= asString(attrs["gen_ai.provider.name"]);
@@ -198,7 +205,7 @@ export class HarnessRunSummaryAccumulator implements ObservationSink {
     if (observation.kind === "run.end") {
       this.value.finishedAt = observation.timestamp;
       this.value.durations.wallMs = observation.measurements?.durationMs;
-      this.value.durations.queueMs = observation.measurements?.queueDurationMs;
+      this.value.durations.queueMs = observation.measurements?.queueDurationMs ?? this.value.durations.queueMs;
       const outcome = asString(attrs["openneko.outcome"]);
       this.value.status =
         outcome === "cancelled"

--- a/packages/telemetry/test/startup.test.ts
+++ b/packages/telemetry/test/startup.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { createHarnessObserver, HarnessRunSummaryAccumulator, MemoryObservationSink } from "../src";
+import { bindStartupRun, startupEvent, startupPhase, withStartupTrace } from "../src/startup";
+afterEach(() => vi.restoreAllMocks());
+it("links preflight phases, pairs failures, persists durations, and redacts values", async () => {
+  const log = vi.spyOn(console, "log").mockImplementation(() => {});
+  const sink = new MemoryObservationSink();
+  const summary = new HarnessRunSummaryAccumulator("r");
+  const observer = createHarnessObserver({ runId: "r", sinks: [sink, summary] });
+  await withStartupTrace({ requestId: "q", threadId: "t" }, async () => {
+    await startupPhase("identity", async () => 42);
+    await bindStartupRun("r", observer);
+    await expect(startupPhase("broken", async () => { throw new Error("original"); })).rejects.toThrow("original");
+    startupEvent("cache", { outcome: "hit", authorization: "private", prompt: "private" });
+  });
+  expect(sink.observations.map(o => [o.kind, o.parentOperationId])).toEqual([
+    ["stage.start", "work:r"], ["stage.end", "work:r"], ["stage.start", "work:r"], ["stage.end", "work:r"],
+  ]);
+  expect(summary.snapshot().phases).toEqual([
+    { name: "identity", durationMs: expect.any(Number), ok: true },
+    { name: "broken", durationMs: expect.any(Number), ok: false },
+  ]);
+  const event = JSON.parse(log.mock.calls.at(-1)![0]);
+  expect(event).toMatchObject({ requestId: "q", threadId: "t", runId: "r", outcome: "hit" });
+  expect(event).not.toHaveProperty("authorization");
+  expect(event).not.toHaveProperty("prompt");
+});
+it("isolates overlapping runs and tolerates a failed observer/logger", async () => {
+  const log = vi.spyOn(console, "log").mockImplementation(() => {});
+  await Promise.all(["a", "b"].map(runId => withStartupTrace({ runId }, async () => {
+    await startupPhase("outer", async () => { await Promise.resolve(); startupEvent("inside", {}); });
+  })));
+  expect(log.mock.calls.map(call => JSON.parse(call[0])).filter(e => e.phase === "inside").map(e => e.runId).sort()).toEqual(["a", "b"]);
+  log.mockImplementation(() => { throw new Error("log down"); });
+  const observer = { observe: vi.fn().mockRejectedValue(new Error("sink down")), flush: async () => {}, shutdown: async () => {} };
+  await expect(withStartupTrace({ runId: "c", observer }, () => startupPhase("safe", async () => 7))).resolves.toBe(7);
+});
+
+it("keeps the enclosing HTTP phase linked when the run is created inside it", async () => {
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  const sink = new MemoryObservationSink();
+  const observer = createHarnessObserver({ runId: "r", sinks: [sink] });
+  await withStartupTrace({ requestId: "q" }, () => startupPhase("http.submit", async () => { await bindStartupRun("r", observer); }));
+  expect(sink.observations.map(o => [o.kind, o.parentOperationId])).toEqual([["stage.start", "work:r"], ["stage.end", "work:r"]]);
+});
+
+it("attaches workflow preflight phases to the workflow root", async () => {
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  const sink = new MemoryObservationSink();
+  const observer = createHarnessObserver({ runId: "r", sinks: [sink] });
+  await withStartupTrace({ requestId: "q" }, async () => {
+    await startupPhase("prepare", async () => 1);
+    await bindStartupRun("r", observer, "workflow:r");
+    await startupPhase("ready", async () => 2);
+  });
+  expect(sink.observations.every(o => o.parentOperationId === "workflow:r")).toBe(true);
+});


### PR DESCRIPTION
## Summary

A second turn could rebuild the same GraphJin knowledge and miss warm capacity even when submitted immediately after the previous answer. Cache complete knowledge snapshots and check catalog revisions every 60 seconds, replenish expired generic spares, and retain assigned sandboxes until the idle timeout after release. Model/configuration/authorization changes still invalidate reuse.

Persist a real solo-admin identity so local operators can reuse their sandbox and later adopt SSO. Migration 0073 adds the owner pointer; lazy, transactional adoption preserves existing unowned local chat history and leaves existing SSO installations alone. A real email is required before SSO activation, not before using a solo installation.

Add correlated startup timings across chat, workflows, metrics, workflow APIs and shared worker dispatch. Capture cache/reuse decisions, preparation, queue/admission delay, database and saved-query work, SSE/browser milestones, and artifact streaming. Release images embed version/commit metadata. Missing queue timing remains unavailable; agent first output is explicitly distinguished from provider TTFT.

## Verification

- [x] Web, worker and telemetry typechecks passed; targeted web lint passed.
- [x] Cache/sandbox suite: 51 tests passed. Chat/database-backed run checks and browser timing authorization tests passed.
- [x] Workflow/metric worker suite: 17 tests passed; workflow core/admission/batch suite: 12 passed; public workflow API: 7 passed; dispatcher: 2 passed; artifact streaming: 1 passed; telemetry: 12 passed.
- [x] Solo-admin migration/adoption, concurrent initialization, existing chat-history preservation and SSO-transition checks passed against disposable PostgreSQL instances earlier in this task.
- [x] `git diff --cached --check` and `pnpm ui:check` passed.
- [x] Changed behavior was exercised locally. Production was not restarted or deployed.

## UI design-system reuse map

| Surface need | Shared component or token | Live/visual evidence |
| --- | --- | --- |
| Optional solo-admin account completion | Existing Users form: `Field`, `Input`, `NativeSelect`, `Button`, `ActionGroup` and table primitives | Inspected at 1280px and 390px: controls measured 40/44px, focus visible, no horizontal overflow. Saving the email retained the same user ID and one user row. |
| Solo account navigation | Existing AppHeader/AppRail identity controls | Solo identity displayed without a nonfunctional sign-out action; no forced account-setup redirect. |
| Chat timing | Existing Work and AppChatSidebar rendering | Instrumentation-only change; no layout or styling changes. Browser timing and authorization checks passed. |

- [x] `pnpm ui:check` passes.
- [x] Desktop and phone layouts were inspected for the solo-account UI earlier in this task.
- [x] Computed control geometry and save/focus verification are recorded above.

## Operational notes

Apply the normal schema migration before running the new application version. Startup phase logs are available without an OTel collector; exporting traces uses the existing collector configuration. Browser paint timing is a paint opportunity, not proof of visible pixels. Other generic worker jobs receive dispatch/lifecycle timing, not a claim that every internal step is instrumented.

Unrelated local `.github/hooks/` and `apps/web/docs/` files are excluded. No deployment is included in this PR.
