### PR TITLE
fix: preserve completed solo onboarding after identity upgrade

### DIFF
--- a/apps/web/src/app/api/onboarding/status/route.ts
+++ b/apps/web/src/app/api/onboarding/status/route.ts
@@ -1,3 +1,4 @@
+import { getAuthProvider } from "@/lib/auth";
 import { NextResponse } from "next/server";
 import {
   and,
@@ -202,14 +203,16 @@ export async function GET() {
   let status: OnboardingStatus;
   if (profileRows.length > 0) {
     const actor = await getCurrentActor();
-    if (actor.userId) {
+    // A persisted solo identity does not opt an existing workspace into SSO personas.
+    const personaUserId = (await getAuthProvider()) ? actor.userId : null;
+    if (personaUserId) {
       const ownPersona = await db()
         .select({ roleTemplate: operator_profile.role_template })
         .from(operator_profile)
         .where(
           and(
             eq(operator_profile.org_id, orgId),
-            eq(operator_profile.user_id, actor.userId),
+            eq(operator_profile.user_id, personaUserId),
           ),
         )
         .limit(1);
@@ -227,8 +230,8 @@ export async function GET() {
     status = {
       state: "ready",
       profileVersion: profileRows[0].version,
-      seats: actor.userId ? [] : (wizardRows[0]?.active_seats ?? []),
-      mode: actor.userId ? "personal" : "shared",
+      seats: personaUserId ? [] : (wizardRows[0]?.active_seats ?? []),
+      mode: personaUserId ? "personal" : "shared",
       ...(metricsProgress ? { metricsProgress } : {}),
     };
   } else if (jobRows.length > 0) {

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -1,3 +1,4 @@
+import { getAuthProvider } from "@/lib/auth";
 import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { connection } from "next/server";
@@ -74,6 +75,7 @@ async function loadOnboarding(): Promise<OnboardingLoadResult> {
   }
 
   const actor = await getCurrentActor();
+  const personaUserId = (await getAuthProvider()) ? actor.userId : null;
 
   const [wizardRows, orgRows, currentProfiles, ownPersonas] = await Promise.all([
     db()
@@ -101,7 +103,7 @@ async function loadOnboarding(): Promise<OnboardingLoadResult> {
         ),
       )
       .limit(1),
-    actor.userId
+    personaUserId
       ? db()
           .select({
             roleTemplate: operator_profile.role_template,
@@ -111,7 +113,7 @@ async function loadOnboarding(): Promise<OnboardingLoadResult> {
           .where(
             and(
               eq(operator_profile.org_id, orgId),
-              eq(operator_profile.user_id, actor.userId),
+              eq(operator_profile.user_id, personaUserId),
             ),
           )
           .limit(1)
@@ -122,7 +124,7 @@ async function loadOnboarding(): Promise<OnboardingLoadResult> {
   // persona. Admins are included: an admin is a person, not the org-default
   // CEO view. Query the exact user row so an org fallback cannot silently
   // count as completed personal setup.
-  if (actor.userId && currentProfiles.length > 0) {
+  if (personaUserId && currentProfiles.length > 0) {
     return {
       kind: "persona",
       initialRoleTemplate: ownPersonas[0]?.roleTemplate ?? "",
@@ -147,5 +149,5 @@ async function loadOnboarding(): Promise<OnboardingLoadResult> {
     priorities: row?.priorities ?? [],
   };
 
-  return { kind: "wizard", initial, teamMode: actor.userId !== null };
+  return { kind: "wizard", initial, teamMode: personaUserId !== null };
 }

--- a/apps/web/test/api/onboarding-status.test.ts
+++ b/apps/web/test/api/onboarding-status.test.ts
@@ -22,6 +22,8 @@ import {
 } from "@neko/db/test-helpers";
 import {
   customer_profile,
+  onboarding_wizard,
+  getOrCreateSoloAdmin,
   db,
   operator_profile,
   pool,
@@ -29,7 +31,8 @@ import {
 } from "@neko/db";
 import { callRoute } from "../_helpers/route";
 
-const { mockGetOrgId, mockGetCurrentActor } = vi.hoisted(() => ({
+const { mockGetOrgId, mockGetCurrentActor, mockGetAuthProvider } = vi.hoisted(() => ({
+  mockGetAuthProvider: vi.fn(),
   mockGetOrgId: vi.fn(),
   mockGetCurrentActor: vi.fn(),
 }));
@@ -42,6 +45,8 @@ vi.mock("@/lib/db", async () => {
 vi.mock("@/lib/actor", () => ({
   getCurrentActor: mockGetCurrentActor,
 }));
+
+vi.mock("@/lib/auth", () => ({ getAuthProvider: mockGetAuthProvider }));
 
 const reachable = await dbReachable();
 const describeIfDb = reachable ? describe : describe.skip;
@@ -92,6 +97,7 @@ describeIfDb("/api/onboarding/status GET (enriched)", () => {
   });
 
   beforeEach(async () => {
+    mockGetAuthProvider.mockResolvedValue(null);
     orgId = uniqueOrgId("api-onboarding-status");
     await createTestOrg(orgId);
     mockGetOrgId.mockResolvedValue(orgId);
@@ -223,7 +229,20 @@ describeIfDb("/api/onboarding/status GET (enriched)", () => {
     });
   });
 
+  it("preserves completed solo onboarding and role views after assigning a real identity", async () => {
+    await db().insert(customer_profile).values({ org_id: orgId, version: 1, is_current: true, business_profile: "existing installation" });
+    await db().insert(onboarding_wizard).values({ org_id: orgId, active_seats: ["CEO", "CFO", "COO", "HR"] });
+    const owner = await getOrCreateSoloAdmin(orgId);
+    expect(owner?.id).toBeTruthy();
+    mockGetCurrentActor.mockResolvedValue({ userId: owner!.id, role: "admin" });
+    expect((await callRoute(GET)).body).toMatchObject({ state: "ready", mode: "shared", seats: ["CEO", "CFO", "COO", "HR"] });
+    // The same owner must complete a personal persona only after SSO becomes active.
+    mockGetAuthProvider.mockResolvedValue({ pluginName: "sso" });
+    expect((await callRoute(GET)).body).toEqual({ state: "needs_persona" });
+  });
+
   it("requires an exact personal persona for an SSO user", async () => {
+    mockGetAuthProvider.mockResolvedValue({ pluginName: "sso" });
     await db().insert(customer_profile).values({
       org_id: orgId,
       version: 1,
@@ -240,6 +259,7 @@ describeIfDb("/api/onboarding/status GET (enriched)", () => {
   });
 
   it("removes shared role views after an SSO user defines their persona", async () => {
+    mockGetAuthProvider.mockResolvedValue({ pluginName: "sso" });
     await db().insert(customer_profile).values({
       org_id: orgId,
       version: 1,


### PR DESCRIPTION
## Summary

Fix the v2.44.2 upgrade regression where assigning a persisted solo-admin user ID caused an already-onboarded installation to return `needs_persona` and lose its shared role views. A real user identity is now distinct from active SSO: personal onboarding and team-mode forms apply only when an authentication provider is active.

The affected VM retained `setup_complete_at`, its current business profile, and the CEO/CFO/COO/HR seats; no reset or data migration is needed. Keep the durable user identity for ownership and sandbox reuse. The same account still requires a personal persona after SSO activation.

## Verification

- [x] Nine onboarding status tests passed against disposable PostgreSQL, including an existing completed solo installation receiving a real owner ID and then switching to SSO.
- [x] Isolated local HTTP check returned `ready`, `mode: shared`, and all four preserved seats with no operator-profile rows.
- [x] Web typecheck, targeted lint, `pnpm ui:check`, and diff checks passed.
- Production diagnosis was read-only. The VM currently returns `needs_persona`; this PR has not been deployed.

## UI design-system reuse map

| Surface need | Shared component or token | Verification |
| --- | --- | --- |
| Preserve completed solo onboarding and shared role selection | Existing OnboardingWizard and PersonaStep; no markup, control, or styling changes | Status API verified via HTTP and database-backed upgrade/SSO tests. Existing solo seats remain available; teamMode is tied to active SSO. |
