### PR TITLE
fix: prepare warm capacity before Work and sync only changed inputs

### DIFF
--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -1,0 +1,12 @@
+/** Prepare the same process-local pool used by Work before serving requests. */
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs" || !process.env.OPENNEKO_AGENT_IMAGE) return;
+  const { prepareSandboxCapacity } = await import("@neko/llm/work/sandbox-launcher");
+  try {
+    await prepareSandboxCapacity();
+  } catch (error) {
+    // Keep setup and existing pages available during a gateway outage. Work
+    // admission still waits for a ready sandbox; the pool retries preparation.
+    console.error("[sandbox] startup preparation failed", error);
+  }
+}

--- a/apps/web/test/instrumentation.test.ts
+++ b/apps/web/test/instrumentation.test.ts
@@ -1,0 +1,24 @@
+import { afterEach, expect, it, vi } from 'vitest';
+const prepare = vi.hoisted(() => vi.fn());
+vi.mock('@neko/llm/work/sandbox-launcher', () => ({ prepareSandboxCapacity: prepare }));
+import { register } from '../src/instrumentation';
+afterEach(() => { vi.unstubAllEnvs(); vi.restoreAllMocks(); prepare.mockReset(); });
+it('waits for warm readiness before registering the Node server', async () => {
+  vi.stubEnv('NEXT_RUNTIME', 'nodejs'); vi.stubEnv('OPENNEKO_AGENT_IMAGE', 'agent:test');
+  let ready!: () => void;
+  prepare.mockImplementation(() => new Promise<void>(resolve => { ready = resolve; }));
+  let registered = false;
+  const registration = register().then(() => { registered = true; });
+  await vi.waitFor(() => expect(prepare).toHaveBeenCalledTimes(1));
+  expect(registered).toBe(false);
+  ready(); await registration; expect(registered).toBe(true);
+});
+it('keeps existing pages available on preparation failure and skips unconfigured runtimes', async () => {
+  vi.stubEnv('NEXT_RUNTIME', 'nodejs'); vi.stubEnv('OPENNEKO_AGENT_IMAGE', 'agent:test');
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  prepare.mockRejectedValue(new Error('gateway offline'));
+  await expect(register()).resolves.toBeUndefined();
+  vi.stubEnv('NEXT_RUNTIME', 'edge'); await register();
+  vi.stubEnv('NEXT_RUNTIME', 'nodejs'); vi.stubEnv('OPENNEKO_AGENT_IMAGE', ''); await register();
+  expect(prepare).toHaveBeenCalledTimes(1);
+});

--- a/apps/worker/benchmarks/2026-09-13-durable-warm-startup.md
+++ b/apps/worker/benchmarks/2026-09-13-durable-warm-startup.md
@@ -1,0 +1,52 @@
+# Durable warm startup validation — 13 September 2026
+
+Working tree: `codex/durable-warm-startup`, based on `c280803` (v2.44.3).
+Not deployed to the demo VM. No production latency claim.
+
+Web instrumentation and worker startup await generic capacity. Pool-enabled
+Work admission shares pending preparation instead of launching a separate
+cold fallback. Exhausted capacity waits; explicitly disabled pools retain the
+existing disposable path. Startup preparation failure leaves setup/pages
+available and schedules retries; Work still requires a ready slot.
+
+Binding reconciles real file hashes against staged inputs, removes stale files
+and symlinks, restores agent-modified inputs, and uploads changed files only.
+New turn inputs and broker credentials remain fresh. Provider/policy scope
+invalidation remains unchanged. Checkout, reconciliation, upload, and transfer
+counts have separate telemetry. Hermes configuration is no longer uploaded
+both inside the run workspace and into the warm home.
+
+## Checks
+
+- 56 focused pool, launcher, and filesystem tests passed.
+- Full local workspace suite: 2,540 passed, 64 opt-in tests skipped, zero
+  failures, against a disposable database with all 73 migrations applied.
+  LLM: 947 passed; web: 476 passed; worker: 618 passed.
+- Repository-wide TypeScript checks passed.
+- Two web instrumentation tests passed (await readiness, gateway failure,
+  and unconfigured/edge runtime behavior).
+- Web and worker TypeScript checks and web instrumentation lint passed.
+- Real OpenShell integration test passed with a disposable local sandbox;
+  the sandbox was deleted afterward. No model calls or production mutations.
+
+The real test used `ghcr.io/open-neko/agent:warm-uncommitted`, one CPU,
+512 MiB, and two files totaling 65,541 bytes. These are single observations:
+
+| Operation | Time | Uploaded |
+| --- | ---: | ---: |
+| Startup preparation to ready | 4,330 ms | — |
+| Initial directory sync | 796 ms | 65,541 bytes |
+| Unchanged directory sync | 58 ms | 0 bytes |
+| Changed turn input only | 109 ms | 5 bytes |
+
+This exercises preparation and real OpenShell reconciliation/upload semantics,
+not a full model turn or a representative production workspace. Provider and
+policy binding are outside these directory-sync timings.
+
+Repeat against a configured local gateway with an available agent image:
+
+```sh
+OPENNEKO_OPENSHELL_WARM_E2E=1 \
+OPENNEKO_AGENT_IMAGE=ghcr.io/open-neko/agent:warm-uncommitted \
+pnpm --filter @neko/llm exec vitest run test/sandbox-warm-e2e.test.ts
+```

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,3 +1,4 @@
+import { prepareSandboxCapacity, closeSandboxPools } from "@neko/llm/work/sandbox-launcher";
 import { withStartupTrace, startupPhase, startupEvent } from "@neko/telemetry/startup";
 import { soloAdminNeedsEmail } from "@neko/db";
 import { dispatchEmbeddingJobs, runEmbeddingIndexJob, type EmbeddingIndexPayload } from "@neko/llm";
@@ -961,6 +962,10 @@ const GRAPHJIN_URL = toGraphqlEndpoint(
 );
 console.log(`[worker] neko graphjin client targeting ${GRAPHJIN_URL}`);
 
+if (process.env.OPENNEKO_AGENT_IMAGE) {
+  try { await prepareSandboxCapacity(); }
+  catch (error) { console.error("[sandbox] startup preparation failed", error); }
+}
 const b = await boss();
 
 {
@@ -1708,6 +1713,8 @@ const shutdown = async (signal: string) => {
   } catch (e) {
     console.error("[worker] records pool shutdown error:", e);
   }
+  try { await closeSandboxPools(); }
+  catch (error) { console.error("[worker] sandbox shutdown error:", error); }
   await shutdownWorkerTelemetry();
   process.exit(0);
 };

--- a/packages/llm/package.json
+++ b/packages/llm/package.json
@@ -26,7 +26,8 @@
     "./graphjin/file-source-assets": "./src/graphjin/file-source-assets.ts",
     "./graphjin/openapi-assets": "./src/graphjin/openapi-assets.ts",
     "./graphjin/openapi-spec": "./src/graphjin/openapi-spec.ts",
-    "./graphjin/persist-source-config": "./src/graphjin/persist-source-config.ts"
+    "./graphjin/persist-source-config": "./src/graphjin/persist-source-config.ts",
+    "./work/sandbox-launcher": "./src/work/sandbox-launcher.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/packages/llm/src/work/sandbox-launcher.ts
+++ b/packages/llm/src/work/sandbox-launcher.ts
@@ -1,5 +1,6 @@
 import { startupEvent, startupPhase } from "@neko/telemetry/startup";
 import { createHash, randomUUID } from "node:crypto";
+import { RECONCILE_COMMAND, syncSandboxDirectory } from "./sandbox-sync";
 import { SandboxPool, type WarmSlot } from "./sandbox-pool";
 import { spawn } from "node:child_process";
 import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
@@ -443,7 +444,16 @@ export async function sandboxAgentBackendForJob(opts: {
   };
 }
 
-const warmPools = new Map<string, SandboxPool>();
+// Next instrumentation and route bundles must see the same process-local pool.
+const poolHost = globalThis as typeof globalThis & { __opennekoWarmPools?: Map<string, SandboxPool> };
+const warmPools = poolHost.__opennekoWarmPools ??= new Map<string, SandboxPool>();
+
+export async function prepareSandboxCapacity(opts = sandboxLauncherOptionsFromEnv()): Promise<void> {
+  makeSandboxRunCore(opts);
+  await startupPhase("sandbox.prewarm", async () => {
+    await Promise.all([...warmPools.values()].map(pool => pool.ready()));
+  });
+}
 
 /** Explicit shutdown hook for hosts/tests; sandbox-side idle expiry also survives host loss. */
 export async function closeSandboxPools(): Promise<void> {
@@ -667,7 +677,7 @@ function makeSandboxCore(
       const hermesStage = opts.hermesHomeHostPath
         ? await stageKeylessHermesHome(
             opts.hermesHomeHostPath,
-            path.join(stageRuntimeRoot, "hermes-home"),
+            pool ? path.join(stageDir, "hermes-home") : path.join(stageRuntimeRoot, "hermes-home"),
           )
         : null;
       const policyFile = path.join(stageDir, "policy.json");
@@ -708,14 +718,15 @@ function makeSandboxCore(
             hermesStage ? await readFile(path.join(hermesStage, "config.yaml"), "utf8") : null,
           ])).digest("hex"),
         } : undefined;
-        lease = await startupPhase("sandbox.acquire", () => pool!.acquire(session));
-        warmSlot = lease.slot ?? await timed("warm_miss", newWarmSlot);
+        lease = await startupPhase("sandbox.acquire", () => pool!.acquire(session, signal));
+        warmSlot = lease.slot;
+        if (!warmSlot) throw new Error("Warm sandbox admission returned no slot");
         name = warmSlot.name;
         sandboxCreated = true;
         if (signal?.aborted) throw abortError();
         await timed("warm_bind", async () => {
-          await run(["sandbox", "exec", "-n", name, "--no-tty", "--",
-            "/usr/local/uv/tools/hermes-agent/bin/python", "/app/hermes-warm.py", "checkout"], 15_000);
+          await timed("warm_checkout", () => run(["sandbox", "exec", "-n", name, "--no-tty", "--",
+            "/usr/local/uv/tools/hermes-agent/bin/python", "/app/hermes-warm.py", "checkout"], 15_000));
           // Replace rather than merge policy. A failed update must never run
           // the agent with the previous turn's permissions.
           if (!lease!.reused) {
@@ -724,13 +735,25 @@ function makeSandboxCore(
             }
             await timed("warm_policy", () => run(["policy", "set", name, "--policy", policyFile, "--wait", "--timeout", "60"], 65_000));
           }
-          await run(["sandbox", "exec", "-n", name, "--no-tty", "--", "sh", "-c",
-            `rm -rf -- ${shellQuote(boxOrgRoot)} /sandbox/.hermes-warm/home; mkdir -p /sandbox/.hermes-warm/home`], 30_000);
-          await run(["sandbox", "upload", name, staged.orgRoot, "/sandbox", "--no-git-ignore"], 120_000);
-          if (hermesStage) {
-            await run(["sandbox", "exec", "-n", name, "--no-tty", "--", "sh", "-c",
-              `cp -R ${shellQuote(path.posix.join(boxWorkspace.runRoot, SANDBOX_RUNTIME_DIR, "hermes-home"))}/. /sandbox/.hermes-warm/home/`], 30_000);
-          }
+          const sync = async (source: string, destination: string, phase: string) => {
+            const result = await timed(`${phase}_sync`, () => syncSandboxDirectory({
+              source, destination, deltaRoot: path.join(stageDir, `delta-${phase}`),
+              reconcile: manifest => timed(`${phase}_reconcile`, () => run([
+                "sandbox", "exec", "-n", name, "--no-tty", "--",
+                "/usr/local/uv/tools/hermes-agent/bin/python", "-c", RECONCILE_COMMAND,
+                destination, manifest,
+              ], 30_000)),
+              upload: directory => timed(`${phase}_upload`, () => run([
+                "sandbox", "upload", name, directory, path.posix.dirname(destination), "--no-git-ignore",
+              ], 120_000)).then(() => {}),
+            }));
+            startupEvent(`sandbox.${phase}_delta`, result);
+          };
+          await sync(staged.orgRoot, boxOrgRoot, "workspace");
+          // Empty desired home also removes any config/cache left by the previous turn.
+          const desiredHome = hermesStage ?? path.join(stageDir, "empty-home");
+          await mkdir(desiredHome, { recursive: true });
+          await sync(desiredHome, sandboxHermesHome, "config");
         });
         log(JSON.stringify({ type: "sandbox_warm", runId: input.runId, sandboxName: name,
           mode: lease.reused ? "user" : lease.slot ? "generic" : "miss" }));

--- a/packages/llm/src/work/sandbox-pool.ts
+++ b/packages/llm/src/work/sandbox-pool.ts
@@ -15,7 +15,8 @@ type IdleSlot = {
 
 export class SandboxPool {
   private generic: WarmSlot[] = [];
-  private pending = 0;
+  private pending = new Set<Promise<void>>();
+  private retry?: ReturnType<typeof setTimeout>;
   private idle = new Map<string, IdleSlot>();
   private busy = new Set<string>();
   private stopped = false;
@@ -35,10 +36,9 @@ export class SandboxPool {
   replenish(): void {
     if (this.stopped) return;
     this.generic = this.generic.filter(slot => slot.alive());
-    while (this.generic.length + this.pending < this.options.size) {
-      this.pending++;
+    while (this.generic.length + this.pending.size < this.options.size) {
       const started = performance.now();
-      void this.options.create().then(async slot => {
+      const preparation = this.options.create().then(async slot => {
         this.event({ outcome: "spare_ready", background: true, slot: slot.name, durationMs: performance.now() - started });
         if (this.stopped) await slot.destroy();
         else {
@@ -51,15 +51,48 @@ export class SandboxPool {
             this.replenish();
           });
         }
-      }).catch(error => { this.event({ outcome: "spare_failed", background: true, durationMs: performance.now() - started }); this.options.onError(error); }).finally(() => { this.pending--; });
+      }).finally(() => {
+        this.pending.delete(preparation);
+      });
+      this.pending.add(preparation);
+      void preparation.catch(error => {
+        this.event({ outcome: "spare_failed", background: true, durationMs: performance.now() - started });
+        this.options.onError(error);
+        if (!this.stopped && !this.retry) {
+          this.retry = setTimeout(() => { this.retry = undefined; this.replenish(); }, 1_000);
+          this.retry.unref();
+        }
+      });
     }
   }
 
-  async acquire(user?: { key: string; scope: string; modelScope?: string; authorizationScope?: string }): Promise<{
+  /** Startup readiness and admission share the same in-flight preparation. */
+  async ready(signal?: AbortSignal): Promise<void> {
+    while (!this.generic.some(slot => slot.alive())) {
+      if (this.stopped) throw new Error("Sandbox pool is closed");
+      signal?.throwIfAborted();
+      this.replenish();
+      if (!this.pending.size) throw new Error("Sandbox pool has no capacity");
+      const preparation = Promise.race(this.pending);
+      if (!signal) { await preparation; continue; }
+      await new Promise<void>((resolve, reject) => {
+        const abort = () => reject(signal.reason);
+        signal.addEventListener("abort", abort, { once: true });
+        preparation.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
+        if (signal.aborted) abort();
+      });
+    }
+    if (this.stopped) throw new Error("Sandbox pool is closed");
+    signal?.throwIfAborted();
+  }
+
+  async acquire(user?: { key: string; scope: string; modelScope?: string; authorizationScope?: string }, signal?: AbortSignal): Promise<{
     slot?: WarmSlot;
     reused: boolean;
     release: (slot: WarmSlot | undefined, healthy: boolean) => Promise<void>;
   }> {
+    if (this.stopped) throw new Error("Sandbox pool is closed");
+    signal?.throwIfAborted();
     // Concurrent turns for the same user get independent disposable slots.
     const retain = user && !this.busy.has(user.key) ? user : undefined;
     if (retain) this.busy.add(retain.key);
@@ -84,11 +117,20 @@ export class SandboxPool {
         }
       }
     }
-    while (!slot && this.generic.length) {
-      const candidate = this.generic.shift()!;
-      if (candidate.alive()) slot = candidate;
+    try {
+      while (!slot) {
+        if (!this.generic.some(candidate => candidate.alive())) {
+          this.event({ outcome: "waiting", reason, pending: this.pending.size });
+          await this.ready(signal);
+        }
+        const candidate = this.generic.shift();
+        if (candidate?.alive()) slot = candidate;
+      }
+    } catch (error) {
+      if (retain) this.busy.delete(retain.key);
+      throw error;
     }
-    this.event({ outcome: reused ? "assigned_hit" : slot ? "generic_hit" : "cold", reason: reused ? "scope_match" : reason, slot: slot?.name });
+    this.event({ outcome: reused ? "assigned_hit" : "generic_hit", reason: reused ? "scope_match" : reason, slot: slot?.name });
     this.replenish();
     let released = false;
     return {
@@ -119,12 +161,13 @@ export class SandboxPool {
 
   async close(): Promise<void> {
     this.stopped = true;
+    clearTimeout(this.retry);
     const slots = [...this.generic, ...[...this.idle.values()].map(value => {
       clearTimeout(value.timer);
       return value.slot;
     })];
     this.generic = [];
     this.idle.clear();
-    await Promise.all(slots.map(slot => slot.destroy()));
+    await Promise.all([...slots.map(slot => slot.destroy()), ...[...this.pending].map(p => p.catch(() => {}))]);
   }
 }

--- a/packages/llm/src/work/sandbox-sync.ts
+++ b/packages/llm/src/work/sandbox-sync.ts
@@ -1,0 +1,91 @@
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { cp, mkdir, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+
+type Entry = { hash: string; mode: number } | null;
+
+/** Reconcile the actual filesystem, not a manifest the agent could leave stale. */
+export const RECONCILE_DIRECTORY = String.raw`
+import hashlib,json,os,pathlib,shutil,sys
+root=pathlib.Path(sys.argv[1])
+wanted=json.loads(sys.argv[2])
+for parent in root.parents:
+    if parent.is_symlink(): raise ValueError('sandbox root ancestor is a symlink')
+def remove(p):
+    if p.is_symlink() or not p.is_dir(): p.unlink()
+    else: shutil.rmtree(p)
+if root.is_symlink() or (root.exists() and not root.is_dir()): remove(root)
+root.mkdir(parents=True,exist_ok=True)
+for base,dirs,files in os.walk(root,topdown=True,followlinks=False):
+    for name in dirs[:] + files:
+        p=pathlib.Path(base)/name
+        rel=p.relative_to(root).as_posix()
+        if p.is_symlink() or rel not in wanted or (p.is_dir() != (wanted[rel] is None)):
+            remove(p)
+            if name in dirs: dirs.remove(name)
+for rel,entry in wanted.items():
+    if entry is None: (root/rel).mkdir(parents=True,exist_ok=True)
+def file_hash(p):
+    h=hashlib.sha256()
+    with p.open('rb') as f:
+        for chunk in iter(lambda: f.read(1048576),b''): h.update(chunk)
+    return h.hexdigest()
+changed=[]
+for rel,entry in wanted.items():
+    if entry is None: continue
+    p=root/rel
+    if not p.is_file() or file_hash(p)!=entry['hash']:
+        if p.exists(): remove(p)
+        changed.append(rel)
+    else: p.chmod(entry['mode'])
+print('__openneko_sync__'+json.dumps(changed))
+`;
+
+// OpenShell rejects newline characters in command arguments.
+export const RECONCILE_COMMAND = `exec(__import__('base64').b64decode('${Buffer.from(RECONCILE_DIRECTORY).toString("base64")}'))`;
+
+export async function syncSandboxDirectory(options: {
+  source: string;
+  destination: string;
+  deltaRoot: string;
+  reconcile: (manifest: string) => Promise<string>;
+  upload: (directory: string) => Promise<void>;
+}): Promise<{ files: number; changed: number; bytes: number }> {
+  const entries: Record<string, Entry> = Object.create(null);
+  async function walk(directory: string): Promise<void> {
+    for (const file of await readdir(directory, { withFileTypes: true })) {
+      const full = path.join(directory, file.name);
+      const relative = path.relative(options.source, full).split(path.sep).join("/");
+      // Staged inputs must never introduce links outside their permitted tree.
+      if (file.isSymbolicLink() || (!file.isDirectory() && !file.isFile())) throw new Error("Unsupported sandbox input file");
+      if (file.isDirectory()) { entries[relative] = null; await walk(full); }
+      else {
+        const hash = createHash("sha256");
+        for await (const chunk of createReadStream(full)) hash.update(chunk);
+        entries[relative] = { hash: hash.digest("hex"), mode: (await stat(full)).mode & 0o777 };
+      }
+    }
+  }
+  await walk(options.source);
+  const output = await options.reconcile(JSON.stringify(entries));
+  const marker = output.split("\n").find(line => line.startsWith("__openneko_sync__"));
+  if (!marker) throw new Error("Sandbox file reconciliation did not return a manifest");
+  const changed: unknown = JSON.parse(marker.slice("__openneko_sync__".length));
+  if (!Array.isArray(changed) || changed.some(file => typeof file !== "string" || !Object.hasOwn(entries, file) || entries[file] === null) || new Set(changed).size !== changed.length) {
+    throw new Error("Invalid sandbox file reconciliation result");
+  }
+  let bytes = 0;
+  if (changed.length) {
+    const delta = path.join(options.deltaRoot, path.basename(options.destination));
+    await mkdir(delta, { recursive: true });
+    for (const file of changed as string[]) {
+      const target = path.join(delta, file);
+      await mkdir(path.dirname(target), { recursive: true });
+      await cp(path.join(options.source, file), target);
+      bytes += (await stat(target)).size;
+    }
+    await options.upload(delta);
+  }
+  return { files: Object.values(entries).filter(Boolean).length, changed: changed.length, bytes };
+}

--- a/packages/llm/test/sandbox-launcher.test.ts
+++ b/packages/llm/test/sandbox-launcher.test.ts
@@ -29,6 +29,7 @@ const h = vi.hoisted(() => {
   const state = {
     holdExec: false,
     failPolicy: false,
+    failReconcile: false,
     deleteMissing: false,
     collideOnNextCreate: false,
     execLines: undefined as string[] | undefined,
@@ -57,13 +58,15 @@ const h = vi.hoisted(() => {
         ? ["Error: × sandbox 'work-run-1' already exists\n"]
         : [],
     );
-    const lines = warmCreate ? ["__openneko_warm_ready__\n"] : failedPolicy ? ["policy submitted\n"] : isExec
+    const reconciliation = args.findIndex(arg => arg.startsWith("exec(__import__('base64')"));
+    const syncLines = reconciliation < 0 ? undefined : state.failReconcile ? ["invalid reconciliation\n"] : ["__openneko_sync__" + JSON.stringify(Object.entries(JSON.parse(args[reconciliation + 2]!)).filter(([, value]) => value !== null).map(([key]) => key)) + "\n"];
+    const lines = syncLines ?? (warmCreate ? ["__openneko_warm_ready__\n"] : failedPolicy ? ["policy submitted\n"] : isExec
       ? state.execLines ?? [
           'noise before\n',
           `\n__openneko_event__${JSON.stringify({ type: "message", role: "assistant", content: "hi" })}\n`,
           `\n__openneko_agent_result__${JSON.stringify({ status: "completed", finalText: "hi there", backendState: { t: 1 } })}\n`,
         ]
-      : [];
+      : []);
     let closed = false;
     const closeOnce = () => {
       if (closed) return;
@@ -129,6 +132,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
 
 const {
   makeSandboxRunCore,
+  prepareSandboxCapacity,
   closeSandboxPools,
   makeSandboxJobRunCore,
   makeSandboxWorkflowRunCore,
@@ -482,6 +486,7 @@ describe("makeSandboxRunCore", () => {
     h.calls.length = 0;
     h.state.holdExec = false;
     h.state.failPolicy = false;
+    h.state.failReconcile = false;
     h.state.deleteMissing = false;
     h.state.collideOnNextCreate = false;
     h.state.execLines = undefined;
@@ -490,6 +495,19 @@ describe("makeSandboxRunCore", () => {
     jobCapture.hermesEnvs.length = 0;
   });
   afterEach(async () => { await closeSandboxPools(); vi.restoreAllMocks(); });
+
+  it("prepares capacity before the first turn and reuses the startup pool", async () => {
+    const logs: string[] = [];
+    const options = { agentImage: "startup-test", onLog: (line: string) => logs.push(line) };
+    await prepareSandboxCapacity(options);
+    expect(h.calls.filter(call => call.args.includes("create"))).toHaveLength(1);
+    await makeSandboxRunCore({ ...options, modelProvider: "configured-after-startup" })(fakeInput(async () => {}));
+    expect(logs.some(line => line.includes('"mode":"generic"'))).toBe(true);
+    expect(logs.some(line => line.includes('"phase":"warm_miss"'))).toBe(false);
+    for (const phase of ["warm_checkout", "workspace_reconcile", "workspace_upload", "config_reconcile"]) {
+      expect(logs.some(line => line.includes(`"phase":"${phase}"`))).toBe(true);
+    }
+  });
 
   it("prewarms by default without an explicit pool option", async () => {
     const logs: string[] = [];
@@ -513,6 +531,15 @@ describe("makeSandboxRunCore", () => {
     expect(policies).toHaveLength(2);
     expect(commands.findIndex(args => args.includes("attach"))).toBeLessThan(commands.findIndex(args => args.includes("set")));
     expect(commands.filter(args => args.includes("create")).every(args => !args.includes("--provider"))).toBe(true);
+  });
+
+  it("discards the slot without executing the agent when file reconciliation fails", async () => {
+    h.state.failReconcile = true;
+    const logs: string[] = [];
+    const core = makeSandboxRunCore({ agentImage: "sync-failure-test", onLog: line => logs.push(line) });
+    await expect(core(fakeInput(async () => {}))).rejects.toThrow(/reconciliation/);
+    expect(logs.some(line => line.includes('"phase":"exec"'))).toBe(false);
+    expect(h.calls.some(call => call.args.includes("delete"))).toBe(true);
   });
 
   it("fails closed on a rejected policy even when the CLI printed stdout", async () => {

--- a/packages/llm/test/sandbox-pool.test.ts
+++ b/packages/llm/test/sandbox-pool.test.ts
@@ -87,3 +87,82 @@ it('keeps assignments private, expires idle slots, and destroys changed/failed s
   expect(onEvent).toHaveBeenCalledWith(expect.objectContaining({ reason: "assigned_idle_timeout" }));
   await pool.close();
 });
+it('shares startup preparation with first admission instead of creating a second sandbox', async () => {
+  let finish!: (slot: WarmSlot) => void;
+  const slot = { name: 'prepared', alive: () => true, destroy: vi.fn(async () => {}) };
+  const create = vi.fn(() => new Promise<WarmSlot>(resolve => { finish = resolve; }));
+  const pool = new SandboxPool({ size: 1, idleMs: 1000, create, onError: vi.fn() });
+  const ready = pool.ready();
+  const admission = pool.acquire({ key: 'alice', scope: 'v1' });
+  expect(create).toHaveBeenCalledTimes(1);
+  finish(slot);
+  await ready;
+  const lease = await admission;
+  expect(lease.slot).toBe(slot);
+  expect(create).toHaveBeenCalledTimes(2); // Only now replenish the consumed spare.
+  finish({ ...slot, name: 'replacement' });
+  await lease.release(slot, true);
+  await pool.close();
+});
+it('cancels a waiter without leaking its user assignment or cancelling shared preparation', async () => {
+  let finish!: (slot: WarmSlot) => void;
+  const create = vi.fn(() => new Promise<WarmSlot>(resolve => { finish = resolve; }));
+  const pool = new SandboxPool({ size: 1, idleMs: 1000, create, onError: vi.fn() });
+  const controller = new AbortController();
+  const session = { key: 'alice', scope: 'v1' };
+  const cancelled = pool.acquire(session, controller.signal);
+  controller.abort(new Error('cancelled'));
+  await expect(cancelled).rejects.toThrow('cancelled');
+  const waiting = pool.acquire(session);
+  const slot = { name: 'ready', alive: () => true, destroy: vi.fn(async () => {}) };
+  finish(slot);
+  const lease = await waiting;
+  finish({ ...slot, name: 'spare' });
+  await lease.release(slot, true);
+  const reused = await pool.acquire(session);
+  expect(reused.reused).toBe(true);
+  await reused.release(slot, true);
+  await pool.close();
+});
+it('fails admission on preparation failure and retries without a new request', async () => {
+  vi.useFakeTimers();
+  const slot = { name: 'recovered', alive: () => true, destroy: vi.fn(async () => {}) };
+  const create = vi.fn().mockRejectedValueOnce(new Error('gateway unavailable')).mockResolvedValue(slot);
+  const pool = new SandboxPool({ size: 1, idleMs: 1000, create, onError: vi.fn() });
+  await expect(pool.acquire({ key: 'alice', scope: 'v1' })).rejects.toThrow('gateway unavailable');
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(create).toHaveBeenCalledTimes(2);
+  const lease = await pool.acquire({ key: 'alice', scope: 'v1' });
+  await lease.release(slot, true);
+  await pool.close();
+});
+it('destroys a slot that becomes ready during shutdown and rejects the waiting admission', async () => {
+  let finish!: (slot: WarmSlot) => void;
+  const slot = { name: 'late', alive: () => true, destroy: vi.fn(async () => {}) };
+  const pool = new SandboxPool({ size: 1, idleMs: 1000,
+    create: () => new Promise(resolve => { finish = resolve; }), onError: vi.fn() });
+  const admission = pool.acquire({ key: 'alice', scope: 'v1' });
+  const rejected = expect(admission).rejects.toThrow('closed');
+  const closing = pool.close();
+  finish(slot);
+  await closing; await rejected;
+  expect(slot.destroy).toHaveBeenCalledTimes(1);
+  await expect(pool.acquire()).rejects.toThrow('closed');
+});
+it('gives simultaneous waiters distinct slots while sharing pending preparation', async () => {
+  const finishes: Array<(slot: WarmSlot) => void> = [];
+  const create = vi.fn(() => new Promise<WarmSlot>(resolve => finishes.push(resolve)));
+  const pool = new SandboxPool({ size: 1, idleMs: 1000, create, onError: vi.fn() });
+  const alice = pool.acquire({ key: 'alice', scope: 'v1' });
+  const bob = pool.acquire({ key: 'bob', scope: 'v1' });
+  expect(create).toHaveBeenCalledTimes(1);
+  const slot = (name: string) => ({ name, alive: () => true, destroy: vi.fn(async () => {}) });
+  finishes.shift()!(slot('one'));
+  const a = await alice;
+  await vi.waitFor(() => expect(finishes).toHaveLength(1));
+  finishes.shift()!(slot('two'));
+  const b = await bob;
+  expect(a.slot).not.toBe(b.slot);
+  finishes.shift()!(slot('spare'));
+  await a.release(a.slot, true); await b.release(b.slot, true); await pool.close();
+});

--- a/packages/llm/test/sandbox-sync.test.ts
+++ b/packages/llm/test/sandbox-sync.test.ts
@@ -1,0 +1,52 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { cp, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile, access } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, expect, it, vi } from 'vitest';
+import { RECONCILE_COMMAND, syncSandboxDirectory } from '../src/work/sandbox-sync';
+const roots: string[] = [];
+afterEach(async () => { await Promise.all(roots.splice(0).map(root => rm(root, { recursive: true, force: true }))); });
+it('skips unchanged files, repairs agent edits, removes stale files and refreshes turn inputs', async () => {
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), 'sandbox-sync-test-'))); roots.push(root);
+  const source = path.join(root, 'source'); const destination = path.join(root, 'box', 'org');
+  await mkdir(path.join(source, 'knowledge'), { recursive: true });
+  await writeFile(path.join(source, 'knowledge', 'catalog'), 'revision 1');
+  await writeFile(path.join(source, 'job.json'), 'turn 1');
+  const upload = vi.fn(async (delta: string) => { await cp(delta, destination, { recursive: true }); });
+  let turn = 0;
+  const sync = () => syncSandboxDirectory({ source, destination, deltaRoot: path.join(root, 'delta'+turn++), upload,
+    reconcile: async manifest => (await promisify(execFile)('python3', ['-c', RECONCILE_COMMAND, destination, manifest])).stdout });
+  expect((await sync()).changed).toBe(2);
+  expect((await sync()).changed).toBe(0);
+  expect(upload).toHaveBeenCalledTimes(1);
+  await writeFile(path.join(destination, 'knowledge', 'catalog'), 'agent modification');
+  await writeFile(path.join(destination, 'old-turn-secret'), 'old');
+  await writeFile(path.join(source, 'job.json'), 'turn 2 fresh credentials');
+  expect((await sync()).changed).toBe(2);
+  expect(await readFile(path.join(destination, 'knowledge', 'catalog'), 'utf8')).toBe('revision 1');
+  expect(await readFile(path.join(destination, 'job.json'), 'utf8')).toBe('turn 2 fresh credentials');
+  await expect(access(path.join(destination, 'old-turn-secret'))).rejects.toThrow();
+  await rm(path.join(source, 'knowledge'), { recursive: true });
+  await sync();
+  await expect(access(path.join(destination, 'knowledge'))).rejects.toThrow();
+  // A sandbox-created link must not redirect cleanup or uploads outside the tree.
+  const outside = path.join(root, 'outside'); await mkdir(outside); await writeFile(path.join(outside, 'keep'), 'safe');
+  await symlink(outside, path.join(destination, 'knowledge'));
+  await mkdir(path.join(source, 'knowledge')); await writeFile(path.join(source, 'knowledge', 'catalog'), 'revision 2');
+  await sync();
+  expect(await readFile(path.join(outside, 'keep'), 'utf8')).toBe('safe');
+  expect(await readFile(path.join(destination, 'knowledge', 'catalog'), 'utf8')).toBe('revision 2');
+});
+it('rejects injected paths and source symlinks', async () => {
+  const root = await realpath(await mkdtemp(path.join(tmpdir(), 'sandbox-sync-test-'))); roots.push(root);
+  const source = path.join(root, 'source'); await mkdir(source);
+  await writeFile(path.join(source, 'config'), 'config');
+  const upload = vi.fn();
+  const options = { source, destination: '/sandbox/org', deltaRoot: path.join(root, 'delta'), upload,
+    reconcile: async () => '__openneko_sync__["../../outside"]' };
+  await expect(syncSandboxDirectory(options)).rejects.toThrow('Invalid sandbox file reconciliation');
+  expect(upload).not.toHaveBeenCalled();
+  await symlink('/tmp', path.join(source, 'link'));
+  await expect(syncSandboxDirectory(options)).rejects.toThrow('Unsupported sandbox input');
+});

--- a/packages/llm/test/sandbox-warm-e2e.test.ts
+++ b/packages/llm/test/sandbox-warm-e2e.test.ts
@@ -1,0 +1,50 @@
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { expect, it, vi } from 'vitest';
+import { closeSandboxPools, prepareSandboxCapacity } from '../src/work/sandbox-launcher';
+import { RECONCILE_COMMAND, syncSandboxDirectory } from '../src/work/sandbox-sync';
+
+// No provider or model call. Uses only a disposable slot on the configured gateway.
+// OPENNEKO_OPENSHELL_WARM_E2E=1 OPENNEKO_AGENT_IMAGE=... pnpm --filter @neko/llm exec vitest run test/sandbox-warm-e2e.test.ts
+it.skipIf(process.env.OPENNEKO_OPENSHELL_WARM_E2E !== '1' || !process.env.OPENNEKO_AGENT_IMAGE)(
+  'prepares a real slot and uploads only changed files through OpenShell', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'warm-sync-e2e-'));
+    let slot = '';
+    const originalLog = console.log;
+    const logger = vi.spyOn(console, 'log').mockImplementation((...args) => {
+      for (const value of args) {
+        try { const event = JSON.parse(String(value)); if (event.outcome === 'spare_ready') slot = event.slot; } catch {}
+      }
+      originalLog(...args);
+    });
+    const run = (args: string[]) => new Promise<string>((resolve, reject) => {
+      const child = execFile('openshell', args, { timeout: 30_000 }, (error, stdout) => error ? reject(error) : resolve(stdout));
+      child.stdin?.end();
+    });
+    try {
+      await prepareSandboxCapacity({ agentImage: process.env.OPENNEKO_AGENT_IMAGE!, cpu: '1', memory: '512Mi', warmPoolSize: 1 });
+      expect(slot).not.toBe('');
+      const source = path.join(root, 'org');
+      await mkdir(path.join(source, 'knowledge'), { recursive: true });
+      await writeFile(path.join(source, 'knowledge', 'catalog'), 'catalog '.repeat(8192));
+      await writeFile(path.join(source, 'job.json'), 'turn1');
+      for (let turn = 0; turn < 3; turn++) {
+        if (turn === 2) await writeFile(path.join(source, 'job.json'), 'turn2');
+        const started = performance.now();
+        const stats = await syncSandboxDirectory({ source, destination: '/sandbox/diagnostic', deltaRoot: path.join(root, 'delta'+turn),
+          reconcile: manifest => run(['sandbox', 'exec', '-n', slot, '--no-tty', '--', '/usr/local/uv/tools/hermes-agent/bin/python', '-c', RECONCILE_COMMAND, '/sandbox/diagnostic', manifest]),
+          upload: async directory => { await run(['sandbox', 'upload', slot, directory, '/sandbox', '--no-git-ignore']); },
+        });
+        console.log('warm_sync_check', { turn, ...stats, durationMs: performance.now() - started });
+        expect(stats.changed).toBe([2, 0, 1][turn]);
+        if (turn === 1) expect(stats.bytes).toBe(0);
+      }
+    } finally {
+      await closeSandboxPools();
+      logger.mockRestore();
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 180_000,
+);


### PR DESCRIPTION
The first Work request after a web restart could create a new sandbox while a spare was already being prepared. Every reused turn also deleted and reuploaded its workspace and Hermes configuration. This change prepares generic capacity during web/worker startup, makes pool-enabled admission await pending preparation, and reconciles actual sandbox files so only changed inputs are uploaded.

Same-user scope checks and provider/policy invalidation remain intact. Reconciliation removes stale turn data and symlinks, restores modified inputs, and fails closed before agent execution. Separate checkout, reconciliation, upload, and transfer-count telemetry makes binding costs visible. Setup and existing pages remain available if startup preparation fails; the pool retries, and Work still requires ready capacity. Exhausted capacity waits; explicitly disabled pools retain disposable creation.

Validation completed locally before opening this PR:

- Full workspace suite: **2,540 passed, 64 opt-in skipped, zero failures**, using a disposable Postgres database with all 73 migrations applied. LLM: 947 passed; web: 476; worker: 618.
- Separate real OpenShell integration test passed on a disposable local sandbox, with no model calls. Unchanged fixture sync uploaded zero bytes; changing a turn input uploaded only that file. This is not a production latency benchmark.
- Added coverage for startup readiness, concurrent waiters, cancellation, preparation failure/retry, shutdown during preparation, scope isolation, failed reconciliation, stale-file removal, modified-file repair, and symlink/path rejection.
- Repository-wide typechecks, changed web-file lint, Hermes-only contract, design-system check, and diff whitespace checks passed.

Based on v2.44.3; the previously merged onboarding fix is not part of this diff. No production deployment performed. Repeatable validation and measurements are recorded in `apps/worker/benchmarks/2026-09-13-durable-warm-startup.md`.
